### PR TITLE
add do...while loop support

### DIFF
--- a/docs/language/limitations.md
+++ b/docs/language/limitations.md
@@ -7,7 +7,7 @@ ChadScript supports a practical subset of TypeScript. All types must be known at
 | Feature | Status |
 |---------|--------|
 | `let`, `const`, `var` | Supported |
-| `if`/`else if`/`else`, `for`, `for...of`, `while`, `switch` | Supported |
+| `if`/`else if`/`else`, `for`, `for...of`, `while`, `do...while`, `switch` | Supported |
 | `break`, `continue`, `return` | Supported |
 | `try`/`catch`/`finally`, `throw` | Supported |
 | Template literals (`` `hello ${name}` ``) | Supported |
@@ -22,7 +22,6 @@ ChadScript supports a practical subset of TypeScript. All types must be known at
 | Regular expressions (`/pattern/flags`) | Supported |
 | `for...in` | Supported (desugared to `for...of Object.keys()`) |
 | Generator functions (`function*`, `yield`) | Not supported |
-| `do...while` | Not supported |
 | Decorators | Not supported |
 | Tagged template literals | Not supported |
 | Labeled statements | Not supported |

--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -430,7 +430,7 @@ export class SemanticAnalyzer {
         const ifStmt = stmt as IfStatement;
         if (ifStmt.thenBlock) this.analyzeBlock(ifStmt.thenBlock);
         if (ifStmt.elseBlock) this.analyzeBlock(ifStmt.elseBlock);
-      } else if (stmtType === "while") {
+      } else if (stmtType === "while" || stmtType === "do_while") {
         const whileStmt = stmt as WhileStatement;
         if (whileStmt.body) this.analyzeBlock(whileStmt.body);
       } else if (stmtType === "for") {

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -294,6 +294,13 @@ export interface WhileStatement {
   loc?: SourceLocation;
 }
 
+export interface DoWhileStatement {
+  type: "do_while";
+  condition: Expression;
+  body: BlockStatement;
+  loc?: SourceLocation;
+}
+
 export interface ForStatement {
   type: "for";
   init: VariableDeclaration | AssignmentStatement | null;
@@ -356,6 +363,7 @@ export type Statement =
   | ReturnStatement
   | IfStatement
   | WhileStatement
+  | DoWhileStatement
   | ForStatement
   | ForOfStatement
   | BreakStatement
@@ -372,6 +380,7 @@ export type TopLevelItem =
   | ForStatement
   | ForOfStatement
   | WhileStatement
+  | DoWhileStatement
   | IfStatement
   | TryStatement
   | ThrowStatement
@@ -459,6 +468,7 @@ export interface AST {
     | ForStatement
     | ForOfStatement
     | WhileStatement
+    | DoWhileStatement
     | IfStatement
     | TryStatement
     | AwaitExpressionNode

--- a/src/ast/visitor.ts
+++ b/src/ast/visitor.ts
@@ -36,6 +36,7 @@ import {
   ReturnStatement,
   IfStatement,
   WhileStatement,
+  DoWhileStatement,
   ForStatement,
   ForOfStatement,
   BreakStatement,
@@ -101,6 +102,7 @@ export class RecursiveASTVisitor {
           e.type === "for" ||
           e.type === "for_of" ||
           e.type === "while" ||
+          e.type === "do_while" ||
           e.type === "if" ||
           e.type === "try"
         ) {
@@ -172,6 +174,8 @@ export class RecursiveASTVisitor {
       this.visitIfStatement(stmt as IfStatement);
     } else if (t === "while") {
       this.visitWhileStatement(stmt as WhileStatement);
+    } else if (t === "do_while") {
+      this.visitDoWhileStatement(stmt as DoWhileStatement);
     } else if (t === "for") {
       this.visitForStatement(stmt as ForStatement);
     } else if (t === "for_of") {
@@ -222,6 +226,11 @@ export class RecursiveASTVisitor {
   }
 
   visitWhileStatement(node: WhileStatement): void {
+    this.visitExpression(node.condition);
+    this.visitBlock(node.body);
+  }
+
+  visitDoWhileStatement(node: DoWhileStatement): void {
     this.visitExpression(node.condition);
     this.visitBlock(node.body);
   }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -19,6 +19,7 @@ import {
   ImportSpecifier,
   IfStatement,
   WhileStatement,
+  DoWhileStatement,
   ForStatement,
   ForOfStatement,
   TryStatement,
@@ -2960,6 +2961,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         // Don't need to sync back - counters are already shared via bound methods
       } else if (stmtType === "while") {
         lastValue = this.controlFlowGen.generateWhileStatement(stmtRaw as Statement, params);
+      } else if (stmtType === "do_while") {
+        lastValue = this.controlFlowGen.generateDoWhileStatement(stmtRaw as Statement, params);
       } else if (stmtType === "for") {
         lastValue = this.controlFlowGen.generateForStatement(stmtRaw as Statement, params);
       } else if (stmtType === "for_of") {
@@ -3173,6 +3176,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     | ForStatement
     | ForOfStatement
     | WhileStatement
+    | DoWhileStatement
     | IfStatement
     | TryStatement
     | UnaryNode
@@ -3212,6 +3216,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       this.controlFlowGen.generateIfStatement(item as IfStatement, []);
     } else if (itemType === "while") {
       this.controlFlowGen.generateWhileStatement(item as WhileStatement, []);
+    } else if (itemType === "do_while") {
+      this.controlFlowGen.generateDoWhileStatement(item as DoWhileStatement, []);
     } else if (itemType === "for") {
       this.controlFlowGen.generateForStatement(item as ForStatement, []);
     } else if (itemType === "for_of") {

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -241,6 +241,48 @@ export class ControlFlowGenerator {
     return "0";
   }
 
+  // do { body } while (condition) — body executes first, then condition is checked.
+  // continue jumps to cond (matching JS semantics), break jumps to end.
+  generateDoWhileStatement(stmt: Statement, params: string[]): string {
+    if (stmt.type !== "do_while") {
+      throw new Error("Expected do_while statement");
+    }
+
+    const doWhileStmt = stmt as { type: string; condition: Expression; body: BlockStatement };
+
+    const bodyLabel = this.nextLabel("dowhile_body");
+    const condLabel = this.nextLabel("dowhile_cond");
+    const endLabel = this.nextLabel("dowhile_end");
+
+    // Jump directly to body (body always executes at least once)
+    this.emit(`br label %${bodyLabel}`);
+
+    // Body block
+    this.emit(`${bodyLabel}:`);
+    this.ctx.setCurrentLabel(bodyLabel);
+    this.loopContinueLabels.push(condLabel);
+    this.loopBreakLabels.push(endLabel);
+    this.ctx.generateBlock(doWhileStmt.body, params);
+    this.loopContinueLabels.pop();
+    this.loopBreakLabels.pop();
+    const bodyHasTerminator = this.ctx.lastInstructionIsTerminator();
+    if (!bodyHasTerminator) {
+      this.emit(`br label %${condLabel}`);
+    }
+
+    // Condition block — evaluated after body
+    this.emit(`${condLabel}:`);
+    this.ctx.setCurrentLabel(condLabel);
+    const condValue = this.ctx.generateExpression(doWhileStmt.condition, params);
+    const condBool = this.convertToBool(condValue);
+    this.emit(`br i1 ${condBool}, label %${bodyLabel}, label %${endLabel}`);
+
+    // End block
+    this.emit(`${endLabel}:`);
+
+    return "0";
+  }
+
   generateForStatement(stmt: Statement, params: string[]): string {
     if (stmt.type !== "for") {
       throw new Error("Expected for statement");

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -25,6 +25,7 @@ import {
   ReturnStatement,
   IfStatement,
   WhileStatement,
+  DoWhileStatement,
   ForStatement,
   ForOfStatement,
   ThrowStatement,
@@ -188,6 +189,15 @@ function transformTopLevelNode(node: TreeSitterNode, ast: AST): void {
         ast.topLevelExpressions.push(whileStmt);
         ast.topLevelItems!.push(whileStmt);
         ast.topLevelItemTypes!.push("while");
+      }
+      break;
+
+    case "do_statement":
+      const doWhileStmt = transformDoWhileStatement(node);
+      if (doWhileStmt) {
+        ast.topLevelExpressions.push(doWhileStmt);
+        ast.topLevelItems!.push(doWhileStmt);
+        ast.topLevelItemTypes!.push("do_while");
       }
       break;
 
@@ -1244,6 +1254,9 @@ function transformStatement(node: TreeSitterNode): Statement | null {
     case "while_statement":
       return transformWhileStatement(node);
 
+    case "do_statement":
+      return transformDoWhileStatement(node);
+
     case "for_statement":
       return transformForStatement(node);
 
@@ -1596,6 +1609,28 @@ function transformWhileStatement(node: TreeSitterNode): WhileStatement {
   const body = bodyNode ? wrapInBlock(bodyNode) : createEmptyBlock();
 
   return { type: "while", condition, body };
+}
+
+function transformDoWhileStatement(node: TreeSitterNode): DoWhileStatement {
+  const condNode = getChildByFieldName(node, "condition");
+  const bodyNode = getChildByFieldName(node, "body");
+
+  let condition: Expression;
+  if (condNode) {
+    const cn = condNode as NodeBase;
+    if (cn.type === "parenthesized_expression") {
+      const inner = getNamedChild(condNode, 0);
+      condition = inner ? transformExpression(inner) : { type: "boolean", value: true };
+    } else {
+      condition = transformExpression(condNode);
+    }
+  } else {
+    condition = { type: "boolean", value: true };
+  }
+
+  const body = bodyNode ? wrapInBlock(bodyNode) : createEmptyBlock();
+
+  return { type: "do_while", condition, body };
 }
 
 function transformForStatement(node: TreeSitterNode): ForStatement {

--- a/src/parser-ts/handlers/statements.ts
+++ b/src/parser-ts/handlers/statements.ts
@@ -8,6 +8,7 @@ import {
   ReturnStatement,
   IfStatement,
   WhileStatement,
+  DoWhileStatement,
   ForStatement,
   ForOfStatement,
   ThrowStatement,
@@ -37,6 +38,9 @@ export function transformStatement(
 
     case ts.SyntaxKind.WhileStatement:
       return transformWhileStatement(node as ts.WhileStatement, checker);
+
+    case ts.SyntaxKind.DoStatement:
+      return transformDoWhileStatement(node as ts.DoStatement, checker);
 
     case ts.SyntaxKind.ForStatement:
       return transformForStatement(node as ts.ForStatement, checker);
@@ -351,6 +355,15 @@ function transformWhileStatement(
   const condition = transformExpression(node.expression, checker);
   const body = wrapInBlock(node.statement, checker);
   return { type: "while", condition, body, loc: getLoc(node) };
+}
+
+function transformDoWhileStatement(
+  node: ts.DoStatement,
+  checker: ts.TypeChecker | undefined,
+): DoWhileStatement {
+  const condition = transformExpression(node.expression, checker);
+  const body = wrapInBlock(node.statement, checker);
+  return { type: "do_while", condition, body, loc: getLoc(node) };
 }
 
 function transformForStatement(

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -13,6 +13,7 @@ import {
   ForStatement,
   ForOfStatement,
   WhileStatement,
+  DoWhileStatement,
   IfStatement,
   TryStatement,
   TopLevelItem,
@@ -225,6 +226,13 @@ function transformTopLevelStatement(
       const whileStmt = transformStatement(node, checker) as WhileStatement;
       ast.topLevelExpressions.push(whileStmt);
       ast.topLevelItems!.push(whileStmt);
+      break;
+    }
+
+    case ts.SyntaxKind.DoStatement: {
+      const doWhileStmt = transformStatement(node, checker) as DoWhileStatement;
+      ast.topLevelExpressions.push(doWhileStmt);
+      ast.topLevelItems!.push(doWhileStmt);
       break;
     }
 

--- a/tests/fixtures/control-flow/do-while-loop.js
+++ b/tests/fixtures/control-flow/do-while-loop.js
@@ -1,0 +1,53 @@
+// @test-exit-code: 0
+// Tests do...while loop: body executes at least once, then checks condition
+
+let count = 0;
+do {
+  count = count + 1;
+} while (count < 5);
+
+// count should be 5
+if (count !== 5) {
+  process.exit(1);
+}
+
+// do...while always runs body at least once, even if condition is false
+let ran = 0;
+do {
+  ran = 1;
+} while (false);
+
+if (ran !== 1) {
+  process.exit(2);
+}
+
+// break inside do...while
+let breakCount = 0;
+do {
+  breakCount = breakCount + 1;
+  if (breakCount === 3) {
+    break;
+  }
+} while (breakCount < 10);
+
+if (breakCount !== 3) {
+  process.exit(3);
+}
+
+// continue inside do...while (should jump to condition check)
+let sum = 0;
+let i = 0;
+do {
+  i = i + 1;
+  if (i === 3) {
+    continue;
+  }
+  sum = sum + i;
+} while (i < 5);
+
+// sum = 1 + 2 + 4 + 5 = 12 (skipped 3)
+if (sum !== 12) {
+  process.exit(4);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Add `do...while` loop support

Implements `do...while` across the full compiler pipeline. The key difference from `while` is the LLVM IR control flow: body executes first, then condition is checked, so the loop body always runs at least once. `continue` jumps to the condition label (matching JS semantics), `break` jumps to the end label.

### Changes

| File | Change |
|------|--------|
| `src/ast/types.ts` | `DoWhileStatement` interface, added to `Statement`, `TopLevelItem`, `AST.topLevelExpressions` unions |
| `src/parser-ts/handlers/statements.ts` | `DoStatement` case + `transformDoWhileStatement()` |
| `src/parser-ts/transformer.ts` | Top-level `DoStatement` dispatch |
| `src/parser-native/transformer.ts` | `do_statement` cases (top-level + statement) + `transformDoWhileStatement()` |
| `src/ast/visitor.ts` | `do_while` dispatch + `visitDoWhileStatement()` |
| `src/analysis/semantic-analyzer.ts` | Extended `while` case to also handle `do_while` |
| `src/codegen/statements/control-flow.ts` | `generateDoWhileStatement()` — body-first IR structure |
| `src/codegen/llvm-generator.ts` | `do_while` dispatch in statement + top-level item processing |
| `docs/language/limitations.md` | Moved `do...while` from "Not supported" to Supported |
| `tests/fixtures/control-flow/do-while-loop.js` | New test fixture |

### Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `npm test` — all 338 tests pass (native), all 205 pass (Node.js rerun)
- [x] `npm run verify:quick` — self-hosting passes (Stage 0 + Stage 1)
- [x] Rebuilt `.build/chad` with do-while support
