### PR TITLE
implement try/catch/finally via setjmp/longjmp

### DIFF
--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -381,7 +381,14 @@ export class SemanticAnalyzer {
       } else if (stmtType === 'try') {
         const tryStmt = stmt as TryStatement;
         if (tryStmt.tryBlock) this.analyzeBlock(tryStmt.tryBlock);
-        if (tryStmt.catchClause && tryStmt.catchClause.body) this.analyzeBlock(tryStmt.catchClause.body);
+        if (tryStmt.catchParam) {
+          this.symbols.set(tryStmt.catchParam, {
+            name: tryStmt.catchParam,
+            type: 'string',
+            llvmType: 'i8*',
+          });
+        }
+        if (tryStmt.catchBody) this.analyzeBlock(tryStmt.catchBody);
         if (tryStmt.finallyBlock) this.analyzeBlock(tryStmt.finallyBlock);
       } else if (stmtType === 'return') {
         const retStmt = stmt as ReturnStatement;

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -304,7 +304,8 @@ export interface ThrowStatement {
 export interface TryStatement {
   type: 'try';
   tryBlock: BlockStatement;
-  catchClause: { param: string; body: BlockStatement } | null;
+  catchParam: string | null;
+  catchBody: BlockStatement | null;
   finallyBlock: BlockStatement | null;
   loc?: SourceLocation;
 }

--- a/src/ast/visitor.ts
+++ b/src/ast/visitor.ts
@@ -210,8 +210,8 @@ export class RecursiveASTVisitor {
 
   visitTryStatement(node: TryStatement): void {
     this.visitBlock(node.tryBlock);
-    if (node.catchClause) {
-      this.visitBlock(node.catchClause.body);
+    if (node.catchBody) {
+      this.visitBlock(node.catchBody);
     }
     if (node.finallyBlock) {
       this.visitBlock(node.finallyBlock);

--- a/src/codegen/infrastructure/closure-analyzer.ts
+++ b/src/codegen/infrastructure/closure-analyzer.ts
@@ -78,7 +78,8 @@ interface CatchHandler {
 interface TryNode {
   type: string;
   tryBlock: BlockStatement;
-  catchClause: CatchHandler | null;
+  catchParam: string | null;
+  catchBody: BlockStatement | null;
   finallyBlock: BlockStatement | null;
 }
 
@@ -322,8 +323,11 @@ export class ClosureAnalyzer {
       this.walkExpression(s.iterable);
       this.walkBlock(s.body);
     } else if (stmtType === 'try') {
-      const tryStmt = stmt as { type: string; tryBlock: BlockStatement; catchClause: { param: string; body: BlockStatement } | null; finallyBlock: BlockStatement | null };
+      const tryStmt = stmt as { type: string; tryBlock: BlockStatement; catchParam: string | null; catchBody: BlockStatement | null; finallyBlock: BlockStatement | null };
       this.walkBlock(tryStmt.tryBlock);
+      if (tryStmt.catchBody !== null) {
+        this.walkBlock(tryStmt.catchBody);
+      }
       if (tryStmt.finallyBlock !== null) {
         this.walkBlock(tryStmt.finallyBlock);
       }

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -213,7 +213,8 @@ export class FunctionGenerator {
       paramStrings.push(`${llvmType} %arg${i}`);
     }
     ir += paramStrings.join(', ');
-    ir += ') nounwind' + this.ctx.getSubprogramDbgRef() + ' {\n';
+    const funcAttrs = this.hasTryStatement(funcBody) ? ') noinline optnone' : ') nounwind';
+    ir += funcAttrs + this.ctx.getSubprogramDbgRef() + ' {\n';
     ir += 'entry:\n';
     this.ctx.setCurrentLabel('entry');
 
@@ -539,6 +540,33 @@ export class FunctionGenerator {
     return false;
   }
 
+  private hasTryStatement(block: BlockStatement): boolean {
+    if (!block) return false;
+    if (!block.statements) return false;
+    for (let i = 0; i < block.statements.length; i++) {
+      const stmt = block.statements[i] as { type: string };
+      if (!stmt) continue;
+      if (stmt.type === 'try') return true;
+      if (stmt.type === 'if') {
+        const ifStmt = block.statements[i] as IfStatement;
+        if (ifStmt.thenBlock && this.hasTryStatement(ifStmt.thenBlock)) return true;
+        if (ifStmt.elseBlock && this.hasTryStatement(ifStmt.elseBlock)) return true;
+      }
+      if (stmt.type === 'while') {
+        const whileStmt = block.statements[i] as WhileStatement;
+        if (whileStmt.body && this.hasTryStatement(whileStmt.body)) return true;
+      }
+      if (stmt.type === 'for') {
+        const forStmt = block.statements[i] as ForStatement;
+        if (forStmt.body && this.hasTryStatement(forStmt.body)) return true;
+      }
+      if (stmt.type === 'block') {
+        const blockStmt = block.statements[i] as BlockStatement;
+        if (this.hasTryStatement(blockStmt)) return true;
+      }
+    }
+    return false;
+  }
   private isEnumType(typeName: string): boolean {
     return this.ctx.isEnumType(typeName);
   }
@@ -703,8 +731,9 @@ export class FunctionGenerator {
     return 'null';
   }
 
-  generateMain(topLevelObjectVariables: Map<string, { ptr: string; keys: string[]; types: string[] }>): string {
-    let ir = 'define i32 @main(i32 %argc, i8** %argv) nounwind' + this.ctx.getSubprogramDbgRef() + ' {\n';
+  generateMain(topLevelObjectVariables: Map<string, { ptr: string; keys: string[]; types: string[] }>, hasTry?: boolean): string {
+    const mainAttrs = hasTry ? 'noinline optnone' : 'nounwind';
+    let ir = 'define i32 @main(i32 %argc, i8** %argv) ' + mainAttrs + this.ctx.getSubprogramDbgRef() + ' {\n';
     ir += 'entry:\n';
     this.ctx.setCurrentLabel('entry');
 

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -17,7 +17,8 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += '%StringMap = type { i8**, i8**, i32, i32 }\n';
   ir += '%Set = type { double*, i32, i32 }\n';
   ir += '%StringSet = type { i8**, i32, i32 }\n';
-  ir += '%struct.timeval = type { i64, i64 }\n\n';
+  ir += '%struct.timeval = type { i64, i64 }\n';
+  ir += '%ExceptionFrame = type { [200 x i8], i8*, i8* }\n\n';
 
   ir += 'declare i8* @malloc(i64)\n';
   ir += 'declare i8* @calloc(i64, i64)\n';
@@ -78,6 +79,8 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += '\n';
 
   ir += 'declare void @exit(i32) noreturn\n';
+  ir += 'declare i32 @setjmp(i8*) returns_twice\n';
+  ir += 'declare void @longjmp(i8*, i32) noreturn\n';
   ir += 'declare i32 @fflush(i8*)\n';
   if (isMac) {
     ir += '@__stdoutp = external global i8*\n';
@@ -339,6 +342,8 @@ export function getGlobalVariables(): string {
   ir += '@__test_failed = global i32 0\n';
   ir += '@__test_current_failed = global i1 0\n';
   ir += '@__describe_depth = global i32 0\n';
+  ir += '@__exception_stack = global i8* null\n';
+  ir += '@__exception_message = global i8* null\n';
   ir += '\n';
   return ir;
 }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2586,7 +2586,15 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       this.currentSubprogramId = this.dbgCreateSubprogram('main', 0);
       this.currentDebugLocId = this.dbgCreateLocation(1, 1, this.currentSubprogramId);
     }
-    const ir = this.funcGen.generateMain(this.topLevelObjectVariables);
+    let hasTry = false;
+    for (let i = 0; i < this.ast.topLevelStatements.length; i++) {
+      const stmt = this.ast.topLevelStatements[i] as { type: string };
+      if (stmt && stmt.type === 'try') {
+        hasTry = true;
+        break;
+      }
+    }
+    const ir = this.funcGen.generateMain(this.topLevelObjectVariables, hasTry);
     this.currentSubprogramId = -1;
     this.currentDebugLocId = -1;
     return ir;

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -1,4 +1,4 @@
-import { Expression, Statement, BlockStatement, MemberAccessNode, VariableNode, BinaryNode, InterfaceDeclaration, ForOfStatement, MethodCallNode, InterfaceField, CommonField, FunctionParameter, SwitchStatement, SwitchCase, StringNode } from '../../ast/types.js';
+import { Expression, Statement, BlockStatement, MemberAccessNode, VariableNode, BinaryNode, InterfaceDeclaration, ForOfStatement, MethodCallNode, InterfaceField, CommonField, FunctionParameter, SwitchStatement, SwitchCase, StringNode, TryStatement } from '../../ast/types.js';
 import { IGeneratorContext } from '../infrastructure/generator-context.js';
 import { SymbolKind, ObjectArrayMetadata, ObjectMetadata, createObjectMetadata, createObjectMetadataWithInterface } from '../infrastructure/symbol-table.js';
 import type { UnionCommonFields } from '../infrastructure/type-resolver/index.js';
@@ -1277,18 +1277,49 @@ export class ControlFlowGenerator {
     }
 
     const throwStmt = stmt as { type: string; argument: Expression };
+    let msgVal: string = 'null';
+
     if (throwStmt.argument) {
       const argTyped = throwStmt.argument as { type: string; className?: string; args?: Expression[] };
       if (argTyped.type === 'new' && argTyped.className === 'Error' && argTyped.args && argTyped.args.length > 0) {
         const msgArg = argTyped.args[0];
-        const msgVal = this.ctx.generateExpression(msgArg, params);
-        const stderrPtr = this.ctx.nextTemp();
-        this.emit(`${stderrPtr} = load i8*, i8** @stderr`);
-        const fprintfResult = this.ctx.nextTemp();
-        this.emit(`${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* getelementptr([11 x i8], [11 x i8]* @.str.throw_fmt, i32 0, i32 0), i8* ${msgVal})`);
+        msgVal = this.ctx.generateExpression(msgArg, params);
+      } else {
+        msgVal = this.ctx.generateExpression(throwStmt.argument, params);
+        const msgType = this.ctx.getVariableType(msgVal);
+        if (msgType === 'double') {
+          const buf = this.nextTemp();
+          this.emit(`${buf} = call i8* @__double_to_string(double ${msgVal})`);
+          msgVal = buf;
+        }
       }
     }
 
+    this.emit(`store i8* ${msgVal}, i8** @__exception_message`);
+
+    const framePtr = this.nextTemp();
+    this.emit(`${framePtr} = load i8*, i8** @__exception_stack`);
+    const hasHandler = this.nextTemp();
+    this.emit(`${hasHandler} = icmp ne i8* ${framePtr}, null`);
+    const doLongjmpLabel = this.nextLabel('do_longjmp');
+    const noHandlerLabel = this.nextLabel('no_handler');
+    this.emit(`br i1 ${hasHandler}, label %${doLongjmpLabel}, label %${noHandlerLabel}`);
+
+    this.emit(`${doLongjmpLabel}:`);
+    this.ctx.setCurrentLabel(doLongjmpLabel);
+    const frameTyped = this.nextTemp();
+    this.emit(`${frameTyped} = bitcast i8* ${framePtr} to %ExceptionFrame*`);
+    const bufPtr = this.nextTemp();
+    this.emit(`${bufPtr} = getelementptr %ExceptionFrame, %ExceptionFrame* ${frameTyped}, i32 0, i32 0, i32 0`);
+    this.emit(`call void @longjmp(i8* ${bufPtr}, i32 1)`);
+    this.emit(`unreachable`);
+
+    this.emit(`${noHandlerLabel}:`);
+    this.ctx.setCurrentLabel(noHandlerLabel);
+    const stderrPtr = this.ctx.nextTemp();
+    this.emit(`${stderrPtr} = load i8*, i8** @stderr`);
+    const fprintfResult = this.ctx.nextTemp();
+    this.emit(`${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* getelementptr([11 x i8], [11 x i8]* @.str.throw_fmt, i32 0, i32 0), i8* ${msgVal})`);
     this.emit(`call void @exit(i32 1)`);
     this.emit(`unreachable`);
     return '0';
@@ -1298,13 +1329,67 @@ export class ControlFlowGenerator {
     if (stmt.type !== 'try') {
       throw new Error('Expected try statement');
     }
-    const tryStmt = stmt as { type: string; tryBlock: BlockStatement; catchClause: { param: string; body: BlockStatement } | null; finallyBlock: BlockStatement | null };
+    const tryStmt = stmt as { type: string; tryBlock: BlockStatement; catchParam: string | null; catchBody: BlockStatement | null; finallyBlock: BlockStatement | null };
 
-    // For now, we'll just execute the try block and ignore catch/finally
-    // Full exception handling would require LLVM's invoke/landingpad support
+    const frameRaw = this.nextTemp();
+    this.emit(`${frameRaw} = call i8* @GC_malloc(i64 216)`);
+    const frame = this.nextTemp();
+    this.emit(`${frame} = bitcast i8* ${frameRaw} to %ExceptionFrame*`);
+
+    const prevFrame = this.nextTemp();
+    this.emit(`${prevFrame} = load i8*, i8** @__exception_stack`);
+    const prevField = this.nextTemp();
+    this.emit(`${prevField} = getelementptr %ExceptionFrame, %ExceptionFrame* ${frame}, i32 0, i32 1`);
+    this.emit(`store i8* ${prevFrame}, i8** ${prevField}`);
+    this.emit(`store i8* ${frameRaw}, i8** @__exception_stack`);
+
+    const bufPtr = this.nextTemp();
+    this.emit(`${bufPtr} = getelementptr %ExceptionFrame, %ExceptionFrame* ${frame}, i32 0, i32 0, i32 0`);
+    const sjVal = this.nextTemp();
+    this.emit(`${sjVal} = call i32 @setjmp(i8* ${bufPtr})`);
+    const isException = this.nextTemp();
+    this.emit(`${isException} = icmp ne i32 ${sjVal}, 0`);
+
+    const tryBodyLabel = this.nextLabel('try_body');
+    const catchEntryLabel = this.nextLabel('catch_entry');
+    const finallyLabel = this.nextLabel('finally_block');
+
+    this.emit(`br i1 ${isException}, label %${catchEntryLabel}, label %${tryBodyLabel}`);
+
+    this.emit(`${tryBodyLabel}:`);
+    this.ctx.setCurrentLabel(tryBodyLabel);
     this.ctx.generateBlock(tryStmt.tryBlock, params);
+    const tryHasTerminator = this.ctx.lastInstructionIsTerminator();
+    if (!tryHasTerminator) {
+      this.emit(`store i8* ${prevFrame}, i8** @__exception_stack`);
+      this.emit(`br label %${finallyLabel}`);
+    }
 
-    // If there's a finally block, execute it unconditionally
+    this.emit(`${catchEntryLabel}:`);
+    this.ctx.setCurrentLabel(catchEntryLabel);
+    this.emit(`store i8* ${prevFrame}, i8** @__exception_stack`);
+
+    if (tryStmt.catchBody) {
+      const paramName = tryStmt.catchParam;
+      if (paramName) {
+        const excMsg = this.nextTemp();
+        this.emit(`${excMsg} = load i8*, i8** @__exception_message`);
+        const paramAlloca = this.ctx.nextAllocaReg(paramName);
+        this.emit(`${paramAlloca} = alloca i8*`);
+        this.emit(`store i8* ${excMsg}, i8** ${paramAlloca}`);
+        this.ctx.defineVariable(paramName, paramAlloca, 'i8*', SymbolKind.String, 'local');
+      }
+      this.ctx.generateBlock(tryStmt.catchBody, params);
+    }
+
+    const catchHasTerminator = this.ctx.lastInstructionIsTerminator();
+    if (!catchHasTerminator) {
+      this.emit(`br label %${finallyLabel}`);
+    }
+
+    this.emit(`${finallyLabel}:`);
+    this.ctx.setCurrentLabel(finallyLabel);
+
     if (tryStmt.finallyBlock) {
       this.ctx.generateBlock(tryStmt.finallyBlock, params);
     }

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -1624,14 +1624,14 @@ function transformTryStatement(node: TreeSitterNode): TryStatement {
 
   const tryBlock = bodyNode ? transformStatementBlock(bodyNode) : createEmptyBlock();
 
-  let catchClause: { param: string; body: BlockStatement } | null = null;
+  let catchParam: string | null = null;
+  let catchBody: BlockStatement | null = null;
   if (handlerNode) {
     const paramNode = getChildByFieldName(handlerNode, 'parameter');
     const catchBodyNode = getChildByFieldName(handlerNode, 'body');
 
-    const param = paramNode ? (paramNode as NodeBase).text : 'e';
-    const body = catchBodyNode ? transformStatementBlock(catchBodyNode) : createEmptyBlock();
-    catchClause = { param, body };
+    catchParam = paramNode ? (paramNode as NodeBase).text : 'e';
+    catchBody = catchBodyNode ? transformStatementBlock(catchBodyNode) : createEmptyBlock();
   }
 
   let finallyBlock: BlockStatement | null = null;
@@ -1642,7 +1642,7 @@ function transformTryStatement(node: TreeSitterNode): TryStatement {
     }
   }
 
-  return { type: 'try', tryBlock, catchClause, finallyBlock };
+  return { type: 'try', tryBlock, catchParam, catchBody, finallyBlock };
 }
 
 function transformSwitchStatement(node: TreeSitterNode): BlockStatement {

--- a/src/parser-ts/handlers/statements.ts
+++ b/src/parser-ts/handlers/statements.ts
@@ -426,13 +426,13 @@ function transformThrowStatement(node: ts.ThrowStatement, checker: ts.TypeChecke
 function transformTryStatement(node: ts.TryStatement, checker: ts.TypeChecker | undefined): TryStatement {
   const tryBlock = transformBlock(node.tryBlock, checker);
 
-  let catchClause: { param: string; body: BlockStatement } | null = null;
+  let catchParam: string | null = null;
+  let catchBody: BlockStatement | null = null;
   if (node.catchClause) {
-    const param = node.catchClause.variableDeclaration && ts.isIdentifier(node.catchClause.variableDeclaration.name)
+    catchParam = node.catchClause.variableDeclaration && ts.isIdentifier(node.catchClause.variableDeclaration.name)
       ? node.catchClause.variableDeclaration.name.text
       : 'e';
-    const body = transformBlock(node.catchClause.block, checker);
-    catchClause = { param, body };
+    catchBody = transformBlock(node.catchClause.block, checker);
   }
 
   let finallyBlock: BlockStatement | null = null;
@@ -440,7 +440,7 @@ function transformTryStatement(node: ts.TryStatement, checker: ts.TypeChecker | 
     finallyBlock = transformBlock(node.finallyBlock, checker);
   }
 
-  return { type: 'try', tryBlock, catchClause, finallyBlock, loc: getLoc(node) };
+  return { type: 'try', tryBlock, catchParam, catchBody, finallyBlock, loc: getLoc(node) };
 }
 
 export function transformBlock(block: ts.Block, checker: ts.TypeChecker | undefined): BlockStatement {

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -209,18 +209,65 @@ describe('ChadScript Compiler', () => {
       const exeFile = path.join(outputDir, baseName);
 
       try {
-        // Compile
         await execAsync(`${compiler} ${fixturePath}`);
 
-        // Run and capture output
-        const { stdout, stderr } = await execAsync(`./${exeFile}`);
-        const output = stdout + stderr;
+        const { stdout } = await execAsync(`./${exeFile}`);
 
-        // Check that try block executed
-        assert.ok(output.includes('before try'), 'Should print before try');
-        assert.ok(output.includes('in try block'), 'Should print in try block');
+        assert.ok(stdout.includes('before try'), 'Should print before try');
+        assert.ok(stdout.includes('in try block'), 'Should print in try block');
+        assert.ok(stdout.includes('caught: test error'), 'Should catch the error');
+        assert.ok(stdout.includes('after try-catch'), 'Should continue after try-catch');
+        assert.ok(stdout.includes('TEST_PASSED'), 'Should print TEST_PASSED');
       } finally {
-        // Clean up
+        try {
+          const llFile = path.join(outputDir, `${baseName}.ll`);
+          if (fsSync.existsSync(llFile)) await fs.unlink(llFile);
+          if (fsSync.existsSync(exeFile)) await fs.unlink(exeFile);
+        } catch (err) {
+          // Ignore cleanup errors
+        }
+      }
+    });
+
+    it('should run finally blocks with and without exceptions', async () => {
+      const fixturePath = 'tests/fixtures/error-handling/try-catch-finally.js';
+      const outputDir = path.join('.build', path.dirname(fixturePath));
+      const baseName = path.basename(fixturePath, '.js');
+      const exeFile = path.join(outputDir, baseName);
+
+      try {
+        await execAsync(`${compiler} ${fixturePath}`);
+
+        const { stdout } = await execAsync(`./${exeFile}`);
+
+        assert.ok(stdout.includes('try catch finally'), 'Should run try, catch, and finally on throw');
+        assert.ok(stdout.includes('try finally'), 'Should run try and finally without throw');
+        assert.ok(stdout.includes('TEST_PASSED'), 'Should print TEST_PASSED');
+      } finally {
+        try {
+          const llFile = path.join(outputDir, `${baseName}.ll`);
+          if (fsSync.existsSync(llFile)) await fs.unlink(llFile);
+          if (fsSync.existsSync(exeFile)) await fs.unlink(exeFile);
+        } catch (err) {
+          // Ignore cleanup errors
+        }
+      }
+    });
+
+    it('should handle nested try-catch correctly', async () => {
+      const fixturePath = 'tests/fixtures/error-handling/try-catch-nested.js';
+      const outputDir = path.join('.build', path.dirname(fixturePath));
+      const baseName = path.basename(fixturePath, '.js');
+      const exeFile = path.join(outputDir, baseName);
+
+      try {
+        await execAsync(`${compiler} ${fixturePath}`);
+
+        const { stdout } = await execAsync(`./${exeFile}`);
+
+        assert.ok(stdout.includes('outer-try inner-try inner-catch after-inner outer-catch'), 'Nested try-catch should work');
+        assert.ok(stdout.includes('TEST_PASSED'), 'Should print TEST_PASSED');
+      } finally {
         try {
           const llFile = path.join(outputDir, `${baseName}.ll`);
           if (fsSync.existsSync(llFile)) await fs.unlink(llFile);

--- a/tests/fixtures/error-handling/try-catch-finally.js
+++ b/tests/fixtures/error-handling/try-catch-finally.js
@@ -1,0 +1,30 @@
+function testFinallyWithThrow() {
+  let result = "";
+  try {
+    result = result + "try ";
+    throw new Error("boom");
+  } catch (e) {
+    result = result + "catch ";
+  } finally {
+    result = result + "finally";
+  }
+  console.log(result);
+  return result;
+}
+
+function testFinallyNoThrow() {
+  let result = "";
+  try {
+    result = result + "try ";
+  } catch (e) {
+    result = result + "catch ";
+  } finally {
+    result = result + "finally";
+  }
+  console.log(result);
+  return result;
+}
+
+testFinallyWithThrow();
+testFinallyNoThrow();
+console.log("TEST_PASSED");

--- a/tests/fixtures/error-handling/try-catch-nested.js
+++ b/tests/fixtures/error-handling/try-catch-nested.js
@@ -1,0 +1,20 @@
+function testNested() {
+  let result = "";
+  try {
+    result = result + "outer-try ";
+    try {
+      result = result + "inner-try ";
+      throw new Error("inner error");
+    } catch (e) {
+      result = result + "inner-catch ";
+    }
+    result = result + "after-inner ";
+    throw new Error("outer error");
+  } catch (e) {
+    result = result + "outer-catch";
+  }
+  console.log(result);
+}
+
+testNested();
+console.log("TEST_PASSED");

--- a/tests/fixtures/error-handling/try-catch-rethrow.js
+++ b/tests/fixtures/error-handling/try-catch-rethrow.js
@@ -1,0 +1,17 @@
+function testRethrow() {
+  let result = "";
+  try {
+    try {
+      throw new Error("original");
+    } catch (inner) {
+      result = result + "inner-caught ";
+      throw new Error("rethrown");
+    }
+  } catch (outer) {
+    result = result + "outer-caught:" + outer;
+  }
+  console.log(result);
+}
+
+testRethrow();
+console.log("TEST_PASSED");

--- a/tests/fixtures/error-handling/try-catch-throw.js
+++ b/tests/fixtures/error-handling/try-catch-throw.js
@@ -2,12 +2,13 @@ function testTryCatch() {
   console.log("before try");
   try {
     console.log("in try block");
+    throw new Error("test error");
   } catch (e) {
-    console.log("in catch block");
+    console.log("caught: " + e);
   }
   console.log("after try-catch");
-  return 0;
 }
 
-// Test try-catch (catch block is never reached in our simple implementation)
 testTryCatch();
+
+console.log("TEST_PASSED");

--- a/tests/test-fixtures.ts
+++ b/tests/test-fixtures.ts
@@ -541,8 +541,26 @@ export const testCases: TestCase[] = [
   {
     name: 'try-catch-throw',
     fixture: 'tests/fixtures/error-handling/try-catch-throw.js',
-    expectedExitCode: 0,
+    expectTestPassed: true,
     description: 'Try-catch-throw flow'
+  },
+  {
+    name: 'try-catch-finally',
+    fixture: 'tests/fixtures/error-handling/try-catch-finally.js',
+    expectTestPassed: true,
+    description: 'Finally blocks run with and without throw'
+  },
+  {
+    name: 'try-catch-nested',
+    fixture: 'tests/fixtures/error-handling/try-catch-nested.js',
+    expectTestPassed: true,
+    description: 'Nested try-catch blocks handle exceptions at correct level'
+  },
+  {
+    name: 'try-catch-rethrow',
+    fixture: 'tests/fixtures/error-handling/try-catch-rethrow.js',
+    expectTestPassed: true,
+    description: 'Throw inside catch propagates to outer try-catch'
   },
   {
     name: 'http-simple-test',


### PR DESCRIPTION
## Add try/catch/finally via setjmp/longjmp

Real exception handling for ChadScript. `throw` now transfers control to the nearest enclosing `catch` block instead of calling `exit(1)`. Unhandled throws still print to stderr and exit — fully backwards compatible.

### How it works

- Each `try` block pushes an `ExceptionFrame` onto a global linked-list stack (`@__exception_stack`) and calls `setjmp` to save CPU state
- `throw` stores the error message in `@__exception_message`, pops the top frame, and calls `longjmp` to restore execution at the `setjmp` point
- `finally` blocks run unconditionally after both normal and exception paths
- Nested try/catch works naturally via the linked-list stack

### Key changes

- **LLVM declarations**: `%ExceptionFrame` struct, `setjmp`/`longjmp` declares, exception globals
- **Codegen**: Rewrote `generateThrowStatement` and `generateTryStatement` in control-flow.ts
- **Function attributes**: Functions containing `try` get `noinline optnone` instead of `nounwind` to prevent the optimizer from caching stack variables in registers across `setjmp` boundaries
- **AST flattening**: Changed `TryStatement.catchClause: { param, body }` to flat `catchParam`/`catchBody` fields — the native compiler doesn't support nested anonymous struct types
- **Semantic analyzer**: Catch parameters are now registered as declared variables

### Tests

- Basic try/catch with throw and catch parameter binding
- Finally blocks (with and without throw)
- Nested try/catch at different levels
- Throw inside catch (rethrow to outer handler)
- Self-hosting passes (Stage 0 + Stage 1)
