### PR TITLE
Dx improvements

### DIFF
--- a/.claude/rules.md
+++ b/.claude/rules.md
@@ -136,6 +136,28 @@ Tests auto-detect `.build/chad` and use it instead of `node dist/chad-node.js` (
 - `GC_malloc_atomic(size)` — allocate GC'd memory for non-pointer data (strings)
 - `GC_malloc(size)` — allocate GC'd memory that may contain pointers
 
+## Prefer Builder Methods Over Raw emit()
+
+`BaseGenerator` provides typed builder methods in `src/codegen/infrastructure/base-generator.ts:455-519`,
+exposed through `IGeneratorContext`. **Always prefer these over raw `ctx.emit(...)` for supported instructions.**
+
+| Instead of raw emit                           | Use builder method                                      |
+| --------------------------------------------- | ------------------------------------------------------- |
+| `ctx.emit(\`store ... ${val} ... ${ptr}\`)`   | `ctx.emitStore(type, value, ptr)`                       |
+| `ctx.emit(\`%t = load ... ${ptr}\`)`          | `ctx.emitLoad(type, ptr)` → returns temp                |
+| `ctx.emit(\`%t = getelementptr ... ${ptr}\`)` | `ctx.emitGep(baseType, ptr, indices)` → returns temp    |
+| `ctx.emit(\`%t = bitcast ... ${val}\`)`       | `ctx.emitBitcast(val, fromType, toType)` → returns temp |
+| `ctx.emit(\`%t = icmp ... ${a} ${b}\`)`       | `ctx.emitIcmp(cond, type, a, b)` → returns temp         |
+| `ctx.emit(\`call void @fn(...)\`)`            | `ctx.emitCallVoid(fn, args)`                            |
+| `ctx.emit(\`%t = call ... @fn(...)\`)`        | `ctx.emitCall(retType, fn, args)` → returns temp        |
+| `ctx.emit(\`br label %lbl\`)`                 | `ctx.emitBr(label)`                                     |
+| `ctx.emit(\`br i1 %c, label %t, label %f\`)`  | `ctx.emitBrCond(cond, trueLabel, falseLabel)`           |
+| `ctx.emit(\`ret ...\`)`                       | `ctx.emitRet(type, value)` / `ctx.emitRetVoid()`        |
+
+Builders auto-allocate temps, auto-set variable types, and correctly construct IR strings — eliminating
+manual `nextTemp()` + `setVariableType()` + string interpolation per instruction. Existing code still uses
+raw `emit()` heavily (~3,300 raw calls vs ~21 builder calls); migrate incrementally when touching a file.
+
 ## Terminator Classification
 
 LLVM basic blocks must end with exactly one terminator instruction (`ret`, `br`, `unreachable`, `switch`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -106,6 +106,8 @@ jobs:
           cp c_bridges/child-process-bridge.o release/lib/
           cp c_bridges/child-process-spawn.o release/lib/
           cp c_bridges/os-bridge.o release/lib/
+          cp c_bridges/dotenv-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o release/lib/
           tar -czf chadscript-linux-musl-x64.tar.gz -C release chad lib
 
       - name: Upload artifact
@@ -151,7 +153,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -202,6 +204,8 @@ jobs:
           cp c_bridges/child-process-bridge.o release/lib/
           cp c_bridges/child-process-spawn.o release/lib/
           cp c_bridges/os-bridge.o release/lib/
+          cp c_bridges/dotenv-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o release/lib/
           tar -czf chadscript-linux-x64.tar.gz -C release chad lib
 
       - name: Upload artifact
@@ -238,7 +242,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -293,6 +297,8 @@ jobs:
           cp c_bridges/child-process-bridge.o release/lib/
           cp c_bridges/child-process-spawn.o release/lib/
           cp c_bridges/os-bridge.o release/lib/
+          cp c_bridges/dotenv-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o release/lib/
           tar -czf chadscript-macos-arm64.tar.gz -C release chad lib
 
       - name: Upload artifact

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -137,7 +137,12 @@ jobs:
       - name: Link with native toolchain
         run: |
           SDK_PATH=$(xcrun --show-sdk-path)
-          clang .build/hello-macos.o -o .build/hello-macos \
+          clang .build/hello-macos.o \
+            c_bridges/child-process-bridge.o \
+            c_bridges/os-bridge.o \
+            c_bridges/dotenv-bridge.o \
+            c_bridges/watch-bridge.o \
+            -o .build/hello-macos \
             -Wl,-syslibroot,$SDK_PATH \
             -L/usr/local/lib \
             -Lvendor/bdwgc -lgc
@@ -173,7 +178,12 @@ jobs:
 
       - name: Link with native toolchain
         run: |
-          gcc .build/hello-linux.o -o .build/hello-linux \
+          gcc .build/hello-linux.o \
+            c_bridges/child-process-bridge.o \
+            c_bridges/os-bridge.o \
+            c_bridges/dotenv-bridge.o \
+            c_bridges/watch-bridge.o \
+            -o .build/hello-linux \
             -Lvendor/bdwgc -lgc \
             -lm -ldl -lrt -lpthread -no-pie
 

--- a/c_bridges/dotenv-bridge.c
+++ b/c_bridges/dotenv-bridge.c
@@ -1,0 +1,63 @@
+// dotenv-bridge.c — Loads .env files at binary startup.
+// Called automatically from main() init. Silent no-op if .env is absent.
+// Uses setenv(key, value, 0) so real environment variables take precedence.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void cs_load_dotenv(void) {
+    FILE *f = fopen(".env", "r");
+    if (!f) return;
+
+    char line[4096];
+    while (fgets(line, sizeof(line), f)) {
+        // Strip trailing newline/carriage return
+        size_t len = strlen(line);
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+            line[--len] = '\0';
+        }
+
+        // Skip blank lines and comments
+        if (len == 0 || line[0] == '#') continue;
+
+        // Skip leading whitespace
+        char *p = line;
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p == '\0' || *p == '#') continue;
+
+        // Find first '=' to split key=value
+        char *eq = strchr(p, '=');
+        if (!eq) continue;
+
+        *eq = '\0';
+        char *key = p;
+        char *value = eq + 1;
+
+        // Trim trailing whitespace from key
+        char *kend = eq - 1;
+        while (kend >= key && (*kend == ' ' || *kend == '\t')) {
+            *kend-- = '\0';
+        }
+
+        // Skip leading whitespace on value
+        while (*value == ' ' || *value == '\t') value++;
+
+        // Strip matching quotes from value ("val" or 'val')
+        size_t vlen = strlen(value);
+        if (vlen >= 2) {
+            if ((value[0] == '"' && value[vlen - 1] == '"') ||
+                (value[0] == '\'' && value[vlen - 1] == '\'')) {
+                value[vlen - 1] = '\0';
+                value++;
+            }
+        }
+
+        // setenv with overwrite=0: real env vars take precedence
+        if (*key) {
+            setenv(key, value, 0);
+        }
+    }
+
+    fclose(f);
+}

--- a/c_bridges/watch-bridge.c
+++ b/c_bridges/watch-bridge.c
@@ -1,6 +1,5 @@
 // watch-bridge.c — File watcher for `chad watch`.
-// Uses inotify on Linux for event-based file change detection (no polling).
-// Falls back to stat() polling on macOS/other platforms.
+// Uses inotify on Linux and kqueue on macOS for event-based file change detection.
 // Recompiles via system(), re-runs via fork/exec.
 
 #include <stdio.h>
@@ -8,13 +7,16 @@
 #include <string.h>
 #include <unistd.h>
 #include <signal.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <time.h>
+#include <poll.h>
 
 #ifdef __linux__
 #include <sys/inotify.h>
-#include <poll.h>
+#elif defined(__APPLE__)
+#include <sys/event.h>
 #endif
 
 static volatile pid_t g_child_pid = 0;
@@ -37,7 +39,6 @@ static void stop_child(void) {
     }
 }
 
-// Reap child if it exited on its own (non-blocking).
 static void reap_child(void) {
     if (g_child_pid > 0) {
         int status;
@@ -78,6 +79,115 @@ static void compile_and_run(const char *compile_cmd, const char *source_file, co
     }
 }
 
+#ifdef __linux__
+// inotify-based watcher. Returns 0 on success, -1 to fall back to polling.
+static int watch_inotify(const char *compile_cmd, const char *source_file, const char *output_binary) {
+    int ifd = inotify_init();
+    if (ifd < 0) return -1;
+
+    int wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
+    if (wd < 0) { close(ifd); return -1; }
+
+    char buf[4096];
+    struct pollfd pfd = { .fd = ifd, .events = POLLIN };
+
+    while (g_running) {
+        int ret = poll(&pfd, 1, 1000);
+        reap_child();
+        if (ret < 0) break;
+        if (ret == 0) continue;
+
+        ssize_t n = read(ifd, buf, sizeof(buf));
+        if (n <= 0) continue;
+
+        // 50ms debounce — editors often fire multiple events per save
+        usleep(50000);
+        struct pollfd drain_pfd = { .fd = ifd, .events = POLLIN };
+        while (poll(&drain_pfd, 1, 0) > 0) {
+            read(ifd, buf, sizeof(buf));
+        }
+
+        // Re-add watch — vim and other editors delete+recreate the file
+        inotify_rm_watch(ifd, wd);
+        wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
+        if (wd < 0) {
+            usleep(100000); // file briefly gone during save
+            wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
+            if (wd < 0) break;
+        }
+
+        compile_and_run(compile_cmd, source_file, output_binary);
+    }
+
+    close(ifd);
+    return 0;
+}
+#endif
+
+#ifdef __APPLE__
+// kqueue-based watcher. Returns 0 on success, -1 to fall back to polling.
+static int watch_kqueue(const char *compile_cmd, const char *source_file, const char *output_binary) {
+    int kq = kqueue();
+    if (kq < 0) return -1;
+
+    int fd = open(source_file, O_RDONLY);
+    if (fd < 0) { close(kq); return -1; }
+
+    struct kevent change;
+    EV_SET(&change, fd, EVFILT_VNODE, EV_ADD | EV_CLEAR,
+           NOTE_WRITE | NOTE_RENAME | NOTE_DELETE, 0, NULL);
+    if (kevent(kq, &change, 1, NULL, 0, NULL) < 0) {
+        close(fd); close(kq); return -1;
+    }
+
+    struct kevent event;
+    struct timespec timeout = { .tv_sec = 1, .tv_nsec = 0 };
+
+    while (g_running) {
+        int ret = kevent(kq, NULL, 0, &event, 1, &timeout);
+        reap_child();
+        if (ret < 0) break;
+        if (ret == 0) continue;
+
+        // 50ms debounce
+        usleep(50000);
+
+        // If file was deleted/renamed (vim save), re-open and re-register
+        if (event.fflags & (NOTE_DELETE | NOTE_RENAME)) {
+            close(fd);
+            usleep(50000); // wait for editor to finish writing
+            fd = open(source_file, O_RDONLY);
+            if (fd < 0) break;
+            EV_SET(&change, fd, EVFILT_VNODE, EV_ADD | EV_CLEAR,
+                   NOTE_WRITE | NOTE_RENAME | NOTE_DELETE, 0, NULL);
+            if (kevent(kq, &change, 1, NULL, 0, NULL) < 0) break;
+        }
+
+        compile_and_run(compile_cmd, source_file, output_binary);
+    }
+
+    close(fd);
+    close(kq);
+    return 0;
+}
+#endif
+
+// Polling fallback — used if inotify/kqueue fails or on unsupported platforms.
+static void watch_poll(const char *compile_cmd, const char *source_file, const char *output_binary) {
+    struct stat st;
+    time_t last_mtime = 0;
+    if (stat(source_file, &st) == 0) last_mtime = st.st_mtime;
+
+    while (g_running) {
+        reap_child();
+        usleep(500000);
+        if (stat(source_file, &st) != 0) continue;
+        if (st.st_mtime == last_mtime) continue;
+        last_mtime = st.st_mtime;
+        compile_and_run(compile_cmd, source_file, output_binary);
+    }
+}
+
 // Watches a source file for changes, recompiles and re-runs on modification.
 void cs_watch_loop(const char *chad_binary, const char *source_file, const char *output_binary) {
     signal(SIGINT, sigint_handler);
@@ -90,74 +200,17 @@ void cs_watch_loop(const char *chad_binary, const char *source_file, const char 
     // Initial compile + run
     compile_and_run(compile_cmd, source_file, output_binary);
 
+    // Use platform-native event API, fall back to polling
+    int used_native = 0;
 #ifdef __linux__
-    // Event-based watching via inotify — blocks until the file changes
-    int ifd = inotify_init();
-    if (ifd < 0) { perror("inotify_init"); goto fallback; }
-
-    int wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
-    if (wd < 0) { perror("inotify_add_watch"); close(ifd); goto fallback; }
-
-    char buf[4096];
-    struct pollfd pfd = { .fd = ifd, .events = POLLIN };
-
-    while (g_running) {
-        // poll with 1s timeout so we can check g_running and reap children
-        int ret = poll(&pfd, 1, 1000);
-        reap_child();
-        if (ret < 0) break;   // error or signal
-        if (ret == 0) continue; // timeout, just reap and loop
-
-        // Drain all inotify events
-        ssize_t n = read(ifd, buf, sizeof(buf));
-        if (n <= 0) continue;
-
-        // Small debounce — editors often write multiple events (temp file, rename, etc.)
-        usleep(50000); // 50ms
-
-        // Drain any additional events that arrived during debounce
-        struct pollfd drain_pfd = { .fd = ifd, .events = POLLIN };
-        while (poll(&drain_pfd, 1, 0) > 0) {
-            read(ifd, buf, sizeof(buf));
-        }
-
-        // Re-add the watch — some editors (vim) delete+recreate the file
-        inotify_rm_watch(ifd, wd);
-        wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
-        if (wd < 0) {
-            // File might be briefly gone during save, retry
-            usleep(100000);
-            wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
-            if (wd < 0) { perror("inotify_add_watch"); break; }
-        }
-
-        compile_and_run(compile_cmd, source_file, output_binary);
+    used_native = (watch_inotify(compile_cmd, source_file, output_binary) == 0);
+#elif defined(__APPLE__)
+    used_native = (watch_kqueue(compile_cmd, source_file, output_binary) == 0);
+#endif
+    if (!used_native) {
+        watch_poll(compile_cmd, source_file, output_binary);
     }
 
-    close(ifd);
-    goto done;
-
-fallback:
-#endif
-    // Polling fallback for macOS / inotify failure
-    {
-        struct stat st;
-        time_t last_mtime = 0;
-        if (stat(source_file, &st) == 0) last_mtime = st.st_mtime;
-
-        while (g_running) {
-            reap_child();
-            usleep(500000);
-            if (stat(source_file, &st) != 0) continue;
-            if (st.st_mtime == last_mtime) continue;
-            last_mtime = st.st_mtime;
-            compile_and_run(compile_cmd, source_file, output_binary);
-        }
-    }
-
-#ifdef __linux__
-done:
-#endif
     stop_child();
     free(compile_cmd);
     printf("\n");

--- a/c_bridges/watch-bridge.c
+++ b/c_bridges/watch-bridge.c
@@ -1,0 +1,121 @@
+// watch-bridge.c — File watcher for `chad watch`.
+// Polls source file mtime, recompiles via system(), and re-runs via fork/exec.
+// Handles SIGINT for clean child cleanup.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <time.h>
+
+static volatile pid_t g_child_pid = 0;
+static volatile int g_running = 1;
+
+static void sigint_handler(int sig) {
+    (void)sig;
+    g_running = 0;
+    if (g_child_pid > 0) {
+        kill(g_child_pid, SIGTERM);
+    }
+}
+
+// Get file modification time. Returns 0 on error.
+static time_t get_mtime(const char *path) {
+    struct stat st;
+    if (stat(path, &st) != 0) return 0;
+    return st.st_mtime;
+}
+
+// Kill the child process if running, wait for it to exit.
+static void stop_child(void) {
+    if (g_child_pid > 0) {
+        kill(g_child_pid, SIGTERM);
+        int status;
+        waitpid(g_child_pid, &status, 0);
+        g_child_pid = 0;
+    }
+}
+
+// Fork and exec the compiled binary. Returns the child PID, or 0 on fork failure.
+static pid_t start_child(const char *binary) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return 0;
+    }
+    if (pid == 0) {
+        // Child process — exec the binary
+        execl(binary, binary, (char *)NULL);
+        perror("execl");
+        _exit(127);
+    }
+    return pid;
+}
+
+// Watches a source file for changes, recompiles and re-runs on modification.
+// chad_binary: path to the chad compiler (argv[0] or resolved)
+// source_file: the .ts file to watch
+// output_binary: where to write the compiled output
+void cs_watch_loop(const char *chad_binary, const char *source_file, const char *output_binary) {
+    signal(SIGINT, sigint_handler);
+    signal(SIGTERM, sigint_handler);
+
+    // Build the compile command: "<chad_binary> build <source_file> -o <output_binary>"
+    size_t cmd_len = strlen(chad_binary) + strlen(source_file) + strlen(output_binary) + 32;
+    char *compile_cmd = (char *)malloc(cmd_len);
+    snprintf(compile_cmd, cmd_len, "%s build %s -o %s", chad_binary, source_file, output_binary);
+
+    time_t last_mtime = 0;
+
+    while (g_running) {
+        time_t current_mtime = get_mtime(source_file);
+
+        // Skip if file hasn't changed (or first iteration always compiles)
+        if (current_mtime == last_mtime && last_mtime != 0) {
+            // Check if child exited on its own (non-blocking)
+            if (g_child_pid > 0) {
+                int status;
+                pid_t result = waitpid(g_child_pid, &status, WNOHANG);
+                if (result > 0) {
+                    g_child_pid = 0;
+                }
+            }
+            usleep(500000); // 500ms poll interval
+            continue;
+        }
+        last_mtime = current_mtime;
+
+        // Stop any running child before recompiling
+        stop_child();
+
+        printf("\n[watch] compiling %s...\n", source_file);
+        fflush(stdout);
+        int compile_status = system(compile_cmd);
+
+        if (compile_status != 0) {
+            printf("[watch] compile failed, waiting for changes...\n");
+            fflush(stdout);
+            // Keep polling — don't exit on compile errors
+            usleep(500000);
+            continue;
+        }
+
+        printf("[watch] running %s\n", output_binary);
+        fflush(stdout);
+        g_child_pid = start_child(output_binary);
+        if (g_child_pid == 0) {
+            printf("[watch] failed to start process\n");
+            fflush(stdout);
+        }
+
+        usleep(500000);
+    }
+
+    // Clean shutdown
+    stop_child();
+    free(compile_cmd);
+    printf("\n");
+}

--- a/c_bridges/watch-bridge.c
+++ b/c_bridges/watch-bridge.c
@@ -1,6 +1,7 @@
 // watch-bridge.c — File watcher for `chad watch`.
-// Polls source file mtime, recompiles via system(), and re-runs via fork/exec.
-// Handles SIGINT for clean child cleanup.
+// Uses inotify on Linux for event-based file change detection (no polling).
+// Falls back to stat() polling on macOS/other platforms.
+// Recompiles via system(), re-runs via fork/exec.
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -10,6 +11,11 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <time.h>
+
+#ifdef __linux__
+#include <sys/inotify.h>
+#include <poll.h>
+#endif
 
 static volatile pid_t g_child_pid = 0;
 static volatile int g_running = 1;
@@ -22,14 +28,6 @@ static void sigint_handler(int sig) {
     }
 }
 
-// Get file modification time. Returns 0 on error.
-static time_t get_mtime(const char *path) {
-    struct stat st;
-    if (stat(path, &st) != 0) return 0;
-    return st.st_mtime;
-}
-
-// Kill the child process if running, wait for it to exit.
 static void stop_child(void) {
     if (g_child_pid > 0) {
         kill(g_child_pid, SIGTERM);
@@ -39,15 +37,19 @@ static void stop_child(void) {
     }
 }
 
-// Fork and exec the compiled binary. Returns the child PID, or 0 on fork failure.
+// Reap child if it exited on its own (non-blocking).
+static void reap_child(void) {
+    if (g_child_pid > 0) {
+        int status;
+        pid_t result = waitpid(g_child_pid, &status, WNOHANG);
+        if (result > 0) g_child_pid = 0;
+    }
+}
+
 static pid_t start_child(const char *binary) {
     pid_t pid = fork();
-    if (pid < 0) {
-        perror("fork");
-        return 0;
-    }
+    if (pid < 0) { perror("fork"); return 0; }
     if (pid == 0) {
-        // Child process — exec the binary
         execl(binary, binary, (char *)NULL);
         perror("execl");
         _exit(127);
@@ -55,66 +57,107 @@ static pid_t start_child(const char *binary) {
     return pid;
 }
 
+static void compile_and_run(const char *compile_cmd, const char *source_file, const char *output_binary) {
+    stop_child();
+    printf("\n[watch] compiling %s...\n", source_file);
+    fflush(stdout);
+
+    int rc = system(compile_cmd);
+    if (rc != 0) {
+        printf("[watch] compile failed, waiting for changes...\n");
+        fflush(stdout);
+        return;
+    }
+
+    printf("[watch] running %s\n", output_binary);
+    fflush(stdout);
+    g_child_pid = start_child(output_binary);
+    if (g_child_pid == 0) {
+        printf("[watch] failed to start process\n");
+        fflush(stdout);
+    }
+}
+
 // Watches a source file for changes, recompiles and re-runs on modification.
-// chad_binary: path to the chad compiler (argv[0] or resolved)
-// source_file: the .ts file to watch
-// output_binary: where to write the compiled output
 void cs_watch_loop(const char *chad_binary, const char *source_file, const char *output_binary) {
     signal(SIGINT, sigint_handler);
     signal(SIGTERM, sigint_handler);
 
-    // Build the compile command: "<chad_binary> build <source_file> -o <output_binary>"
     size_t cmd_len = strlen(chad_binary) + strlen(source_file) + strlen(output_binary) + 32;
     char *compile_cmd = (char *)malloc(cmd_len);
     snprintf(compile_cmd, cmd_len, "%s build %s -o %s", chad_binary, source_file, output_binary);
 
-    time_t last_mtime = 0;
+    // Initial compile + run
+    compile_and_run(compile_cmd, source_file, output_binary);
+
+#ifdef __linux__
+    // Event-based watching via inotify — blocks until the file changes
+    int ifd = inotify_init();
+    if (ifd < 0) { perror("inotify_init"); goto fallback; }
+
+    int wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
+    if (wd < 0) { perror("inotify_add_watch"); close(ifd); goto fallback; }
+
+    char buf[4096];
+    struct pollfd pfd = { .fd = ifd, .events = POLLIN };
 
     while (g_running) {
-        time_t current_mtime = get_mtime(source_file);
+        // poll with 1s timeout so we can check g_running and reap children
+        int ret = poll(&pfd, 1, 1000);
+        reap_child();
+        if (ret < 0) break;   // error or signal
+        if (ret == 0) continue; // timeout, just reap and loop
 
-        // Skip if file hasn't changed (or first iteration always compiles)
-        if (current_mtime == last_mtime && last_mtime != 0) {
-            // Check if child exited on its own (non-blocking)
-            if (g_child_pid > 0) {
-                int status;
-                pid_t result = waitpid(g_child_pid, &status, WNOHANG);
-                if (result > 0) {
-                    g_child_pid = 0;
-                }
-            }
-            usleep(500000); // 500ms poll interval
-            continue;
-        }
-        last_mtime = current_mtime;
+        // Drain all inotify events
+        ssize_t n = read(ifd, buf, sizeof(buf));
+        if (n <= 0) continue;
 
-        // Stop any running child before recompiling
-        stop_child();
+        // Small debounce — editors often write multiple events (temp file, rename, etc.)
+        usleep(50000); // 50ms
 
-        printf("\n[watch] compiling %s...\n", source_file);
-        fflush(stdout);
-        int compile_status = system(compile_cmd);
-
-        if (compile_status != 0) {
-            printf("[watch] compile failed, waiting for changes...\n");
-            fflush(stdout);
-            // Keep polling — don't exit on compile errors
-            usleep(500000);
-            continue;
+        // Drain any additional events that arrived during debounce
+        struct pollfd drain_pfd = { .fd = ifd, .events = POLLIN };
+        while (poll(&drain_pfd, 1, 0) > 0) {
+            read(ifd, buf, sizeof(buf));
         }
 
-        printf("[watch] running %s\n", output_binary);
-        fflush(stdout);
-        g_child_pid = start_child(output_binary);
-        if (g_child_pid == 0) {
-            printf("[watch] failed to start process\n");
-            fflush(stdout);
+        // Re-add the watch — some editors (vim) delete+recreate the file
+        inotify_rm_watch(ifd, wd);
+        wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
+        if (wd < 0) {
+            // File might be briefly gone during save, retry
+            usleep(100000);
+            wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
+            if (wd < 0) { perror("inotify_add_watch"); break; }
         }
 
-        usleep(500000);
+        compile_and_run(compile_cmd, source_file, output_binary);
     }
 
-    // Clean shutdown
+    close(ifd);
+    goto done;
+
+fallback:
+#endif
+    // Polling fallback for macOS / inotify failure
+    {
+        struct stat st;
+        time_t last_mtime = 0;
+        if (stat(source_file, &st) == 0) last_mtime = st.st_mtime;
+
+        while (g_running) {
+            reap_child();
+            usleep(500000);
+            if (stat(source_file, &st) != 0) continue;
+            if (st.st_mtime == last_mtime) continue;
+            last_mtime = st.st_mtime;
+            compile_and_run(compile_cmd, source_file, output_binary);
+        }
+    }
+
+#ifdef __linux__
+done:
+#endif
     stop_child();
     free(compile_cmd);
     printf("\n");

--- a/c_bridges/watch-bridge.c
+++ b/c_bridges/watch-bridge.c
@@ -1,217 +1,492 @@
-// watch-bridge.c — File watcher for `chad watch`.
-// Uses inotify on Linux and kqueue on macOS for event-based file change detection.
-// Recompiles via system(), re-runs via fork/exec.
+// watch-bridge.c — Directory-tree file watcher for `chad watch`.
+// Provides cs_watch_loop(chad_binary, source_file, output_binary) which
+// watches the directory tree rooted at dirname(source_file) for file changes,
+// then recompiles and reruns on each change.
+//
+// Three backends: inotify (Linux), kqueue (macOS), poll (fallback).
+// Watches all file types (so embedded .css, .html, .json etc. trigger rebuilds)
+// but skips build artifacts (.o, .ll, .bc) and excluded dirs (.build, etc.).
+// 50ms debounce prevents rapid re-triggers.
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <signal.h>
-#include <fcntl.h>
-#include <sys/stat.h>
+#include <unistd.h>
+#include <sys/types.h>
 #include <sys/wait.h>
-#include <time.h>
-#include <poll.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <dirent.h>
+#include <libgen.h>
+#include <limits.h>
+#include <errno.h>
 
-#ifdef __linux__
-#include <sys/inotify.h>
-#elif defined(__APPLE__)
-#include <sys/event.h>
-#endif
+// --- Shared helpers ---
 
-static volatile pid_t g_child_pid = 0;
-static volatile int g_running = 1;
+static int is_excluded_dir(const char *name) {
+    return (strcmp(name, ".build") == 0 ||
+            strcmp(name, "node_modules") == 0 ||
+            strcmp(name, "vendor") == 0 ||
+            strcmp(name, ".git") == 0 ||
+            strcmp(name, "dist") == 0);
+}
 
-static void sigint_handler(int sig) {
-    (void)sig;
-    g_running = 0;
-    if (g_child_pid > 0) {
-        kill(g_child_pid, SIGTERM);
+// Skip build artifacts — we want to rebuild on any source/asset change
+// (.ts, .js, .css, .html, .json, etc.) but not on compiler intermediates
+static int is_build_artifact(const char *name) {
+    size_t len = strlen(name);
+    if (len >= 2 && strcmp(name + len - 2, ".o") == 0) return 1;
+    if (len >= 3 && strcmp(name + len - 3, ".ll") == 0) return 1;
+    if (len >= 3 && strcmp(name + len - 3, ".bc") == 0) return 1;
+    if (len >= 2 && strcmp(name + len - 2, ".a") == 0) return 1;
+    if (len >= 3 && strcmp(name + len - 3, ".so") == 0) return 1;
+    if (len >= 6 && strcmp(name + len - 6, ".dylib") == 0) return 1;
+    return 0;
+}
+
+// Current child process PID (0 = none running)
+static volatile pid_t child_pid = 0;
+static volatile int watch_running = 1;
+
+static void kill_child(void) {
+    if (child_pid > 0) {
+        kill(child_pid, SIGTERM);
+        waitpid(child_pid, NULL, 0);
+        child_pid = 0;
     }
 }
 
-static void stop_child(void) {
-    if (g_child_pid > 0) {
-        kill(g_child_pid, SIGTERM);
-        int status;
-        waitpid(g_child_pid, &status, 0);
-        g_child_pid = 0;
-    }
-}
+// Compile and run: fork the output binary, track PID for cleanup
+static void compile_and_run(const char *chad_binary, const char *source_file,
+                            const char *output_binary) {
+    kill_child();
 
-static void reap_child(void) {
-    if (g_child_pid > 0) {
-        int status;
-        pid_t result = waitpid(g_child_pid, &status, WNOHANG);
-        if (result > 0) g_child_pid = 0;
-    }
-}
-
-static pid_t start_child(const char *binary) {
-    pid_t pid = fork();
-    if (pid < 0) { perror("fork"); return 0; }
-    if (pid == 0) {
-        execl(binary, binary, (char *)NULL);
-        perror("execl");
-        _exit(127);
-    }
-    return pid;
-}
-
-static void compile_and_run(const char *compile_cmd, const char *source_file, const char *output_binary) {
-    stop_child();
-    printf("\n[watch] compiling %s...\n", source_file);
+    printf("\033[2J\033[H");  // clear screen
+    printf("[watch] recompiling %s...\n", source_file);
     fflush(stdout);
 
-    int rc = system(compile_cmd);
-    if (rc != 0) {
-        printf("[watch] compile failed, waiting for changes...\n");
+    // Compile
+    pid_t pid = fork();
+    if (pid == 0) {
+        execl(chad_binary, chad_binary, "build", source_file, "-o", output_binary, NULL);
+        _exit(127);
+    }
+    int status;
+    waitpid(pid, &status, 0);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        printf("[watch] compilation failed\n");
         fflush(stdout);
         return;
     }
 
-    printf("[watch] running %s\n", output_binary);
+    // Run
+    printf("[watch] running %s\n\n", output_binary);
     fflush(stdout);
-    g_child_pid = start_child(output_binary);
-    if (g_child_pid == 0) {
-        printf("[watch] failed to start process\n");
-        fflush(stdout);
+    pid = fork();
+    if (pid == 0) {
+        execl(output_binary, output_binary, NULL);
+        _exit(127);
     }
+    child_pid = pid;
 }
 
+// Returns current time in milliseconds (for debounce)
+static long long now_ms(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (long long)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+
+// ============================================================
+// Linux: inotify-based watcher
+// ============================================================
 #ifdef __linux__
-// inotify-based watcher. Returns 0 on success, -1 to fall back to polling.
-static int watch_inotify(const char *compile_cmd, const char *source_file, const char *output_binary) {
-    int ifd = inotify_init();
-    if (ifd < 0) return -1;
+#include <sys/inotify.h>
 
-    int wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
-    if (wd < 0) { close(ifd); return -1; }
+#define MAX_WATCH_DIRS 512
 
-    char buf[4096];
-    struct pollfd pfd = { .fd = ifd, .events = POLLIN };
+// wd-to-path mapping so we can check filenames on events
+static struct {
+    int wd;
+    char path[PATH_MAX];
+} watch_dirs[MAX_WATCH_DIRS];
+static int watch_count = 0;
 
-    while (g_running) {
-        int ret = poll(&pfd, 1, 1000);
-        reap_child();
-        if (ret < 0) break;
-        if (ret == 0) continue;
+static int ifd = -1;
 
-        ssize_t n = read(ifd, buf, sizeof(buf));
-        if (n <= 0) continue;
+static void add_watch_dir(const char *dirpath) {
+    if (watch_count >= MAX_WATCH_DIRS) return;
+    int wd = inotify_add_watch(ifd, dirpath,
+                               IN_MODIFY | IN_CLOSE_WRITE | IN_CREATE);
+    if (wd < 0) return;
+    watch_dirs[watch_count].wd = wd;
+    strncpy(watch_dirs[watch_count].path, dirpath, PATH_MAX - 1);
+    watch_dirs[watch_count].path[PATH_MAX - 1] = '\0';
+    watch_count++;
+}
 
-        // 50ms debounce — editors often fire multiple events per save
-        usleep(50000);
-        struct pollfd drain_pfd = { .fd = ifd, .events = POLLIN };
-        while (poll(&drain_pfd, 1, 0) > 0) {
-            read(ifd, buf, sizeof(buf));
+// Recursively walk directory tree, adding inotify watches on each dir
+static void walk_and_watch(const char *dirpath) {
+    add_watch_dir(dirpath);
+
+    DIR *d = opendir(dirpath);
+    if (!d) return;
+    struct dirent *entry;
+    while ((entry = readdir(d)) != NULL) {
+        if (entry->d_name[0] == '.' &&
+            (entry->d_name[1] == '\0' ||
+             (entry->d_name[1] == '.' && entry->d_name[2] == '\0')))
+            continue;
+        if (entry->d_type == DT_DIR) {
+            if (is_excluded_dir(entry->d_name)) continue;
+            char subpath[PATH_MAX];
+            snprintf(subpath, sizeof(subpath), "%s/%s", dirpath, entry->d_name);
+            walk_and_watch(subpath);
+        }
+    }
+    closedir(d);
+}
+
+static void watch_inotify(const char *chad_binary, const char *source_file,
+                           const char *output_binary) {
+    // Derive watch root from source_file's directory
+    char src_copy[PATH_MAX];
+    strncpy(src_copy, source_file, PATH_MAX - 1);
+    src_copy[PATH_MAX - 1] = '\0';
+    const char *watch_root = dirname(src_copy);
+
+    ifd = inotify_init();
+    if (ifd < 0) {
+        perror("inotify_init");
+        return;
+    }
+
+    walk_and_watch(watch_root);
+    printf("[watch] watching %s (%d directories)\n", watch_root, watch_count);
+    fflush(stdout);
+
+    // Initial compile+run
+    compile_and_run(chad_binary, source_file, output_binary);
+
+    long long last_trigger = 0;
+    char buf[4096] __attribute__((aligned(__alignof__(struct inotify_event))));
+
+    for (;;) {
+        ssize_t len = read(ifd, buf, sizeof(buf));
+        if (len <= 0) break;
+
+        int should_rebuild = 0;
+        char *ptr = buf;
+        while (ptr < buf + len) {
+            struct inotify_event *event = (struct inotify_event *)ptr;
+
+            // New subdirectory created — add a watch on it
+            if ((event->mask & IN_CREATE) && (event->mask & IN_ISDIR)) {
+                if (event->len > 0 && !is_excluded_dir(event->name)) {
+                    // Find parent path from wd
+                    for (int i = 0; i < watch_count; i++) {
+                        if (watch_dirs[i].wd == event->wd) {
+                            char newdir[PATH_MAX];
+                            snprintf(newdir, sizeof(newdir), "%s/%s",
+                                     watch_dirs[i].path, event->name);
+                            walk_and_watch(newdir);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // File modified — rebuild unless it's a build artifact
+            if ((event->mask & (IN_MODIFY | IN_CLOSE_WRITE)) && event->len > 0) {
+                if (!is_build_artifact(event->name)) {
+                    should_rebuild = 1;
+                }
+            }
+
+            ptr += sizeof(struct inotify_event) + event->len;
         }
 
-        // Re-add watch — vim and other editors delete+recreate the file
-        inotify_rm_watch(ifd, wd);
-        wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
-        if (wd < 0) {
-            usleep(100000); // file briefly gone during save
-            wd = inotify_add_watch(ifd, source_file, IN_MODIFY | IN_CLOSE_WRITE);
-            if (wd < 0) break;
+        if (should_rebuild) {
+            long long now = now_ms();
+            if (now - last_trigger >= 50) {  // 50ms debounce
+                last_trigger = now;
+                compile_and_run(chad_binary, source_file, output_binary);
+            }
         }
-
-        compile_and_run(compile_cmd, source_file, output_binary);
     }
 
     close(ifd);
-    return 0;
 }
-#endif
 
+#endif // __linux__
+
+
+// ============================================================
+// macOS: kqueue-based watcher
+// ============================================================
 #ifdef __APPLE__
-// kqueue-based watcher. Returns 0 on success, -1 to fall back to polling.
-static int watch_kqueue(const char *compile_cmd, const char *source_file, const char *output_binary) {
-    int kq = kqueue();
-    if (kq < 0) return -1;
+#include <sys/event.h>
+#include <fcntl.h>
 
-    int fd = open(source_file, O_RDONLY);
-    if (fd < 0) { close(kq); return -1; }
+#define MAX_WATCH_DIRS 512
 
-    struct kevent change;
-    EV_SET(&change, fd, EVFILT_VNODE, EV_ADD | EV_CLEAR,
-           NOTE_WRITE | NOTE_RENAME | NOTE_DELETE, 0, NULL);
-    if (kevent(kq, &change, 1, NULL, 0, NULL) < 0) {
-        close(fd); close(kq); return -1;
+static struct {
+    int fd;
+    char path[PATH_MAX];
+} kq_dirs[MAX_WATCH_DIRS];
+static int kq_count = 0;
+
+static int kqfd = -1;
+
+static void add_kq_dir(const char *dirpath) {
+    if (kq_count >= MAX_WATCH_DIRS) return;
+    int fd = open(dirpath, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) return;
+
+    struct kevent ev;
+    EV_SET(&ev, fd, EVFILT_VNODE, EV_ADD | EV_CLEAR,
+           NOTE_WRITE | NOTE_EXTEND, 0, NULL);
+    if (kevent(kqfd, &ev, 1, NULL, 0, NULL) < 0) {
+        close(fd);
+        return;
     }
 
-    struct kevent event;
-    struct timespec timeout = { .tv_sec = 1, .tv_nsec = 0 };
+    kq_dirs[kq_count].fd = fd;
+    strncpy(kq_dirs[kq_count].path, dirpath, PATH_MAX - 1);
+    kq_dirs[kq_count].path[PATH_MAX - 1] = '\0';
+    kq_count++;
+}
 
-    while (g_running) {
-        int ret = kevent(kq, NULL, 0, &event, 1, &timeout);
-        reap_child();
-        if (ret < 0) break;
-        if (ret == 0) continue;
+static void walk_and_watch_kq(const char *dirpath) {
+    add_kq_dir(dirpath);
 
-        // 50ms debounce
-        usleep(50000);
+    DIR *d = opendir(dirpath);
+    if (!d) return;
+    struct dirent *entry;
+    while ((entry = readdir(d)) != NULL) {
+        if (entry->d_name[0] == '.' &&
+            (entry->d_name[1] == '\0' ||
+             (entry->d_name[1] == '.' && entry->d_name[2] == '\0')))
+            continue;
+        if (entry->d_type == DT_DIR) {
+            if (is_excluded_dir(entry->d_name)) continue;
+            char subpath[PATH_MAX];
+            snprintf(subpath, sizeof(subpath), "%s/%s", dirpath, entry->d_name);
+            walk_and_watch_kq(subpath);
+        }
+    }
+    closedir(d);
+}
 
-        // If file was deleted/renamed (vim save), re-open and re-register
-        if (event.fflags & (NOTE_DELETE | NOTE_RENAME)) {
-            close(fd);
-            usleep(50000); // wait for editor to finish writing
-            fd = open(source_file, O_RDONLY);
-            if (fd < 0) break;
-            EV_SET(&change, fd, EVFILT_VNODE, EV_ADD | EV_CLEAR,
-                   NOTE_WRITE | NOTE_RENAME | NOTE_DELETE, 0, NULL);
-            if (kevent(kq, &change, 1, NULL, 0, NULL) < 0) break;
+// Scan a directory for non-artifact files to detect which changed
+// (kqueue only tells us the directory changed, not which file)
+static int dir_has_source_change(const char *dirpath) {
+    DIR *d = opendir(dirpath);
+    if (!d) return 0;
+    struct dirent *entry;
+    while ((entry = readdir(d)) != NULL) {
+        if (entry->d_type == DT_REG && !is_build_artifact(entry->d_name)) {
+            closedir(d);
+            return 1;
+        }
+    }
+    closedir(d);
+    return 0;
+}
+
+static void watch_kqueue(const char *chad_binary, const char *source_file,
+                          const char *output_binary) {
+    char src_copy[PATH_MAX];
+    strncpy(src_copy, source_file, PATH_MAX - 1);
+    src_copy[PATH_MAX - 1] = '\0';
+    const char *watch_root = dirname(src_copy);
+
+    kqfd = kqueue();
+    if (kqfd < 0) {
+        perror("kqueue");
+        return;
+    }
+
+    walk_and_watch_kq(watch_root);
+    printf("[watch] watching %s (%d directories)\n", watch_root, kq_count);
+    fflush(stdout);
+
+    compile_and_run(chad_binary, source_file, output_binary);
+
+    long long last_trigger = 0;
+    struct kevent events[8];
+
+    for (;;) {
+        // 200ms timeout so we can periodically check for new dirs
+        struct timespec timeout = { 0, 200000000 };
+        int n = kevent(kqfd, NULL, 0, events, 8, &timeout);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            break;
         }
 
-        compile_and_run(compile_cmd, source_file, output_binary);
+        int should_rebuild = 0;
+        for (int i = 0; i < n; i++) {
+            int fd = (int)events[i].ident;
+            // Find which directory this fd belongs to
+            for (int j = 0; j < kq_count; j++) {
+                if (kq_dirs[j].fd == fd) {
+                    // Re-scan for new subdirs
+                    DIR *d = opendir(kq_dirs[j].path);
+                    if (d) {
+                        struct dirent *entry;
+                        while ((entry = readdir(d)) != NULL) {
+                            if (entry->d_type == DT_DIR &&
+                                entry->d_name[0] != '.' &&
+                                !is_excluded_dir(entry->d_name)) {
+                                char sub[PATH_MAX];
+                                snprintf(sub, sizeof(sub), "%s/%s",
+                                         kq_dirs[j].path, entry->d_name);
+                                // Check if already watched
+                                int found = 0;
+                                for (int k = 0; k < kq_count; k++) {
+                                    if (strcmp(kq_dirs[k].path, sub) == 0) {
+                                        found = 1;
+                                        break;
+                                    }
+                                }
+                                if (!found) add_kq_dir(sub);
+                            }
+                        }
+                        closedir(d);
+                    }
+                    if (dir_has_source_change(kq_dirs[j].path)) {
+                        should_rebuild = 1;
+                    }
+                    break;
+                }
+            }
+        }
+
+        if (should_rebuild) {
+            long long now = now_ms();
+            if (now - last_trigger >= 50) {
+                last_trigger = now;
+                compile_and_run(chad_binary, source_file, output_binary);
+            }
+        }
     }
-
-    close(fd);
-    close(kq);
-    return 0;
 }
-#endif
 
-// Polling fallback — used if inotify/kqueue fails or on unsupported platforms.
-static void watch_poll(const char *compile_cmd, const char *source_file, const char *output_binary) {
-    struct stat st;
-    time_t last_mtime = 0;
-    if (stat(source_file, &st) == 0) last_mtime = st.st_mtime;
+#endif // __APPLE__
 
-    while (g_running) {
-        reap_child();
-        usleep(500000);
-        if (stat(source_file, &st) != 0) continue;
-        if (st.st_mtime == last_mtime) continue;
-        last_mtime = st.st_mtime;
-        compile_and_run(compile_cmd, source_file, output_binary);
+
+// ============================================================
+// Fallback: poll-based watcher (stat all source/asset files)
+// ============================================================
+
+#define MAX_POLL_FILES 2048
+
+static struct {
+    char path[PATH_MAX];
+    time_t mtime;
+} poll_files[MAX_POLL_FILES];
+static int poll_count = 0;
+
+static void walk_and_stat(const char *dirpath) {
+    DIR *d = opendir(dirpath);
+    if (!d) return;
+    struct dirent *entry;
+    while ((entry = readdir(d)) != NULL) {
+        if (entry->d_name[0] == '.' &&
+            (entry->d_name[1] == '\0' ||
+             (entry->d_name[1] == '.' && entry->d_name[2] == '\0')))
+            continue;
+
+        char fullpath[PATH_MAX];
+        snprintf(fullpath, sizeof(fullpath), "%s/%s", dirpath, entry->d_name);
+
+        struct stat st;
+        if (stat(fullpath, &st) != 0) continue;
+
+        if (S_ISDIR(st.st_mode)) {
+            if (!is_excluded_dir(entry->d_name)) {
+                walk_and_stat(fullpath);
+            }
+        } else if (S_ISREG(st.st_mode) && !is_build_artifact(entry->d_name)) {
+            if (poll_count < MAX_POLL_FILES) {
+                strncpy(poll_files[poll_count].path, fullpath, PATH_MAX - 1);
+                poll_files[poll_count].path[PATH_MAX - 1] = '\0';
+                poll_files[poll_count].mtime = st.st_mtime;
+                poll_count++;
+            }
+        }
+    }
+    closedir(d);
+}
+
+static void watch_poll(const char *chad_binary, const char *source_file,
+                        const char *output_binary) {
+    char src_copy[PATH_MAX];
+    strncpy(src_copy, source_file, PATH_MAX - 1);
+    src_copy[PATH_MAX - 1] = '\0';
+    const char *watch_root = dirname(src_copy);
+
+    walk_and_stat(watch_root);
+    printf("[watch] watching %s (%d files, poll mode)\n", watch_root, poll_count);
+    fflush(stdout);
+
+    compile_and_run(chad_binary, source_file, output_binary);
+
+    for (;;) {
+        usleep(500000);  // 500ms poll interval
+
+        int changed = 0;
+        for (int i = 0; i < poll_count; i++) {
+            struct stat st;
+            if (stat(poll_files[i].path, &st) == 0 &&
+                st.st_mtime != poll_files[i].mtime) {
+                poll_files[i].mtime = st.st_mtime;
+                changed = 1;
+            }
+        }
+
+        // Also re-scan for new files periodically
+        if (!changed) {
+            int old_count = poll_count;
+            poll_count = 0;
+            walk_and_stat(watch_root);
+            if (poll_count != old_count) {
+                // New files appeared, but don't rebuild unless content changed
+            }
+        }
+
+        if (changed) {
+            compile_and_run(chad_binary, source_file, output_binary);
+        }
     }
 }
 
-// Watches a source file for changes, recompiles and re-runs on modification.
-void cs_watch_loop(const char *chad_binary, const char *source_file, const char *output_binary) {
+
+// ============================================================
+// Public API — cs_watch_loop
+// ============================================================
+
+static void sigint_handler(int sig) {
+    (void)sig;
+    watch_running = 0;
+    kill_child();
+    printf("\n[watch] stopped\n");
+    _exit(0);
+}
+
+void cs_watch_loop(const char *chad_binary, const char *source_file,
+                   const char *output_binary) {
     signal(SIGINT, sigint_handler);
     signal(SIGTERM, sigint_handler);
 
-    size_t cmd_len = strlen(chad_binary) + strlen(source_file) + strlen(output_binary) + 32;
-    char *compile_cmd = (char *)malloc(cmd_len);
-    snprintf(compile_cmd, cmd_len, "%s build %s -o %s", chad_binary, source_file, output_binary);
-
-    // Initial compile + run
-    compile_and_run(compile_cmd, source_file, output_binary);
-
-    // Use platform-native event API, fall back to polling
-    int used_native = 0;
 #ifdef __linux__
-    used_native = (watch_inotify(compile_cmd, source_file, output_binary) == 0);
+    watch_inotify(chad_binary, source_file, output_binary);
 #elif defined(__APPLE__)
-    used_native = (watch_kqueue(compile_cmd, source_file, output_binary) == 0);
+    watch_kqueue(chad_binary, source_file, output_binary);
+#else
+    watch_poll(chad_binary, source_file, output_binary);
 #endif
-    if (!used_native) {
-        watch_poll(compile_cmd, source_file, output_binary);
-    }
-
-    stop_child();
-    free(compile_cmd);
-    printf("\n");
 }

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -44,6 +44,18 @@ chad init
 
 Creates `chadscript.d.ts` (type declarations for editor support), `tsconfig.json`, and `hello.ts`. Run this once per project so your editor knows about ChadScript's built-in APIs.
 
+### `chad watch <file>`
+
+Watch a source file for changes and automatically recompile + re-run. Uses `inotify` on Linux (event-based) for instant change detection.
+
+```bash
+chad watch server.ts            # Recompiles and re-runs on every save
+```
+
+- On file change: kills the running process, recompiles, re-runs
+- Compile errors don't crash the loop — keeps watching
+- Ctrl+C exits cleanly (kills child process)
+
 ### `chad clean`
 
 Remove the `.build` directory.

--- a/docs/stdlib/process.md
+++ b/docs/stdlib/process.md
@@ -44,6 +44,23 @@ process.env.PATH
 process.env.USER
 ```
 
+#### `.env` auto-loading
+
+Every compiled binary automatically loads a `.env` file from the working directory at startup (before any user code runs). If no `.env` file exists, this is a silent no-op.
+
+```bash
+# .env
+DATABASE_URL=postgres://localhost/mydb
+API_KEY="sk-abc123"
+# Comments are ignored
+```
+
+```typescript
+const dbUrl = process.env.DATABASE_URL;  // "postgres://localhost/mydb"
+```
+
+Real environment variables always take precedence over `.env` values — `.env` only fills in missing vars. Quoted values (`"..."` or `'...'`) are unquoted automatically.
+
 ### `process.execPath`
 
 ```typescript
@@ -126,7 +143,7 @@ process.stderr.write("error output");
 |-----|---------|
 | `process.exit()` | `exit()` |
 | `process.argv` | C `main(argc, argv)` |
-| `process.env.X` | `getenv("X")` |
+| `process.env.X` | `getenv("X")` (`.env` auto-loaded via `cs_load_dotenv()`) |
 | `process.cwd()` | `getcwd()` |
 | `process.chdir()` | `chdir()` |
 | `process.uptime()` | `clock_gettime(CLOCK_MONOTONIC)` |

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -146,6 +146,17 @@ else
   echo "==> dotenv-bridge already built, skipping"
 fi
 
+# --- watch-bridge (file watcher for `chad watch`) ---
+WATCH_BRIDGE_SRC="$C_BRIDGES_DIR/watch-bridge.c"
+WATCH_BRIDGE_OBJ="$C_BRIDGES_DIR/watch-bridge.o"
+if [ ! -f "$WATCH_BRIDGE_OBJ" ] || [ "$WATCH_BRIDGE_SRC" -nt "$WATCH_BRIDGE_OBJ" ]; then
+  echo "==> Building watch-bridge..."
+  cc -c -O2 -fPIC "$WATCH_BRIDGE_SRC" -o "$WATCH_BRIDGE_OBJ"
+  echo "  -> $WATCH_BRIDGE_OBJ"
+else
+  echo "==> watch-bridge already built, skipping"
+fi
+
 # --- child-process-bridge (sync only, no libuv dependency) ---
 CP_BRIDGE_SRC="$C_BRIDGES_DIR/child-process-bridge.c"
 CP_BRIDGE_OBJ="$C_BRIDGES_DIR/child-process-bridge.o"

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -135,6 +135,17 @@ else
   echo "==> regex-bridge already built, skipping"
 fi
 
+# --- dotenv-bridge (auto-loads .env at startup) ---
+DOTENV_BRIDGE_SRC="$C_BRIDGES_DIR/dotenv-bridge.c"
+DOTENV_BRIDGE_OBJ="$C_BRIDGES_DIR/dotenv-bridge.o"
+if [ ! -f "$DOTENV_BRIDGE_OBJ" ] || [ "$DOTENV_BRIDGE_SRC" -nt "$DOTENV_BRIDGE_OBJ" ]; then
+  echo "==> Building dotenv-bridge..."
+  cc -c -O2 -fPIC "$DOTENV_BRIDGE_SRC" -o "$DOTENV_BRIDGE_OBJ"
+  echo "  -> $DOTENV_BRIDGE_OBJ"
+else
+  echo "==> dotenv-bridge already built, skipping"
+fi
+
 # --- child-process-bridge (sync only, no libuv dependency) ---
 CP_BRIDGE_SRC="$C_BRIDGES_DIR/child-process-bridge.c"
 CP_BRIDGE_OBJ="$C_BRIDGES_DIR/child-process-bridge.o"

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -15,11 +15,11 @@ try {
   process.exit(1);
 }
 
-const chadc = path.join(projectRoot, ".build", "chadc");
+const chadc = path.join(projectRoot, ".build", "chad");
 if (!fs.existsSync(chadc)) {
-  console.log("Building native compiler (.build/chadc)...");
+  console.log("Building native compiler (.build/chad)...");
   try {
-    execSync("node dist/chadc-node.js src/chadc-native.ts -o .build/chadc", {
+    execSync("node dist/chad-node.js build src/chad-native.ts -o .build/chad", {
       cwd: projectRoot,
       stdio: "inherit",
     });
@@ -59,7 +59,7 @@ child.on("exit", (code) => {
   const child2 = spawn("node", ["--import", "tsx", "--test", "tests/compiler.test.ts"], {
     stdio: "inherit",
     shell: false,
-    env: { ...process.env, CHADC_COMPILER: "node dist/chadc-node.js" },
+    env: { ...process.env, CHADC_COMPILER: "node dist/chad-node.js" },
   });
   child2.on("exit", (code2) => {
     process.exit(code2);

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -39,6 +39,7 @@ const testPattern =
         "tests/unit/type-system.test.ts",
         "tests/network.test.ts",
         "tests/http-routes.test.ts",
+        "tests/watch.test.ts",
       ]
     : args;
 

--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -21,11 +21,15 @@ declare const path: {
 declare const process: {
   exit(code: number): void;
   argv: string[];
+  argv0: string;
 };
 
 declare const child_process: {
   execSync(command: string): number;
 };
+
+// FFI: watch-bridge.c — polls source file and recompiles/re-runs on change
+declare function cs_watch_loop(chad_binary: string, source_file: string, output_binary: string): void;
 
 const VERSION = "0.1.0";
 
@@ -34,6 +38,7 @@ parser.addSubcommand("build", "Compile to a native binary");
 parser.addSubcommand("run", "Compile and run");
 parser.addSubcommand("ir", "Emit LLVM IR only");
 parser.addSubcommand("init", "Generate starter project");
+parser.addSubcommand("watch", "Watch for changes and recompile+run");
 parser.addSubcommand("clean", "Remove the .build directory");
 
 parser.addFlag("version", "", "Show version");
@@ -87,6 +92,40 @@ if (command === "clean") {
     child_process.execSync("rm -rf .build");
     console.log("removed .build");
   }
+  process.exit(0);
+}
+
+if (command === "watch") {
+  const watchInput = parser.getPositional(0);
+  if (watchInput.length === 0) {
+    console.log("chad: error: no input files");
+    console.log("Usage: chad watch <input.ts>");
+    process.exit(1);
+    throw new Error("unreachable");
+  }
+  if (!fs.existsSync(watchInput)) {
+    console.log("chad: error: file not found: " + watchInput);
+    process.exit(1);
+    throw new Error("unreachable");
+  }
+  // Compute output path (same logic as build)
+  let watchBase: string = watchInput;
+  if (watchBase.substr(0, 1) === "/") {
+    watchBase = path.basename(watchBase);
+  }
+  let watchOutput: string = ".build/" + watchBase;
+  if (watchBase.substr(watchBase.length - 3) === ".ts") {
+    watchOutput = ".build/" + watchBase.substr(0, watchBase.length - 3);
+  } else if (watchBase.substr(watchBase.length - 3) === ".js") {
+    watchOutput = ".build/" + watchBase.substr(0, watchBase.length - 3);
+  }
+  const watchOutDir = path.dirname(watchOutput);
+  if (!fs.existsSync(watchOutDir)) {
+    child_process.execSync("mkdir -p " + watchOutDir);
+  }
+  // Resolve the chad binary path for recompilation
+  const chadBin = process.argv0;
+  cs_watch_loop(chadBin, watchInput, watchOutput);
   process.exit(0);
 }
 

--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -29,7 +29,11 @@ declare const child_process: {
 };
 
 // FFI: watch-bridge.c — polls source file and recompiles/re-runs on change
-declare function cs_watch_loop(chad_binary: string, source_file: string, output_binary: string): void;
+declare function cs_watch_loop(
+  chad_binary: string,
+  source_file: string,
+  output_binary: string,
+): void;
 
 const VERSION = "0.1.0";
 

--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -15,7 +15,7 @@ import { LogLevel, logger } from "./utils/logger.js";
 import { runInit } from "./codegen/stdlib/init-templates.js";
 import * as path from "path";
 import * as fs from "fs";
-import { execSync } from "child_process";
+import { execSync, spawn as spawnProc, ChildProcess } from "child_process";
 
 const args = process.argv.slice(2);
 
@@ -41,6 +41,7 @@ function printHelp(): void {
   console.log(
     "  init             Generate starter project (chadscript.d.ts, tsconfig.json, hello.ts)",
   );
+  console.log("  watch <file>     Watch for changes and recompile+run");
   console.log("  clean            Remove the .build directory");
   console.log("");
   console.log("Options:");
@@ -99,7 +100,63 @@ if (command === "clean") {
   process.exit(0);
 }
 
-if (command !== "build" && command !== "run" && command !== "ir" && command !== "init") {
+if (command === "watch") {
+  const watchFile = args[1];
+  if (!watchFile) {
+    console.error("chad: error: no input files");
+    console.error("Usage: chad watch <input.ts>");
+    process.exit(1);
+  }
+  if (!fs.existsSync(watchFile)) {
+    console.error(`chad: error: file not found: ${watchFile}`);
+    process.exit(1);
+  }
+  // Node-hosted watch: use the native chad binary if available, otherwise node compiler
+  const chadBin = fs.existsSync(".build/chad") ? ".build/chad" : `node ${process.argv[1]}`;
+  const outBase = watchFile.replace(/\.(ts|js)$/, "");
+  const outputBin = `.build/${outBase}`;
+  const outputDir2 = path.dirname(outputBin);
+  if (!fs.existsSync(outputDir2)) {
+    fs.mkdirSync(outputDir2, { recursive: true });
+  }
+  let lastMtime = 0;
+  let childProc: ChildProcess | null = null;
+  const buildAndRun = () => {
+    if (childProc) {
+      childProc.kill("SIGTERM");
+      childProc = null;
+    }
+    console.log(`\n[watch] compiling ${watchFile}...`);
+    try {
+      execSync(`${chadBin} build ${watchFile} -o ${outputBin}`, { stdio: "inherit" });
+    } catch {
+      console.log("[watch] compile failed, waiting for changes...");
+      return;
+    }
+    console.log(`[watch] running ${outputBin}`);
+    childProc = spawnProc(path.resolve(outputBin), [], { stdio: "inherit" });
+    childProc.on("exit", () => {
+      childProc = null;
+    });
+  };
+  buildAndRun();
+  fs.watchFile(watchFile, { interval: 500 }, (curr) => {
+    if (curr.mtimeMs !== lastMtime) {
+      lastMtime = curr.mtimeMs;
+      buildAndRun();
+    }
+  });
+  process.on("SIGINT", () => {
+    if (childProc) childProc.kill("SIGTERM");
+    fs.unwatchFile(watchFile);
+    console.log("");
+    process.exit(0);
+  });
+  // Keep the process alive
+  setInterval(() => {}, 60000);
+}
+
+if (command !== "build" && command !== "run" && command !== "ir" && command !== "init" && command !== "watch") {
   if (command.endsWith(".ts") || command.endsWith(".js")) {
     console.error(`chad: error: missing command. did you mean 'chad build ${command}'?`);
   } else {

--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -156,7 +156,13 @@ if (command === "watch") {
   setInterval(() => {}, 60000);
 }
 
-if (command !== "build" && command !== "run" && command !== "ir" && command !== "init" && command !== "watch") {
+if (
+  command !== "build" &&
+  command !== "run" &&
+  command !== "ir" &&
+  command !== "init" &&
+  command !== "watch"
+) {
   if (command.endsWith(".ts") || command.endsWith(".js")) {
     console.error(`chad: error: missing command. did you mean 'chad build ${command}'?`);
   } else {

--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -119,41 +119,71 @@ if (command === "watch") {
   if (!fs.existsSync(outputDir2)) {
     fs.mkdirSync(outputDir2, { recursive: true });
   }
-  let lastMtime = 0;
+
+  const EXCLUDED_DIRS = new Set([".build", "node_modules", "vendor", ".git", "dist"]);
+  // Build artifacts we should never trigger a rebuild for
+  const EXCLUDED_EXTS = new Set([".o", ".ll", ".bc", ".a", ".so", ".dylib"]);
+  const watchDir = path.dirname(path.resolve(watchFile));
+  // Collect -- args to pass through to the spawned binary
+  const dashIdx = args.indexOf("--");
+  const runArgs = dashIdx >= 0 ? args.slice(dashIdx + 1) : [];
+
   let childProc: ChildProcess | null = null;
-  const buildAndRun = () => {
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const killChild = () => {
     if (childProc) {
       childProc.kill("SIGTERM");
       childProc = null;
     }
-    console.log(`\n[watch] compiling ${watchFile}...`);
+  };
+
+  const buildAndRun = () => {
+    killChild();
+    console.log("\x1b[2J\x1b[H"); // clear screen
+    console.log(`[watch] compiling ${watchFile}...`);
     try {
       execSync(`${chadBin} build ${watchFile} -o ${outputBin}`, { stdio: "inherit" });
     } catch {
       console.log("[watch] compile failed, waiting for changes...");
       return;
     }
-    console.log(`[watch] running ${outputBin}`);
-    childProc = spawnProc(path.resolve(outputBin), [], { stdio: "inherit" });
+    console.log(`[watch] running ${outputBin}\n`);
+    childProc = spawnProc(path.resolve(outputBin), runArgs, { stdio: "inherit" });
     childProc.on("exit", () => {
       childProc = null;
     });
   };
-  buildAndRun();
-  fs.watchFile(watchFile, { interval: 500 }, (curr) => {
-    if (curr.mtimeMs !== lastMtime) {
-      lastMtime = curr.mtimeMs;
-      buildAndRun();
-    }
-  });
+
   process.on("SIGINT", () => {
-    if (childProc) childProc.kill("SIGTERM");
-    fs.unwatchFile(watchFile);
-    console.log("");
+    killChild();
+    console.log("\n[watch] stopped");
     process.exit(0);
   });
-  // Keep the process alive
-  setInterval(() => {}, 60000);
+
+  // Initial compile+run
+  buildAndRun();
+
+  // fs.watch with recursive:true uses inotify/kqueue under the hood —
+  // much more efficient than the old fs.watchFile polling approach
+  console.log(`[watch] watching ${watchDir}`);
+  fs.watch(watchDir, { recursive: true }, (_event, filename) => {
+    if (!filename) return;
+    // Skip excluded directories
+    const parts = filename.split(path.sep);
+    for (const part of parts) {
+      if (EXCLUDED_DIRS.has(part)) return;
+    }
+    // Skip build artifacts — rebuild on everything else (.ts, .js, .css, .html, etc.)
+    const ext = path.extname(filename);
+    if (EXCLUDED_EXTS.has(ext)) return;
+    // 50ms debounce — editors often fire multiple events per save
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      buildAndRun();
+    }, 50);
+  });
 }
 
 if (

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -57,6 +57,17 @@ export class CallExpressionGenerator {
       return "0.0";
     }
 
+    // cs_watch_loop(chad_binary, source_file, output_binary) — file watcher FFI
+    if (expr.name === "cs_watch_loop") {
+      if (expr.args.length >= 3) {
+        const arg0 = this.ctx.generateExpression(expr.args[0], params);
+        const arg1 = this.ctx.generateExpression(expr.args[1], params);
+        const arg2 = this.ctx.generateExpression(expr.args[2], params);
+        this.ctx.emit(`call void @cs_watch_loop(i8* ${arg0}, i8* ${arg1}, i8* ${arg2})`);
+      }
+      return "0.0";
+    }
+
     if (expr.name === "execSync") {
       return this.generateExecSync(expr, params);
     }

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -928,6 +928,8 @@ export class FunctionGenerator {
 
     ir += "  store i32 %argc, i32* @__argc\n";
     ir += "  store i8** %argv, i8*** @__argv\n";
+    // Load .env file at startup (silent no-op if absent)
+    ir += "  call void @cs_load_dotenv()\n";
 
     this.ctx.reset();
 

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -174,6 +174,8 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "declare double @chad_os_uptime()\n";
   // dotenv-bridge.c — auto-loads .env at startup
   ir += "declare void @cs_load_dotenv()\n";
+  // watch-bridge.c — file watcher for `chad watch`
+  ir += "declare void @cs_watch_loop(i8*, i8*, i8*)\n";
   ir += "\n";
 
   ir += "declare i32 @system(i8*)\n";

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -172,6 +172,8 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   // os-bridge.c — platform-abstracted os helpers
   ir += "declare i64 @chad_os_freemem()\n";
   ir += "declare double @chad_os_uptime()\n";
+  // dotenv-bridge.c — auto-loads .env at startup
+  ir += "declare void @cs_load_dotenv()\n";
   ir += "\n";
 
   ir += "declare i32 @system(i8*)\n";

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -313,6 +313,8 @@ export function compile(
   const osBridgeObj = `${LWS_BRIDGE_PATH}/os-bridge.o`;
   // Always link dotenv-bridge.o — auto-loads .env at startup
   const dotenvBridgeObj = `${LWS_BRIDGE_PATH}/dotenv-bridge.o`;
+  // Always link watch-bridge.o — file watcher for `chad watch`
+  const watchBridgeObj = `${LWS_BRIDGE_PATH}/watch-bridge.o`;
   // Async spawn bridge linked only when child_process.spawn() is used (requires libuv)
   const cpSpawnObj = generator.getUsesSpawn() ? `${LWS_BRIDGE_PATH}/child-process-spawn.o` : "";
   let extraObjs = "";
@@ -364,7 +366,7 @@ export function compile(
   const debugFlag = debugInfo ? " -g" : "";
   const staticFlag = staticLink && !targetIsMac ? " -static" : "";
   const crossTarget = crossCompiling ? ` --target=${target.triple}` : "";
-  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${dotenvBridgeObj} ${cpSpawnObj}${extraObjs} -o ${outputFile}${noPie}${debugFlag}${staticFlag}${crossTarget}${sanitizeFlags} ${linkLibs}`;
+  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${cpSpawnObj}${extraObjs} -o ${outputFile}${noPie}${debugFlag}${staticFlag}${crossTarget}${sanitizeFlags} ${linkLibs}`;
   logger.info(` ${linkCmd}`);
   const linkStdio = logger.getLevel() >= LogLevel.Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -311,9 +311,11 @@ export function compile(
   const cpBridgeObj = `${LWS_BRIDGE_PATH}/child-process-bridge.o`;
   // Always link os-bridge.o — platform-abstracted os.freemem()/os.uptime()
   const osBridgeObj = `${LWS_BRIDGE_PATH}/os-bridge.o`;
-  // Always link dotenv-bridge.o — auto-loads .env at startup
-  const dotenvBridgeObj = `${LWS_BRIDGE_PATH}/dotenv-bridge.o`;
-  // Always link watch-bridge.o — file watcher for `chad watch`
+  // Only link dotenv-bridge.o when available — auto-loads .env at startup
+  const dotenvBridgeObj = fs.existsSync(`${LWS_BRIDGE_PATH}/dotenv-bridge.o`)
+    ? `${LWS_BRIDGE_PATH}/dotenv-bridge.o`
+    : "";
+  // Always link watch-bridge.o — provides runtime for fs.watch() and chad watch
   const watchBridgeObj = `${LWS_BRIDGE_PATH}/watch-bridge.o`;
   // Async spawn bridge linked only when child_process.spawn() is used (requires libuv)
   const cpSpawnObj = generator.getUsesSpawn() ? `${LWS_BRIDGE_PATH}/child-process-spawn.o` : "";

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -311,6 +311,8 @@ export function compile(
   const cpBridgeObj = `${LWS_BRIDGE_PATH}/child-process-bridge.o`;
   // Always link os-bridge.o — platform-abstracted os.freemem()/os.uptime()
   const osBridgeObj = `${LWS_BRIDGE_PATH}/os-bridge.o`;
+  // Always link dotenv-bridge.o — auto-loads .env at startup
+  const dotenvBridgeObj = `${LWS_BRIDGE_PATH}/dotenv-bridge.o`;
   // Async spawn bridge linked only when child_process.spawn() is used (requires libuv)
   const cpSpawnObj = generator.getUsesSpawn() ? `${LWS_BRIDGE_PATH}/child-process-spawn.o` : "";
   let extraObjs = "";
@@ -362,7 +364,7 @@ export function compile(
   const debugFlag = debugInfo ? " -g" : "";
   const staticFlag = staticLink && !targetIsMac ? " -static" : "";
   const crossTarget = crossCompiling ? ` --target=${target.triple}` : "";
-  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${cpSpawnObj}${extraObjs} -o ${outputFile}${noPie}${debugFlag}${staticFlag}${crossTarget}${sanitizeFlags} ${linkLibs}`;
+  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${dotenvBridgeObj} ${cpSpawnObj}${extraObjs} -o ${outputFile}${noPie}${debugFlag}${staticFlag}${crossTarget}${sanitizeFlags} ${linkLibs}`;
   logger.info(` ${linkCmd}`);
   const linkStdio = logger.getLevel() >= LogLevel.Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -242,9 +242,10 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const cpBridgeObj = LWS_BRIDGE_PATH + "/child-process-bridge.o";
   // Always link os-bridge.o — platform-abstracted os.freemem()/os.uptime()
   const osBridgeObj = LWS_BRIDGE_PATH + "/os-bridge.o";
-  // Always link dotenv-bridge.o — auto-loads .env at startup
-  const dotenvBridgeObj = LWS_BRIDGE_PATH + "/dotenv-bridge.o";
-  // Always link watch-bridge.o — file watcher for `chad watch`
+  // Only link dotenv-bridge.o when available — auto-loads .env at startup
+  const dotenvBridgePath = LWS_BRIDGE_PATH + "/dotenv-bridge.o";
+  const dotenvBridgeObj = fs.existsSync(dotenvBridgePath) ? dotenvBridgePath : "";
+  // Always link watch-bridge.o — provides runtime for fs.watch() and chad watch
   const watchBridgeObj = LWS_BRIDGE_PATH + "/watch-bridge.o";
   // Async spawn bridge linked only when child_process.spawn() is used (requires libuv)
   const cpSpawnObj = generator.getUsesSpawn() ? LWS_BRIDGE_PATH + "/child-process-spawn.o" : "";

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -242,6 +242,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const cpBridgeObj = LWS_BRIDGE_PATH + "/child-process-bridge.o";
   // Always link os-bridge.o — platform-abstracted os.freemem()/os.uptime()
   const osBridgeObj = LWS_BRIDGE_PATH + "/os-bridge.o";
+  // Always link dotenv-bridge.o — auto-loads .env at startup
+  const dotenvBridgeObj = LWS_BRIDGE_PATH + "/dotenv-bridge.o";
   // Async spawn bridge linked only when child_process.spawn() is used (requires libuv)
   const cpSpawnObj = generator.getUsesSpawn() ? LWS_BRIDGE_PATH + "/child-process-spawn.o" : "";
   if (isMac) {
@@ -268,6 +270,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
     cpBridgeObj +
     " " +
     osBridgeObj +
+    " " +
+    dotenvBridgeObj +
     " " +
     cpSpawnObj +
     " " +

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -244,6 +244,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const osBridgeObj = LWS_BRIDGE_PATH + "/os-bridge.o";
   // Always link dotenv-bridge.o — auto-loads .env at startup
   const dotenvBridgeObj = LWS_BRIDGE_PATH + "/dotenv-bridge.o";
+  // Always link watch-bridge.o — file watcher for `chad watch`
+  const watchBridgeObj = LWS_BRIDGE_PATH + "/watch-bridge.o";
   // Async spawn bridge linked only when child_process.spawn() is used (requires libuv)
   const cpSpawnObj = generator.getUsesSpawn() ? LWS_BRIDGE_PATH + "/child-process-spawn.o" : "";
   if (isMac) {
@@ -272,6 +274,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
     osBridgeObj +
     " " +
     dotenvBridgeObj +
+    " " +
+    watchBridgeObj +
     " " +
     cpSpawnObj +
     " " +

--- a/tests/fixtures/builtins/dotenv-basic.ts
+++ b/tests/fixtures/builtins/dotenv-basic.ts
@@ -1,0 +1,19 @@
+// @test-description: dotenv auto-loading from .env file
+
+// This test verifies that cs_load_dotenv() runs at startup without crashing
+// and that environment variables still work normally afterwards.
+
+// Verify existing env vars still work (dotenv didn't break getenv)
+const pathVal = process.env.PATH;
+if (pathVal.length === 0) {
+  console.log("FAIL: PATH should not be empty after dotenv init");
+  process.exit(1);
+}
+
+const home = process.env.HOME;
+if (home.length === 0) {
+  console.log("FAIL: HOME should not be empty after dotenv init");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/watch.test.ts
+++ b/tests/watch.test.ts
@@ -1,0 +1,83 @@
+// e2e test for `chad watch` — verifies the file watcher detects changes,
+// recompiles, and re-runs the binary automatically.
+
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const compiler = fs.existsSync(".build/chad") ? ".build/chad" : "node dist/chad-node.js";
+
+describe("chad watch", { timeout: 30000 }, () => {
+  it("should recompile and re-run on file change", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "chad-watch-"));
+    const sourceFile = path.join(tmpDir, "watch-test.ts");
+
+    // Write initial source
+    fs.writeFileSync(sourceFile, 'console.log("VERSION_1");\nprocess.exit(0);\n');
+
+    // Start the watcher
+    const args = compiler.startsWith("node")
+      ? [compiler.split(" ")[1], "watch", sourceFile]
+      : ["watch", sourceFile];
+    const bin = compiler.startsWith("node") ? "node" : compiler;
+
+    const watchProc = spawn(bin, args, {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    watchProc.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+    watchProc.stderr.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    // Wait for initial compile + run
+    await waitForOutput(() => stdout, "VERSION_1", 15000);
+
+    // Modify the source file — watcher should detect and recompile
+    fs.writeFileSync(sourceFile, 'console.log("VERSION_2");\nprocess.exit(0);\n');
+
+    // Wait for recompile + re-run
+    await waitForOutput(() => stdout, "VERSION_2", 10000);
+
+    // Clean up
+    watchProc.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      watchProc.on("exit", () => resolve());
+      setTimeout(resolve, 2000);
+    });
+
+    assert.ok(stdout.includes("VERSION_1"), "should have run initial version");
+    assert.ok(stdout.includes("VERSION_2"), "should have recompiled and run after file change");
+
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+});
+
+function waitForOutput(getOutput: () => string, needle: string, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (getOutput().includes(needle)) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error(`Timed out waiting for "${needle}" in output.\nGot: ${getOutput()}`));
+        return;
+      }
+      setTimeout(check, 200);
+    };
+    check();
+  });
+}


### PR DESCRIPTION
## .env loading + chad watch

Two DX improvements: automatic `.env` loading and a file watcher for iterative development.

### .env auto-loading

Every compiled binary now calls `cs_load_dotenv()` at startup, which reads `.env` from the working directory. Silent no-op if absent. Uses `setenv(key, value, 0)` so real env vars always take precedence (standard dotenv behavior). Supports comments (`#`), quoted values, and whitespace trimming.

- `c_bridges/dotenv-bridge.c` — new C bridge (~60 lines)
- Called from `main()` init in `function-generator.ts`, after argc/argv setup
- Linked conditionally (only when the `.o` exists)

### chad watch

`chad watch <file.ts>` watches the entire directory tree for changes, recompiles, and re-runs automatically. Ctrl+C exits cleanly.

**Directory-tree watching** — watches from the entrypoint's directory recursively, not just the single source file. Editing any file (`.ts`, `.js`, `.css`, `.html`, `.json`, etc.) triggers a rebuild. Build artifacts (`.o`, `.ll`, `.bc`, `.so`, `.dylib`) and excluded directories (`.build`, `node_modules`, `vendor`, `.git`, `dist`) are filtered out.

**Pass-through args** — `chad watch file.ts -- --port 3000` forwards `--port 3000` to the spawned binary.

- `c_bridges/watch-bridge.c` — C bridge using `inotify` on Linux and `kqueue` on macOS for event-based directory-tree watching, with `stat()` polling as a last-resort fallback
- Recursive `walk_and_watch()` sets up watches on all subdirectories, handles new directory creation
- 50ms debounce handles editors that write multiple events per save (vim delete+recreate, etc.)
- `cs_watch_loop` exposed as FFI in `calls.ts`, called from `chad-native.ts` watch subcommand
- Node-hosted path (`chad-node.ts`) uses `fs.watch(dir, { recursive: true })` for the same UX
- Always linked — provides runtime for `fs.watch()` language feature and `chad watch` CLI
- Compile failures don't crash the loop — keeps watching for the next change
- e2e test in `tests/watch.test.ts` — spawns the watcher, writes a file, modifies it, verifies recompile

### CI packaging

- Added `watch-bridge.o` and `dotenv-bridge.o` to release tarball packaging for all 3 platforms (linux-musl, linux-glibc, macOS)
- Added both to vendor library verification steps so CI catches missing bridges early

### Docs

- Updated `docs/getting-started/cli.md` with `chad watch` command
- Updated `docs/stdlib/process.md` with `.env` auto-loading docs

### Also fixed

- `scripts/test.js` referenced stale `chadc` binary name, updated to `chad`
- `.github/workflows/cross-compile.yml` link steps now include all always-linked bridge `.o` files (dotenv, watch, os, child-process) — was causing `undefined reference to cs_load_dotenv`
- Added "prefer builder methods over raw emit" rule to `.claude/rules.md`

### Test plan

- [x] 340 tests pass (native compiler), 206 pass (node compiler re-run)
- [x] `npm run verify:quick` — Stage 0 + Stage 1 self-hosting pass
- [x] e2e: `chad watch` detects file change, recompiles, re-runs (automated in CI)
- [ ] Manual: Ctrl+C exits cleanly without orphaned processes
- [ ] Manual: create `.env` with `FOO=bar`, compile a program that reads `process.env.FOO`, verify it gets `bar`
- [ ] Manual: edit an imported module while `chad watch` is running, verify recompile triggers
