### PR TITLE
add IR builder methods to BaseGenerator and IGeneratorContext

### DIFF
--- a/src/codegen/infrastructure/base-generator.ts
+++ b/src/codegen/infrastructure/base-generator.ts
@@ -460,6 +460,48 @@ export class BaseGenerator {
     this.emit(`${name}:`);
   }
 
+  emitCall(retType: string, func: string, args: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = call ${retType} ${func}(${args})`);
+    this.setVariableType(temp, retType);
+    return temp;
+  }
+
+  emitCallVoid(func: string, args: string): void {
+    this.emit(`call void ${func}(${args})`);
+  }
+
+  emitLoad(type: string, ptr: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = load ${type}, ${type}* ${ptr}`);
+    this.setVariableType(temp, type);
+    return temp;
+  }
+
+  emitStore(type: string, value: string, ptr: string): void {
+    this.emit(`store ${type} ${value}, ${type}* ${ptr}`);
+  }
+
+  emitGep(baseType: string, ptr: string, indices: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = getelementptr ${baseType}, ${baseType}* ${ptr}, ${indices}`);
+    return temp;
+  }
+
+  emitIcmp(pred: string, type: string, lhs: string, rhs: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = icmp ${pred} ${type} ${lhs}, ${rhs}`);
+    this.setVariableType(temp, 'i1');
+    return temp;
+  }
+
+  emitBitcast(value: string, fromType: string, toType: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = bitcast ${fromType} ${value} to ${toType}`);
+    this.setVariableType(temp, toType);
+    return temp;
+  }
+
   // ============================================
   // Symbol table convenience methods
   // ============================================

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -555,6 +555,14 @@ export interface IGeneratorContext {
   emitUnreachable(): void;
   emitLabel(name: string): void;
 
+  emitCall(retType: string, func: string, args: string): string;
+  emitCallVoid(func: string, args: string): void;
+  emitLoad(type: string, ptr: string): string;
+  emitStore(type: string, value: string, ptr: string): void;
+  emitGep(baseType: string, ptr: string, indices: string): string;
+  emitIcmp(pred: string, type: string, lhs: string, rhs: string): string;
+  emitBitcast(value: string, fromType: string, toType: string): string;
+
   getOutput(): string[];
   clearOutput(): void;
   pushOutput(line: string): void;
@@ -1198,6 +1206,48 @@ export class MockGeneratorContext implements IGeneratorContext {
 
   emitLabel(name: string): void {
     this.emit(`${name}:`);
+  }
+
+  emitCall(retType: string, func: string, args: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = call ${retType} ${func}(${args})`);
+    this.setVariableType(temp, retType);
+    return temp;
+  }
+
+  emitCallVoid(func: string, args: string): void {
+    this.emit(`call void ${func}(${args})`);
+  }
+
+  emitLoad(type: string, ptr: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = load ${type}, ${type}* ${ptr}`);
+    this.setVariableType(temp, type);
+    return temp;
+  }
+
+  emitStore(type: string, value: string, ptr: string): void {
+    this.emit(`store ${type} ${value}, ${type}* ${ptr}`);
+  }
+
+  emitGep(baseType: string, ptr: string, indices: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = getelementptr ${baseType}, ${baseType}* ${ptr}, ${indices}`);
+    return temp;
+  }
+
+  emitIcmp(pred: string, type: string, lhs: string, rhs: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = icmp ${pred} ${type} ${lhs}, ${rhs}`);
+    this.setVariableType(temp, 'i1');
+    return temp;
+  }
+
+  emitBitcast(value: string, fromType: string, toType: string): string {
+    const temp = this.nextTemp();
+    this.emit(`${temp} = bitcast ${fromType} ${value} to ${toType}`);
+    this.setVariableType(temp, toType);
+    return temp;
   }
 
   getOutput(): string[] {

--- a/src/codegen/stdlib/date.ts
+++ b/src/codegen/stdlib/date.ts
@@ -19,18 +19,13 @@ export class DateGenerator {
     const tvAlloca = this.ctx.nextTemp();
     this.ctx.emit(`${tvAlloca} = alloca %struct.timeval`);
 
-    const callResult = this.ctx.nextTemp();
-    this.ctx.emit(`${callResult} = call i32 @gettimeofday(%struct.timeval* ${tvAlloca}, i8* null)`);
+    this.ctx.emitCall('i32', '@gettimeofday', `%struct.timeval* ${tvAlloca}, i8* null`);
 
-    const secPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${secPtr} = getelementptr %struct.timeval, %struct.timeval* ${tvAlloca}, i32 0, i32 0`);
-    const secVal = this.ctx.nextTemp();
-    this.ctx.emit(`${secVal} = load i64, i64* ${secPtr}`);
+    const secPtr = this.ctx.emitGep('%struct.timeval', tvAlloca, 'i32 0, i32 0');
+    const secVal = this.ctx.emitLoad('i64', secPtr);
 
-    const usecPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${usecPtr} = getelementptr %struct.timeval, %struct.timeval* ${tvAlloca}, i32 0, i32 1`);
-    const usecVal = this.ctx.nextTemp();
-    this.ctx.emit(`${usecVal} = load i64, i64* ${usecPtr}`);
+    const usecPtr = this.ctx.emitGep('%struct.timeval', tvAlloca, 'i32 0, i32 1');
+    const usecVal = this.ctx.emitLoad('i64', usecPtr);
 
     const secDouble = this.ctx.nextTemp();
     this.ctx.emit(`${secDouble} = sitofp i64 ${secVal} to double`);


### PR DESCRIPTION
## Summary

- Add 7 IR builder methods to `BaseGenerator`, `IGeneratorContext`, and `MockGeneratorContext` (three-way sync): `emitCall`, `emitCallVoid`, `emitLoad`, `emitStore`, `emitGep`, `emitIcmp`, `emitBitcast`
- Each method auto-allocates a temp register, emits the LLVM IR instruction, tracks the result type via `setVariableType()`, and returns the register name
- Pilot migration: convert `DateGenerator.generateNow()` in `date.ts` to use the new builders as proof of concept

This is Shard C of the compiler rearchitecture plan. All files are disjoint from Shards A/B/D.

## Files changed

- `src/codegen/infrastructure/base-generator.ts` — builder method implementations
- `src/codegen/infrastructure/generator-context.ts` — interface declarations + mock implementations
- `src/codegen/stdlib/date.ts` — pilot migration (5 of 10 nextTemp+emit pairs replaced with single-line builder calls)

## Test plan

- `npm run build` passes clean
- `npm test` — 324 passing, 18 failing (all pre-existing try-catch failures, identical to clean main)
- `npm run verify:quick` — self-hosting stages pass, same pre-existing failures only
