### PR TITLE
add http response/request headers, serveEmbedded, and header tests

### DIFF
--- a/c_bridges/lws-bridge.c
+++ b/c_bridges/lws-bridge.c
@@ -32,6 +32,7 @@ typedef struct http_conn_s {
     size_t content_length;
     char content_type_str[256];
     char accept_encoding[256];
+    char headers_raw[4096];  // all request headers as "Key: Value\n..." string
     char ws_key[64];
     int headers_complete;
     size_t header_end;
@@ -212,6 +213,7 @@ static void on_http_write_done_fallback(uv_write_t *req, int status) {
 }
 
 static void send_http_response(http_conn_t *conn, int status, const char *resp_ct,
+                                const char *extra_headers,
                                 const unsigned char *body, size_t body_len) {
     const unsigned char *send_body = body;
     size_t send_len = body_len;
@@ -246,8 +248,34 @@ static void send_http_response(http_conn_t *conn, int status, const char *resp_c
         }
     }
 
+    // Format extra headers (normalize \n to \r\n, skip Content-Type lines)
+    char extra_hdr_buf[2048];
+    int extra_hdr_len = 0;
+    if (extra_headers && extra_headers[0]) {
+        const char *src = extra_headers;
+        char *dst = extra_hdr_buf;
+        char *dst_end = extra_hdr_buf + sizeof(extra_hdr_buf) - 4;
+        while (*src && dst < dst_end) {
+            const char *line_start = src;
+            while (*src && *src != '\n') src++;
+            size_t line_len = (size_t)(src - line_start);
+            // Skip empty lines and Content-Type (already handled separately)
+            if (line_len > 0 && strncasecmp(line_start, "Content-Type:", 13) != 0) {
+                if (dst + line_len + 2 <= dst_end) {
+                    memcpy(dst, line_start, line_len);
+                    dst += line_len;
+                    *dst++ = '\r';
+                    *dst++ = '\n';
+                }
+            }
+            if (*src == '\n') src++;
+        }
+        *dst = '\0';
+        extra_hdr_len = (int)(dst - extra_hdr_buf);
+    }
+
     int hlen;
-    int use_fast_path = (status == 200 && !content_encoding);
+    int use_fast_path = (status == 200 && !content_encoding && !extra_hdr_len);
 
     if (use_fast_path) {
         char *p = conn->resp_buf;
@@ -268,19 +296,23 @@ static void send_http_response(http_conn_t *conn, int status, const char *resp_c
                 "HTTP/1.1 %d OK\r\n"
                 "Content-Type: %s\r\n"
                 "Content-Length: %zu\r\n"
-                "Content-Encoding: %s\r\n"
-                "Connection: keep-alive\r\n"
-                "\r\n",
+                "Content-Encoding: %s\r\n",
                 status, resp_ct, send_len, content_encoding);
         } else {
             hlen = snprintf(conn->resp_buf, 4096,
                 "HTTP/1.1 %d OK\r\n"
                 "Content-Type: %s\r\n"
-                "Content-Length: %zu\r\n"
-                "Connection: keep-alive\r\n"
-                "\r\n",
+                "Content-Length: %zu\r\n",
                 status, resp_ct, send_len);
         }
+        // Splice extra headers before the final Connection + blank line
+        if (extra_hdr_len > 0 && hlen + extra_hdr_len < 4096 - 32) {
+            memcpy(conn->resp_buf + hlen, extra_hdr_buf, (size_t)extra_hdr_len);
+            hlen += extra_hdr_len;
+        }
+        int tail = snprintf(conn->resp_buf + hlen, 4096 - hlen,
+            "Connection: keep-alive\r\n\r\n");
+        hlen += tail;
     }
 
     size_t total = (size_t)hlen + send_len;
@@ -331,18 +363,49 @@ static void dispatch_http_request(http_conn_t *conn) {
     req.path = conn->path_str;
     req.body = conn->body ? conn->body : "";
     req.content_type = conn->content_type_str;
+    req.headers_raw = conn->headers_raw;
 
     lws_bridge_response resp;
     resp.status = 200;
     resp.body = "";
     resp.body_len = 0;
+    resp.extra_headers = NULL;
 
     g_http_handler(&req, &resp);
 
-    const char *resp_ct = sniff_content_type(req.path, resp.body);
+    // Check if extra_headers provides a Content-Type override
+    const char *resp_ct = NULL;
+    if (resp.extra_headers && resp.extra_headers[0]) {
+        // Scan extra_headers for "Content-Type:" (case-insensitive)
+        const char *p = resp.extra_headers;
+        while (*p) {
+            if (strncasecmp(p, "Content-Type:", 13) == 0) {
+                p += 13;
+                while (*p == ' ') p++;
+                // Extract value until \n or end
+                const char *end = p;
+                while (*end && *end != '\n') end++;
+                // Copy to a temp buffer (static is fine, single-threaded)
+                static char ct_buf[256];
+                size_t ct_len = (size_t)(end - p);
+                if (ct_len >= sizeof(ct_buf)) ct_len = sizeof(ct_buf) - 1;
+                memcpy(ct_buf, p, ct_len);
+                ct_buf[ct_len] = '\0';
+                resp_ct = ct_buf;
+                break;
+            }
+            // Skip to next line
+            while (*p && *p != '\n') p++;
+            if (*p == '\n') p++;
+        }
+    }
+    if (!resp_ct) {
+        resp_ct = sniff_content_type(req.path, resp.body);
+    }
+
     size_t body_len = resp.body_len > 0 ? (size_t)resp.body_len : (resp.body ? strlen(resp.body) : 0);
 
-    send_http_response(conn, resp.status, resp_ct,
+    send_http_response(conn, resp.status, resp_ct, resp.extra_headers,
                        (const unsigned char *)resp.body, body_len);
 }
 
@@ -515,8 +578,26 @@ static void try_parse_request(http_conn_t *conn) {
         conn->content_length = 0;
         conn->content_type_str[0] = '\0';
         conn->accept_encoding[0] = '\0';
+        conn->headers_raw[0] = '\0';
         conn->ws_key[0] = '\0';
         int is_upgrade = 0;
+
+        // Format all request headers into headers_raw as "Key: Value\n..." string
+        {
+            size_t hoff = 0;
+            for (size_t hi = 0; hi < num_headers; hi++) {
+                size_t needed = headers[hi].name_len + 2 + headers[hi].value_len + 1;
+                if (hoff + needed >= sizeof(conn->headers_raw)) break;
+                memcpy(conn->headers_raw + hoff, headers[hi].name, headers[hi].name_len);
+                hoff += headers[hi].name_len;
+                conn->headers_raw[hoff++] = ':';
+                conn->headers_raw[hoff++] = ' ';
+                memcpy(conn->headers_raw + hoff, headers[hi].value, headers[hi].value_len);
+                hoff += headers[hi].value_len;
+                conn->headers_raw[hoff++] = '\n';
+            }
+            conn->headers_raw[hoff] = '\0';
+        }
 
         for (size_t i = 0; i < num_headers; i++) {
             if (headers[i].name_len == 14 &&
@@ -601,6 +682,7 @@ static void try_parse_request(http_conn_t *conn) {
         conn->content_length = 0;
         conn->content_type_str[0] = '\0';
         conn->accept_encoding[0] = '\0';
+        conn->headers_raw[0] = '\0';
         conn->ws_key[0] = '\0';
         conn->method_str[0] = '\0';
         conn->path_str[0] = '\0';

--- a/c_bridges/lws-bridge.h
+++ b/c_bridges/lws-bridge.h
@@ -8,12 +8,14 @@ typedef struct {
     const char *path;
     const char *body;
     const char *content_type;
+    const char *headers_raw;  // all headers as "Key: Value\n..." string
 } lws_bridge_request;
 
 typedef struct {
     int status;
     const char *body;
     int64_t body_len;
+    const char *extra_headers;  // "\n"-separated header lines, or NULL
 } lws_bridge_response;
 
 typedef void (*lws_bridge_http_handler)(lws_bridge_request *req, lws_bridge_response *resp);

--- a/docs/stdlib/embed.md
+++ b/docs/stdlib/embed.md
@@ -39,6 +39,23 @@ const nested = ChadScript.getEmbeddedFile("images/logo.txt");
 
 Returns an empty string if the key is not found.
 
+## `ChadScript.serveEmbedded(path)`
+
+Return an `HttpResponse` for an embedded file. Strips the leading `/` from the path, looks up the file in the embedded table, and returns `{ status: 200, body: content, headers: "" }` if found or `{ status: 404, body: "Not Found", headers: "" }` if not.
+
+This eliminates per-file route boilerplate for serving static assets:
+
+```typescript
+ChadScript.embedDir("./public");
+
+function handleRequest(req: HttpRequest): HttpResponse {
+  if (req.path.startsWith("/api/")) return handleApi(req);
+  return ChadScript.serveEmbedded(req.path);
+}
+
+httpServe(3000, handleRequest);
+```
+
 ## Example: HTTP Server with Embedded Files
 
 A common pattern is embedding HTML/CSS for a web server so the entire app is a single binary with no external file dependencies:
@@ -55,13 +72,26 @@ my-server/
 ChadScript.embedDir("./public");
 
 function handleRequest(req: HttpRequest): HttpResponse {
-  if (req.path === "/") {
-    return { status: 200, body: ChadScript.getEmbeddedFile("index.html") };
+  // Serve all embedded files with a single line
+  return ChadScript.serveEmbedded(req.path);
+}
+
+httpServe(3000, handleRequest);
+```
+
+Or with manual routing for more control:
+
+```typescript
+ChadScript.embedDir("./public");
+
+function handleRequest(req: HttpRequest): HttpResponse {
+  if (req.path == "/") {
+    return { status: 200, body: ChadScript.getEmbeddedFile("index.html"), headers: "" };
   }
-  if (req.path === "/style.css") {
-    return { status: 200, body: ChadScript.getEmbeddedFile("style.css") };
+  if (req.path == "/style.css") {
+    return { status: 200, body: ChadScript.getEmbeddedFile("style.css"), headers: "Content-Type: text/css" };
   }
-  return { status: 404, body: "Not Found" };
+  return { status: 404, body: "Not Found", headers: "" };
 }
 
 httpServe(3000, handleRequest);
@@ -84,6 +114,7 @@ At compile time, the compiler reads the file(s) from disk and emits them as LLVM
 | `embedFile(path)` | Compile time | Reads file, returns contents as string |
 | `embedDir(path)` | Compile time | Recursively reads all files in directory |
 | `getEmbeddedFile(key)` | Runtime | Looks up embedded content by filename/path |
+| `serveEmbedded(path)` | Runtime | Returns HttpResponse for embedded file (200 or 404) |
 
 ## Notes
 

--- a/docs/stdlib/http-server.md
+++ b/docs/stdlib/http-server.md
@@ -9,9 +9,9 @@ Start an HTTP server on the given port. The handler function receives an `HttpRe
 ```typescript
 function handleRequest(req: HttpRequest): HttpResponse {
   if (req.path == "/") {
-    return { status: 200, body: "Hello!" };
+    return { status: 200, body: "Hello!", headers: "" };
   }
-  return { status: 404, body: "Not Found" };
+  return { status: 404, body: "Not Found", headers: "" };
 }
 
 httpServe(3000, handleRequest);
@@ -56,6 +56,7 @@ wsBroadcast("hello everyone");
 | `path` | `string` | Request path (`"/"`, `"/api/users"`, etc.) |
 | `body` | `string` | Request body |
 | `contentType` | `string` | Content-Type header value |
+| `headers` | `string` | All request headers as `"Key: Value\n..."` string |
 
 ## HttpResponse Object
 
@@ -63,6 +64,9 @@ wsBroadcast("hello everyone");
 |----------|------|-------------|
 | `status` | `number` | HTTP status code |
 | `body` | `string` | Response body |
+| `headers` | `string` | Extra response headers as `"\n"`-separated lines (e.g. `"Set-Cookie: session=abc\nX-Custom: value"`) |
+
+If `headers` contains a `Content-Type:` line, it overrides the auto-sniffed content type. Set `headers` to `""` when no extra headers are needed.
 
 ## WsEvent Object
 
@@ -77,11 +81,11 @@ A full HTTP server with routing:
 
 ```typescript
 function homeHandler(req: HttpRequest): HttpResponse {
-  return { status: 200, body: "<h1>Hello from ChadScript</h1>" };
+  return { status: 200, body: "<h1>Hello from ChadScript</h1>", headers: "" };
 }
 
 function jsonHandler(req: HttpRequest): HttpResponse {
-  return { status: 200, body: '{"message":"hello","count":42}' };
+  return { status: 200, body: '{"message":"hello","count":42}', headers: "Content-Type: application/json" };
 }
 
 function handleRequest(req: HttpRequest): HttpResponse {
@@ -89,7 +93,7 @@ function handleRequest(req: HttpRequest): HttpResponse {
     if (req.path == "/") return homeHandler(req);
     if (req.path == "/json") return jsonHandler(req);
   }
-  return { status: 404, body: "Not Found" };
+  return { status: 404, body: "Not Found", headers: "" };
 }
 
 httpServe(3000, handleRequest);
@@ -117,11 +121,13 @@ interface HttpRequest {
   path: string;
   body: string;
   contentType: string;
+  headers: string;
 }
 
 interface HttpResponse {
   status: number;
   body: string;
+  headers: string;
 }
 
 function wsHandler(event: WsEvent): string {
@@ -133,7 +139,7 @@ function wsHandler(event: WsEvent): string {
 }
 
 function handleRequest(req: HttpRequest): HttpResponse {
-  return { status: 200, body: "<h1>WebSocket Chat</h1>" };
+  return { status: 200, body: "<h1>WebSocket Chat</h1>", headers: "" };
 }
 
 httpServe(8080, handleRequest, wsHandler);
@@ -145,6 +151,39 @@ $ ./chat &
 $ websocat ws://localhost:8080/
 > hello
 < echo: hello
+```
+
+## Response Headers Example
+
+Set cookies, CORS headers, or override Content-Type:
+
+```typescript
+function handleRequest(req: HttpRequest): HttpResponse {
+  if (req.path == "/api/data") {
+    return {
+      status: 200,
+      body: '{"ok":true}',
+      headers: "Content-Type: application/json\nSet-Cookie: session=abc; Path=/",
+    };
+  }
+  return { status: 404, body: "Not Found", headers: "" };
+}
+```
+
+Multiple headers are separated by `\n`. The server normalizes them to `\r\n` in the HTTP response.
+
+## Request Headers Example
+
+Access incoming request headers (e.g. for authentication):
+
+```typescript
+function handleRequest(req: HttpRequest): HttpResponse {
+  // req.headers contains all headers as "Key: Value\n..." string
+  if (req.headers.indexOf("Authorization:") >= 0) {
+    return { status: 200, body: "Authenticated", headers: "" };
+  }
+  return { status: 401, body: "Unauthorized", headers: "" };
+}
 ```
 
 ## Native Implementation

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -389,6 +389,8 @@ export class MethodCallGenerator {
         return this.ctx.embedGen.generateEmbedDir(expr, params);
       } else if (method === "getEmbeddedFile") {
         return this.ctx.embedGen.generateGetEmbeddedFile(expr, params);
+      } else if (method === "serveEmbedded") {
+        return this.ctx.embedGen.generateServeEmbedded(expr, params);
       }
       return this.ctx.emitError(`ChadScript.${method}() is not a supported method`, expr.loc);
     }

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -216,6 +216,7 @@ export interface IEmbedGenerator {
   generateEmbedFile(expr: MethodCallNode, params: string[]): string;
   generateEmbedDir(expr: MethodCallNode, params: string[]): string;
   generateGetEmbeddedFile(expr: MethodCallNode, params: string[]): string;
+  generateServeEmbedded(expr: MethodCallNode, params: string[]): string;
   generateLookupFunction(): string;
   hasEmbeddedFiles(): boolean;
 }
@@ -1845,6 +1846,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     generateEmbedDir: (_expr: MethodCallNode, _params: string[]): string => "%mock_embed_dir",
     generateGetEmbeddedFile: (_expr: MethodCallNode, _params: string[]): string =>
       "%mock_get_embedded",
+    generateServeEmbedded: (_expr: MethodCallNode, _params: string[]): string =>
+      "%mock_serve_embedded",
     generateLookupFunction: (): string => "",
     hasEmbeddedFiles: (): boolean => false,
   };

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2244,9 +2244,31 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         irParts.push(httpServe);
       }
       irParts.push("\n");
+
+      // Detect if the handler's return type interface has a "headers" field
+      let hasHeaders = false;
+      const handlerName = this.httpHandlers[0];
+      for (let fi = 0; fi < this.ast.functions.length; fi++) {
+        const func = this.ast.functions[fi];
+        if (func && func.name === handlerName && func.returnType) {
+          const retIface = this.getInterfaceFromAST(func.returnType);
+          if (retIface) {
+            const fields = (retIface as { fields: { name: string }[] }).fields;
+            for (let fj = 0; fj < fields.length; fj++) {
+              if (fields[fj].name === "headers") {
+                hasHeaders = true;
+                break;
+              }
+            }
+          }
+          break;
+        }
+      }
+
       const eventHandler = this.httpServerGen.generateEventHandler(
         mangledHttpHandler,
         mangledWsHandler,
+        hasHeaders,
       );
       if (eventHandler) {
         irParts.push(eventHandler);

--- a/src/codegen/stdlib/embed.ts
+++ b/src/codegen/stdlib/embed.ts
@@ -189,6 +189,170 @@ export class EmbedGenerator {
     }
   }
 
+  /**
+   * ChadScript.serveEmbedded(path) — returns an HttpResponse struct pointer.
+   * Strips leading "/" from path, looks up the embedded file, and returns
+   * { 200.0, content, "" } if found, or { 404.0, "Not Found", "" } if not.
+   */
+  generateServeEmbedded(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("ChadScript.serveEmbedded() requires 1 argument (path)", expr.loc);
+    }
+
+    const pathPtr = this.ctx.generateExpression(expr.args[0], params);
+
+    // Strip leading "/" from path: if path[0] == '/', advance by 1
+    const firstChar = this.ctx.nextTemp();
+    this.ctx.emit(firstChar + " = load i8, i8* " + pathPtr);
+    const isSlash = this.ctx.nextTemp();
+    this.ctx.emit(isSlash + " = icmp eq i8 " + firstChar + ", 47"); // '/' = 47
+    const stripped = this.ctx.nextTemp();
+    const onePtr = this.ctx.nextTemp();
+    this.ctx.emit(onePtr + " = getelementptr i8, i8* " + pathPtr + ", i64 1");
+    this.ctx.emit(stripped + " = select i1 " + isSlash + ", i8* " + onePtr + ", i8* " + pathPtr);
+
+    // Look up the embedded file
+    const content = this.ctx.nextTemp();
+    this.ctx.emit(content + " = call i8* @__cs_get_embedded_file(i8* " + stripped + ")");
+
+    // Check if found (strlen > 0)
+    const contentLen = this.ctx.nextTemp();
+    this.ctx.emit(contentLen + " = call i64 @strlen(i8* " + content + ")");
+    const found = this.ctx.nextTemp();
+    this.ctx.emit(found + " = icmp ugt i64 " + contentLen + ", 0");
+
+    const foundLabel = this.ctx.nextLabel("serve_found");
+    const notFoundLabel = this.ctx.nextLabel("serve_notfound");
+    const joinLabel = this.ctx.nextLabel("serve_join");
+
+    this.ctx.emit("br i1 " + found + ", label %" + foundLabel + ", label %" + notFoundLabel);
+
+    // Found: allocate { 200.0, content, "" }
+    this.ctx.emit(foundLabel + ":");
+    const foundStruct = this.ctx.nextTemp();
+    this.ctx.emit(foundStruct + " = call i8* @GC_malloc(i64 24)");
+    const foundTyped = this.ctx.nextTemp();
+    this.ctx.emit(foundTyped + " = bitcast i8* " + foundStruct + " to { double, i8*, i8* }*");
+    const fStatusPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      fStatusPtr +
+        " = getelementptr { double, i8*, i8* }, { double, i8*, i8* }* " +
+        foundTyped +
+        ", i32 0, i32 0",
+    );
+    this.ctx.emit("store double 200.0, double* " + fStatusPtr);
+    const fBodyPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      fBodyPtr +
+        " = getelementptr { double, i8*, i8* }, { double, i8*, i8* }* " +
+        foundTyped +
+        ", i32 0, i32 1",
+    );
+    this.ctx.emit("store i8* " + content + ", i8** " + fBodyPtr);
+    // Empty headers string
+    this.createGlobalStringDirect("");
+    const emptyStrId = this._lastStrId;
+    const emptyStrLen = this._lastLen;
+    const emptyStr = this.ctx.nextTemp();
+    this.ctx.emit(
+      emptyStr +
+        " = getelementptr inbounds [" +
+        emptyStrLen +
+        " x i8], [" +
+        emptyStrLen +
+        " x i8]* " +
+        emptyStrId +
+        ", i64 0, i64 0",
+    );
+    const fHdrsPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      fHdrsPtr +
+        " = getelementptr { double, i8*, i8* }, { double, i8*, i8* }* " +
+        foundTyped +
+        ", i32 0, i32 2",
+    );
+    this.ctx.emit("store i8* " + emptyStr + ", i8** " + fHdrsPtr);
+    this.ctx.emit("br label %" + joinLabel);
+
+    // Not found: allocate { 404.0, "Not Found", "" }
+    this.ctx.emit(notFoundLabel + ":");
+    const nfStruct = this.ctx.nextTemp();
+    this.ctx.emit(nfStruct + " = call i8* @GC_malloc(i64 24)");
+    const nfTyped = this.ctx.nextTemp();
+    this.ctx.emit(nfTyped + " = bitcast i8* " + nfStruct + " to { double, i8*, i8* }*");
+    const nfStatusPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      nfStatusPtr +
+        " = getelementptr { double, i8*, i8* }, { double, i8*, i8* }* " +
+        nfTyped +
+        ", i32 0, i32 0",
+    );
+    this.ctx.emit("store double 404.0, double* " + nfStatusPtr);
+    // Create "Not Found" string constant
+    this.createGlobalStringDirect("Not Found");
+    const nfBodyStrId = this._lastStrId;
+    const nfBodyLen = this._lastLen;
+    const nfBodyStr = this.ctx.nextTemp();
+    this.ctx.emit(
+      nfBodyStr +
+        " = getelementptr inbounds [" +
+        nfBodyLen +
+        " x i8], [" +
+        nfBodyLen +
+        " x i8]* " +
+        nfBodyStrId +
+        ", i64 0, i64 0",
+    );
+    const nfBodyPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      nfBodyPtr +
+        " = getelementptr { double, i8*, i8* }, { double, i8*, i8* }* " +
+        nfTyped +
+        ", i32 0, i32 1",
+    );
+    this.ctx.emit("store i8* " + nfBodyStr + ", i8** " + nfBodyPtr);
+    // Reuse same empty string global
+    const emptyStr2 = this.ctx.nextTemp();
+    this.ctx.emit(
+      emptyStr2 +
+        " = getelementptr inbounds [" +
+        emptyStrLen +
+        " x i8], [" +
+        emptyStrLen +
+        " x i8]* " +
+        emptyStrId +
+        ", i64 0, i64 0",
+    );
+    const nfHdrsPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      nfHdrsPtr +
+        " = getelementptr { double, i8*, i8* }, { double, i8*, i8* }* " +
+        nfTyped +
+        ", i32 0, i32 2",
+    );
+    this.ctx.emit("store i8* " + emptyStr2 + ", i8** " + nfHdrsPtr);
+    this.ctx.emit("br label %" + joinLabel);
+
+    // Join: phi node to select the result
+    this.ctx.emit(joinLabel + ":");
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(
+      result +
+        " = phi i8* [ " +
+        foundStruct +
+        ", %" +
+        foundLabel +
+        " ], [ " +
+        nfStruct +
+        ", %" +
+        notFoundLabel +
+        " ]",
+    );
+    this.ctx.setVariableType(result, "i8*");
+
+    return result;
+  }
+
   generateGetEmbeddedFile(expr: MethodCallNode, params: string[]): string {
     if (expr.args.length < 1) {
       return this.ctx.emitError(

--- a/src/codegen/stdlib/http-server.ts
+++ b/src/codegen/stdlib/http-server.ts
@@ -17,8 +17,8 @@ export class HttpServerGenerator {
     let ir = "; libwebsockets HTTP server declarations (via lws-bridge)\n\n";
 
     ir += "; lws bridge types (match lws-bridge.h structs)\n";
-    ir += "%struct.lws_bridge_request = type { i8*, i8*, i8*, i8* }\n";
-    ir += "%struct.lws_bridge_response = type { i32, i8*, i64 }\n\n";
+    ir += "%struct.lws_bridge_request = type { i8*, i8*, i8*, i8*, i8* }\n";
+    ir += "%struct.lws_bridge_response = type { i32, i8*, i64, i8* }\n\n";
 
     ir += "; lws bridge functions\n";
     ir +=
@@ -35,12 +35,23 @@ export class HttpServerGenerator {
    * calling convention and ChadScript's handler signature.
    *
    * Bridge calls: void wrapper(lws_bridge_request*, lws_bridge_response*)
-   * User handler: i8* handler(i8* req) -> returns { double status, i8* body }*
+   * User handler: i8* handler(i8* req) -> returns { double status, i8* body [, i8* headers] }*
    *
-   * The lws_bridge_request struct { i8*, i8*, i8*, i8* } has the same layout
+   * The lws_bridge_request struct { i8*, i8*, i8*, i8*, i8* } has the same layout
    * as the ChadScript Request object, so we can cast the pointer directly.
+   *
+   * When hasHeaders is true, the response struct is { double, i8*, i8* } and the
+   * third field (headers) is read and stored into extra_headers. When false,
+   * null is stored for extra_headers (backwards compatible).
    */
-  generateEventHandler(httpHandlerName: string, _wsHandlerName?: string): string {
+  generateEventHandler(
+    httpHandlerName: string,
+    _wsHandlerName?: string,
+    hasHeaders?: boolean,
+  ): string {
+    // Response struct type depends on whether user's Response has headers field
+    const respType = hasHeaders ? "{ double, i8*, i8* }" : "{ double, i8* }";
+
     let ir = "; HTTP handler wrapper for lws-bridge\n";
     ir +=
       "define void @__lws_http_handler(%struct.lws_bridge_request* %req, %struct.lws_bridge_response* %resp) {\n";
@@ -50,22 +61,27 @@ export class HttpServerGenerator {
     ir += `  %response_ptr = call i8* @${httpHandlerName}(i8* %req_i8)\n`;
     ir += "\n";
 
-    ir += "  %response_struct = bitcast i8* %response_ptr to { double, i8* }*\n";
+    ir += `  %response_struct = bitcast i8* %response_ptr to ${respType}*\n`;
     ir += "\n";
 
-    ir +=
-      "  %status_ptr = getelementptr { double, i8* }, { double, i8* }* %response_struct, i32 0, i32 0\n";
+    ir += `  %status_ptr = getelementptr ${respType}, ${respType}* %response_struct, i32 0, i32 0\n`;
     ir += "  %status_dbl = load double, double* %status_ptr\n";
     ir += "  %status_code = fptosi double %status_dbl to i32\n";
     ir += "\n";
 
-    ir +=
-      "  %body_ptr_loc = getelementptr { double, i8* }, { double, i8* }* %response_struct, i32 0, i32 1\n";
+    ir += `  %body_ptr_loc = getelementptr ${respType}, ${respType}* %response_struct, i32 0, i32 1\n`;
     ir += "  %response_body = load i8*, i8** %body_ptr_loc\n";
     ir += "\n";
 
     ir += "  %body_len = call i64 @strlen(i8* %response_body)\n";
     ir += "\n";
+
+    // Read headers from response struct if present, otherwise null
+    if (hasHeaders) {
+      ir += `  %headers_ptr_loc = getelementptr ${respType}, ${respType}* %response_struct, i32 0, i32 2\n`;
+      ir += "  %response_headers = load i8*, i8** %headers_ptr_loc\n";
+      ir += "\n";
+    }
 
     ir +=
       "  %resp_status_ptr = getelementptr %struct.lws_bridge_response, %struct.lws_bridge_response* %resp, i32 0, i32 0\n";
@@ -80,6 +96,16 @@ export class HttpServerGenerator {
     ir +=
       "  %resp_len_ptr = getelementptr %struct.lws_bridge_response, %struct.lws_bridge_response* %resp, i32 0, i32 2\n";
     ir += "  store i64 %body_len, i64* %resp_len_ptr\n";
+    ir += "\n";
+
+    // Store extra_headers into response struct field 3
+    ir +=
+      "  %resp_hdrs_ptr = getelementptr %struct.lws_bridge_response, %struct.lws_bridge_response* %resp, i32 0, i32 3\n";
+    if (hasHeaders) {
+      ir += "  store i8* %response_headers, i8** %resp_hdrs_ptr\n";
+    } else {
+      ir += "  store i8* null, i8** %resp_hdrs_ptr\n";
+    }
     ir += "\n";
 
     ir += "  ret void\n";

--- a/tests/fixtures/network/http-headers-test.ts
+++ b/tests/fixtures/network/http-headers-test.ts
@@ -1,0 +1,55 @@
+// @test-skip
+// HTTP headers fixture used by http-headers.test.ts (needs external test orchestration)
+// Tests: custom response headers, Content-Type override, request header access
+
+interface Request {
+  method: string;
+  path: string;
+  body: string;
+  contentType: string;
+  headers: string;
+}
+
+interface Response {
+  status: number;
+  body: string;
+  headers: string;
+}
+
+function handleRequest(req: Request): Response {
+  // /custom-ct — override Content-Type via headers field
+  if (req.path == "/custom-ct") {
+    return {
+      status: 200,
+      body: '{"data":true}',
+      headers: "Content-Type: application/json",
+    };
+  }
+
+  // /set-cookie — send a Set-Cookie header
+  if (req.path == "/set-cookie") {
+    return {
+      status: 200,
+      body: "cookie set",
+      headers: "Set-Cookie: session=abc123; Path=/",
+    };
+  }
+
+  // /multi-header — multiple custom headers
+  if (req.path == "/multi-header") {
+    return {
+      status: 200,
+      body: "multi",
+      headers: "X-Custom: hello\nX-Another: world",
+    };
+  }
+
+  // /echo-headers — echo back request headers
+  if (req.path == "/echo-headers") {
+    return { status: 200, body: req.headers, headers: "" };
+  }
+
+  return { status: 404, body: "Not Found", headers: "" };
+}
+
+httpServe(9986, handleRequest);

--- a/tests/fixtures/network/http-route-isolation-test.ts
+++ b/tests/fixtures/network/http-route-isolation-test.ts
@@ -6,44 +6,45 @@ interface Request {
   path: string;
   body: string;
   contentType: string;
+  headers: string;
 }
 
 interface Response {
   status: number;
   body: string;
+  headers: string;
 }
 
 function homeHandler(req: Request): Response {
-  return { status: 200, body: "Hello from ChadScript!" };
+  return { status: 200, body: "Hello from ChadScript!", headers: "" };
 }
 
 function jsonHandler(req: Request): Response {
-  return { status: 200, body: '{"message":"hello","count":42}' };
+  return { status: 200, body: '{"message":"hello","count":42}', headers: "" };
 }
 
 function echoHandler(req: Request): Response {
-  return { status: 200, body: req.body };
+  return { status: 200, body: req.body, headers: "" };
 }
 
 function echoQueryHandler(req: Request): Response {
-  return { status: 200, body: req.path.substring(10, req.path.length) };
+  return { status: 200, body: req.path.substring(10, req.path.length), headers: "" };
 }
 
 function statusHandler(req: Request): Response {
-  const code = req.path.substring(8, req.path.length);
-  return { status: 200, body: "Status " + code };
+  return { status: 200, body: "Status " + req.path.substring(8, req.path.length), headers: "" };
 }
 
 function contentTypeHandler(req: Request): Response {
-  return { status: 200, body: "Content-Type: " + req.contentType };
+  return { status: 200, body: "Content-Type: " + req.contentType, headers: "" };
 }
 
 function errorHandler(req: Request): Response {
-  return { status: 500, body: "Internal Server Error" };
+  return { status: 500, body: "Internal Server Error", headers: "" };
 }
 
 function createdHandler(req: Request): Response {
-  return { status: 201, body: "Resource Created" };
+  return { status: 201, body: "Resource Created", headers: "" };
 }
 
 function largeHandler(req: Request): Response {
@@ -58,12 +59,11 @@ function largeHandler(req: Request): Response {
   body =
     body +
     "<p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>";
-  body = body + "</body></html>";
-  return { status: 200, body: body };
+  return { status: 200, body: body, headers: "" };
 }
 
 function notFoundHandler(req: Request): Response {
-  return { status: 404, body: "Not Found" };
+  return { status: 404, body: "Not Found", headers: "" };
 }
 
 function handleRequest(req: Request): Response {

--- a/tests/fixtures/network/http-server-test.ts
+++ b/tests/fixtures/network/http-server-test.ts
@@ -6,21 +6,23 @@ interface Request {
   path: string;
   body: string;
   contentType: string;
+  headers: string;
 }
 
 interface Response {
   status: number;
   body: string;
+  headers: string;
 }
 
 function handleRequest(req: Request): Response {
   if (req.path == "/") {
-    return { status: 200, body: "Hello from ChadScript!" };
+    return { status: 200, body: "Hello from ChadScript!", headers: "" };
   }
   if (req.path == "/json") {
-    return { status: 200, body: '{"ok":true}' };
+    return { status: 200, body: '{"ok":true}', headers: "" };
   }
-  return { status: 404, body: "Not Found" };
+  return { status: 404, body: "Not Found", headers: "" };
 }
 
 httpServe(9997, handleRequest);

--- a/tests/http-headers.test.ts
+++ b/tests/http-headers.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { exec, spawn, ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import * as fsSync from "node:fs";
+import * as http from "node:http";
+
+const execAsync = promisify(exec);
+
+const SERVER_SOURCE = "tests/fixtures/network/http-headers-test.ts";
+const SERVER_BINARY = ".build/tests/fixtures/network/http-headers-test";
+const PORT = 9986;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("HTTP Headers Tests", { concurrency: 1 }, () => {
+  let serverProcess: ChildProcess | null = null;
+
+  before(async () => {
+    await execAsync(`node dist/chad-node.js build ${SERVER_SOURCE}`, { timeout: 60000 });
+    assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");
+  });
+
+  after(async () => {
+    if (serverProcess?.pid) {
+      try {
+        process.kill(-serverProcess.pid, "SIGTERM");
+      } catch {}
+    }
+  });
+
+  async function waitForServer(maxAttempts = 50): Promise<void> {
+    for (let i = 0; i < maxAttempts; i++) {
+      try {
+        const resp = await fetch(`http://127.0.0.1:${PORT}/custom-ct`);
+        await resp.text();
+        return;
+      } catch {
+        await sleep(100);
+      }
+    }
+    throw new Error(`Server not ready after ${maxAttempts * 100}ms`);
+  }
+
+  async function startServer(): Promise<ChildProcess> {
+    if (serverProcess?.pid && isProcessAlive(serverProcess.pid)) {
+      try {
+        process.kill(-serverProcess.pid, "SIGTERM");
+      } catch {}
+      await sleep(500);
+    }
+
+    serverProcess = spawn(SERVER_BINARY, [], {
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    assert.ok(serverProcess.pid, "Server should have a PID");
+    await waitForServer();
+    assert.ok(isProcessAlive(serverProcess.pid), "Server should be alive after start");
+
+    return serverProcess;
+  }
+
+  async function stopServer(): Promise<void> {
+    if (serverProcess?.pid) {
+      try {
+        process.kill(-serverProcess.pid, "SIGTERM");
+      } catch {}
+      await sleep(500);
+      serverProcess = null;
+    }
+  }
+
+  // Helper that uses Node's http module to get raw headers
+  async function rawRequest(
+    path: string,
+    reqHeaders?: Record<string, string>,
+  ): Promise<{ headers: http.IncomingHttpHeaders; body: string; statusCode: number }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: PORT,
+          path,
+          method: "GET",
+          headers: reqHeaders,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk: Buffer) => chunks.push(chunk));
+          res.on("end", () =>
+            resolve({
+              headers: res.headers,
+              body: Buffer.concat(chunks).toString("utf-8"),
+              statusCode: res.statusCode ?? 0,
+            }),
+          );
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+  }
+
+  it("Content-Type override via headers field", async () => {
+    const srv = await startServer();
+    try {
+      const { headers, body } = await rawRequest("/custom-ct");
+      assert.ok(isProcessAlive(srv.pid!), "Server should be alive");
+      assert.strictEqual(headers["content-type"], "application/json");
+      assert.strictEqual(body, '{"data":true}');
+    } finally {
+      await stopServer();
+    }
+  });
+
+  it("Set-Cookie header in response", async () => {
+    const srv = await startServer();
+    try {
+      const { headers } = await rawRequest("/set-cookie");
+      assert.ok(isProcessAlive(srv.pid!), "Server should be alive");
+      assert.ok(
+        headers["set-cookie"]?.toString().includes("session=abc123"),
+        `Expected Set-Cookie to contain session=abc123, got: ${headers["set-cookie"]}`,
+      );
+    } finally {
+      await stopServer();
+    }
+  });
+
+  it("Multiple custom headers in response", async () => {
+    const srv = await startServer();
+    try {
+      const { headers } = await rawRequest("/multi-header");
+      assert.ok(isProcessAlive(srv.pid!), "Server should be alive");
+      assert.strictEqual(headers["x-custom"], "hello");
+      assert.strictEqual(headers["x-another"], "world");
+    } finally {
+      await stopServer();
+    }
+  });
+
+  it("Request headers accessible in handler", async () => {
+    const srv = await startServer();
+    try {
+      const { body } = await rawRequest("/echo-headers", {
+        "X-Test-Header": "test-value",
+        Cookie: "foo=bar",
+      });
+      assert.ok(isProcessAlive(srv.pid!), "Server should be alive");
+      assert.ok(
+        body.includes("X-Test-Header") || body.includes("x-test-header"),
+        `Expected request headers to contain X-Test-Header, got: ${body.substring(0, 200)}`,
+      );
+      assert.ok(
+        body.includes("test-value"),
+        `Expected request headers to contain test-value, got: ${body.substring(0, 200)}`,
+      );
+    } finally {
+      await stopServer();
+    }
+  });
+
+  it("Empty headers field works (backwards compat)", async () => {
+    const srv = await startServer();
+    try {
+      const { statusCode, body } = await rawRequest("/nonexistent");
+      assert.ok(isProcessAlive(srv.pid!), "Server should be alive");
+      assert.strictEqual(statusCode, 404);
+      assert.strictEqual(body, "Not Found");
+    } finally {
+      await stopServer();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add response headers support: `HttpResponse` now has a `headers` field (`\n`-separated header lines) that gets spliced into the HTTP response. Content-Type in headers overrides auto-sniffing. Backwards compatible — old code without `headers` passes null.
- Add request headers support: `HttpRequest` now has a `headers` field containing all request headers as `"Key: Value\n..."`. Naturally backwards compatible (old 4-field interfaces ignore the 5th field).
- Add `ChadScript.serveEmbedded(path)`: returns `{ 200, content, "" }` for embedded files or `{ 404, "Not Found", "" }` for missing ones. Strips leading `/` from path before lookup.
- Update stdlib docs for http-server and embed to cover new headers fields and `serveEmbedded`

## Test plan

- [x] All 543 existing unit tests pass
- [x] All 16 existing HTTP route integration tests pass with updated fixtures
- [x] 5 new HTTP header integration tests pass (Content-Type override, Set-Cookie, multi-header, request header echo, backwards compat)
- [x] `npm run verify:quick` passes (self-hosting Stage 0 + Stage 1)
