### PR TITLE
Fix struct field access in standalone functions and migrate to IR builders     

### DIFF
--- a/.claude/rules.md
+++ b/.claude/rules.md
@@ -230,7 +230,6 @@ Additional self-hosting limitations:
 
 - **No import aliases** — `import { foo as bar }` compiles `bar(...)` as `@_cs_bar` which doesn't match the original `@_cs_foo`. Use the original name.
 - **No union type parameters in standalone functions** — `fn(x: Expression)` where `Expression` is a union emits the TS type name literally. Keep union-typed parameters in class methods.
-- **No `expr.args[0].type` in standalone functions** — accessing `.type` on an array-indexed struct field fails in standalone functions. Move such access into class methods and pass pre-resolved values.
 
 ## Async/Await Type Tracking
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -51,12 +51,12 @@ export class CallExpressionGenerator {
     }
 
     if (expr.name === "__gc_disable") {
-      this.ctx.emit("call void @GC_disable()");
+      this.ctx.emitCallVoid("@GC_disable", "");
       return "0.0";
     }
 
     if (expr.name === "__gc_enable") {
-      this.ctx.emit("call void @GC_enable()");
+      this.ctx.emitCallVoid("@GC_enable", "");
       return "0.0";
     }
 
@@ -66,7 +66,7 @@ export class CallExpressionGenerator {
         const arg0 = this.ctx.generateExpression(expr.args[0], params);
         const arg1 = this.ctx.generateExpression(expr.args[1], params);
         const arg2 = this.ctx.generateExpression(expr.args[2], params);
-        this.ctx.emit(`call void @cs_watch_loop(i8* ${arg0}, i8* ${arg1}, i8* ${arg2})`);
+        this.ctx.emitCallVoid("@cs_watch_loop", `i8* ${arg0}, i8* ${arg1}, i8* ${arg2}`);
       }
       return "0.0";
     }
@@ -127,12 +127,10 @@ export class CallExpressionGenerator {
         return this.ctx.emitError("fetch() requires at least 1 argument (URL)", expr.loc);
       }
       const urlValue = this.ctx.generateExpression(expr.args[0], params);
-      const temp = this.ctx.nextTemp();
       this.ctx.setUsesPromises(true);
       this.ctx.setUsesCurl(true);
       this.ctx.setUsesJson(true);
-      this.ctx.emit(`${temp} = call %Promise* @fetch_async(i8* ${urlValue})`);
-      this.ctx.setVariableType(temp, "%Promise*");
+      const temp = this.ctx.emitCall("%Promise*", "@fetch_async", `i8* ${urlValue}`);
       return temp;
     }
 
@@ -276,9 +274,10 @@ export class CallExpressionGenerator {
     const nullPtr = this.ctx.nextTemp();
     this.ctx.emit(`${nullPtr} = inttoptr i32 0 to i8**`);
 
-    const resultI64 = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${resultI64} = call i64 @strtol(i8* ${strValue}, i8** ${nullPtr}, i32 ${radixValue})`,
+    const resultI64 = this.ctx.emitCall(
+      "i64",
+      "@strtol",
+      `i8* ${strValue}, i8** ${nullPtr}, i32 ${radixValue}`,
     );
 
     // Convert i64 to double for compatibility with ChadScript's numeric type
@@ -296,8 +295,7 @@ export class CallExpressionGenerator {
     const strValue = this.ctx.generateExpression(expr.args[0], params);
     const nullPtr = this.ctx.nextTemp();
     this.ctx.emit(`${nullPtr} = inttoptr i32 0 to i8**`);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @strtod(i8* ${strValue}, i8** ${nullPtr})`);
+    const result = this.ctx.emitCall("double", "@strtod", `i8* ${strValue}, i8** ${nullPtr}`);
     return result;
   }
 
@@ -311,8 +309,11 @@ export class CallExpressionGenerator {
       const strValue = this.ctx.generateExpression(arg, params);
       const nullPtr = this.ctx.nextTemp();
       this.ctx.emit(`${nullPtr} = inttoptr i32 0 to i8**`);
-      const resultDouble = this.ctx.nextTemp();
-      this.ctx.emit(`${resultDouble} = call double @strtod(i8* ${strValue}, i8** ${nullPtr})`);
+      const resultDouble = this.ctx.emitCall(
+        "double",
+        "@strtod",
+        `i8* ${strValue}, i8** ${nullPtr}`,
+      );
       return resultDouble;
     }
     return this.ctx.generateExpression(arg, params);
@@ -342,8 +343,7 @@ export class CallExpressionGenerator {
       const strValue = this.ctx.generateExpression(arg, params);
       const nullPtr = this.ctx.nextTemp();
       this.ctx.emit(`${nullPtr} = inttoptr i32 0 to i8**`);
-      doubleValue = this.ctx.nextTemp();
-      this.ctx.emit(`${doubleValue} = call double @strtod(i8* ${strValue}, i8** ${nullPtr})`);
+      doubleValue = this.ctx.emitCall("double", "@strtod", `i8* ${strValue}, i8** ${nullPtr}`);
     } else {
       doubleValue = this.ctx.generateExpression(arg, params);
       doubleValue = this.ctx.ensureDouble(doubleValue);
@@ -367,8 +367,7 @@ export class CallExpressionGenerator {
     const dblSize = this.ctx.ensureDouble(sizeDouble);
     const sizeI64 = this.ctx.nextTemp();
     this.ctx.emit(`${sizeI64} = fptosi double ${dblSize} to i64`);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call i8* @malloc(i64 ${sizeI64})`);
+    const result = this.ctx.emitCall("i8*", "@malloc", `i64 ${sizeI64}`);
     const resultI64 = this.ctx.nextTemp();
     this.ctx.emit(`${resultI64} = ptrtoint i8* ${result} to i64`);
     const resultDouble = this.ctx.nextTemp();
@@ -383,7 +382,7 @@ export class CallExpressionGenerator {
     this.ctx.emit(`${ptrI64} = fptosi double ${dblPtr} to i64`);
     const ptr = this.ctx.nextTemp();
     this.ctx.emit(`${ptr} = inttoptr i64 ${ptrI64} to i8*`);
-    this.ctx.emit(`call void @free(i8* ${ptr})`);
+    this.ctx.emitCallVoid("@free", `i8* ${ptr}`);
     return "0.0";
   }
 
@@ -401,8 +400,11 @@ export class CallExpressionGenerator {
     const dblProtocol = this.ctx.ensureDouble(protocolDouble);
     const protocol = this.ctx.nextTemp();
     this.ctx.emit(`${protocol} = fptosi double ${dblProtocol} to i32`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @socket(i32 ${domain}, i32 ${type}, i32 ${protocol})`);
+    const resultI32 = this.ctx.emitCall(
+      "i32",
+      "@socket",
+      `i32 ${domain}, i32 ${type}, i32 ${protocol}`,
+    );
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -414,8 +416,7 @@ export class CallExpressionGenerator {
     const dblFd = this.ctx.ensureDouble(fdDouble);
     const fd = this.ctx.nextTemp();
     this.ctx.emit(`${fd} = fptosi double ${dblFd} to i32`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @close(i32 ${fd})`);
+    const resultI32 = this.ctx.emitCall("i32", "@close", `i32 ${fd}`);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -454,8 +455,7 @@ export class CallExpressionGenerator {
     const dblAddrlen = this.ctx.ensureDouble(addrlenDouble);
     const addrlen = this.ctx.nextTemp();
     this.ctx.emit(`${addrlen} = fptosi double ${dblAddrlen} to i32`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @bind(i32 ${fd}, i8* ${addr}, i32 ${addrlen})`);
+    const resultI32 = this.ctx.emitCall("i32", "@bind", `i32 ${fd}, i8* ${addr}, i32 ${addrlen}`);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -470,8 +470,7 @@ export class CallExpressionGenerator {
     const dblBacklog = this.ctx.ensureDouble(backlogDouble);
     const backlog = this.ctx.nextTemp();
     this.ctx.emit(`${backlog} = fptosi double ${dblBacklog} to i32`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @listen(i32 ${fd}, i32 ${backlog})`);
+    const resultI32 = this.ctx.emitCall("i32", "@listen", `i32 ${fd}, i32 ${backlog}`);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -494,8 +493,11 @@ export class CallExpressionGenerator {
     this.ctx.emit(`${addrlenI64} = fptosi double ${dblAddrlen2} to i64`);
     const addrlen = this.ctx.nextTemp();
     this.ctx.emit(`${addrlen} = inttoptr i64 ${addrlenI64} to i32*`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @accept(i32 ${fd}, i8* ${addr}, i32* ${addrlen})`);
+    const resultI32 = this.ctx.emitCall(
+      "i32",
+      "@accept",
+      `i32 ${fd}, i8* ${addr}, i32* ${addrlen}`,
+    );
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -619,17 +621,15 @@ export class CallExpressionGenerator {
     }
 
     if (returnType === "void") {
-      this.ctx.emit(
-        `call void @${this.ctx.mangleUserName(resolvedFuncName)}(${argsList.join(", ")})`,
-      );
+      this.ctx.emitCallVoid(`@${this.ctx.mangleUserName(resolvedFuncName)}`, argsList.join(", "));
       return "0";
     }
 
-    const temp = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${temp} = call ${returnType} @${this.ctx.mangleUserName(resolvedFuncName)}(${argsList.join(", ")})`,
+    const temp = this.ctx.emitCall(
+      returnType,
+      `@${this.ctx.mangleUserName(resolvedFuncName)}`,
+      argsList.join(", "),
     );
-    this.ctx.setVariableType(temp, returnType);
 
     return temp;
   }
@@ -660,9 +660,7 @@ export class CallExpressionGenerator {
       argsList.push(`double ${coerced}`);
     }
 
-    const temp = this.ctx.nextTemp();
-    this.ctx.emit(`${temp} = call ${returnType} @${lambdaName}(${argsList.join(", ")})`);
-    this.ctx.setVariableType(temp, returnType);
+    const temp = this.ctx.emitCall(returnType, `@${lambdaName}`, argsList.join(", "));
 
     return temp;
   }
@@ -683,16 +681,17 @@ export class CallExpressionGenerator {
     const delayValue = this.ctx.generateExpression(expr.args[1], params);
     const dblDelay = this.ctx.ensureDouble(delayValue);
 
-    const callbackPtr = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${callbackPtr} = bitcast void ()* @${this.ctx.mangleUserName(callbackName)} to void ()*`,
+    const callbackPtr = this.ctx.emitBitcast(
+      `@${this.ctx.mangleUserName(callbackName)}`,
+      "void ()*",
+      "void ()*",
     );
 
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${result} = call i8* @__setTimeout(void ()* ${callbackPtr}, double ${dblDelay})`,
+    const result = this.ctx.emitCall(
+      "i8*",
+      "@__setTimeout",
+      `void ()* ${callbackPtr}, double ${dblDelay}`,
     );
-    this.ctx.setVariableType(result, "i8*");
 
     return result;
   }
@@ -716,54 +715,52 @@ export class CallExpressionGenerator {
     const intervalValue = this.ctx.generateExpression(expr.args[1], params);
     const dblInterval = this.ctx.ensureDouble(intervalValue);
 
-    const callbackPtr = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${callbackPtr} = bitcast void ()* @${this.ctx.mangleUserName(callbackName)} to void ()*`,
+    const callbackPtr = this.ctx.emitBitcast(
+      `@${this.ctx.mangleUserName(callbackName)}`,
+      "void ()*",
+      "void ()*",
     );
 
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${result} = call i8* @__setInterval(void ()* ${callbackPtr}, double ${dblInterval})`,
+    const result = this.ctx.emitCall(
+      "i8*",
+      "@__setInterval",
+      `void ()* ${callbackPtr}, double ${dblInterval}`,
     );
-    this.ctx.setVariableType(result, "i8*");
 
     return result;
   }
 
   private emitIndentPrintf(prefix: string): void {
-    const depth = this.ctx.nextTemp();
-    this.ctx.emit(`${depth} = load i32, i32* @__describe_depth`);
-    const hasDepth = this.ctx.nextTemp();
-    this.ctx.emit(`${hasDepth} = icmp sgt i32 ${depth}, 0`);
+    const depth = this.ctx.emitLoad("i32", "@__describe_depth");
+    const hasDepth = this.ctx.emitIcmp("sgt", "i32", depth, "0");
     const preLabel = this.ctx.nextLabel(`${prefix}_pre`);
     const loopLabel = this.ctx.nextLabel(`${prefix}_loop`);
     const bodyLabel = this.ctx.nextLabel(`${prefix}_body`);
     const doneLabel = this.ctx.nextLabel(`${prefix}_done`);
-    this.ctx.emit(`br i1 ${hasDepth}, label %${preLabel}, label %${doneLabel}`);
+    this.ctx.emitBrCond(hasDepth, preLabel, doneLabel);
 
-    this.ctx.emit(`${preLabel}:`);
+    this.ctx.emitLabel(preLabel);
     this.ctx.setCurrentLabel(preLabel);
-    this.ctx.emit(`br label %${loopLabel}`);
+    this.ctx.emitBr(loopLabel);
 
-    this.ctx.emit(`${loopLabel}:`);
+    this.ctx.emitLabel(loopLabel);
     this.ctx.setCurrentLabel(loopLabel);
     const idx = `%__indent_idx_${loopLabel}`;
     const nextIdx = `%__indent_next_${loopLabel}`;
     this.ctx.emit(`${idx} = phi i32 [ 0, %${preLabel} ], [ ${nextIdx}, %${bodyLabel} ]`);
-    const cmp = this.ctx.nextTemp();
-    this.ctx.emit(`${cmp} = icmp slt i32 ${idx}, ${depth}`);
-    this.ctx.emit(`br i1 ${cmp}, label %${bodyLabel}, label %${doneLabel}`);
+    const cmp = this.ctx.emitIcmp("slt", "i32", idx, depth);
+    this.ctx.emitBrCond(cmp, bodyLabel, doneLabel);
 
-    this.ctx.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     this.ctx.setCurrentLabel(bodyLabel);
     const fmt = this.ctx.nextTemp();
     this.ctx.emit(`${fmt} = getelementptr [3 x i8], [3 x i8]* @.str.indent_unit, i32 0, i32 0`);
     const printResult = this.ctx.nextTemp();
     this.ctx.emit(`${printResult} = call i32 (i8*, ...) @printf(i8* ${fmt})`);
     this.ctx.emit(`${nextIdx} = add i32 ${idx}, 1`);
-    this.ctx.emit(`br label %${loopLabel}`);
+    this.ctx.emitBr(loopLabel);
 
-    this.ctx.emit(`${doneLabel}:`);
+    this.ctx.emitLabel(doneLabel);
     this.ctx.setCurrentLabel(doneLabel);
   }
 
@@ -772,13 +769,12 @@ export class CallExpressionGenerator {
 
     const nameValue = this.ctx.generateExpression(expr.args[0], params);
 
-    this.ctx.emit("store i1 0, i1* @__test_current_failed");
+    this.ctx.emitStore("i1", "0", "@__test_current_failed");
 
-    const totalPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${totalPtr} = load i32, i32* @__test_total`);
+    const totalPtr = this.ctx.emitLoad("i32", "@__test_total");
     const totalInc = this.ctx.nextTemp();
     this.ctx.emit(`${totalInc} = add i32 ${totalPtr}, 1`);
-    this.ctx.emit(`store i32 ${totalInc}, i32* @__test_total`);
+    this.ctx.emitStore("i32", totalInc, "@__test_total");
 
     const callbackArg = expr.args[1];
     let callbackFn: string;
@@ -794,47 +790,43 @@ export class CallExpressionGenerator {
       );
     }
 
-    const callResult = this.ctx.nextTemp();
-    this.ctx.emit(`${callResult} = call double @${callbackFn}()`);
+    const callResult = this.ctx.emitCall("double", `@${callbackFn}`, "");
 
-    const failed = this.ctx.nextTemp();
-    this.ctx.emit(`${failed} = load i1, i1* @__test_current_failed`);
+    const failed = this.ctx.emitLoad("i1", "@__test_current_failed");
 
     const passLabel = this.ctx.nextLabel("test_pass");
     const failLabel = this.ctx.nextLabel("test_fail");
     const mergeLabel = this.ctx.nextLabel("test_merge");
 
-    this.ctx.emit(`br i1 ${failed}, label %${failLabel}, label %${passLabel}`);
+    this.ctx.emitBrCond(failed, failLabel, passLabel);
 
-    this.ctx.emit(`${passLabel}:`);
+    this.ctx.emitLabel(passLabel);
     this.ctx.setCurrentLabel(passLabel);
-    const passedPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${passedPtr} = load i32, i32* @__test_passed`);
+    const passedPtr = this.ctx.emitLoad("i32", "@__test_passed");
     const passedInc = this.ctx.nextTemp();
     this.ctx.emit(`${passedInc} = add i32 ${passedPtr}, 1`);
-    this.ctx.emit(`store i32 ${passedInc}, i32* @__test_passed`);
+    this.ctx.emitStore("i32", passedInc, "@__test_passed");
     this.emitIndentPrintf("test_pass_indent");
     const printPass = this.ctx.nextTemp();
     this.ctx.emit(
       `${printPass} = call i32 (i8*, ...) @printf(i8* getelementptr([12 x i8], [12 x i8]* @.str.test_pass, i32 0, i32 0), i8* ${nameValue})`,
     );
-    this.ctx.emit(`br label %${mergeLabel}`);
+    this.ctx.emitBr(mergeLabel);
 
-    this.ctx.emit(`${failLabel}:`);
+    this.ctx.emitLabel(failLabel);
     this.ctx.setCurrentLabel(failLabel);
-    const failedPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${failedPtr} = load i32, i32* @__test_failed`);
+    const failedPtr = this.ctx.emitLoad("i32", "@__test_failed");
     const failedInc = this.ctx.nextTemp();
     this.ctx.emit(`${failedInc} = add i32 ${failedPtr}, 1`);
-    this.ctx.emit(`store i32 ${failedInc}, i32* @__test_failed`);
+    this.ctx.emitStore("i32", failedInc, "@__test_failed");
     this.emitIndentPrintf("test_fail_indent");
     const printFail = this.ctx.nextTemp();
     this.ctx.emit(
       `${printFail} = call i32 (i8*, ...) @printf(i8* getelementptr([12 x i8], [12 x i8]* @.str.test_fail, i32 0, i32 0), i8* ${nameValue})`,
     );
-    this.ctx.emit(`br label %${mergeLabel}`);
+    this.ctx.emitBr(mergeLabel);
 
-    this.ctx.emit(`${mergeLabel}:`);
+    this.ctx.emitLabel(mergeLabel);
     this.ctx.setCurrentLabel(mergeLabel);
 
     return "0";
@@ -856,11 +848,10 @@ export class CallExpressionGenerator {
       `${headerPrint} = call i32 (i8*, ...) @printf(i8* ${headerFmt}, i8* ${nameValue})`,
     );
 
-    const oldDepth = this.ctx.nextTemp();
-    this.ctx.emit(`${oldDepth} = load i32, i32* @__describe_depth`);
+    const oldDepth = this.ctx.emitLoad("i32", "@__describe_depth");
     const newDepth = this.ctx.nextTemp();
     this.ctx.emit(`${newDepth} = add i32 ${oldDepth}, 1`);
-    this.ctx.emit(`store i32 ${newDepth}, i32* @__describe_depth`);
+    this.ctx.emitStore("i32", newDepth, "@__describe_depth");
 
     const callbackArg = expr.args[1];
     let callbackFn: string;
@@ -876,14 +867,12 @@ export class CallExpressionGenerator {
       );
     }
 
-    const callResult = this.ctx.nextTemp();
-    this.ctx.emit(`${callResult} = call double @${callbackFn}()`);
+    const callResult = this.ctx.emitCall("double", `@${callbackFn}`, "");
 
-    const restoredDepth = this.ctx.nextTemp();
-    this.ctx.emit(`${restoredDepth} = load i32, i32* @__describe_depth`);
+    const restoredDepth = this.ctx.emitLoad("i32", "@__describe_depth");
     const decDepth = this.ctx.nextTemp();
     this.ctx.emit(`${decDepth} = sub i32 ${restoredDepth}, 1`);
-    this.ctx.emit(`store i32 ${decDepth}, i32* @__describe_depth`);
+    this.ctx.emitStore("i32", decDepth, "@__describe_depth");
 
     return "0";
   }
@@ -898,14 +887,14 @@ export class CallExpressionGenerator {
 
     const timerIdValue = this.ctx.generateExpression(expr.args[0], params);
 
-    this.ctx.emit(`call void @__clearTimer(i8* ${timerIdValue})`);
+    this.ctx.emitCallVoid("@__clearTimer", `i8* ${timerIdValue}`);
 
     return "0.0";
   }
 
   private generateRunEventLoop(): string {
     this.ctx.setUsesTimers(true);
-    this.ctx.emit("call void @__runEventLoop()");
+    this.ctx.emitCallVoid("@__runEventLoop", "");
     return "0.0";
   }
 
@@ -915,44 +904,34 @@ export class CallExpressionGenerator {
     const dblLength = this.ctx.ensureDouble(lengthDouble);
     const lengthI32 = this.ctx.nextTemp();
     this.ctx.emit(`${lengthI32} = fptosi double ${dblLength} to i32`);
-    const resultPtr = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${resultPtr} = call %TSTree* @__ts_parse_source(i8* ${sourceValue}, i32 ${lengthI32})`,
+    const resultPtr = this.ctx.emitCall(
+      "%TSTree*",
+      "@__ts_parse_source",
+      `i8* ${sourceValue}, i32 ${lengthI32}`,
     );
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = bitcast %TSTree* ${resultPtr} to i8*`);
-    this.ctx.setVariableType(result, "i8*");
+    const result = this.ctx.emitBitcast(resultPtr, "%TSTree*", "i8*");
     return result;
   }
 
   private generateTsGetRootNode(expr: CallNode, params: string[]): string {
     const treeValue = this.ctx.generateExpression(expr.args[0], params);
-    const treePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${treePtr} = bitcast i8* ${treeValue} to %TSTree*`);
-    const resultPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${resultPtr} = call %TSNode* @__ts_get_root_node(%TSTree* ${treePtr})`);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = bitcast %TSNode* ${resultPtr} to i8*`);
-    this.ctx.setVariableType(result, "i8*");
+    const treePtr = this.ctx.emitBitcast(treeValue, "i8*", "%TSTree*");
+    const resultPtr = this.ctx.emitCall("%TSNode*", "@__ts_get_root_node", `%TSTree* ${treePtr}`);
+    const result = this.ctx.emitBitcast(resultPtr, "%TSNode*", "i8*");
     return result;
   }
 
   private generateTsNodeType(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call i8* @__ts_node_type(%TSNode* ${nodePtr})`);
-    this.ctx.setVariableType(result, "i8*");
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
+    const result = this.ctx.emitCall("i8*", "@__ts_node_type", `%TSNode* ${nodePtr}`);
     return result;
   }
 
   private generateTsNodeChildCount(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @__ts_node_child_count(%TSNode* ${nodePtr})`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
+    const resultI32 = this.ctx.emitCall("i32", "@__ts_node_child_count", `%TSNode* ${nodePtr}`);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -960,10 +939,12 @@ export class CallExpressionGenerator {
 
   private generateTsNodeNamedChildCount(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @__ts_node_named_child_count(%TSNode* ${nodePtr})`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
+    const resultI32 = this.ctx.emitCall(
+      "i32",
+      "@__ts_node_named_child_count",
+      `%TSNode* ${nodePtr}`,
+    );
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -971,57 +952,52 @@ export class CallExpressionGenerator {
 
   private generateTsNodeChild(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
     const indexDouble = this.ctx.generateExpression(expr.args[1], params);
     const dblIdx = this.ctx.ensureDouble(indexDouble);
     const indexI32 = this.ctx.nextTemp();
     this.ctx.emit(`${indexI32} = fptosi double ${dblIdx} to i32`);
-    const resultPtr = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${resultPtr} = call %TSNode* @__ts_node_child(%TSNode* ${nodePtr}, i32 ${indexI32})`,
+    const resultPtr = this.ctx.emitCall(
+      "%TSNode*",
+      "@__ts_node_child",
+      `%TSNode* ${nodePtr}, i32 ${indexI32}`,
     );
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = bitcast %TSNode* ${resultPtr} to i8*`);
-    this.ctx.setVariableType(result, "i8*");
+    const result = this.ctx.emitBitcast(resultPtr, "%TSNode*", "i8*");
     return result;
   }
 
   private generateTsNodeNamedChild(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
     const indexDouble = this.ctx.generateExpression(expr.args[1], params);
     const dblIdx2 = this.ctx.ensureDouble(indexDouble);
     const indexI32 = this.ctx.nextTemp();
     this.ctx.emit(`${indexI32} = fptosi double ${dblIdx2} to i32`);
-    const resultPtr = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${resultPtr} = call %TSNode* @__ts_node_named_child(%TSNode* ${nodePtr}, i32 ${indexI32})`,
+    const resultPtr = this.ctx.emitCall(
+      "%TSNode*",
+      "@__ts_node_named_child",
+      `%TSNode* ${nodePtr}, i32 ${indexI32}`,
     );
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = bitcast %TSNode* ${resultPtr} to i8*`);
-    this.ctx.setVariableType(result, "i8*");
+    const result = this.ctx.emitBitcast(resultPtr, "%TSNode*", "i8*");
     return result;
   }
 
   private generateTsNodeText(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
     const sourceValue = this.ctx.generateExpression(expr.args[1], params);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call i8* @__ts_node_text(%TSNode* ${nodePtr}, i8* ${sourceValue})`);
-    this.ctx.setVariableType(result, "i8*");
+    const result = this.ctx.emitCall(
+      "i8*",
+      "@__ts_node_text",
+      `%TSNode* ${nodePtr}, i8* ${sourceValue}`,
+    );
     return result;
   }
 
   private generateTsNodeIsNull(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
-    const resultI1 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI1} = call i1 @__ts_node_is_null(%TSNode* ${nodePtr})`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
+    const resultI1 = this.ctx.emitCall("i1", "@__ts_node_is_null", `%TSNode* ${nodePtr}`);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = uitofp i1 ${resultI1} to double`);
     return resultDouble;
@@ -1029,10 +1005,8 @@ export class CallExpressionGenerator {
 
   private generateTsNodeIsNamed(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
-    const resultI1 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI1} = call i1 @__ts_node_is_named(%TSNode* ${nodePtr})`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
+    const resultI1 = this.ctx.emitCall("i1", "@__ts_node_is_named", `%TSNode* ${nodePtr}`);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = uitofp i1 ${resultI1} to double`);
     return resultDouble;
@@ -1040,10 +1014,8 @@ export class CallExpressionGenerator {
 
   private generateTsNodeStartByte(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @__ts_node_start_byte(%TSNode* ${nodePtr})`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
+    const resultI32 = this.ctx.emitCall("i32", "@__ts_node_start_byte", `%TSNode* ${nodePtr}`);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -1051,10 +1023,8 @@ export class CallExpressionGenerator {
 
   private generateTsNodeEndByte(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
-    const resultI32 = this.ctx.nextTemp();
-    this.ctx.emit(`${resultI32} = call i32 @__ts_node_end_byte(%TSNode* ${nodePtr})`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
+    const resultI32 = this.ctx.emitCall("i32", "@__ts_node_end_byte", `%TSNode* ${nodePtr}`);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i32 ${resultI32} to double`);
     return resultDouble;
@@ -1062,20 +1032,18 @@ export class CallExpressionGenerator {
 
   private generateTsNodeChildByFieldName(expr: CallNode, params: string[]): string {
     const nodeValue = this.ctx.generateExpression(expr.args[0], params);
-    const nodePtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nodePtr} = bitcast i8* ${nodeValue} to %TSNode*`);
+    const nodePtr = this.ctx.emitBitcast(nodeValue, "i8*", "%TSNode*");
     const fieldValue = this.ctx.generateExpression(expr.args[1], params);
     const fieldLenDouble = this.ctx.generateExpression(expr.args[2], params);
     const dblFieldLen = this.ctx.ensureDouble(fieldLenDouble);
     const fieldLenI32 = this.ctx.nextTemp();
     this.ctx.emit(`${fieldLenI32} = fptosi double ${dblFieldLen} to i32`);
-    const resultPtr = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${resultPtr} = call %TSNode* @__ts_node_child_by_field_name(%TSNode* ${nodePtr}, i8* ${fieldValue}, i32 ${fieldLenI32})`,
+    const resultPtr = this.ctx.emitCall(
+      "%TSNode*",
+      "@__ts_node_child_by_field_name",
+      `%TSNode* ${nodePtr}, i8* ${fieldValue}, i32 ${fieldLenI32}`,
     );
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = bitcast %TSNode* ${resultPtr} to i8*`);
-    this.ctx.setVariableType(result, "i8*");
+    const result = this.ctx.emitBitcast(resultPtr, "%TSNode*", "i8*");
     return result;
   }
 
@@ -1118,22 +1086,16 @@ export class CallExpressionGenerator {
       argsWithTypesParts.push("i8* " + argValues[ai]);
     }
     const argsWithTypes = argsWithTypesParts.join(", ");
-    const parentObj = this.ctx.nextTemp();
-    if (argValues.length === 0) {
-      this.ctx.emit(
-        `${parentObj} = call ${parentStructType} @${this.ctx.mangleUserName(parentClassName)}_constructor()`,
-      );
-    } else {
-      this.ctx.emit(
-        `${parentObj} = call ${parentStructType} @${this.ctx.mangleUserName(parentClassName)}_constructor(${argsWithTypes})`,
-      );
-    }
+    const parentObj = this.ctx.emitCall(
+      parentStructType,
+      `@${this.ctx.mangleUserName(parentClassName)}_constructor`,
+      argValues.length === 0 ? "" : argsWithTypes,
+    );
 
     const parentFields = this.ctx.classGenGetClassFields(parentClassName);
     if (parentFields.length > 0) {
       const childStructType = `%${currentClassName}_struct*`;
-      const castedThis = this.ctx.nextTemp();
-      this.ctx.emit(`${castedThis} = bitcast i8* ${thisPtr} to ${childStructType}`);
+      const castedThis = this.ctx.emitBitcast(thisPtr, "i8*", childStructType);
 
       for (let i = 0; i < parentFields.length; i++) {
         const parentFieldPtr = this.ctx.nextTemp();
@@ -1145,9 +1107,8 @@ export class CallExpressionGenerator {
           `${thisFieldPtr} = getelementptr inbounds ${childStructType.slice(0, -1)}, ${childStructType} ${castedThis}, i32 0, i32 ${i}`,
         );
         const fieldLlvmType = this.getFieldLlvmType(parentFields[i]);
-        const fieldValue = this.ctx.nextTemp();
-        this.ctx.emit(`${fieldValue} = load ${fieldLlvmType}, ${fieldLlvmType}* ${parentFieldPtr}`);
-        this.ctx.emit(`store ${fieldLlvmType} ${fieldValue}, ${fieldLlvmType}* ${thisFieldPtr}`);
+        const fieldValue = this.ctx.emitLoad(fieldLlvmType, parentFieldPtr);
+        this.ctx.emitStore(fieldLlvmType, fieldValue, thisFieldPtr);
       }
     }
     return "0";

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -206,6 +206,7 @@ export interface VariableAllocatorContext {
   setCurrentDeclaredInterfaceType(type: string | undefined): void;
   getCurrentDeclaredInterfaceType(): string | undefined;
   getCurrentClassName(): string | null;
+  getParameterTypeFromAST(paramName: string): string | null;
   typeResolverGetInterface(name: string): InterfaceDeclaration | null;
   typeResolverGetTypeAlias(name: string): TypeAliasDeclaration | null;
   typeResolverGetMapGetInterfaceType(expr: Expression): string | null;
@@ -2355,22 +2356,35 @@ export class VariableAllocator {
       const varName = (memberAccess.object as VariableNode).name;
       if (!varName) return null;
       const objMeta = this.ctx.symbolTable.getObjectMetadata(varName);
-      if (!objMeta) return null;
-      if (!objMeta.keys) return null;
+      if (objMeta && objMeta.keys) {
+        const propIndex = objMeta.keys.indexOf(propertyName);
+        if (propIndex !== -1) {
+          const objMetaTsTypes = objMeta.tsTypes as string[];
+          if (objMetaTsTypes) {
+            const propTsType = objMetaTsTypes[propIndex];
+            if (propTsType) {
+              const arrayParsed = parseArrayTypeString(propTsType);
+              if (arrayParsed) {
+                return this.getTypeInfoForElementType(arrayParsed.elementType);
+              }
+            }
+          }
+        }
+      }
 
-      const propIndex = objMeta.keys.indexOf(propertyName);
-      if (propIndex === -1) return null;
+      // Fallback: resolve via parameter type annotation (e.g. container: Container)
+      const paramType = this.ctx.getParameterTypeFromAST(varName);
+      if (paramType) {
+        const fieldType = this.getInterfaceFieldTypeByName(paramType, propertyName);
+        if (fieldType) {
+          const arrayParsed = parseArrayTypeString(fieldType);
+          if (arrayParsed) {
+            return this.getTypeInfoForElementType(arrayParsed.elementType);
+          }
+        }
+      }
 
-      const objMetaTsTypes = objMeta.tsTypes as string[];
-      if (!objMetaTsTypes) return null;
-      const propTsType = objMetaTsTypes[propIndex];
-      if (!propTsType) return null;
-
-      const arrayParsed = parseArrayTypeString(propTsType);
-      if (!arrayParsed) return null;
-
-      const elementType = arrayParsed.elementType;
-      return this.getTypeInfoForElementType(elementType);
+      return null;
     }
 
     if (memberObjBase.type === "member_access" || memberObjBase.type === "this") {
@@ -2414,6 +2428,11 @@ export class VariableAllocator {
       const objMeta = this.ctx.symbolTable.getObjectMetadata(varName);
       if (objMeta && objMeta.tsTypes) {
         return this.ctx.symbolTable.getType(varName) || null;
+      }
+      // Fallback: resolve via parameter type annotation (e.g. container: Container)
+      const paramType = this.ctx.getParameterTypeFromAST(varName);
+      if (paramType) {
+        return paramType;
       }
       return null;
     }

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -77,17 +77,14 @@ export class ControlFlowGenerator {
       const isValidLlvmType =
         !valueType.startsWith("%{") && !valueType.includes("|") && !valueType.includes(":");
       const llvmType = isValidLlvmType ? valueType : "i8*";
-      const condBool = this.nextTemp();
-      this.emit(`${condBool} = icmp ne ${llvmType} ${value}, null`);
+      const condBool = this.ctx.emitIcmp("ne", llvmType, value, "null");
       return condBool;
     } else if (valueType === "i32") {
       // Value is i32, use icmp ne for integer comparison
-      const condBool = this.nextTemp();
-      this.emit(`${condBool} = icmp ne i32 ${value}, 0`);
+      const condBool = this.ctx.emitIcmp("ne", "i32", value, "0");
       return condBool;
     } else if (valueType === "i64") {
-      const condBool = this.nextTemp();
-      this.emit(`${condBool} = icmp ne i64 ${value}, 0`);
+      const condBool = this.ctx.emitIcmp("ne", "i64", value, "0");
       return condBool;
     } else {
       // Unknown type - assume double for temp registers
@@ -112,20 +109,17 @@ export class ControlFlowGenerator {
       valueType === "i32" ||
       valueType === "i64"
     ) {
-      const condBool = this.nextTemp();
-      this.emit(`${condBool} = icmp eq i32 1, 1`);
+      const condBool = this.ctx.emitIcmp("eq", "i32", "1", "1");
       return condBool;
     }
     if (valueType && valueType.indexOf("*") !== -1) {
       const isValidLlvmType =
         !valueType.startsWith("%{") && !valueType.includes("|") && !valueType.includes(":");
       const llvmType = isValidLlvmType ? valueType : "i8*";
-      const condBool = this.nextTemp();
-      this.emit(`${condBool} = icmp ne ${llvmType} ${value}, null`);
+      const condBool = this.ctx.emitIcmp("ne", llvmType, value, "null");
       return condBool;
     }
-    const condBool = this.nextTemp();
-    this.emit(`${condBool} = icmp eq i32 1, 1`);
+    const condBool = this.ctx.emitIcmp("eq", "i32", "1", "1");
     return condBool;
   }
 
@@ -151,12 +145,12 @@ export class ControlFlowGenerator {
     const condBool = this.convertToBool(condValue);
 
     if (ifStmt.elseBlock) {
-      this.emit(`br i1 ${condBool}, label %${thenLabel}, label %${elseLabel}`);
+      this.ctx.emitBrCond(condBool, thenLabel, elseLabel);
     } else {
-      this.emit(`br i1 ${condBool}, label %${thenLabel}, label %${mergeLabel}`);
+      this.ctx.emitBrCond(condBool, thenLabel, mergeLabel);
     }
 
-    this.emit(`${thenLabel}:`);
+    this.ctx.emitLabel(thenLabel);
     this.ctx.setCurrentLabel(thenLabel);
 
     if (typeGuard) {
@@ -179,17 +173,17 @@ export class ControlFlowGenerator {
 
     const thenHasTerminator = this.ctx.lastInstructionIsTerminator();
     if (!thenHasTerminator) {
-      this.emit(`br label %${mergeLabel}`);
+      this.ctx.emitBr(mergeLabel);
     }
 
     let elseHasTerminator = false;
     if (ifStmt.elseBlock) {
-      this.emit(`${elseLabel}:`);
+      this.ctx.emitLabel(elseLabel);
       this.ctx.setCurrentLabel(elseLabel);
       this.ctx.generateBlock(ifStmt.elseBlock, params);
       elseHasTerminator = this.ctx.lastInstructionIsTerminator();
       if (!elseHasTerminator) {
-        this.emit(`br label %${mergeLabel}`);
+        this.ctx.emitBr(mergeLabel);
       }
     }
 
@@ -198,7 +192,7 @@ export class ControlFlowGenerator {
     }
 
     // Merge point
-    this.emit(`${mergeLabel}:`);
+    this.ctx.emitLabel(mergeLabel);
     this.ctx.setCurrentLabel(mergeLabel);
 
     return "0";
@@ -217,16 +211,16 @@ export class ControlFlowGenerator {
     const endLabel = this.nextLabel("while_end");
 
     // Jump to condition check
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitBr(condLabel);
 
     // Condition block
-    this.emit(`${condLabel}:`);
+    this.ctx.emitLabel(condLabel);
     const condValue = this.ctx.generateExpression(whileStmt.condition, params);
     const condBool = this.convertToBool(condValue);
-    this.emit(`br i1 ${condBool}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
 
     // Body block - push loop context for break/continue
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     this.ctx.setCurrentLabel(bodyLabel);
     this.loopContinueLabels.push(condLabel);
     this.loopBreakLabels.push(endLabel);
@@ -235,11 +229,11 @@ export class ControlFlowGenerator {
     this.loopBreakLabels.pop();
     const bodyHasTerminator = this.ctx.lastInstructionIsTerminator();
     if (!bodyHasTerminator) {
-      this.emit(`br label %${condLabel}`);
+      this.ctx.emitBr(condLabel);
     }
 
     // End block
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return "0";
   }
@@ -258,30 +252,30 @@ export class ControlFlowGenerator {
     const endLabel = this.nextLabel("dowhile_end");
 
     // Jump directly to body (body always executes at least once)
-    this.emit(`br label %${bodyLabel}`);
+    this.ctx.emitBr(bodyLabel);
 
     // Body block
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     this.ctx.setCurrentLabel(bodyLabel);
     this.loopContinueLabels.push(condLabel);
     this.loopBreakLabels.push(endLabel);
     this.ctx.generateBlock(doWhileStmt.body, params);
     this.loopContinueLabels.pop();
     this.loopBreakLabels.pop();
-    const bodyHasTerminator = this.ctx.lastInstructionIsTerminator();
-    if (!bodyHasTerminator) {
-      this.emit(`br label %${condLabel}`);
+    const bodyHasTerminator2 = this.ctx.lastInstructionIsTerminator();
+    if (!bodyHasTerminator2) {
+      this.ctx.emitBr(condLabel);
     }
 
     // Condition block — evaluated after body
-    this.emit(`${condLabel}:`);
+    this.ctx.emitLabel(condLabel);
     this.ctx.setCurrentLabel(condLabel);
     const condValue = this.ctx.generateExpression(doWhileStmt.condition, params);
     const condBool = this.convertToBool(condValue);
-    this.emit(`br i1 ${condBool}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
 
     // End block
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return "0";
   }
@@ -318,7 +312,7 @@ export class ControlFlowGenerator {
         const allocaReg = this.ctx.nextAllocaReg(initVarDecl.name);
         this.ctx.defineVariable(initVarDecl.name, allocaReg, "double", SymbolKind.Number, "local");
         this.emit(`${allocaReg} = alloca double`);
-        this.emit(`store double ${dblValue}, double* ${allocaReg}`);
+        this.ctx.emitStore("double", dblValue, allocaReg);
       } else if (initBase.type === "assignment") {
         const initAssign = forStmt.init as { type: string; name: string; value: Expression };
         let value = this.ctx.generateExpression(initAssign.value, params);
@@ -333,7 +327,7 @@ export class ControlFlowGenerator {
         } else if (varType === "i64" && valType === "double") {
           value = this.ctx.ensureI64(value);
         }
-        this.emit(`store ${varType} ${value}, ${varType}* ${allocaReg}`);
+        this.ctx.emitStore(varType, value, allocaReg);
       }
     }
 
@@ -344,21 +338,21 @@ export class ControlFlowGenerator {
     const endLabel = this.nextLabel("for_end");
 
     // Jump to condition check
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitBr(condLabel);
 
     // Condition block
-    this.emit(`${condLabel}:`);
+    this.ctx.emitLabel(condLabel);
     if (forStmt.condition) {
       const condValue = this.ctx.generateExpression(forStmt.condition, params);
       const condBool = this.convertToBool(condValue);
-      this.emit(`br i1 ${condBool}, label %${bodyLabel}, label %${endLabel}`);
+      this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
     } else {
       // No condition means infinite loop
-      this.emit(`br label %${bodyLabel}`);
+      this.ctx.emitBr(bodyLabel);
     }
 
     // Body block - push loop context for break/continue
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     this.ctx.setCurrentLabel(bodyLabel);
     this.loopContinueLabels.push(updateLabel);
     this.loopBreakLabels.push(endLabel);
@@ -366,13 +360,13 @@ export class ControlFlowGenerator {
     this.loopContinueLabels.pop();
     this.loopBreakLabels.pop();
     // Check if the LAST instruction is a terminator
-    const bodyHasTerminator = this.ctx.lastInstructionIsTerminator();
-    if (!bodyHasTerminator) {
-      this.emit(`br label %${updateLabel}`);
+    const bodyHasTerminator3 = this.ctx.lastInstructionIsTerminator();
+    if (!bodyHasTerminator3) {
+      this.ctx.emitBr(updateLabel);
     }
 
     // Update block
-    this.emit(`${updateLabel}:`);
+    this.ctx.emitLabel(updateLabel);
     if (forStmt.update) {
       const updateTyped = forStmt.update as { type: string; name: string; value: Expression };
       const updateType = updateTyped.type;
@@ -393,16 +387,16 @@ export class ControlFlowGenerator {
         } else if (varType === "i64" && valType === "double") {
           value = this.ctx.ensureI64(value);
         }
-        this.emit(`store ${varType} ${value}, ${varType}* ${allocaReg}`);
+        this.ctx.emitStore(varType, value, allocaReg);
       } else {
         // It's an expression (like i++)
         this.ctx.generateExpression(forStmt.update as Expression, params);
       }
     }
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitBr(condLabel);
 
     // End block
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return "0";
   }
@@ -470,7 +464,7 @@ export class ControlFlowGenerator {
 
     const indexAlloca = this.ctx.nextAllocaReg("__forof_idx");
     this.emit(`${indexAlloca} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexAlloca}`);
+    this.ctx.emitStore("i32", "0", indexAlloca);
 
     const elemAlloca = this.ctx.nextAllocaReg(forOfStmt.variableName);
     this.emit(`${elemAlloca} = alloca ${elementType}`);
@@ -483,22 +477,20 @@ export class ControlFlowGenerator {
     const endLabel = this.nextLabel("forof_end");
 
     // Jump to condition check
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitBr(condLabel);
 
     // Condition block: check if index < length
-    this.emit(`${condLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexAlloca}`);
-    const condBool = this.nextTemp();
-    this.emit(`${condBool} = icmp slt i32 ${currentIndex}, ${lengthI32}`);
-    this.emit(`br i1 ${condBool}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(condLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexAlloca);
+    const condBool = this.ctx.emitIcmp("slt", "i32", currentIndex, lengthI32);
+    this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
 
     // Body block
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     this.ctx.setCurrentLabel(bodyLabel);
 
     // Load current element from array
-    // Get pointer to the data array
+    // Get pointer to the data array (inbounds GEP + tbaa loads stay raw)
     const dataPtr = this.nextTemp();
     this.emit(
       `${dataPtr} = getelementptr inbounds ${arrayType}, ${arrayType}* ${iterableValue}, i32 0, i32 0`,
@@ -510,8 +502,7 @@ export class ControlFlowGenerator {
     } else if (isObjectArray) {
       const dataI8 = this.nextTemp();
       this.emit(`${dataI8} = load i8*, i8** ${dataPtr}, !tbaa !5`);
-      dataArray = this.nextTemp();
-      this.emit(`${dataArray} = bitcast i8* ${dataI8} to i8**`);
+      dataArray = this.ctx.emitBitcast(dataI8, "i8*", "i8**");
     } else {
       dataArray = this.nextTemp();
       this.emit(`${dataArray} = load double*, double** ${dataPtr}, !tbaa !5`);
@@ -528,11 +519,10 @@ export class ControlFlowGenerator {
         `${elemPtr} = getelementptr inbounds double, double* ${dataArray}, i64 ${indexI64}`,
       );
     }
-    const elemValue = this.nextTemp();
-    this.emit(`${elemValue} = load ${elementType}, ${elementType}* ${elemPtr}`);
+    const elemValue = this.ctx.emitLoad(elementType, elemPtr);
 
     // Store in loop variable
-    this.emit(`store ${elementType} ${elemValue}, ${elementType}* ${elemAlloca}`);
+    this.ctx.emitStore(elementType, elemValue, elemAlloca);
 
     // Execute the loop body
     this.loopContinueLabels.push(updateLabel);
@@ -542,22 +532,21 @@ export class ControlFlowGenerator {
     this.loopBreakLabels.pop();
 
     // Check if body has terminator
-    const bodyHasTerminator = this.ctx.lastInstructionIsTerminator();
-    if (!bodyHasTerminator) {
-      this.emit(`br label %${updateLabel}`);
+    const bodyHasTerminator4 = this.ctx.lastInstructionIsTerminator();
+    if (!bodyHasTerminator4) {
+      this.ctx.emitBr(updateLabel);
     }
 
     // Update block: increment index
-    this.emit(`${updateLabel}:`);
-    const loadedIndex = this.nextTemp();
-    this.emit(`${loadedIndex} = load i32, i32* ${indexAlloca}`);
+    this.ctx.emitLabel(updateLabel);
+    const loadedIndex = this.ctx.emitLoad("i32", indexAlloca);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${loadedIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexAlloca}`);
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexAlloca);
+    this.ctx.emitBr(condLabel);
 
     // End block
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return "0";
   }
@@ -1351,7 +1340,7 @@ export class ControlFlowGenerator {
 
     const indexAlloca = this.ctx.nextAllocaReg("__forof_idx");
     this.emit(`${indexAlloca} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexAlloca}`);
+    this.ctx.emitStore("i32", "0", indexAlloca);
 
     const elemAlloca = this.ctx.nextAllocaReg(forOfStmt.variableName);
     this.emit(`${elemAlloca} = alloca i8*`);
@@ -1380,34 +1369,31 @@ export class ControlFlowGenerator {
     const updateLabel = this.nextLabel("forof_update");
     const endLabel = this.nextLabel("forof_end");
 
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitBr(condLabel);
 
-    this.emit(`${condLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexAlloca}`);
-    const condBool = this.nextTemp();
-    this.emit(`${condBool} = icmp slt i32 ${currentIndex}, ${lengthI32}`);
-    this.emit(`br i1 ${condBool}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(condLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexAlloca);
+    const condBool = this.ctx.emitIcmp("slt", "i32", currentIndex, lengthI32);
+    this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     this.ctx.setCurrentLabel(bodyLabel);
 
+    // inbounds GEP + tbaa loads stay raw
     const dataPtr = this.nextTemp();
     this.emit(`${dataPtr} = getelementptr inbounds %Array, %Array* ${iterableValue}, i32 0, i32 0`);
     const dataArray = this.nextTemp();
     this.emit(`${dataArray} = load double*, double** ${dataPtr}, !tbaa !5`);
 
-    const elemPtrRaw = this.nextTemp();
-    this.emit(`${elemPtrRaw} = bitcast double* ${dataArray} to i8**`);
+    const elemPtrRaw = this.ctx.emitBitcast(dataArray, "double*", "i8**");
 
     const indexI64 = this.nextTemp();
     this.emit(`${indexI64} = sext i32 ${currentIndex} to i64`);
     const elemPtrPtr = this.nextTemp();
     this.emit(`${elemPtrPtr} = getelementptr inbounds i8*, i8** ${elemPtrRaw}, i64 ${indexI64}`);
-    const elemValue = this.nextTemp();
-    this.emit(`${elemValue} = load i8*, i8** ${elemPtrPtr}`);
+    const elemValue = this.ctx.emitLoad("i8*", elemPtrPtr);
 
-    this.emit(`store i8* ${elemValue}, i8** ${elemAlloca}`);
+    this.ctx.emitStore("i8*", elemValue, elemAlloca);
 
     this.loopContinueLabels.push(updateLabel);
     this.loopBreakLabels.push(endLabel);
@@ -1415,20 +1401,19 @@ export class ControlFlowGenerator {
     this.loopContinueLabels.pop();
     this.loopBreakLabels.pop();
 
-    const bodyHasTerminator = this.ctx.lastInstructionIsTerminator();
-    if (!bodyHasTerminator) {
-      this.emit(`br label %${updateLabel}`);
+    const bodyHasTerminator5 = this.ctx.lastInstructionIsTerminator();
+    if (!bodyHasTerminator5) {
+      this.ctx.emitBr(updateLabel);
     }
 
-    this.emit(`${updateLabel}:`);
-    const loadedIndex = this.nextTemp();
-    this.emit(`${loadedIndex} = load i32, i32* ${indexAlloca}`);
+    this.ctx.emitLabel(updateLabel);
+    const loadedIndex = this.ctx.emitLoad("i32", indexAlloca);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${loadedIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexAlloca}`);
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexAlloca);
+    this.ctx.emitBr(condLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return "0";
   }
@@ -1438,7 +1423,7 @@ export class ControlFlowGenerator {
       throw new Error("break statement outside of loop");
     }
     const breakLabel = this.loopBreakLabels[this.loopBreakLabels.length - 1];
-    this.emit(`br label %${breakLabel}`);
+    this.ctx.emitBr(breakLabel);
     return "0";
   }
 
@@ -1447,7 +1432,7 @@ export class ControlFlowGenerator {
       throw new Error("continue statement outside of loop");
     }
     const continueLabel = this.loopContinueLabels[this.loopContinueLabels.length - 1];
-    this.emit(`br label %${continueLabel}`);
+    this.ctx.emitBr(continueLabel);
     return "0";
   }
 
@@ -1477,38 +1462,29 @@ export class ControlFlowGenerator {
         msgVal = this.ctx.generateExpression(throwStmt.argument, params);
         const msgType = this.ctx.getVariableType(msgVal);
         if (msgType === "double") {
-          const buf = this.nextTemp();
-          this.emit(`${buf} = call i8* @__double_to_string(double ${msgVal})`);
-          msgVal = buf;
+          msgVal = this.ctx.emitCall("i8*", "@__double_to_string", `double ${msgVal}`);
         }
       }
     }
 
-    this.emit(`store i8* ${msgVal}, i8** @__exception_message`);
+    this.ctx.emitStore("i8*", msgVal, "@__exception_message");
 
-    const framePtr = this.nextTemp();
-    this.emit(`${framePtr} = load i8*, i8** @__exception_stack`);
-    const hasHandler = this.nextTemp();
-    this.emit(`${hasHandler} = icmp ne i8* ${framePtr}, null`);
+    const framePtr = this.ctx.emitLoad("i8*", "@__exception_stack");
+    const hasHandler = this.ctx.emitIcmp("ne", "i8*", framePtr, "null");
     const doLongjmpLabel = this.nextLabel("do_longjmp");
     const noHandlerLabel = this.nextLabel("no_handler");
-    this.emit(`br i1 ${hasHandler}, label %${doLongjmpLabel}, label %${noHandlerLabel}`);
+    this.ctx.emitBrCond(hasHandler, doLongjmpLabel, noHandlerLabel);
 
-    this.emit(`${doLongjmpLabel}:`);
+    this.ctx.emitLabel(doLongjmpLabel);
     this.ctx.setCurrentLabel(doLongjmpLabel);
-    const frameTyped = this.nextTemp();
-    this.emit(`${frameTyped} = bitcast i8* ${framePtr} to %ExceptionFrame*`);
-    const bufPtr = this.nextTemp();
-    this.emit(
-      `${bufPtr} = getelementptr %ExceptionFrame, %ExceptionFrame* ${frameTyped}, i32 0, i32 0, i32 0`,
-    );
+    const frameTyped = this.ctx.emitBitcast(framePtr, "i8*", "%ExceptionFrame*");
+    const bufPtr = this.ctx.emitGep("%ExceptionFrame", frameTyped, "i32 0, i32 0, i32 0");
     this.emit(`call void @longjmp(i8* ${bufPtr}, i32 1)`);
     this.emit(`unreachable`);
 
-    this.emit(`${noHandlerLabel}:`);
+    this.ctx.emitLabel(noHandlerLabel);
     this.ctx.setCurrentLabel(noHandlerLabel);
-    const stderrPtr = this.ctx.nextTemp();
-    this.emit(`${stderrPtr} = load i8*, i8** @stderr`);
+    const stderrPtr = this.ctx.emitLoad("i8*", "@stderr");
     const fprintfResult = this.ctx.nextTemp();
     this.emit(
       `${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* getelementptr([11 x i8], [11 x i8]* @.str.throw_fmt, i32 0, i32 0), i8* ${msgVal})`,
@@ -1530,56 +1506,44 @@ export class ControlFlowGenerator {
       finallyBlock: BlockStatement | null;
     };
 
-    const frameRaw = this.nextTemp();
-    this.emit(`${frameRaw} = call i8* @GC_malloc(i64 216)`);
-    const frame = this.nextTemp();
-    this.emit(`${frame} = bitcast i8* ${frameRaw} to %ExceptionFrame*`);
+    const frameRaw = this.ctx.emitCall("i8*", "@GC_malloc", "i64 216");
+    const frame = this.ctx.emitBitcast(frameRaw, "i8*", "%ExceptionFrame*");
 
-    const prevFrame = this.nextTemp();
-    this.emit(`${prevFrame} = load i8*, i8** @__exception_stack`);
-    const prevField = this.nextTemp();
-    this.emit(
-      `${prevField} = getelementptr %ExceptionFrame, %ExceptionFrame* ${frame}, i32 0, i32 1`,
-    );
-    this.emit(`store i8* ${prevFrame}, i8** ${prevField}`);
-    this.emit(`store i8* ${frameRaw}, i8** @__exception_stack`);
+    const prevFrame = this.ctx.emitLoad("i8*", "@__exception_stack");
+    const prevField = this.ctx.emitGep("%ExceptionFrame", frame, "i32 0, i32 1");
+    this.ctx.emitStore("i8*", prevFrame, prevField);
+    this.ctx.emitStore("i8*", frameRaw, "@__exception_stack");
 
-    const bufPtr = this.nextTemp();
-    this.emit(
-      `${bufPtr} = getelementptr %ExceptionFrame, %ExceptionFrame* ${frame}, i32 0, i32 0, i32 0`,
-    );
-    const sjVal = this.nextTemp();
-    this.emit(`${sjVal} = call i32 @setjmp(i8* ${bufPtr})`);
-    const isException = this.nextTemp();
-    this.emit(`${isException} = icmp ne i32 ${sjVal}, 0`);
+    const bufPtr = this.ctx.emitGep("%ExceptionFrame", frame, "i32 0, i32 0, i32 0");
+    const sjVal = this.ctx.emitCall("i32", "@setjmp", `i8* ${bufPtr}`);
+    const isException = this.ctx.emitIcmp("ne", "i32", sjVal, "0");
 
     const tryBodyLabel = this.nextLabel("try_body");
     const catchEntryLabel = this.nextLabel("catch_entry");
     const finallyLabel = this.nextLabel("finally_block");
 
-    this.emit(`br i1 ${isException}, label %${catchEntryLabel}, label %${tryBodyLabel}`);
+    this.ctx.emitBrCond(isException, catchEntryLabel, tryBodyLabel);
 
-    this.emit(`${tryBodyLabel}:`);
+    this.ctx.emitLabel(tryBodyLabel);
     this.ctx.setCurrentLabel(tryBodyLabel);
     this.ctx.generateBlock(tryStmt.tryBlock, params);
     const tryHasTerminator = this.ctx.lastInstructionIsTerminator();
     if (!tryHasTerminator) {
-      this.emit(`store i8* ${prevFrame}, i8** @__exception_stack`);
-      this.emit(`br label %${finallyLabel}`);
+      this.ctx.emitStore("i8*", prevFrame, "@__exception_stack");
+      this.ctx.emitBr(finallyLabel);
     }
 
-    this.emit(`${catchEntryLabel}:`);
+    this.ctx.emitLabel(catchEntryLabel);
     this.ctx.setCurrentLabel(catchEntryLabel);
-    this.emit(`store i8* ${prevFrame}, i8** @__exception_stack`);
+    this.ctx.emitStore("i8*", prevFrame, "@__exception_stack");
 
     if (tryStmt.catchBody) {
       const paramName = tryStmt.catchParam;
       if (paramName) {
-        const excMsg = this.nextTemp();
-        this.emit(`${excMsg} = load i8*, i8** @__exception_message`);
+        const excMsg = this.ctx.emitLoad("i8*", "@__exception_message");
         const paramAlloca = this.ctx.nextAllocaReg(paramName);
         this.emit(`${paramAlloca} = alloca i8*`);
-        this.emit(`store i8* ${excMsg}, i8** ${paramAlloca}`);
+        this.ctx.emitStore("i8*", excMsg, paramAlloca);
         this.ctx.defineVariable(paramName, paramAlloca, "i8*", SymbolKind.String, "local");
       }
       this.ctx.generateBlock(tryStmt.catchBody, params);
@@ -1587,10 +1551,10 @@ export class ControlFlowGenerator {
 
     const catchHasTerminator = this.ctx.lastInstructionIsTerminator();
     if (!catchHasTerminator) {
-      this.emit(`br label %${finallyLabel}`);
+      this.ctx.emitBr(finallyLabel);
     }
 
-    this.emit(`${finallyLabel}:`);
+    this.ctx.emitLabel(finallyLabel);
     this.ctx.setCurrentLabel(finallyLabel);
 
     if (tryStmt.finallyBlock) {
@@ -1615,12 +1579,12 @@ export class ControlFlowGenerator {
     const leftCoerceLabel = this.nextLabel("logop_left_coerce");
 
     if (op === "||" || op === "??") {
-      this.emit(`br i1 ${leftBool}, label %${leftCoerceLabel}, label %${evalRightLabel}`);
+      this.ctx.emitBrCond(leftBool, leftCoerceLabel, evalRightLabel);
     } else {
-      this.emit(`br i1 ${leftBool}, label %${evalRightLabel}, label %${leftCoerceLabel}`);
+      this.ctx.emitBrCond(leftBool, evalRightLabel, leftCoerceLabel);
     }
 
-    this.emit(`${evalRightLabel}:`);
+    this.ctx.emitLabel(evalRightLabel);
     const savedExpectedType = this.ctx.getExpectedArrayElementType();
     const rightTyped = right as { type: string; elements?: Expression[] };
     if (rightTyped.type === "array" && (!rightTyped.elements || rightTyped.elements.length === 0)) {
@@ -1638,14 +1602,14 @@ export class ControlFlowGenerator {
     const resultType = this.getPhiType(leftType, rightType);
     const rightForPhi = this.coerceToTypeNoPhi(rightValue, rightType, resultType);
     const rightCoerceEndLabel = this.ctx.getCurrentLabel();
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${leftCoerceLabel}:`);
+    this.ctx.emitLabel(leftCoerceLabel);
     const leftForPhi = this.coerceToTypeNoPhi(leftValue, leftType, resultType);
     const leftCoerceEndLabel = this.ctx.getCurrentLabel();
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
     const result = this.nextTemp();
     this.emit(
       `${result} = phi ${resultType} [ ${leftForPhi}, %${leftCoerceEndLabel} ], [ ${rightForPhi}, %${rightCoerceEndLabel} ]`,
@@ -2112,12 +2076,11 @@ export class ControlFlowGenerator {
 
     const lenPtr = this.nextTemp();
     this.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${iterableValue}, i32 0, i32 0`);
-    const lengthI32 = this.nextTemp();
-    this.emit(`${lengthI32} = load i32, i32* ${lenPtr}`);
+    const lengthI32 = this.ctx.emitLoad("i32", lenPtr);
 
     const indexAlloca = this.ctx.nextAllocaReg("__forof_idx");
     this.emit(`${indexAlloca} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexAlloca}`);
+    this.ctx.emitStore("i32", "0", indexAlloca);
 
     const keyAlloca = this.ctx.nextAllocaReg(keyName);
     this.emit(`${keyAlloca} = alloca i8*`);
@@ -2152,52 +2115,47 @@ export class ControlFlowGenerator {
     const updateLabel = this.nextLabel("mapof_update");
     const endLabel = this.nextLabel("mapof_end");
 
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitBr(condLabel);
 
-    this.emit(`${condLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexAlloca}`);
-    const condBool = this.nextTemp();
-    this.emit(`${condBool} = icmp slt i32 ${currentIndex}, ${lengthI32}`);
-    this.emit(`br i1 ${condBool}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(condLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexAlloca);
+    const condBool = this.ctx.emitIcmp("slt", "i32", currentIndex, lengthI32);
+    this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     this.ctx.setCurrentLabel(bodyLabel);
 
+    // inbounds GEP + tbaa loads stay raw
     const dataFieldPtr = this.nextTemp();
     this.emit(
       `${dataFieldPtr} = getelementptr inbounds %Array, %Array* ${iterableValue}, i32 0, i32 2`,
     );
     const dataPtr = this.nextTemp();
     this.emit(`${dataPtr} = load double*, double** ${dataFieldPtr}, !tbaa !5`);
-    const dataCast = this.nextTemp();
-    this.emit(`${dataCast} = bitcast double* ${dataPtr} to i8**`);
+    const dataCast = this.ctx.emitBitcast(dataPtr, "double*", "i8**");
 
     const indexI64 = this.nextTemp();
     this.emit(`${indexI64} = sext i32 ${currentIndex} to i64`);
     const elemPtr = this.nextTemp();
     this.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataCast}, i64 ${indexI64}`);
-    const entryRaw = this.nextTemp();
-    this.emit(`${entryRaw} = load i8*, i8** ${elemPtr}`);
+    const entryRaw = this.ctx.emitLoad("i8*", elemPtr);
 
-    const entryPtr = this.nextTemp();
-    this.emit(`${entryPtr} = bitcast i8* ${entryRaw} to { i8*, i8* }*`);
+    const entryPtr = this.ctx.emitBitcast(entryRaw, "i8*", "{ i8*, i8* }*");
 
+    // inbounds GEPs stay raw
     const keySlotPtr = this.nextTemp();
     this.emit(
       `${keySlotPtr} = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* ${entryPtr}, i32 0, i32 0`,
     );
-    const keyVal = this.nextTemp();
-    this.emit(`${keyVal} = load i8*, i8** ${keySlotPtr}`);
-    this.emit(`store i8* ${keyVal}, i8** ${keyAlloca}`);
+    const keyVal = this.ctx.emitLoad("i8*", keySlotPtr);
+    this.ctx.emitStore("i8*", keyVal, keyAlloca);
 
     const valueSlotPtr = this.nextTemp();
     this.emit(
       `${valueSlotPtr} = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* ${entryPtr}, i32 0, i32 1`,
     );
-    const valueVal = this.nextTemp();
-    this.emit(`${valueVal} = load i8*, i8** ${valueSlotPtr}`);
-    this.emit(`store i8* ${valueVal}, i8** ${valueAlloca}`);
+    const valueVal = this.ctx.emitLoad("i8*", valueSlotPtr);
+    this.ctx.emitStore("i8*", valueVal, valueAlloca);
 
     this.loopContinueLabels.push(updateLabel);
     this.loopBreakLabels.push(endLabel);
@@ -2205,20 +2163,19 @@ export class ControlFlowGenerator {
     this.loopContinueLabels.pop();
     this.loopBreakLabels.pop();
 
-    const bodyHasTerminator = this.ctx.lastInstructionIsTerminator();
-    if (!bodyHasTerminator) {
-      this.emit(`br label %${updateLabel}`);
+    const bodyHasTerminator6 = this.ctx.lastInstructionIsTerminator();
+    if (!bodyHasTerminator6) {
+      this.ctx.emitBr(updateLabel);
     }
 
-    this.emit(`${updateLabel}:`);
-    const loadedIndex = this.nextTemp();
-    this.emit(`${loadedIndex} = load i32, i32* ${indexAlloca}`);
+    this.ctx.emitLabel(updateLabel);
+    const loadedIndex = this.ctx.emitLoad("i32", indexAlloca);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${loadedIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexAlloca}`);
-    this.emit(`br label %${condLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexAlloca);
+    this.ctx.emitBr(condLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return "0";
   }
@@ -2274,25 +2231,27 @@ export class ControlFlowGenerator {
       if (!caseItem) continue;
       if (caseItem.test !== null) {
         if (checkIndex > 0) {
-          this.emit(`${checkLabels[checkIndex - 1]}:`);
+          this.ctx.emitLabel(checkLabels[checkIndex - 1]);
         }
 
         const testValue = this.ctx.generateExpression(caseItem.test, params);
 
         if (isString) {
-          const strCmp = this.nextTemp();
-          this.emit(`${strCmp} = call i32 @strcmp(i8* ${discriminantValue}, i8* ${testValue})`);
-          const cmpResult = this.nextTemp();
-          this.emit(`${cmpResult} = icmp eq i32 ${strCmp}, 0`);
+          const strCmp = this.ctx.emitCall(
+            "i32",
+            "@strcmp",
+            `i8* ${discriminantValue}, i8* ${testValue}`,
+          );
+          const cmpResult = this.ctx.emitIcmp("eq", "i32", strCmp, "0");
           const nextLabel = checkIndex < testCaseCount - 1 ? checkLabels[checkIndex] : defaultLabel;
-          this.emit(`br i1 ${cmpResult}, label %${caseLabels[i]}, label %${nextLabel}`);
+          this.ctx.emitBrCond(cmpResult, caseLabels[i], nextLabel);
         } else {
           const dblDiscriminant = this.ctx.ensureDouble(discriminantValue);
           const dblTest = this.ctx.ensureDouble(testValue);
           const cmpResult = this.nextTemp();
           this.emit(`${cmpResult} = fcmp oeq double ${dblDiscriminant}, ${dblTest}`);
           const nextLabel = checkIndex < testCaseCount - 1 ? checkLabels[checkIndex] : defaultLabel;
-          this.emit(`br i1 ${cmpResult}, label %${caseLabels[i]}, label %${nextLabel}`);
+          this.ctx.emitBrCond(cmpResult, caseLabels[i], nextLabel);
         }
         checkIndex++;
       }
@@ -2301,14 +2260,14 @@ export class ControlFlowGenerator {
     for (let i = 0; i < switchStmt.cases.length; i++) {
       const caseItem = switchStmt.cases[i];
       if (!caseItem) continue;
-      this.emit(`${caseLabels[i]}:`);
+      this.ctx.emitLabel(caseLabels[i]);
       this.ctx.setCurrentLabel(caseLabels[i]);
 
       for (let j = 0; j < caseItem.consequent.length; j++) {
         const consequentStmt = caseItem.consequent[j];
         if (!consequentStmt) continue;
         if (consequentStmt.type === "break") {
-          this.emit(`br label %${endLabel}`);
+          this.ctx.emitBr(endLabel);
         } else if (
           consequentStmt.type === "variable_declaration" ||
           consequentStmt.type === "return" ||
@@ -2334,13 +2293,13 @@ export class ControlFlowGenerator {
         (lastStmt.type !== "break" && lastStmt.type !== "return" && lastStmt.type !== "throw")
       ) {
         const nextCaseLabel = i < switchStmt.cases.length - 1 ? caseLabels[i + 1] : endLabel;
-        this.emit(`br label %${nextCaseLabel}`);
+        this.ctx.emitBr(nextCaseLabel);
       }
     }
 
     this.loopContinueLabels.pop();
     this.loopBreakLabels.pop();
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return "0";
   }

--- a/src/codegen/types/collections/array.ts
+++ b/src/codegen/types/collections/array.ts
@@ -3,9 +3,8 @@
  * New array methods should go in the appropriate submodule, NOT this file.
  */
 
-import { Expression, MethodCallNode, VariableNode } from "../../../ast/types.js";
+import { Expression, MethodCallNode } from "../../../ast/types.js";
 import { IGeneratorContext } from "../../infrastructure/generator-context.js";
-import { detectArrayType } from "./array/context.js";
 
 // Array sub-modules
 // No alias — ChadScript doesn't resolve import aliases in self-hosting
@@ -14,11 +13,7 @@ import { generateArrayPush, generateArrayPop } from "./array/mutators.js";
 import { generateArrayReverse, generateArrayShift, generateArrayUnshift } from "./array/reorder.js";
 import { generateArrayIndexOf, generateArrayFindIndex } from "./array/search.js";
 import { generateArraySplice } from "./array/splice.js";
-import {
-  generateDefaultNumericSort,
-  generateDefaultStringSort,
-  generateNumericSortWithFn,
-} from "./array/sort.js";
+import { generateArraySort } from "./array/sort.js";
 import {
   generateArrayFind,
   generateArraySome,
@@ -39,10 +34,6 @@ import {
   generateArrayConcat,
 } from "./array/combine.js";
 
-interface ExprBase {
-  type: string;
-}
-
 export class ArrayGenerator {
   constructor(private ctx: IGeneratorContext) {}
 
@@ -51,7 +42,7 @@ export class ArrayGenerator {
     const arrExpr = expr as { type: string; elements: Expression[] };
     if (arrExpr.elements) {
       for (let i = 0; i < arrExpr.elements.length; i++) {
-        const el = arrExpr.elements[i] as ExprBase;
+        const el = arrExpr.elements[i] as { type: string };
         if (el.type === "spread_element" || el.type.indexOf("spread:") === 0) {
           return generateArrayLiteralWithSpread(this.ctx, arrExpr, params);
         }
@@ -69,221 +60,35 @@ export class ArrayGenerator {
   }
 
   generateArrayFind(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 1) {
-      throw new Error("find() requires exactly 1 argument (predicate function)");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-    const { isStringArray, isObjectArray } = detectArrayType(this.ctx, expr, arrayPtr);
-
-    const predicateArg = expr.args[0];
-    let predicateFn: string;
-    if (predicateArg.type === "variable") {
-      predicateFn = this.ctx.mangleUserName((predicateArg as VariableNode).name);
-    } else if (predicateArg.type === "arrow_function") {
-      if (isStringArray || isObjectArray) {
-        this.ctx.setExpectedCallbackParamType("string");
-      }
-      predicateFn = this.ctx.generateExpression(predicateArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-    } else {
-      throw new Error("find() argument must be a function name or inline function");
-    }
-
-    return generateArrayFind(this.ctx, arrayPtr, predicateFn, isStringArray, isObjectArray);
+    return generateArrayFind(this.ctx, expr, params);
   }
 
   generateArraySome(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 1) {
-      throw new Error("some() requires exactly 1 argument (predicate function)");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-    const { isStringArray, isObjectArray } = detectArrayType(this.ctx, expr, arrayPtr);
-
-    const predicateArg = expr.args[0];
-    let predicateFn: string;
-    if (predicateArg.type === "variable") {
-      predicateFn = this.ctx.mangleUserName((predicateArg as VariableNode).name);
-    } else if (predicateArg.type === "arrow_function") {
-      if (isStringArray || isObjectArray) {
-        this.ctx.setExpectedCallbackParamType("string");
-      }
-      predicateFn = this.ctx.generateExpression(predicateArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-    } else {
-      throw new Error("some() argument must be a function name or inline function");
-    }
-
-    return generateArraySome(this.ctx, arrayPtr, predicateFn, isStringArray, isObjectArray);
+    return generateArraySome(this.ctx, expr, params);
   }
 
   generateArrayEvery(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 1) {
-      throw new Error("every() requires exactly 1 argument (predicate function)");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-    const { isStringArray, isObjectArray } = detectArrayType(this.ctx, expr, arrayPtr);
-
-    const predicateArg = expr.args[0];
-    let predicateFn: string;
-    if (predicateArg.type === "variable") {
-      predicateFn = this.ctx.mangleUserName((predicateArg as VariableNode).name);
-    } else if (predicateArg.type === "arrow_function") {
-      if (isStringArray || isObjectArray) {
-        this.ctx.setExpectedCallbackParamType("string");
-      }
-      predicateFn = this.ctx.generateExpression(predicateArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-    } else {
-      throw new Error("every() argument must be a function name or inline function");
-    }
-
-    return generateArrayEvery(this.ctx, arrayPtr, predicateFn, isStringArray, isObjectArray);
+    return generateArrayEvery(this.ctx, expr, params);
   }
 
   generateArrayFilter(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 1) {
-      throw new Error("filter() requires exactly 1 argument (predicate function)");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-    const { isStringArray, isObjectArray } = detectArrayType(this.ctx, expr, arrayPtr);
-
-    const predicateArg = expr.args[0];
-    let predicateFn: string;
-    if (predicateArg.type === "variable") {
-      predicateFn = this.ctx.mangleUserName((predicateArg as VariableNode).name);
-    } else if (predicateArg.type === "arrow_function") {
-      if (isStringArray || isObjectArray) {
-        this.ctx.setExpectedCallbackParamType("string");
-      }
-      predicateFn = this.ctx.generateExpression(predicateArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-    } else {
-      throw new Error("filter() argument must be a function name or inline function");
-    }
-
-    return generateArrayFilter(this.ctx, arrayPtr, predicateFn, isStringArray, isObjectArray);
+    return generateArrayFilter(this.ctx, expr, params);
   }
 
   generateArrayForEach(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 1) {
-      throw new Error("forEach() requires exactly 1 argument (callback function)");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-    const { isStringArray, isObjectArray } = detectArrayType(this.ctx, expr, arrayPtr);
-
-    const callbackArg = expr.args[0];
-    let callbackFn: string;
-    if (callbackArg.type === "variable") {
-      callbackFn = this.ctx.mangleUserName((callbackArg as VariableNode).name);
-    } else if (callbackArg.type === "arrow_function") {
-      if (isStringArray || isObjectArray) {
-        this.ctx.setExpectedCallbackParamType("string");
-      }
-      callbackFn = this.ctx.generateExpression(callbackArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-    } else {
-      throw new Error("forEach() argument must be a function name or inline function");
-    }
-
-    return generateArrayForEach(this.ctx, arrayPtr, callbackFn, isStringArray, isObjectArray);
+    return generateArrayForEach(this.ctx, expr, params);
   }
 
   generateArrayReduce(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length < 1 || expr.args.length > 2) {
-      throw new Error("reduce() requires 1-2 arguments (callback, optional initialValue)");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-
-    let isStringArray = false;
-    const exprObjBase = expr.object as ExprBase;
-    if (exprObjBase.type === "variable") {
-      const varName = (expr.object as VariableNode).name;
-      const varType = this.ctx.getVariableType(varName);
-      isStringArray = varType === "%StringArray*" || varType === "%StringArray";
-    } else {
-      const ptrType = this.ctx.getVariableType(arrayPtr);
-      isStringArray = ptrType === "%StringArray*";
-    }
-
-    const callbackArg = expr.args[0];
-    let callbackFn: string;
-    if (callbackArg.type === "variable") {
-      callbackFn = this.ctx.mangleUserName((callbackArg as VariableNode).name);
-    } else if (callbackArg.type === "arrow_function") {
-      if (isStringArray) {
-        this.ctx.setExpectedCallbackParamType("string");
-      }
-      callbackFn = this.ctx.generateExpression(callbackArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-    } else {
-      throw new Error("reduce() argument must be a function name or inline function");
-    }
-
-    let initialValue: string | null = null;
-    if (expr.args.length === 2) {
-      initialValue = this.ctx.generateExpression(expr.args[1], params);
-    }
-
-    return generateArrayReduce(this.ctx, arrayPtr, callbackFn, isStringArray, initialValue);
+    return generateArrayReduce(this.ctx, expr, params);
   }
 
   generateArrayMap(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 1) {
-      throw new Error("map() requires exactly 1 argument (callback function)");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-    const { isStringArray, isObjectArray } = detectArrayType(this.ctx, expr, arrayPtr);
-
-    const callbackArg = expr.args[0];
-    let callbackFn: string;
-    if (callbackArg.type === "variable") {
-      callbackFn = this.ctx.mangleUserName((callbackArg as VariableNode).name);
-    } else if (callbackArg.type === "arrow_function") {
-      if (isStringArray || isObjectArray) {
-        this.ctx.setExpectedCallbackParamType("string");
-        this.ctx.setExpectedCallbackReturnType("string");
-      } else {
-        this.ctx.setExpectedCallbackReturnType("number");
-      }
-      callbackFn = this.ctx.generateExpression(callbackArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-      this.ctx.setExpectedCallbackReturnType(null);
-    } else {
-      throw new Error("map() argument must be a function name or inline function");
-    }
-
-    return generateArrayMap(this.ctx, arrayPtr, callbackFn, isStringArray, isObjectArray);
+    return generateArrayMap(this.ctx, expr, params);
   }
 
   generateStringArrayMap(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 1) {
-      throw new Error("map() requires exactly 1 argument (callback function)");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-
-    const callbackArg = expr.args[0];
-    let callbackFn: string;
-    if (callbackArg.type === "variable") {
-      callbackFn = this.ctx.mangleUserName((callbackArg as VariableNode).name);
-    } else if (callbackArg.type === "arrow_function") {
-      this.ctx.setExpectedCallbackParamType("string");
-      this.ctx.setExpectedCallbackReturnType("string");
-      callbackFn = this.ctx.generateExpression(callbackArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-      this.ctx.setExpectedCallbackReturnType(null);
-    } else {
-      throw new Error("map() argument must be a function name or inline function");
-    }
-
-    return generateStringArrayMap(this.ctx, arrayPtr, callbackFn);
+    return generateStringArrayMap(this.ctx, expr, params);
   }
 
   generateArrayIncludes(expr: MethodCallNode, params: string[]): string {
@@ -318,78 +123,12 @@ export class ArrayGenerator {
     return generateArrayIndexOf(this.ctx, expr, params);
   }
 
-  // findIndex needs facade-level predicate resolution before delegating to search.ts
   generateArrayFindIndex(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 1) {
-      throw new Error("findIndex() requires exactly 1 argument (predicate function)");
-    }
-
-    const exprObjBase = expr.object as ExprBase;
-    let isStringArray = false;
-    if (exprObjBase.type === "variable") {
-      const varName = (expr.object as VariableNode).name;
-      const varType = this.ctx.getVariableType(varName);
-      isStringArray = varType === "%StringArray*" || varType === "%StringArray";
-    }
-
-    const predicateArg = expr.args[0];
-    let predicateFn: string;
-
-    if (predicateArg.type === "variable") {
-      predicateFn = this.ctx.mangleUserName((predicateArg as VariableNode).name);
-    } else if (predicateArg.type === "arrow_function") {
-      if (isStringArray) {
-        this.ctx.setExpectedCallbackParamType("string");
-      }
-      predicateFn = this.ctx.generateExpression(predicateArg, params);
-      this.ctx.setExpectedCallbackParamType(null);
-    } else {
-      throw new Error("findIndex() argument must be a function name or inline function");
-    }
-
-    return generateArrayFindIndex(this.ctx, expr, params, predicateFn, isStringArray);
+    return generateArrayFindIndex(this.ctx, expr, params);
   }
 
-  // sort needs facade-level type detection and comparator resolution
   generateArraySort(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length > 1) {
-      throw new Error("sort() expects 0 or 1 arguments");
-    }
-
-    const arrayPtr = this.ctx.generateExpression(expr.object, params);
-    this.ctx.setUsesArraySort(true);
-
-    let isStringArray = false;
-    const exprObjBase = expr.object as ExprBase;
-    if (exprObjBase.type === "variable") {
-      const varName = (expr.object as VariableNode).name;
-      const varType = this.ctx.getVariableType(varName);
-      isStringArray = varType === "%StringArray*" || varType === "%StringArray";
-    }
-    if (!isStringArray) {
-      const ptrType = this.ctx.getVariableType(arrayPtr);
-      if (ptrType === "%StringArray*" || ptrType === "%StringArray") isStringArray = true;
-    }
-
-    if (expr.args.length === 0) {
-      if (isStringArray) {
-        return generateDefaultStringSort(this.ctx, arrayPtr);
-      }
-      return generateDefaultNumericSort(this.ctx, arrayPtr);
-    }
-
-    const predicateArg = expr.args[0];
-    let compareFn: string;
-
-    if (predicateArg.type === "variable") {
-      compareFn = this.ctx.mangleUserName((predicateArg as VariableNode).name);
-    } else if (predicateArg.type === "arrow_function") {
-      compareFn = this.ctx.generateExpression(predicateArg, params);
-    } else {
-      throw new Error("sort() comparator must be a function name or inline function");
-    }
-
-    return generateNumericSortWithFn(this.ctx, arrayPtr, compareFn);
+    return generateArraySort(this.ctx, expr, params);
   }
 
   generateArraySplice(expr: MethodCallNode, params: string[]): string {

--- a/src/codegen/types/collections/array.ts
+++ b/src/codegen/types/collections/array.ts
@@ -68,8 +68,6 @@ export class ArrayGenerator {
     return generateArrayPop(this.ctx, expr, params);
   }
 
-  // Predicate/callback resolution must happen here (class method) not in standalone
-  // functions, because ChadScript can't access expr.args[0].type in standalone functions.
   generateArrayFind(expr: MethodCallNode, params: string[]): string {
     if (expr.args.length !== 1) {
       throw new Error("find() requires exactly 1 argument (predicate function)");

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -1,10 +1,12 @@
 // Array iteration operations: filter, forEach, reduce, map
-// Extracted from array.ts to reduce file size. Uses IGeneratorContext for IR emission.
+// Exported functions accept (gen, expr, params) and handle callback resolution internally.
 
-import { IGeneratorContext, loadArrayMeta } from "./context.js";
+import { MethodCallNode, VariableNode } from "../../../../ast/types.js";
+import { IGeneratorContext, loadArrayMeta, detectArrayType } from "./context.js";
 
-// Callback resolution happens in the facade (array.ts class methods) to work around
-// ChadScript self-hosting issues with expr.args[0].type access in standalone functions.
+interface ExprBase {
+  type: string;
+}
 
 // ============================================
 // filter
@@ -12,15 +14,41 @@ import { IGeneratorContext, loadArrayMeta } from "./context.js";
 
 export function generateArrayFilter(
   gen: IGeneratorContext,
-  arrayPtr: string,
-  predicateFn: string,
-  isStringArray: boolean,
-  isObjectArray: boolean,
+  expr: MethodCallNode,
+  params: string[],
 ): string {
+  if (expr.args.length !== 1) {
+    throw new Error("filter() requires exactly 1 argument (predicate function)");
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+
+  const callbackArg = expr.args[0];
+  let predicateFn: string;
+  if (callbackArg.type === "variable") {
+    predicateFn = gen.mangleUserName((callbackArg as VariableNode).name);
+  } else if (callbackArg.type === "arrow_function") {
+    if (isStringArray || isObjectArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
+    predicateFn = gen.generateExpression(callbackArg, params);
+    gen.setExpectedCallbackParamType(null);
+  } else {
+    throw new Error("filter() argument must be a function name or inline function");
+  }
+
   if (isStringArray || isObjectArray) {
     return generateStringArrayFilter(gen, arrayPtr, predicateFn);
   }
+  return generateNumericArrayFilter(gen, arrayPtr, predicateFn);
+}
 
+function generateNumericArrayFilter(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  predicateFn: string,
+): string {
   const lenPtr = gen.nextTemp();
   gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
   const length = gen.emitLoad("i32", lenPtr);
@@ -216,15 +244,41 @@ function generateStringArrayFilter(
 
 export function generateArrayForEach(
   gen: IGeneratorContext,
-  arrayPtr: string,
-  callbackFn: string,
-  isStringArray: boolean,
-  isObjectArray: boolean,
+  expr: MethodCallNode,
+  params: string[],
 ): string {
+  if (expr.args.length !== 1) {
+    throw new Error("forEach() requires exactly 1 argument (callback function)");
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+
+  const callbackArg = expr.args[0];
+  let callbackFn: string;
+  if (callbackArg.type === "variable") {
+    callbackFn = gen.mangleUserName((callbackArg as VariableNode).name);
+  } else if (callbackArg.type === "arrow_function") {
+    if (isStringArray || isObjectArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
+    callbackFn = gen.generateExpression(callbackArg, params);
+    gen.setExpectedCallbackParamType(null);
+  } else {
+    throw new Error("forEach() argument must be a function name or inline function");
+  }
+
   if (isStringArray || isObjectArray) {
     return generateStringArrayForEach(gen, arrayPtr, callbackFn);
   }
+  return generateNumericArrayForEach(gen, arrayPtr, callbackFn);
+}
 
+function generateNumericArrayForEach(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  callbackFn: string,
+): string {
   const arrayMeta = loadArrayMeta(gen, arrayPtr);
   const length = arrayMeta.length;
   const dataPtr = arrayMeta.dataPtr;
@@ -317,15 +371,58 @@ function generateStringArrayForEach(
 
 export function generateArrayReduce(
   gen: IGeneratorContext,
-  arrayPtr: string,
-  callbackFn: string,
-  isStringArray: boolean,
-  initialValue: string | null,
+  expr: MethodCallNode,
+  params: string[],
 ): string {
+  if (expr.args.length < 1 || expr.args.length > 2) {
+    throw new Error("reduce() requires 1-2 arguments (callback, optional initialValue)");
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+
+  // reduce uses manual string detection (not detectArrayType) — only checks string, not object
+  let isStringArray = false;
+  const exprObjBase = expr.object as ExprBase;
+  if (exprObjBase.type === "variable") {
+    const varName = (expr.object as VariableNode).name;
+    const varType = gen.getVariableType(varName);
+    isStringArray = varType === "%StringArray*" || varType === "%StringArray";
+  } else {
+    const ptrType = gen.getVariableType(arrayPtr);
+    isStringArray = ptrType === "%StringArray*";
+  }
+
+  const callbackArg = expr.args[0];
+  let callbackFn: string;
+  if (callbackArg.type === "variable") {
+    callbackFn = gen.mangleUserName((callbackArg as VariableNode).name);
+  } else if (callbackArg.type === "arrow_function") {
+    if (isStringArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
+    callbackFn = gen.generateExpression(callbackArg, params);
+    gen.setExpectedCallbackParamType(null);
+  } else {
+    throw new Error("reduce() argument must be a function name or inline function");
+  }
+
+  let initialValue: string | null = null;
+  if (expr.args.length === 2) {
+    initialValue = gen.generateExpression(expr.args[1], params);
+  }
+
   if (isStringArray) {
     return generateStringArrayReduce(gen, arrayPtr, callbackFn, initialValue);
   }
+  return generateNumericArrayReduce(gen, arrayPtr, callbackFn, initialValue);
+}
 
+function generateNumericArrayReduce(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  callbackFn: string,
+  initialValue: string | null,
+): string {
   const arrayMeta = loadArrayMeta(gen, arrayPtr);
   const length = arrayMeta.length;
   const dataPtr = arrayMeta.dataPtr;
@@ -456,15 +553,73 @@ function generateStringArrayReduce(
 
 export function generateArrayMap(
   gen: IGeneratorContext,
-  arrayPtr: string,
-  callbackFn: string,
-  isStringArray: boolean,
-  isObjectArray: boolean,
+  expr: MethodCallNode,
+  params: string[],
 ): string {
-  if (isStringArray || isObjectArray) {
-    return generateStringArrayMap(gen, arrayPtr, callbackFn);
+  if (expr.args.length !== 1) {
+    throw new Error("map() requires exactly 1 argument (callback function)");
   }
 
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+
+  const callbackArg = expr.args[0];
+  let callbackFn: string;
+  if (callbackArg.type === "variable") {
+    callbackFn = gen.mangleUserName((callbackArg as VariableNode).name);
+  } else if (callbackArg.type === "arrow_function") {
+    if (isStringArray || isObjectArray) {
+      gen.setExpectedCallbackParamType("string");
+      gen.setExpectedCallbackReturnType("string");
+    } else {
+      gen.setExpectedCallbackReturnType("number");
+    }
+    callbackFn = gen.generateExpression(callbackArg, params);
+    gen.setExpectedCallbackParamType(null);
+    gen.setExpectedCallbackReturnType(null);
+  } else {
+    throw new Error("map() argument must be a function name or inline function");
+  }
+
+  if (isStringArray || isObjectArray) {
+    return generateStringArrayMapImpl(gen, arrayPtr, callbackFn);
+  }
+  return generateNumericArrayMap(gen, arrayPtr, callbackFn);
+}
+
+export function generateStringArrayMap(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+): string {
+  if (expr.args.length !== 1) {
+    throw new Error("map() requires exactly 1 argument (callback function)");
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+
+  const callbackArg = expr.args[0];
+  let callbackFn: string;
+  if (callbackArg.type === "variable") {
+    callbackFn = gen.mangleUserName((callbackArg as VariableNode).name);
+  } else if (callbackArg.type === "arrow_function") {
+    gen.setExpectedCallbackParamType("string");
+    gen.setExpectedCallbackReturnType("string");
+    callbackFn = gen.generateExpression(callbackArg, params);
+    gen.setExpectedCallbackParamType(null);
+    gen.setExpectedCallbackReturnType(null);
+  } else {
+    throw new Error("map() argument must be a function name or inline function");
+  }
+
+  return generateStringArrayMapImpl(gen, arrayPtr, callbackFn);
+}
+
+function generateNumericArrayMap(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  callbackFn: string,
+): string {
   const lenPtr = gen.nextTemp();
   gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
   const length = gen.emitLoad("i32", lenPtr);
@@ -541,7 +696,7 @@ export function generateArrayMap(
   return resultArrayPtr;
 }
 
-export function generateStringArrayMap(
+function generateStringArrayMapImpl(
   gen: IGeneratorContext,
   arrayPtr: string,
   callbackFn: string,

--- a/src/codegen/types/collections/array/mutators.ts
+++ b/src/codegen/types/collections/array/mutators.ts
@@ -1,7 +1,7 @@
-// NOTE: This file uses raw ctx.emit() extensively. Prefer structured IR builders
-// (emitStore, emitLoad, emitCall, etc.) when modifying — see .claude/rules.md.
+// Array mutator operations: push, pop.
+// Uses structured IR builders where possible; raw emit() for inbounds GEP, tbaa, intrinsics, etc.
 
-import { Expression, MethodCallNode, VariableNode } from "../../../../ast/types.js";
+import { MethodCallNode, VariableNode } from "../../../../ast/types.js";
 import { IGeneratorContext } from "./context.js";
 
 interface ExprBase {
@@ -110,21 +110,20 @@ function generateIntArrayPop(gen: IGeneratorContext, arrayPtr: string): string {
   gen.emit(`${currentLen} = load i32, i32* ${lenPtr}`);
 
   // Check if array is empty
-  const isEmpty = gen.nextTemp();
-  gen.emit(`${isEmpty} = icmp eq i32 ${currentLen}, 0`);
+  const isEmpty = gen.emitIcmp("eq", "i32", currentLen, "0");
 
   const emptyLabel = gen.nextLabel("pop_empty");
   const notEmptyLabel = gen.nextLabel("pop_notempty");
   const endLabel = gen.nextLabel("pop_end");
 
-  gen.emit(`br i1 ${isEmpty}, label %${emptyLabel}, label %${notEmptyLabel}`);
+  gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
   // Empty case - return 0.0
-  gen.emit(`${emptyLabel}:`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitLabel(emptyLabel);
+  gen.emitBr(endLabel);
 
   // Not empty - pop element
-  gen.emit(`${notEmptyLabel}:`);
+  gen.emitLabel(notEmptyLabel);
 
   // Calculate index of last element (length - 1)
   const lastIndex = gen.nextTemp();
@@ -143,12 +142,12 @@ function generateIntArrayPop(gen: IGeneratorContext, arrayPtr: string): string {
   gen.emit(`${lastElem} = load double, double* ${elemPtr}, !tbaa !4`);
 
   // Decrement length
-  gen.emit(`store i32 ${lastIndex}, i32* ${lenPtr}`);
+  gen.emitStore("i32", lastIndex, lenPtr);
 
-  gen.emit(`br label %${endLabel}`);
+  gen.emitBr(endLabel);
 
   // End - phi node to select result
-  gen.emit(`${endLabel}:`);
+  gen.emitLabel(endLabel);
   const result = gen.nextTemp();
   gen.emit(`${result} = phi double [ 0.0, %${emptyLabel} ], [ ${lastElem}, %${notEmptyLabel} ]`);
 
@@ -167,24 +166,22 @@ function generateStringArrayPop(gen: IGeneratorContext, arrayPtr: string): strin
   gen.emit(`${currentLen} = load i32, i32* ${lenPtr}`);
 
   // Check if array is empty
-  const isEmpty = gen.nextTemp();
-  gen.emit(`${isEmpty} = icmp eq i32 ${currentLen}, 0`);
+  const isEmpty = gen.emitIcmp("eq", "i32", currentLen, "0");
 
   const emptyLabel = gen.nextLabel("pop_empty");
   const notEmptyLabel = gen.nextLabel("pop_notempty");
   const endLabel = gen.nextLabel("pop_end");
 
-  gen.emit(`br i1 ${isEmpty}, label %${emptyLabel}, label %${notEmptyLabel}`);
+  gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
   // Empty case - return empty string
-  gen.emit(`${emptyLabel}:`);
-  const emptyStr = gen.nextTemp();
-  gen.emit(`${emptyStr} = call i8* @GC_malloc_atomic(i64 1)`);
-  gen.emit(`store i8 0, i8* ${emptyStr}`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitLabel(emptyLabel);
+  const emptyStr = gen.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  gen.emitStore("i8", "0", emptyStr);
+  gen.emitBr(endLabel);
 
   // Not empty - pop element
-  gen.emit(`${notEmptyLabel}:`);
+  gen.emitLabel(notEmptyLabel);
 
   // Calculate index of last element (length - 1)
   const lastIndex = gen.nextTemp();
@@ -205,12 +202,12 @@ function generateStringArrayPop(gen: IGeneratorContext, arrayPtr: string): strin
   gen.emit(`${lastElem} = load i8*, i8** ${elemPtr}, !tbaa !5`);
 
   // Decrement length
-  gen.emit(`store i32 ${lastIndex}, i32* ${lenPtr}`);
+  gen.emitStore("i32", lastIndex, lenPtr);
 
-  gen.emit(`br label %${endLabel}`);
+  gen.emitBr(endLabel);
 
   // End - phi node to select result
-  gen.emit(`${endLabel}:`);
+  gen.emitLabel(endLabel);
   const result = gen.nextTemp();
   gen.emit(
     `${result} = phi i8* [ ${emptyStr}, %${emptyLabel} ], [ ${lastElem}, %${notEmptyLabel} ]`,
@@ -221,29 +218,27 @@ function generateStringArrayPop(gen: IGeneratorContext, arrayPtr: string): strin
 }
 
 function generatePointerArrayPop(gen: IGeneratorContext, arrayPtr: string): string {
-  const castPtr = gen.nextTemp();
-  gen.emit(`${castPtr} = bitcast i8* ${arrayPtr} to %Array*`);
+  const castPtr = gen.emitBitcast(arrayPtr, "i8*", "%Array*");
 
   const lenPtr = gen.nextTemp();
   gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${castPtr}, i32 0, i32 1`);
   const currentLen = gen.nextTemp();
   gen.emit(`${currentLen} = load i32, i32* ${lenPtr}`);
 
-  const isEmpty = gen.nextTemp();
-  gen.emit(`${isEmpty} = icmp eq i32 ${currentLen}, 0`);
+  const isEmpty = gen.emitIcmp("eq", "i32", currentLen, "0");
 
   const emptyLabel = gen.nextLabel("pop_empty");
   const notEmptyLabel = gen.nextLabel("pop_notempty");
   const endLabel = gen.nextLabel("pop_end");
 
-  gen.emit(`br i1 ${isEmpty}, label %${emptyLabel}, label %${notEmptyLabel}`);
+  gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
-  gen.emit(`${emptyLabel}:`);
+  gen.emitLabel(emptyLabel);
   const nullPtr = gen.nextTemp();
   gen.emit(`${nullPtr} = inttoptr i64 0 to i8*`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${notEmptyLabel}:`);
+  gen.emitLabel(notEmptyLabel);
 
   const lastIndex = gen.nextTemp();
   gen.emit(`${lastIndex} = sub i32 ${currentLen}, 1`);
@@ -252,19 +247,18 @@ function generatePointerArrayPop(gen: IGeneratorContext, arrayPtr: string): stri
   gen.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${castPtr}, i32 0, i32 0`);
   const dataPtrRaw = gen.nextTemp();
   gen.emit(`${dataPtrRaw} = load double*, double** ${dataPtrField}, !tbaa !5`);
-  const dataPtr = gen.nextTemp();
-  gen.emit(`${dataPtr} = bitcast double* ${dataPtrRaw} to i8**`);
+  const dataPtr = gen.emitBitcast(dataPtrRaw, "double*", "i8**");
 
   const elemPtr = gen.nextTemp();
   gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${lastIndex}`);
   const lastElem = gen.nextTemp();
   gen.emit(`${lastElem} = load i8*, i8** ${elemPtr}, !tbaa !5`);
 
-  gen.emit(`store i32 ${lastIndex}, i32* ${lenPtr}`);
+  gen.emitStore("i32", lastIndex, lenPtr);
 
-  gen.emit(`br label %${endLabel}`);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${endLabel}:`);
+  gen.emitLabel(endLabel);
   const result = gen.nextTemp();
   gen.emit(
     `${result} = phi i8* [ ${nullPtr}, %${emptyLabel} ], [ ${lastElem}, %${notEmptyLabel} ]`,
@@ -290,20 +284,18 @@ function generateIntArrayPush(gen: IGeneratorContext, arrayPtr: string, value: s
   gen.emit(`${currentCap} = load i32, i32* ${capPtr}`);
 
   // Check if we need to resize (length == capacity)
-  const needResize = gen.nextTemp();
-  gen.emit(`${needResize} = icmp eq i32 ${currentLen}, ${currentCap}`);
+  const needResize = gen.emitIcmp("eq", "i32", currentLen, currentCap);
 
   // Create labels for resize and continue paths
   const resizeLabel = gen.nextLabel("resize");
   const continueLabel = gen.nextLabel("continue");
 
-  gen.emit(`br i1 ${needResize}, label %${resizeLabel}, label %${continueLabel}`);
+  gen.emitBrCond(needResize, resizeLabel, continueLabel);
 
   // Resize block
-  gen.emit(`${resizeLabel}:`);
+  gen.emitLabel(resizeLabel);
   // Handle case where currentCap is 0 - set to 2, otherwise double it
-  const isZero = gen.nextTemp();
-  gen.emit(`${isZero} = icmp eq i32 ${currentCap}, 0`);
+  const isZero = gen.emitIcmp("eq", "i32", currentCap, "0");
   const doubled = gen.nextTemp();
   gen.emit(`${doubled} = mul i32 ${currentCap}, 2`);
   const newCap = gen.nextTemp();
@@ -314,21 +306,16 @@ function generateIntArrayPush(gen: IGeneratorContext, arrayPtr: string, value: s
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
   gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.nextTemp();
-  gen.emit(`${newMem} = call i8* @GC_malloc_atomic(i64 ${newMemSize})`); // GC_malloc_atomic for numeric data
-  const newDataPtr = gen.nextTemp();
-  gen.emit(`${newDataPtr} = bitcast i8* ${newMem} to double*`);
+  const newMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newMemSize}`);
+  const newDataPtr = gen.emitBitcast(newMem, "i8*", "double*");
 
   // Copy old data to new array
   const dataPtrField = gen.nextTemp();
   gen.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
-  const oldDataPtr = gen.nextTemp();
-  gen.emit(`${oldDataPtr} = load double*, double** ${dataPtrField}`);
+  const oldDataPtr = gen.emitLoad("double*", dataPtrField);
 
-  const oldDataI8 = gen.nextTemp();
-  gen.emit(`${oldDataI8} = bitcast double* ${oldDataPtr} to i8*`);
-  const newDataI8 = gen.nextTemp();
-  gen.emit(`${newDataI8} = bitcast double* ${newDataPtr} to i8*`);
+  const oldDataI8 = gen.emitBitcast(oldDataPtr, "double*", "i8*");
+  const newDataI8 = gen.emitBitcast(newDataPtr, "double*", "i8*");
   // Compute copy size dynamically based on double size
   const doubleSize = gen.getDoubleSize();
   const currentLenI64 = gen.nextTemp();
@@ -340,15 +327,15 @@ function generateIntArrayPush(gen: IGeneratorContext, arrayPtr: string, value: s
   );
 
   // Update pointer (GC will free old data)
-  gen.emit(`store double* ${newDataPtr}, double** ${dataPtrField}`);
+  gen.emitStore("double*", newDataPtr, dataPtrField);
 
   // Update capacity
-  gen.emit(`store i32 ${newCap}, i32* ${capPtr}`);
+  gen.emitStore("i32", newCap, capPtr);
 
-  gen.emit(`br label %${continueLabel}`);
+  gen.emitBr(continueLabel);
 
   // Continue block
-  gen.emit(`${continueLabel}:`);
+  gen.emitLabel(continueLabel);
 
   // Get current data pointer (may have been updated)
   const dataPtrField2 = gen.nextTemp();
@@ -365,7 +352,7 @@ function generateIntArrayPush(gen: IGeneratorContext, arrayPtr: string, value: s
   // Increment length
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = add i32 ${currentLen}, 1`);
-  gen.emit(`store i32 ${newLen}, i32* ${lenPtr}`);
+  gen.emitStore("i32", newLen, lenPtr);
 
   // Return new length as double (JavaScript semantics)
   const newLenDouble = gen.nextTemp();
@@ -394,20 +381,18 @@ function generateStringArrayPush(gen: IGeneratorContext, arrayPtr: string, value
   gen.emit(`${currentCap} = load i32, i32* ${capPtr}`);
 
   // Check if we need to resize (length == capacity)
-  const needResize = gen.nextTemp();
-  gen.emit(`${needResize} = icmp eq i32 ${currentLen}, ${currentCap}`);
+  const needResize = gen.emitIcmp("eq", "i32", currentLen, currentCap);
 
   // Create labels for resize and continue paths
   const resizeLabel = gen.nextLabel("resize");
   const continueLabel = gen.nextLabel("continue");
 
-  gen.emit(`br i1 ${needResize}, label %${resizeLabel}, label %${continueLabel}`);
+  gen.emitBrCond(needResize, resizeLabel, continueLabel);
 
   // Resize block
-  gen.emit(`${resizeLabel}:`);
+  gen.emitLabel(resizeLabel);
   // Handle case where currentCap is 0 - set to 2, otherwise double it
-  const isZero = gen.nextTemp();
-  gen.emit(`${isZero} = icmp eq i32 ${currentCap}, 0`);
+  const isZero = gen.emitIcmp("eq", "i32", currentCap, "0");
   const doubled = gen.nextTemp();
   gen.emit(`${doubled} = mul i32 ${currentCap}, 2`);
   const newCap = gen.nextTemp();
@@ -418,23 +403,18 @@ function generateStringArrayPush(gen: IGeneratorContext, arrayPtr: string, value
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
   gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.nextTemp();
-  gen.emit(`${newMem} = call i8* @GC_malloc(i64 ${newMemSize})`); // GC_malloc for pointer array
-  const newDataPtr = gen.nextTemp();
-  gen.emit(`${newDataPtr} = bitcast i8* ${newMem} to i8**`);
+  const newMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${newMemSize}`);
+  const newDataPtr = gen.emitBitcast(newMem, "i8*", "i8**");
 
   // Copy old data to new array
   const dataPtrField = gen.nextTemp();
   gen.emit(
     `${dataPtrField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
   );
-  const oldDataPtr = gen.nextTemp();
-  gen.emit(`${oldDataPtr} = load i8**, i8*** ${dataPtrField}`);
+  const oldDataPtr = gen.emitLoad("i8**", dataPtrField);
 
-  const oldDataI8 = gen.nextTemp();
-  gen.emit(`${oldDataI8} = bitcast i8** ${oldDataPtr} to i8*`);
-  const newDataI8 = gen.nextTemp();
-  gen.emit(`${newDataI8} = bitcast i8** ${newDataPtr} to i8*`);
+  const oldDataI8 = gen.emitBitcast(oldDataPtr, "i8**", "i8*");
+  const newDataI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
   const copySize = gen.nextTemp();
   gen.emit(`${copySize} = mul i32 ${currentLen}, 8`); // 8 bytes per pointer
   const copySizeI64 = gen.nextTemp();
@@ -444,15 +424,15 @@ function generateStringArrayPush(gen: IGeneratorContext, arrayPtr: string, value
   );
 
   // Update pointer (GC will free old data)
-  gen.emit(`store i8** ${newDataPtr}, i8*** ${dataPtrField}`);
+  gen.emitStore("i8**", newDataPtr, dataPtrField);
 
   // Update capacity
-  gen.emit(`store i32 ${newCap}, i32* ${capPtr}`);
+  gen.emitStore("i32", newCap, capPtr);
 
-  gen.emit(`br label %${continueLabel}`);
+  gen.emitBr(continueLabel);
 
   // Continue block
-  gen.emit(`${continueLabel}:`);
+  gen.emitLabel(continueLabel);
 
   // Get current data pointer (may have been updated)
   const dataPtrField2 = gen.nextTemp();
@@ -470,7 +450,7 @@ function generateStringArrayPush(gen: IGeneratorContext, arrayPtr: string, value
   // Increment length
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = add i32 ${currentLen}, 1`);
-  gen.emit(`store i32 ${newLen}, i32* ${lenPtr}`);
+  gen.emitStore("i32", newLen, lenPtr);
 
   // Return new length as double (JavaScript semantics)
   const newLenDouble = gen.nextTemp();
@@ -495,17 +475,15 @@ function generatePointerArrayPush(
   const currentCap = gen.nextTemp();
   gen.emit(`${currentCap} = load i32, i32* ${capPtr}`);
 
-  const needResize = gen.nextTemp();
-  gen.emit(`${needResize} = icmp eq i32 ${currentLen}, ${currentCap}`);
+  const needResize = gen.emitIcmp("eq", "i32", currentLen, currentCap);
 
   const resizeLabel = gen.nextLabel("resize");
   const continueLabel = gen.nextLabel("continue");
 
-  gen.emit(`br i1 ${needResize}, label %${resizeLabel}, label %${continueLabel}`);
+  gen.emitBrCond(needResize, resizeLabel, continueLabel);
 
-  gen.emit(`${resizeLabel}:`);
-  const isZero = gen.nextTemp();
-  gen.emit(`${isZero} = icmp eq i32 ${currentCap}, 0`);
+  gen.emitLabel(resizeLabel);
+  const isZero = gen.emitIcmp("eq", "i32", currentCap, "0");
   const doubled = gen.nextTemp();
   gen.emit(`${doubled} = mul i32 ${currentCap}, 2`);
   const newCap = gen.nextTemp();
@@ -515,22 +493,16 @@ function generatePointerArrayPush(
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
   gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.nextTemp();
-  gen.emit(`${newMem} = call i8* @GC_malloc(i64 ${newMemSize})`);
-  const newDataPtr = gen.nextTemp();
-  gen.emit(`${newDataPtr} = bitcast i8* ${newMem} to i8**`);
+  const newMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${newMemSize}`);
+  const newDataPtr = gen.emitBitcast(newMem, "i8*", "i8**");
 
   const dataPtrField = gen.nextTemp();
   gen.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
-  const oldDataPtrRaw = gen.nextTemp();
-  gen.emit(`${oldDataPtrRaw} = load double*, double** ${dataPtrField}`);
-  const oldDataPtr = gen.nextTemp();
-  gen.emit(`${oldDataPtr} = bitcast double* ${oldDataPtrRaw} to i8**`);
+  const oldDataPtrRaw = gen.emitLoad("double*", dataPtrField);
+  const oldDataPtr = gen.emitBitcast(oldDataPtrRaw, "double*", "i8**");
 
-  const oldDataI8 = gen.nextTemp();
-  gen.emit(`${oldDataI8} = bitcast i8** ${oldDataPtr} to i8*`);
-  const newDataI8 = gen.nextTemp();
-  gen.emit(`${newDataI8} = bitcast i8** ${newDataPtr} to i8*`);
+  const oldDataI8 = gen.emitBitcast(oldDataPtr, "i8**", "i8*");
+  const newDataI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
   const copySize = gen.nextTemp();
   gen.emit(`${copySize} = mul i32 ${currentLen}, 8`);
   const copySizeI64 = gen.nextTemp();
@@ -539,32 +511,29 @@ function generatePointerArrayPush(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newDataI8}, i8* ${oldDataI8}, i64 ${copySizeI64}, i1 false)`,
   );
 
-  const newDataPtrAsDouble = gen.nextTemp();
-  gen.emit(`${newDataPtrAsDouble} = bitcast i8** ${newDataPtr} to double*`);
-  gen.emit(`store double* ${newDataPtrAsDouble}, double** ${dataPtrField}`);
+  const newDataPtrAsDouble = gen.emitBitcast(newDataPtr, "i8**", "double*");
+  gen.emitStore("double*", newDataPtrAsDouble, dataPtrField);
 
-  gen.emit(`store i32 ${newCap}, i32* ${capPtr}`);
+  gen.emitStore("i32", newCap, capPtr);
 
-  gen.emit(`br label %${continueLabel}`);
+  gen.emitBr(continueLabel);
 
-  gen.emit(`${continueLabel}:`);
+  gen.emitLabel(continueLabel);
 
   const dataPtrField2 = gen.nextTemp();
   gen.emit(`${dataPtrField2} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
   const dataPtrRaw = gen.nextTemp();
   gen.emit(`${dataPtrRaw} = load double*, double** ${dataPtrField2}, !tbaa !5`);
-  const dataPtr = gen.nextTemp();
-  gen.emit(`${dataPtr} = bitcast double* ${dataPtrRaw} to i8**`);
+  const dataPtr = gen.emitBitcast(dataPtrRaw, "double*", "i8**");
 
   const elemPtr = gen.nextTemp();
   gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${currentLen}`);
-  const valueAsI8 = gen.nextTemp();
-  gen.emit(`${valueAsI8} = bitcast ${valueType} ${value} to i8*`);
+  const valueAsI8 = gen.emitBitcast(value, valueType, "i8*");
   gen.emit(`store i8* ${valueAsI8}, i8** ${elemPtr}, !tbaa !5`);
 
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = add i32 ${currentLen}, 1`);
-  gen.emit(`store i32 ${newLen}, i32* ${lenPtr}`);
+  gen.emitStore("i32", newLen, lenPtr);
 
   const newLenDouble = gen.nextTemp();
   gen.emit(`${newLenDouble} = sitofp i32 ${newLen} to double`);
@@ -592,17 +561,15 @@ function generateObjectArrayPush(
   const currentCap = gen.nextTemp();
   gen.emit(`${currentCap} = load i32, i32* ${capPtr}`);
 
-  const needResize = gen.nextTemp();
-  gen.emit(`${needResize} = icmp eq i32 ${currentLen}, ${currentCap}`);
+  const needResize = gen.emitIcmp("eq", "i32", currentLen, currentCap);
 
   const resizeLabel = gen.nextLabel("resize");
   const continueLabel = gen.nextLabel("continue");
 
-  gen.emit(`br i1 ${needResize}, label %${resizeLabel}, label %${continueLabel}`);
+  gen.emitBrCond(needResize, resizeLabel, continueLabel);
 
-  gen.emit(`${resizeLabel}:`);
-  const isZero = gen.nextTemp();
-  gen.emit(`${isZero} = icmp eq i32 ${currentCap}, 0`);
+  gen.emitLabel(resizeLabel);
+  const isZero = gen.emitIcmp("eq", "i32", currentCap, "0");
   const doubled = gen.nextTemp();
   gen.emit(`${doubled} = mul i32 ${currentCap}, 2`);
   const newCap = gen.nextTemp();
@@ -612,24 +579,18 @@ function generateObjectArrayPush(
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
   gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.nextTemp();
-  gen.emit(`${newMem} = call i8* @GC_malloc(i64 ${newMemSize})`);
-  const newDataPtr = gen.nextTemp();
-  gen.emit(`${newDataPtr} = bitcast i8* ${newMem} to i8**`);
+  const newMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${newMemSize}`);
+  const newDataPtr = gen.emitBitcast(newMem, "i8*", "i8**");
 
   const dataPtrField = gen.nextTemp();
   gen.emit(
     `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
   );
-  const oldDataPtrRaw = gen.nextTemp();
-  gen.emit(`${oldDataPtrRaw} = load i8*, i8** ${dataPtrField}`);
-  const oldDataPtr = gen.nextTemp();
-  gen.emit(`${oldDataPtr} = bitcast i8* ${oldDataPtrRaw} to i8**`);
+  const oldDataPtrRaw = gen.emitLoad("i8*", dataPtrField);
+  const oldDataPtr = gen.emitBitcast(oldDataPtrRaw, "i8*", "i8**");
 
-  const oldDataI8 = gen.nextTemp();
-  gen.emit(`${oldDataI8} = bitcast i8** ${oldDataPtr} to i8*`);
-  const newDataI8 = gen.nextTemp();
-  gen.emit(`${newDataI8} = bitcast i8** ${newDataPtr} to i8*`);
+  const oldDataI8 = gen.emitBitcast(oldDataPtr, "i8**", "i8*");
+  const newDataI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
   const copySize = gen.nextTemp();
   gen.emit(`${copySize} = mul i32 ${currentLen}, 8`);
   const copySizeI64 = gen.nextTemp();
@@ -638,15 +599,14 @@ function generateObjectArrayPush(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newDataI8}, i8* ${oldDataI8}, i64 ${copySizeI64}, i1 false)`,
   );
 
-  const newDataPtrAsI8 = gen.nextTemp();
-  gen.emit(`${newDataPtrAsI8} = bitcast i8** ${newDataPtr} to i8*`);
-  gen.emit(`store i8* ${newDataPtrAsI8}, i8** ${dataPtrField}`);
+  const newDataPtrAsI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
+  gen.emitStore("i8*", newDataPtrAsI8, dataPtrField);
 
-  gen.emit(`store i32 ${newCap}, i32* ${capPtr}`);
+  gen.emitStore("i32", newCap, capPtr);
 
-  gen.emit(`br label %${continueLabel}`);
+  gen.emitBr(continueLabel);
 
-  gen.emit(`${continueLabel}:`);
+  gen.emitLabel(continueLabel);
 
   const dataPtrField2 = gen.nextTemp();
   gen.emit(
@@ -654,18 +614,16 @@ function generateObjectArrayPush(
   );
   const dataPtrRaw = gen.nextTemp();
   gen.emit(`${dataPtrRaw} = load i8*, i8** ${dataPtrField2}, !tbaa !5`);
-  const dataPtr = gen.nextTemp();
-  gen.emit(`${dataPtr} = bitcast i8* ${dataPtrRaw} to i8**`);
+  const dataPtr = gen.emitBitcast(dataPtrRaw, "i8*", "i8**");
 
   const elemPtr = gen.nextTemp();
   gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${currentLen}`);
-  const valueAsI8 = gen.nextTemp();
-  gen.emit(`${valueAsI8} = bitcast ${valueType} ${value} to i8*`);
+  const valueAsI8 = gen.emitBitcast(value, valueType, "i8*");
   gen.emit(`store i8* ${valueAsI8}, i8** ${elemPtr}, !tbaa !5`);
 
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = add i32 ${currentLen}, 1`);
-  gen.emit(`store i32 ${newLen}, i32* ${lenPtr}`);
+  gen.emitStore("i32", newLen, lenPtr);
 
   const newLenDouble = gen.nextTemp();
   gen.emit(`${newLenDouble} = sitofp i32 ${newLen} to double`);

--- a/src/codegen/types/collections/array/reorder.ts
+++ b/src/codegen/types/collections/array/reorder.ts
@@ -1,24 +1,15 @@
-// NOTE: This file uses raw ctx.emit() extensively. Prefer structured IR builders
-// (emitStore, emitLoad, emitCall, etc.) when modifying — see .claude/rules.md.
+// Array reorder operations: reverse, shift, unshift.
+// Uses structured IR builders where possible; raw emit() for inbounds GEP, tbaa, intrinsics, etc.
 
-import { Expression, MethodCallNode, VariableNode } from "../../../../ast/types.js";
+import { MethodCallNode, VariableNode } from "../../../../ast/types.js";
+import { IGeneratorContext } from "./context.js";
 
 interface ExprBase {
   type: string;
 }
 
-interface ArrayReorderContext {
-  nextTemp(): string;
-  nextLabel(prefix: string): string;
-  emit(instruction: string): void;
-  getVariableType(name: string): string | undefined;
-  setVariableType(name: string, type: string): void;
-  generateExpression(expr: Expression, params: string[]): string;
-  ensureDouble(value: string): string;
-}
-
 export function generateArrayReverse(
-  gen: ArrayReorderContext,
+  gen: IGeneratorContext,
   expr: MethodCallNode,
   params: string[],
 ): string {
@@ -46,7 +37,7 @@ export function generateArrayReverse(
   return generateNumericArrayReverseInPlace(gen, arrayPtr);
 }
 
-function generateNumericArrayReverseInPlace(gen: ArrayReorderContext, arrayPtr: string): string {
+function generateNumericArrayReverseInPlace(gen: IGeneratorContext, arrayPtr: string): string {
   const lenPtr = gen.nextTemp();
   gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
   const length = gen.nextTemp();
@@ -64,50 +55,46 @@ function generateNumericArrayReverseInPlace(gen: ArrayReorderContext, arrayPtr: 
 
   const loopPtr = gen.nextTemp();
   gen.emit(`${loopPtr} = alloca i32`);
-  gen.emit(`store i32 0, i32* ${loopPtr}`);
+  gen.emitStore("i32", "0", loopPtr);
 
   const checkLabel = gen.nextLabel("rev_check");
   const bodyLabel = gen.nextLabel("rev_body");
   const endLabel = gen.nextLabel("rev_end");
 
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${checkLabel}:`);
-  const i = gen.nextTemp();
-  gen.emit(`${i} = load i32, i32* ${loopPtr}`);
-  const cond = gen.nextTemp();
-  gen.emit(`${cond} = icmp slt i32 ${i}, ${half}`);
-  gen.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+  gen.emitLabel(checkLabel);
+  const i = gen.emitLoad("i32", loopPtr);
+  const cond = gen.emitIcmp("slt", "i32", i, half);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
 
-  gen.emit(`${bodyLabel}:`);
+  gen.emitLabel(bodyLabel);
   const j = gen.nextTemp();
   gen.emit(`${j} = sub i32 ${lastIdx}, ${i}`);
 
   const ptrI = gen.nextTemp();
   gen.emit(`${ptrI} = getelementptr inbounds double, double* ${dataPtr}, i32 ${i}`);
-  const valI = gen.nextTemp();
-  gen.emit(`${valI} = load double, double* ${ptrI}`);
+  const valI = gen.emitLoad("double", ptrI);
 
   const ptrJ = gen.nextTemp();
   gen.emit(`${ptrJ} = getelementptr inbounds double, double* ${dataPtr}, i32 ${j}`);
-  const valJ = gen.nextTemp();
-  gen.emit(`${valJ} = load double, double* ${ptrJ}`);
+  const valJ = gen.emitLoad("double", ptrJ);
 
-  gen.emit(`store double ${valJ}, double* ${ptrI}`);
-  gen.emit(`store double ${valI}, double* ${ptrJ}`);
+  gen.emitStore("double", valJ, ptrI);
+  gen.emitStore("double", valI, ptrJ);
 
   const nextI = gen.nextTemp();
   gen.emit(`${nextI} = add i32 ${i}, 1`);
-  gen.emit(`store i32 ${nextI}, i32* ${loopPtr}`);
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitStore("i32", nextI, loopPtr);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${endLabel}:`);
+  gen.emitLabel(endLabel);
 
   gen.setVariableType(arrayPtr, "%Array*");
   return arrayPtr;
 }
 
-function generateStringArrayReverseInPlace(gen: ArrayReorderContext, arrayPtr: string): string {
+function generateStringArrayReverseInPlace(gen: IGeneratorContext, arrayPtr: string): string {
   const lenPtr = gen.nextTemp();
   gen.emit(
     `${lenPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
@@ -129,51 +116,47 @@ function generateStringArrayReverseInPlace(gen: ArrayReorderContext, arrayPtr: s
 
   const loopPtr = gen.nextTemp();
   gen.emit(`${loopPtr} = alloca i32`);
-  gen.emit(`store i32 0, i32* ${loopPtr}`);
+  gen.emitStore("i32", "0", loopPtr);
 
   const checkLabel = gen.nextLabel("rev_check");
   const bodyLabel = gen.nextLabel("rev_body");
   const endLabel = gen.nextLabel("rev_end");
 
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${checkLabel}:`);
-  const i = gen.nextTemp();
-  gen.emit(`${i} = load i32, i32* ${loopPtr}`);
-  const cond = gen.nextTemp();
-  gen.emit(`${cond} = icmp slt i32 ${i}, ${half}`);
-  gen.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+  gen.emitLabel(checkLabel);
+  const i = gen.emitLoad("i32", loopPtr);
+  const cond = gen.emitIcmp("slt", "i32", i, half);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
 
-  gen.emit(`${bodyLabel}:`);
+  gen.emitLabel(bodyLabel);
   const j = gen.nextTemp();
   gen.emit(`${j} = sub i32 ${lastIdx}, ${i}`);
 
   const ptrI = gen.nextTemp();
   gen.emit(`${ptrI} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${i}`);
-  const valI = gen.nextTemp();
-  gen.emit(`${valI} = load i8*, i8** ${ptrI}`);
+  const valI = gen.emitLoad("i8*", ptrI);
 
   const ptrJ = gen.nextTemp();
   gen.emit(`${ptrJ} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${j}`);
-  const valJ = gen.nextTemp();
-  gen.emit(`${valJ} = load i8*, i8** ${ptrJ}`);
+  const valJ = gen.emitLoad("i8*", ptrJ);
 
-  gen.emit(`store i8* ${valJ}, i8** ${ptrI}`);
-  gen.emit(`store i8* ${valI}, i8** ${ptrJ}`);
+  gen.emitStore("i8*", valJ, ptrI);
+  gen.emitStore("i8*", valI, ptrJ);
 
   const nextI = gen.nextTemp();
   gen.emit(`${nextI} = add i32 ${i}, 1`);
-  gen.emit(`store i32 ${nextI}, i32* ${loopPtr}`);
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitStore("i32", nextI, loopPtr);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${endLabel}:`);
+  gen.emitLabel(endLabel);
 
   gen.setVariableType(arrayPtr, "%StringArray*");
   return arrayPtr;
 }
 
 export function generateArrayShift(
-  gen: ArrayReorderContext,
+  gen: IGeneratorContext,
   expr: MethodCallNode,
   params: string[],
 ): string {
@@ -201,42 +184,38 @@ export function generateArrayShift(
   return generateNumericArrayShift(gen, arrayPtr);
 }
 
-function generateNumericArrayShift(gen: ArrayReorderContext, arrayPtr: string): string {
+function generateNumericArrayShift(gen: IGeneratorContext, arrayPtr: string): string {
   const lenPtr = gen.nextTemp();
   gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
   const currentLen = gen.nextTemp();
   gen.emit(`${currentLen} = load i32, i32* ${lenPtr}`);
 
-  const isEmpty = gen.nextTemp();
-  gen.emit(`${isEmpty} = icmp eq i32 ${currentLen}, 0`);
+  const isEmpty = gen.emitIcmp("eq", "i32", currentLen, "0");
 
   const emptyLabel = gen.nextLabel("shift_empty");
   const notEmptyLabel = gen.nextLabel("shift_notempty");
   const endLabel = gen.nextLabel("shift_end");
 
-  gen.emit(`br i1 ${isEmpty}, label %${emptyLabel}, label %${notEmptyLabel}`);
+  gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
-  gen.emit(`${emptyLabel}:`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitLabel(emptyLabel);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${notEmptyLabel}:`);
+  gen.emitLabel(notEmptyLabel);
   const dataPtrField = gen.nextTemp();
   gen.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
   const dataPtr = gen.nextTemp();
   gen.emit(`${dataPtr} = load double*, double** ${dataPtrField}, !tbaa !5`);
 
-  const firstElem = gen.nextTemp();
-  gen.emit(`${firstElem} = load double, double* ${dataPtr}`);
+  const firstElem = gen.emitLoad("double", dataPtr);
 
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = sub i32 ${currentLen}, 1`);
 
-  const destI8 = gen.nextTemp();
-  gen.emit(`${destI8} = bitcast double* ${dataPtr} to i8*`);
+  const destI8 = gen.emitBitcast(dataPtr, "double*", "i8*");
   const srcPtr = gen.nextTemp();
   gen.emit(`${srcPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 1`);
-  const srcI8 = gen.nextTemp();
-  gen.emit(`${srcI8} = bitcast double* ${srcPtr} to i8*`);
+  const srcI8 = gen.emitBitcast(srcPtr, "double*", "i8*");
   const moveLen = gen.nextTemp();
   gen.emit(`${moveLen} = zext i32 ${newLen} to i64`);
   const moveBytes = gen.nextTemp();
@@ -245,16 +224,16 @@ function generateNumericArrayShift(gen: ArrayReorderContext, arrayPtr: string): 
     `call void @llvm.memmove.p0i8.p0i8.i64(i8* ${destI8}, i8* ${srcI8}, i64 ${moveBytes}, i1 false)`,
   );
 
-  gen.emit(`store i32 ${newLen}, i32* ${lenPtr}`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitStore("i32", newLen, lenPtr);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${endLabel}:`);
+  gen.emitLabel(endLabel);
   const result = gen.nextTemp();
   gen.emit(`${result} = phi double [ 0.0, %${emptyLabel} ], [ ${firstElem}, %${notEmptyLabel} ]`);
   return result;
 }
 
-function generateStringArrayShift(gen: ArrayReorderContext, arrayPtr: string): string {
+function generateStringArrayShift(gen: IGeneratorContext, arrayPtr: string): string {
   const lenPtr = gen.nextTemp();
   gen.emit(
     `${lenPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
@@ -262,22 +241,20 @@ function generateStringArrayShift(gen: ArrayReorderContext, arrayPtr: string): s
   const currentLen = gen.nextTemp();
   gen.emit(`${currentLen} = load i32, i32* ${lenPtr}`);
 
-  const isEmpty = gen.nextTemp();
-  gen.emit(`${isEmpty} = icmp eq i32 ${currentLen}, 0`);
+  const isEmpty = gen.emitIcmp("eq", "i32", currentLen, "0");
 
   const emptyLabel = gen.nextLabel("shift_empty");
   const notEmptyLabel = gen.nextLabel("shift_notempty");
   const endLabel = gen.nextLabel("shift_end");
 
-  gen.emit(`br i1 ${isEmpty}, label %${emptyLabel}, label %${notEmptyLabel}`);
+  gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
-  gen.emit(`${emptyLabel}:`);
-  const emptyStr = gen.nextTemp();
-  gen.emit(`${emptyStr} = call i8* @GC_malloc_atomic(i64 1)`);
-  gen.emit(`store i8 0, i8* ${emptyStr}`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitLabel(emptyLabel);
+  const emptyStr = gen.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  gen.emitStore("i8", "0", emptyStr);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${notEmptyLabel}:`);
+  gen.emitLabel(notEmptyLabel);
   const dataPtrField = gen.nextTemp();
   gen.emit(
     `${dataPtrField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
@@ -285,18 +262,16 @@ function generateStringArrayShift(gen: ArrayReorderContext, arrayPtr: string): s
   const dataPtr = gen.nextTemp();
   gen.emit(`${dataPtr} = load i8**, i8*** ${dataPtrField}, !tbaa !5`);
 
-  const firstElem = gen.nextTemp();
-  gen.emit(`${firstElem} = load i8*, i8** ${dataPtr}`);
+  const firstElem = gen.emitLoad("i8*", dataPtr);
 
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = sub i32 ${currentLen}, 1`);
 
-  const destI8 = gen.nextTemp();
-  gen.emit(`${destI8} = bitcast i8** ${dataPtr} to i8*`);
+  const destI8 = gen.emitBitcast(dataPtr, "i8**", "i8*");
   const srcPtr = gen.nextTemp();
   gen.emit(`${srcPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 1`);
-  const srcI8 = gen.nextTemp();
-  gen.emit(`${srcI8} = bitcast i8* ${srcPtr} to i8*`);
+  // srcPtr is i8* (GEP result of i8** → i8*), cast to i8* for memmove
+  const srcI8 = gen.emitBitcast(srcPtr, "i8*", "i8*");
   const moveLen = gen.nextTemp();
   gen.emit(`${moveLen} = zext i32 ${newLen} to i64`);
   const moveBytes = gen.nextTemp();
@@ -305,10 +280,10 @@ function generateStringArrayShift(gen: ArrayReorderContext, arrayPtr: string): s
     `call void @llvm.memmove.p0i8.p0i8.i64(i8* ${destI8}, i8* ${srcI8}, i64 ${moveBytes}, i1 false)`,
   );
 
-  gen.emit(`store i32 ${newLen}, i32* ${lenPtr}`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitStore("i32", newLen, lenPtr);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${endLabel}:`);
+  gen.emitLabel(endLabel);
   const result = gen.nextTemp();
   gen.emit(
     `${result} = phi i8* [ ${emptyStr}, %${emptyLabel} ], [ ${firstElem}, %${notEmptyLabel} ]`,
@@ -318,7 +293,7 @@ function generateStringArrayShift(gen: ArrayReorderContext, arrayPtr: string): s
 }
 
 export function generateArrayUnshift(
-  gen: ArrayReorderContext,
+  gen: IGeneratorContext,
   expr: MethodCallNode,
   params: string[],
 ): string {
@@ -348,7 +323,7 @@ export function generateArrayUnshift(
 }
 
 function generateNumericArrayUnshift(
-  gen: ArrayReorderContext,
+  gen: IGeneratorContext,
   arrayPtr: string,
   value: string,
 ): string {
@@ -362,17 +337,15 @@ function generateNumericArrayUnshift(
   const currentCap = gen.nextTemp();
   gen.emit(`${currentCap} = load i32, i32* ${capPtr}`);
 
-  const needResize = gen.nextTemp();
-  gen.emit(`${needResize} = icmp eq i32 ${currentLen}, ${currentCap}`);
+  const needResize = gen.emitIcmp("eq", "i32", currentLen, currentCap);
 
   const resizeLabel = gen.nextLabel("unshift_resize");
   const continueLabel = gen.nextLabel("unshift_continue");
 
-  gen.emit(`br i1 ${needResize}, label %${resizeLabel}, label %${continueLabel}`);
+  gen.emitBrCond(needResize, resizeLabel, continueLabel);
 
-  gen.emit(`${resizeLabel}:`);
-  const isZero = gen.nextTemp();
-  gen.emit(`${isZero} = icmp eq i32 ${currentCap}, 0`);
+  gen.emitLabel(resizeLabel);
+  const isZero = gen.emitIcmp("eq", "i32", currentCap, "0");
   const doubled = gen.nextTemp();
   gen.emit(`${doubled} = mul i32 ${currentCap}, 2`);
   const newCap = gen.nextTemp();
@@ -382,19 +355,14 @@ function generateNumericArrayUnshift(
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
   gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.nextTemp();
-  gen.emit(`${newMem} = call i8* @GC_malloc_atomic(i64 ${newMemSize})`);
-  const newDataPtr = gen.nextTemp();
-  gen.emit(`${newDataPtr} = bitcast i8* ${newMem} to double*`);
+  const newMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newMemSize}`);
+  const newDataPtr = gen.emitBitcast(newMem, "i8*", "double*");
 
   const dataPtrField = gen.nextTemp();
   gen.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
-  const oldDataPtr = gen.nextTemp();
-  gen.emit(`${oldDataPtr} = load double*, double** ${dataPtrField}`);
-  const oldDataI8 = gen.nextTemp();
-  gen.emit(`${oldDataI8} = bitcast double* ${oldDataPtr} to i8*`);
-  const newDataI8 = gen.nextTemp();
-  gen.emit(`${newDataI8} = bitcast double* ${newDataPtr} to i8*`);
+  const oldDataPtr = gen.emitLoad("double*", dataPtrField);
+  const oldDataI8 = gen.emitBitcast(oldDataPtr, "double*", "i8*");
+  const newDataI8 = gen.emitBitcast(newDataPtr, "double*", "i8*");
   const currentLenI64 = gen.nextTemp();
   gen.emit(`${currentLenI64} = zext i32 ${currentLen} to i64`);
   const copySize = gen.nextTemp();
@@ -403,11 +371,11 @@ function generateNumericArrayUnshift(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newDataI8}, i8* ${oldDataI8}, i64 ${copySize}, i1 false)`,
   );
 
-  gen.emit(`store double* ${newDataPtr}, double** ${dataPtrField}`);
-  gen.emit(`store i32 ${newCap}, i32* ${capPtr}`);
-  gen.emit(`br label %${continueLabel}`);
+  gen.emitStore("double*", newDataPtr, dataPtrField);
+  gen.emitStore("i32", newCap, capPtr);
+  gen.emitBr(continueLabel);
 
-  gen.emit(`${continueLabel}:`);
+  gen.emitLabel(continueLabel);
 
   const dataPtrField2 = gen.nextTemp();
   gen.emit(`${dataPtrField2} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
@@ -416,10 +384,8 @@ function generateNumericArrayUnshift(
 
   const destPtr = gen.nextTemp();
   gen.emit(`${destPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 1`);
-  const destI8 = gen.nextTemp();
-  gen.emit(`${destI8} = bitcast double* ${destPtr} to i8*`);
-  const srcI8 = gen.nextTemp();
-  gen.emit(`${srcI8} = bitcast double* ${dataPtr} to i8*`);
+  const destI8 = gen.emitBitcast(destPtr, "double*", "i8*");
+  const srcI8 = gen.emitBitcast(dataPtr, "double*", "i8*");
   const moveLenI64 = gen.nextTemp();
   gen.emit(`${moveLenI64} = zext i32 ${currentLen} to i64`);
   const moveBytes = gen.nextTemp();
@@ -433,7 +399,7 @@ function generateNumericArrayUnshift(
 
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = add i32 ${currentLen}, 1`);
-  gen.emit(`store i32 ${newLen}, i32* ${lenPtr}`);
+  gen.emitStore("i32", newLen, lenPtr);
 
   const newLenDouble = gen.nextTemp();
   gen.emit(`${newLenDouble} = sitofp i32 ${newLen} to double`);
@@ -442,7 +408,7 @@ function generateNumericArrayUnshift(
 }
 
 function generateStringArrayUnshift(
-  gen: ArrayReorderContext,
+  gen: IGeneratorContext,
   arrayPtr: string,
   value: string,
 ): string {
@@ -460,17 +426,15 @@ function generateStringArrayUnshift(
   const currentCap = gen.nextTemp();
   gen.emit(`${currentCap} = load i32, i32* ${capPtr}`);
 
-  const needResize = gen.nextTemp();
-  gen.emit(`${needResize} = icmp eq i32 ${currentLen}, ${currentCap}`);
+  const needResize = gen.emitIcmp("eq", "i32", currentLen, currentCap);
 
   const resizeLabel = gen.nextLabel("unshift_resize");
   const continueLabel = gen.nextLabel("unshift_continue");
 
-  gen.emit(`br i1 ${needResize}, label %${resizeLabel}, label %${continueLabel}`);
+  gen.emitBrCond(needResize, resizeLabel, continueLabel);
 
-  gen.emit(`${resizeLabel}:`);
-  const isZero = gen.nextTemp();
-  gen.emit(`${isZero} = icmp eq i32 ${currentCap}, 0`);
+  gen.emitLabel(resizeLabel);
+  const isZero = gen.emitIcmp("eq", "i32", currentCap, "0");
   const doubled = gen.nextTemp();
   gen.emit(`${doubled} = mul i32 ${currentCap}, 2`);
   const newCap = gen.nextTemp();
@@ -480,21 +444,16 @@ function generateStringArrayUnshift(
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
   gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.nextTemp();
-  gen.emit(`${newMem} = call i8* @GC_malloc(i64 ${newMemSize})`);
-  const newDataPtr = gen.nextTemp();
-  gen.emit(`${newDataPtr} = bitcast i8* ${newMem} to i8**`);
+  const newMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${newMemSize}`);
+  const newDataPtr = gen.emitBitcast(newMem, "i8*", "i8**");
 
   const dataPtrField = gen.nextTemp();
   gen.emit(
     `${dataPtrField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
   );
-  const oldDataPtr = gen.nextTemp();
-  gen.emit(`${oldDataPtr} = load i8**, i8*** ${dataPtrField}`);
-  const oldDataI8 = gen.nextTemp();
-  gen.emit(`${oldDataI8} = bitcast i8** ${oldDataPtr} to i8*`);
-  const newDataI8 = gen.nextTemp();
-  gen.emit(`${newDataI8} = bitcast i8** ${newDataPtr} to i8*`);
+  const oldDataPtr = gen.emitLoad("i8**", dataPtrField);
+  const oldDataI8 = gen.emitBitcast(oldDataPtr, "i8**", "i8*");
+  const newDataI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
   const currentLenI64 = gen.nextTemp();
   gen.emit(`${currentLenI64} = zext i32 ${currentLen} to i64`);
   const copySize = gen.nextTemp();
@@ -503,11 +462,11 @@ function generateStringArrayUnshift(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newDataI8}, i8* ${oldDataI8}, i64 ${copySize}, i1 false)`,
   );
 
-  gen.emit(`store i8** ${newDataPtr}, i8*** ${dataPtrField}`);
-  gen.emit(`store i32 ${newCap}, i32* ${capPtr}`);
-  gen.emit(`br label %${continueLabel}`);
+  gen.emitStore("i8**", newDataPtr, dataPtrField);
+  gen.emitStore("i32", newCap, capPtr);
+  gen.emitBr(continueLabel);
 
-  gen.emit(`${continueLabel}:`);
+  gen.emitLabel(continueLabel);
 
   const dataPtrField2 = gen.nextTemp();
   gen.emit(
@@ -518,10 +477,9 @@ function generateStringArrayUnshift(
 
   const destPtr = gen.nextTemp();
   gen.emit(`${destPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 1`);
-  const destI8 = gen.nextTemp();
-  gen.emit(`${destI8} = bitcast i8* ${destPtr} to i8*`);
-  const srcI8 = gen.nextTemp();
-  gen.emit(`${srcI8} = bitcast i8** ${dataPtr} to i8*`);
+  // destPtr GEP result type is i8*, needs cast to i8* for memmove (identity cast, keeps IR identical)
+  const destI8 = gen.emitBitcast(destPtr, "i8*", "i8*");
+  const srcI8 = gen.emitBitcast(dataPtr, "i8**", "i8*");
   const moveLenI64 = gen.nextTemp();
   gen.emit(`${moveLenI64} = zext i32 ${currentLen} to i64`);
   const moveBytes = gen.nextTemp();
@@ -534,7 +492,7 @@ function generateStringArrayUnshift(
 
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = add i32 ${currentLen}, 1`);
-  gen.emit(`store i32 ${newLen}, i32* ${lenPtr}`);
+  gen.emitStore("i32", newLen, lenPtr);
 
   const newLenDouble = gen.nextTemp();
   gen.emit(`${newLenDouble} = sitofp i32 ${newLen} to double`);

--- a/src/codegen/types/collections/array/search-predicate.ts
+++ b/src/codegen/types/collections/array/search-predicate.ts
@@ -1,15 +1,12 @@
 // Array search-predicate operations: find, some, every, includes
-// Extracted from array.ts to reduce file size. Uses IGeneratorContext for IR emission.
+// Exported functions accept (gen, expr, params) and handle predicate resolution internally.
 
 import { MethodCallNode, VariableNode } from "../../../../ast/types.js";
-import { IGeneratorContext, loadArrayMeta } from "./context.js";
+import { IGeneratorContext, loadArrayMeta, detectArrayType } from "./context.js";
 
 interface ExprBase {
   type: string;
 }
-
-// Predicate resolution happens in the facade (array.ts class methods) to work around
-// ChadScript self-hosting issues with expr.args[0].type access in standalone functions.
 
 // ============================================
 // find
@@ -17,15 +14,41 @@ interface ExprBase {
 
 export function generateArrayFind(
   gen: IGeneratorContext,
-  arrayPtr: string,
-  predicateFn: string,
-  isStringArray: boolean,
-  isObjectArray: boolean,
+  expr: MethodCallNode,
+  params: string[],
 ): string {
+  if (expr.args.length !== 1) {
+    throw new Error("find() requires exactly 1 argument (predicate function)");
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+
+  const predicateArg = expr.args[0];
+  let predicateFn: string;
+  if (predicateArg.type === "variable") {
+    predicateFn = gen.mangleUserName((predicateArg as VariableNode).name);
+  } else if (predicateArg.type === "arrow_function") {
+    if (isStringArray || isObjectArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
+    predicateFn = gen.generateExpression(predicateArg, params);
+    gen.setExpectedCallbackParamType(null);
+  } else {
+    throw new Error("find() argument must be a function name or inline function");
+  }
+
   if (isStringArray || isObjectArray) {
     return generateStringArrayFind(gen, arrayPtr, predicateFn);
   }
+  return generateNumericArrayFind(gen, arrayPtr, predicateFn);
+}
 
+function generateNumericArrayFind(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  predicateFn: string,
+): string {
   const arrayMeta = loadArrayMeta(gen, arrayPtr);
   const length = arrayMeta.length;
   const dataPtr = arrayMeta.dataPtr;
@@ -151,15 +174,41 @@ function generateStringArrayFind(
 
 export function generateArraySome(
   gen: IGeneratorContext,
-  arrayPtr: string,
-  predicateFn: string,
-  isStringArray: boolean,
-  isObjectArray: boolean,
+  expr: MethodCallNode,
+  params: string[],
 ): string {
+  if (expr.args.length !== 1) {
+    throw new Error("some() requires exactly 1 argument (predicate function)");
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+
+  const predicateArg = expr.args[0];
+  let predicateFn: string;
+  if (predicateArg.type === "variable") {
+    predicateFn = gen.mangleUserName((predicateArg as VariableNode).name);
+  } else if (predicateArg.type === "arrow_function") {
+    if (isStringArray || isObjectArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
+    predicateFn = gen.generateExpression(predicateArg, params);
+    gen.setExpectedCallbackParamType(null);
+  } else {
+    throw new Error("some() argument must be a function name or inline function");
+  }
+
   if (isStringArray || isObjectArray) {
     return generateStringArraySome(gen, arrayPtr, predicateFn);
   }
+  return generateNumericArraySome(gen, arrayPtr, predicateFn);
+}
 
+function generateNumericArraySome(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  predicateFn: string,
+): string {
   const arrayMeta = loadArrayMeta(gen, arrayPtr);
   const length = arrayMeta.length;
   const dataPtr = arrayMeta.dataPtr;
@@ -287,15 +336,41 @@ function generateStringArraySome(
 
 export function generateArrayEvery(
   gen: IGeneratorContext,
-  arrayPtr: string,
-  predicateFn: string,
-  isStringArray: boolean,
-  isObjectArray: boolean,
+  expr: MethodCallNode,
+  params: string[],
 ): string {
+  if (expr.args.length !== 1) {
+    throw new Error("every() requires exactly 1 argument (predicate function)");
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+
+  const predicateArg = expr.args[0];
+  let predicateFn: string;
+  if (predicateArg.type === "variable") {
+    predicateFn = gen.mangleUserName((predicateArg as VariableNode).name);
+  } else if (predicateArg.type === "arrow_function") {
+    if (isStringArray || isObjectArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
+    predicateFn = gen.generateExpression(predicateArg, params);
+    gen.setExpectedCallbackParamType(null);
+  } else {
+    throw new Error("every() argument must be a function name or inline function");
+  }
+
   if (isStringArray || isObjectArray) {
     return generateStringArrayEvery(gen, arrayPtr, predicateFn);
   }
+  return generateNumericArrayEvery(gen, arrayPtr, predicateFn);
+}
 
+function generateNumericArrayEvery(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  predicateFn: string,
+): string {
   const arrayMeta = loadArrayMeta(gen, arrayPtr);
   const length = arrayMeta.length;
   const dataPtr = arrayMeta.dataPtr;

--- a/src/codegen/types/collections/array/search.ts
+++ b/src/codegen/types/collections/array/search.ts
@@ -1,24 +1,15 @@
-// NOTE: This file uses raw ctx.emit() extensively. Prefer structured IR builders
-// (emitStore, emitLoad, emitCall, etc.) when modifying — see .claude/rules.md.
+// Array search operations: indexOf, findIndex.
+// Uses structured IR builders where possible; raw emit() for inbounds GEP, tbaa, intrinsics, etc.
 
-import { Expression, MethodCallNode, VariableNode } from "../../../../ast/types.js";
+import { MethodCallNode, VariableNode } from "../../../../ast/types.js";
+import { IGeneratorContext } from "./context.js";
 
 interface ExprBase {
   type: string;
 }
 
-interface ArraySearchContext {
-  nextTemp(): string;
-  nextLabel(prefix: string): string;
-  emit(instruction: string): void;
-  getVariableType(name: string): string | undefined;
-  setVariableType(name: string, type: string): void;
-  generateExpression(expr: Expression, params: string[]): string;
-  ensureDouble(value: string): string;
-}
-
 export function generateArrayIndexOf(
-  gen: ArraySearchContext,
+  gen: IGeneratorContext,
   expr: MethodCallNode,
   params: string[],
 ): string {
@@ -48,7 +39,7 @@ export function generateArrayIndexOf(
 }
 
 function generateNumericArrayIndexOf(
-  gen: ArraySearchContext,
+  gen: IGeneratorContext,
   arrayPtr: string,
   searchValue: string,
 ): string {
@@ -64,11 +55,11 @@ function generateNumericArrayIndexOf(
 
   const resultPtr = gen.nextTemp();
   gen.emit(`${resultPtr} = alloca i32`);
-  gen.emit(`store i32 -1, i32* ${resultPtr}`);
+  gen.emitStore("i32", "-1", resultPtr);
 
   const loopPtr = gen.nextTemp();
   gen.emit(`${loopPtr} = alloca i32`);
-  gen.emit(`store i32 0, i32* ${loopPtr}`);
+  gen.emitStore("i32", "0", loopPtr);
 
   const checkLabel = gen.nextLabel("indexof_check");
   const bodyLabel = gen.nextLabel("indexof_body");
@@ -76,46 +67,42 @@ function generateNumericArrayIndexOf(
   const nextLabel = gen.nextLabel("indexof_next");
   const endLabel = gen.nextLabel("indexof_end");
 
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${checkLabel}:`);
-  const i = gen.nextTemp();
-  gen.emit(`${i} = load i32, i32* ${loopPtr}`);
-  const cond = gen.nextTemp();
-  gen.emit(`${cond} = icmp slt i32 ${i}, ${length}`);
-  gen.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+  gen.emitLabel(checkLabel);
+  const i = gen.emitLoad("i32", loopPtr);
+  const cond = gen.emitIcmp("slt", "i32", i, length);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
 
-  gen.emit(`${bodyLabel}:`);
+  gen.emitLabel(bodyLabel);
   const elemPtr = gen.nextTemp();
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${i}`);
-  const elem = gen.nextTemp();
-  gen.emit(`${elem} = load double, double* ${elemPtr}`);
+  const elem = gen.emitLoad("double", elemPtr);
 
   const dblSearch = gen.ensureDouble(searchValue);
   const eq = gen.nextTemp();
   gen.emit(`${eq} = fcmp oeq double ${elem}, ${dblSearch}`);
-  gen.emit(`br i1 ${eq}, label %${foundLabel}, label %${nextLabel}`);
+  gen.emitBrCond(eq, foundLabel, nextLabel);
 
-  gen.emit(`${foundLabel}:`);
-  gen.emit(`store i32 ${i}, i32* ${resultPtr}`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitLabel(foundLabel);
+  gen.emitStore("i32", i, resultPtr);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${nextLabel}:`);
+  gen.emitLabel(nextLabel);
   const nextI = gen.nextTemp();
   gen.emit(`${nextI} = add i32 ${i}, 1`);
-  gen.emit(`store i32 ${nextI}, i32* ${loopPtr}`);
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitStore("i32", nextI, loopPtr);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${endLabel}:`);
-  const resultI32 = gen.nextTemp();
-  gen.emit(`${resultI32} = load i32, i32* ${resultPtr}`);
+  gen.emitLabel(endLabel);
+  const resultI32 = gen.emitLoad("i32", resultPtr);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
   return result;
 }
 
 function generateStringArrayIndexOf(
-  gen: ArraySearchContext,
+  gen: IGeneratorContext,
   arrayPtr: string,
   searchValue: string,
 ): string {
@@ -135,11 +122,11 @@ function generateStringArrayIndexOf(
 
   const resultPtr = gen.nextTemp();
   gen.emit(`${resultPtr} = alloca i32`);
-  gen.emit(`store i32 -1, i32* ${resultPtr}`);
+  gen.emitStore("i32", "-1", resultPtr);
 
   const loopPtr = gen.nextTemp();
   gen.emit(`${loopPtr} = alloca i32`);
-  gen.emit(`store i32 0, i32* ${loopPtr}`);
+  gen.emitStore("i32", "0", loopPtr);
 
   const checkLabel = gen.nextLabel("indexof_check");
   const bodyLabel = gen.nextLabel("indexof_body");
@@ -147,53 +134,71 @@ function generateStringArrayIndexOf(
   const nextLabel = gen.nextLabel("indexof_next");
   const endLabel = gen.nextLabel("indexof_end");
 
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${checkLabel}:`);
-  const i = gen.nextTemp();
-  gen.emit(`${i} = load i32, i32* ${loopPtr}`);
-  const cond = gen.nextTemp();
-  gen.emit(`${cond} = icmp slt i32 ${i}, ${length}`);
-  gen.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+  gen.emitLabel(checkLabel);
+  const i = gen.emitLoad("i32", loopPtr);
+  const cond = gen.emitIcmp("slt", "i32", i, length);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
 
-  gen.emit(`${bodyLabel}:`);
+  gen.emitLabel(bodyLabel);
   const elemPtr = gen.nextTemp();
   gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${i}`);
-  const elem = gen.nextTemp();
-  gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
+  const elem = gen.emitLoad("i8*", elemPtr);
 
-  const cmpResult = gen.nextTemp();
-  gen.emit(`${cmpResult} = call i32 @strcmp(i8* ${elem}, i8* ${searchValue})`);
-  const eq = gen.nextTemp();
-  gen.emit(`${eq} = icmp eq i32 ${cmpResult}, 0`);
-  gen.emit(`br i1 ${eq}, label %${foundLabel}, label %${nextLabel}`);
+  const cmpResult = gen.emitCall("i32", "@strcmp", `i8* ${elem}, i8* ${searchValue}`);
+  const eq = gen.emitIcmp("eq", "i32", cmpResult, "0");
+  gen.emitBrCond(eq, foundLabel, nextLabel);
 
-  gen.emit(`${foundLabel}:`);
-  gen.emit(`store i32 ${i}, i32* ${resultPtr}`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitLabel(foundLabel);
+  gen.emitStore("i32", i, resultPtr);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${nextLabel}:`);
+  gen.emitLabel(nextLabel);
   const nextI = gen.nextTemp();
   gen.emit(`${nextI} = add i32 ${i}, 1`);
-  gen.emit(`store i32 ${nextI}, i32* ${loopPtr}`);
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitStore("i32", nextI, loopPtr);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${endLabel}:`);
-  const resultI32 = gen.nextTemp();
-  gen.emit(`${resultI32} = load i32, i32* ${resultPtr}`);
+  gen.emitLabel(endLabel);
+  const resultI32 = gen.emitLoad("i32", resultPtr);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
   return result;
 }
 
 export function generateArrayFindIndex(
-  gen: ArraySearchContext,
+  gen: IGeneratorContext,
   expr: MethodCallNode,
   params: string[],
-  predicateFn: string,
-  isStringArray: boolean,
 ): string {
+  if (expr.args.length !== 1) {
+    throw new Error("findIndex() requires exactly 1 argument (predicate function)");
+  }
+
   const arrayPtr = gen.generateExpression(expr.object, params);
+
+  let isStringArray = false;
+  const exprObjBase = expr.object as ExprBase;
+  if (exprObjBase.type === "variable") {
+    const varName = (expr.object as VariableNode).name;
+    const varType = gen.getVariableType(varName);
+    isStringArray = varType === "%StringArray*" || varType === "%StringArray";
+  }
+
+  const predicateArg = expr.args[0];
+  let predicateFn: string;
+  if (predicateArg.type === "variable") {
+    predicateFn = gen.mangleUserName((predicateArg as VariableNode).name);
+  } else if (predicateArg.type === "arrow_function") {
+    if (isStringArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
+    predicateFn = gen.generateExpression(predicateArg, params);
+    gen.setExpectedCallbackParamType(null);
+  } else {
+    throw new Error("findIndex() argument must be a function name or inline function");
+  }
 
   if (isStringArray) {
     return generateStringArrayFindIndex(gen, arrayPtr, predicateFn);
@@ -202,7 +207,7 @@ export function generateArrayFindIndex(
 }
 
 function generateNumericArrayFindIndex(
-  gen: ArraySearchContext,
+  gen: IGeneratorContext,
   arrayPtr: string,
   predicateFn: string,
 ): string {
@@ -218,11 +223,11 @@ function generateNumericArrayFindIndex(
 
   const resultPtr = gen.nextTemp();
   gen.emit(`${resultPtr} = alloca i32`);
-  gen.emit(`store i32 -1, i32* ${resultPtr}`);
+  gen.emitStore("i32", "-1", resultPtr);
 
   const loopPtr = gen.nextTemp();
   gen.emit(`${loopPtr} = alloca i32`);
-  gen.emit(`store i32 0, i32* ${loopPtr}`);
+  gen.emitStore("i32", "0", loopPtr);
 
   const checkLabel = gen.nextLabel("findidx_check");
   const bodyLabel = gen.nextLabel("findidx_body");
@@ -230,47 +235,42 @@ function generateNumericArrayFindIndex(
   const nextLabel = gen.nextLabel("findidx_next");
   const endLabel = gen.nextLabel("findidx_end");
 
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${checkLabel}:`);
-  const i = gen.nextTemp();
-  gen.emit(`${i} = load i32, i32* ${loopPtr}`);
-  const cond = gen.nextTemp();
-  gen.emit(`${cond} = icmp slt i32 ${i}, ${length}`);
-  gen.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+  gen.emitLabel(checkLabel);
+  const i = gen.emitLoad("i32", loopPtr);
+  const cond = gen.emitIcmp("slt", "i32", i, length);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
 
-  gen.emit(`${bodyLabel}:`);
+  gen.emitLabel(bodyLabel);
   const elemPtr = gen.nextTemp();
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${i}`);
-  const elem = gen.nextTemp();
-  gen.emit(`${elem} = load double, double* ${elemPtr}`);
+  const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.nextTemp();
-  gen.emit(`${predicateResult} = call double @${predicateFn}(double ${elem})`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `double ${elem}`);
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
-  gen.emit(`br i1 ${isTruthy}, label %${foundLabel}, label %${nextLabel}`);
+  gen.emitBrCond(isTruthy, foundLabel, nextLabel);
 
-  gen.emit(`${foundLabel}:`);
-  gen.emit(`store i32 ${i}, i32* ${resultPtr}`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitLabel(foundLabel);
+  gen.emitStore("i32", i, resultPtr);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${nextLabel}:`);
+  gen.emitLabel(nextLabel);
   const nextI = gen.nextTemp();
   gen.emit(`${nextI} = add i32 ${i}, 1`);
-  gen.emit(`store i32 ${nextI}, i32* ${loopPtr}`);
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitStore("i32", nextI, loopPtr);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${endLabel}:`);
-  const resultI32 = gen.nextTemp();
-  gen.emit(`${resultI32} = load i32, i32* ${resultPtr}`);
+  gen.emitLabel(endLabel);
+  const resultI32 = gen.emitLoad("i32", resultPtr);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
   return result;
 }
 
 function generateStringArrayFindIndex(
-  gen: ArraySearchContext,
+  gen: IGeneratorContext,
   arrayPtr: string,
   predicateFn: string,
 ): string {
@@ -290,11 +290,11 @@ function generateStringArrayFindIndex(
 
   const resultPtr = gen.nextTemp();
   gen.emit(`${resultPtr} = alloca i32`);
-  gen.emit(`store i32 -1, i32* ${resultPtr}`);
+  gen.emitStore("i32", "-1", resultPtr);
 
   const loopPtr = gen.nextTemp();
   gen.emit(`${loopPtr} = alloca i32`);
-  gen.emit(`store i32 0, i32* ${loopPtr}`);
+  gen.emitStore("i32", "0", loopPtr);
 
   const checkLabel = gen.nextLabel("findidx_check");
   const bodyLabel = gen.nextLabel("findidx_body");
@@ -302,40 +302,35 @@ function generateStringArrayFindIndex(
   const nextLabel = gen.nextLabel("findidx_next");
   const endLabel = gen.nextLabel("findidx_end");
 
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${checkLabel}:`);
-  const i = gen.nextTemp();
-  gen.emit(`${i} = load i32, i32* ${loopPtr}`);
-  const cond = gen.nextTemp();
-  gen.emit(`${cond} = icmp slt i32 ${i}, ${length}`);
-  gen.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+  gen.emitLabel(checkLabel);
+  const i = gen.emitLoad("i32", loopPtr);
+  const cond = gen.emitIcmp("slt", "i32", i, length);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
 
-  gen.emit(`${bodyLabel}:`);
+  gen.emitLabel(bodyLabel);
   const elemPtr = gen.nextTemp();
   gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${i}`);
-  const elem = gen.nextTemp();
-  gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
+  const elem = gen.emitLoad("i8*", elemPtr);
 
-  const predicateResult = gen.nextTemp();
-  gen.emit(`${predicateResult} = call double @${predicateFn}(i8* ${elem})`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `i8* ${elem}`);
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
-  gen.emit(`br i1 ${isTruthy}, label %${foundLabel}, label %${nextLabel}`);
+  gen.emitBrCond(isTruthy, foundLabel, nextLabel);
 
-  gen.emit(`${foundLabel}:`);
-  gen.emit(`store i32 ${i}, i32* ${resultPtr}`);
-  gen.emit(`br label %${endLabel}`);
+  gen.emitLabel(foundLabel);
+  gen.emitStore("i32", i, resultPtr);
+  gen.emitBr(endLabel);
 
-  gen.emit(`${nextLabel}:`);
+  gen.emitLabel(nextLabel);
   const nextI = gen.nextTemp();
   gen.emit(`${nextI} = add i32 ${i}, 1`);
-  gen.emit(`store i32 ${nextI}, i32* ${loopPtr}`);
-  gen.emit(`br label %${checkLabel}`);
+  gen.emitStore("i32", nextI, loopPtr);
+  gen.emitBr(checkLabel);
 
-  gen.emit(`${endLabel}:`);
-  const resultI32 = gen.nextTemp();
-  gen.emit(`${resultI32} = load i32, i32* ${resultPtr}`);
+  gen.emitLabel(endLabel);
+  const resultI32 = gen.emitLoad("i32", resultPtr);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
   return result;

--- a/src/codegen/types/collections/array/sort.ts
+++ b/src/codegen/types/collections/array/sort.ts
@@ -1,4 +1,12 @@
-import { Expression } from "../../../../ast/types.js";
+// Array sort operations: default numeric/string sort, custom comparator sort
+// generateArraySort accepts (gen, expr, params) and handles type detection + dispatch internally.
+
+import { Expression, MethodCallNode, VariableNode } from "../../../../ast/types.js";
+import { IGeneratorContext } from "./context.js";
+
+interface ExprBase {
+  type: string;
+}
 
 interface ArraySortContext {
   nextTemp(): string;
@@ -43,7 +51,51 @@ export function generateDefaultSortComparators(): string {
   return ir;
 }
 
-export function generateDefaultNumericSort(gen: ArraySortContext, arrayPtr: string): string {
+export function generateArraySort(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+): string {
+  if (expr.args.length > 1) {
+    throw new Error("sort() expects 0 or 1 arguments");
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  gen.setUsesArraySort(true);
+
+  let isStringArray = false;
+  const exprObjBase = expr.object as ExprBase;
+  if (exprObjBase.type === "variable") {
+    const varName = (expr.object as VariableNode).name;
+    const varType = gen.getVariableType(varName);
+    isStringArray = varType === "%StringArray*" || varType === "%StringArray";
+  }
+  if (!isStringArray) {
+    const ptrType = gen.getVariableType(arrayPtr);
+    if (ptrType === "%StringArray*" || ptrType === "%StringArray") isStringArray = true;
+  }
+
+  if (expr.args.length === 0) {
+    if (isStringArray) {
+      return generateDefaultStringSort(gen, arrayPtr);
+    }
+    return generateDefaultNumericSort(gen, arrayPtr);
+  }
+
+  const predicateArg = expr.args[0];
+  let compareFn: string;
+  if (predicateArg.type === "variable") {
+    compareFn = gen.mangleUserName((predicateArg as VariableNode).name);
+  } else if (predicateArg.type === "arrow_function") {
+    compareFn = gen.generateExpression(predicateArg, params);
+  } else {
+    throw new Error("sort() comparator must be a function name or inline function");
+  }
+
+  return generateNumericSortWithFn(gen, arrayPtr, compareFn);
+}
+
+function generateDefaultNumericSort(gen: ArraySortContext, arrayPtr: string): string {
   const lenPtr = gen.nextTemp();
   gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
   const length = gen.nextTemp();
@@ -67,7 +119,7 @@ export function generateDefaultNumericSort(gen: ArraySortContext, arrayPtr: stri
   return arrayPtr;
 }
 
-export function generateDefaultStringSort(gen: ArraySortContext, arrayPtr: string): string {
+function generateDefaultStringSort(gen: ArraySortContext, arrayPtr: string): string {
   const lenPtr = gen.nextTemp();
   gen.emit(
     `${lenPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
@@ -95,7 +147,7 @@ export function generateDefaultStringSort(gen: ArraySortContext, arrayPtr: strin
   return arrayPtr;
 }
 
-export function generateNumericSortWithFn(
+function generateNumericSortWithFn(
   gen: ArraySortContext,
   arrayPtr: string,
   compareFn: string,

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -1,5 +1,6 @@
-// NOTE: This file uses raw ctx.emit() extensively. Prefer structured IR builders
-// (emitStore, emitLoad, emitCall, etc.) when modifying — see .claude/rules.md.
+// Map codegen: numeric Map, StringMap, and PointerMap generators.
+// Uses structured IR builders where possible; raw emit() for inbounds GEP,
+// alloca, arithmetic, fcmp, ptrtoint, sext, zext, shl, and, memcpy.
 
 import { Expression, MethodCallNode, MapEntry } from "../../../ast/types.js";
 import { IGeneratorContext } from "../../infrastructure/generator-context.js";
@@ -45,10 +46,8 @@ export class MapGenerator {
     this.emit(`${sizeofPtr} = getelementptr %Map, %Map* null, i32 1`);
     const structSize = this.nextTemp();
     this.emit(`${structSize} = ptrtoint %Map* ${sizeofPtr} to i64`);
-    const mapMem = this.nextTemp();
-    this.emit(`${mapMem} = call i8* @GC_malloc(i64 ${structSize})`);
-    const mapPtr = this.nextTemp();
-    this.emit(`${mapPtr} = bitcast i8* ${mapMem} to %Map*`);
+    const mapMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${structSize}`);
+    const mapPtr = this.ctx.emitBitcast(mapMem, "i8*", "%Map*");
 
     // Initialize with empty arrays
     const initialCapacity = entries.length > 4 ? entries.length : 4;
@@ -59,40 +58,36 @@ export class MapGenerator {
     this.emit(`${keysCapI64} = zext i32 ${initialCapacity} to i64`);
     const keysSize = this.nextTemp();
     this.emit(`${keysSize} = mul i64 ${keysCapI64}, ${doubleSize}`);
-    const keysMem = this.nextTemp();
-    this.emit(`${keysMem} = call i8* @GC_malloc_atomic(i64 ${keysSize})`);
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = bitcast i8* ${keysMem} to double*`);
+    const keysMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${keysSize}`);
+    const keysPtr = this.ctx.emitBitcast(keysMem, "i8*", "double*");
 
     // Allocate values array - use double* for JavaScript semantics
     const valuesCapI64 = this.nextTemp();
     this.emit(`${valuesCapI64} = zext i32 ${initialCapacity} to i64`);
     const valuesSize = this.nextTemp();
     this.emit(`${valuesSize} = mul i64 ${valuesCapI64}, ${doubleSize}`);
-    const valuesMem = this.nextTemp();
-    this.emit(`${valuesMem} = call i8* @GC_malloc_atomic(i64 ${valuesSize})`);
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = bitcast i8* ${valuesMem} to double*`);
+    const valuesMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${valuesSize}`);
+    const valuesPtr = this.ctx.emitBitcast(valuesMem, "i8*", "double*");
 
     // Store keys pointer in Map struct
     const keysFieldPtr = this.nextTemp();
     this.emit(`${keysFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 0`);
-    this.emit(`store double* ${keysPtr}, double** ${keysFieldPtr}`);
+    this.ctx.emitStore("double*", keysPtr, keysFieldPtr);
 
     // Store values pointer in Map struct
     const valuesFieldPtr = this.nextTemp();
     this.emit(`${valuesFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 1`);
-    this.emit(`store double* ${valuesPtr}, double** ${valuesFieldPtr}`);
+    this.ctx.emitStore("double*", valuesPtr, valuesFieldPtr);
 
     // Store size
     const sizeFieldPtr = this.nextTemp();
     this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
-    this.emit(`store i32 ${entries.length}, i32* ${sizeFieldPtr}`);
+    this.ctx.emitStore("i32", `${entries.length}`, sizeFieldPtr);
 
     // Store capacity
     const capacityFieldPtr = this.nextTemp();
     this.emit(`${capacityFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 3`);
-    this.emit(`store i32 ${initialCapacity}, i32* ${capacityFieldPtr}`);
+    this.ctx.emitStore("i32", `${initialCapacity}`, capacityFieldPtr);
 
     // Populate initial entries
     for (let i = 0; i < entries.length; i++) {
@@ -103,15 +98,15 @@ export class MapGenerator {
       // Store key
       const keyElemPtr = this.nextTemp();
       this.emit(`${keyElemPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${i}`);
-      this.emit(`store double ${this.ctx.ensureDouble(keyValue)}, double* ${keyElemPtr}`);
+      this.ctx.emitStore("double", this.ctx.ensureDouble(keyValue), keyElemPtr);
 
       // Store value
       const valueElemPtr = this.nextTemp();
       this.emit(`${valueElemPtr} = getelementptr inbounds double, double* ${valuesPtr}, i32 ${i}`);
-      this.emit(`store double ${this.ctx.ensureDouble(valueValue)}, double* ${valueElemPtr}`);
+      this.ctx.emitStore("double", this.ctx.ensureDouble(valueValue), valueElemPtr);
     }
 
-    this.ctx.setVariableType(mapPtr, "%Map*");
+    // emitBitcast already set mapPtr type to %Map*
     return mapPtr;
   }
 
@@ -126,18 +121,15 @@ export class MapGenerator {
 
     const keysFieldPtr = this.nextTemp();
     this.emit(`${keysFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 0`);
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load double*, double** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("double*", keysFieldPtr);
 
     const valuesFieldPtr = this.nextTemp();
     this.emit(`${valuesFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 1`);
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load double*, double** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("double*", valuesFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
-    const currentSize = this.nextTemp();
-    this.emit(`${currentSize} = load i32, i32* ${sizeFieldPtr}`);
+    const currentSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     const searchLoopLabel = this.nextLabel("map_set_search");
     const searchBodyLabel = this.nextLabel("map_set_body");
@@ -148,59 +140,53 @@ export class MapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
-    this.emit(`br label %${searchLoopLabel}`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(searchLoopLabel);
 
-    this.emit(`${searchLoopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const searchCond = this.nextTemp();
-    this.emit(`${searchCond} = icmp slt i32 ${currentIndex}, ${currentSize}`);
-    this.emit(`br i1 ${searchCond}, label %${searchBodyLabel}, label %${notFoundLabel}`);
+    this.ctx.emitLabel(searchLoopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const searchCond = this.ctx.emitIcmp("slt", "i32", currentIndex, currentSize);
+    this.ctx.emitBrCond(searchCond, searchBodyLabel, notFoundLabel);
 
-    this.emit(`${searchBodyLabel}:`);
+    this.ctx.emitLabel(searchBodyLabel);
     const keyElemPtrSearch = this.nextTemp();
     this.emit(
       `${keyElemPtrSearch} = getelementptr inbounds double, double* ${keysPtr}, i32 ${currentIndex}`,
     );
-    const keyAtIndex = this.nextTemp();
-    this.emit(`${keyAtIndex} = load double, double* ${keyElemPtrSearch}`);
+    const keyAtIndex = this.ctx.emitLoad("double", keyElemPtrSearch);
     const dblKeyValue = this.ctx.ensureDouble(keyValue);
     const keyMatch = this.nextTemp();
     this.emit(`${keyMatch} = fcmp oeq double ${keyAtIndex}, ${dblKeyValue}`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${searchLoopLabel}_next`);
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${searchLoopLabel}_next`);
 
-    this.emit(`${searchLoopLabel}_next:`);
+    this.ctx.emitLabel(`${searchLoopLabel}_next`);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${searchLoopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(searchLoopLabel);
 
-    this.emit(`${foundLabel}:`);
-    const foundIdx = this.nextTemp();
-    this.emit(`${foundIdx} = load i32, i32* ${indexReg}`);
+    this.ctx.emitLabel(foundLabel);
+    const foundIdx = this.ctx.emitLoad("i32", indexReg);
     const valueElemPtrFound = this.nextTemp();
     this.emit(
       `${valueElemPtrFound} = getelementptr inbounds double, double* ${valuesPtr}, i32 ${foundIdx}`,
     );
-    this.emit(`store double ${this.ctx.ensureDouble(valueValue)}, double* ${valueElemPtrFound}`);
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitStore("double", this.ctx.ensureDouble(valueValue), valueElemPtrFound);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${notFoundLabel}:`);
-    this.emit(`br label %${insertLabel}`);
+    this.ctx.emitLabel(notFoundLabel);
+    this.ctx.emitBr(insertLabel);
 
-    this.emit(`${insertLabel}:`);
+    this.ctx.emitLabel(insertLabel);
     const capacityFieldPtr = this.nextTemp();
     this.emit(`${capacityFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 3`);
-    const currentCapacity = this.nextTemp();
-    this.emit(`${currentCapacity} = load i32, i32* ${capacityFieldPtr}`);
-    const needsResize = this.nextTemp();
-    this.emit(`${needsResize} = icmp sge i32 ${currentSize}, ${currentCapacity}`);
+    const currentCapacity = this.ctx.emitLoad("i32", capacityFieldPtr);
+    const needsResize = this.ctx.emitIcmp("sge", "i32", currentSize, currentCapacity);
     const resizeLabel = this.nextLabel("map_set_resize");
     const doInsertLabel = this.nextLabel("map_set_doinsert");
-    this.emit(`br i1 ${needsResize}, label %${resizeLabel}, label %${doInsertLabel}`);
+    this.ctx.emitBrCond(needsResize, resizeLabel, doInsertLabel);
 
-    this.emit(`${resizeLabel}:`);
+    this.ctx.emitLabel(resizeLabel);
     const newCapacity = this.nextTemp();
     this.emit(`${newCapacity} = mul i32 ${currentCapacity}, 2`);
     const newCapI64 = this.nextTemp();
@@ -208,12 +194,9 @@ export class MapGenerator {
     const doubleSize = this.getDoubleSize();
     const newKeysSize = this.nextTemp();
     this.emit(`${newKeysSize} = mul i64 ${newCapI64}, ${doubleSize}`);
-    const newKeysMem = this.nextTemp();
-    this.emit(`${newKeysMem} = call i8* @GC_malloc_atomic(i64 ${newKeysSize})`);
-    const newKeysPtr = this.nextTemp();
-    this.emit(`${newKeysPtr} = bitcast i8* ${newKeysMem} to double*`);
-    const oldKeysI8 = this.nextTemp();
-    this.emit(`${oldKeysI8} = bitcast double* ${keysPtr} to i8*`);
+    const newKeysMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newKeysSize}`);
+    const newKeysPtr = this.ctx.emitBitcast(newKeysMem, "i8*", "double*");
+    const oldKeysI8 = this.ctx.emitBitcast(keysPtr, "double*", "i8*");
     const oldCapI64 = this.nextTemp();
     this.emit(`${oldCapI64} = zext i32 ${currentCapacity} to i64`);
     const oldKeysSize = this.nextTemp();
@@ -221,45 +204,40 @@ export class MapGenerator {
     this.emit(
       `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newKeysMem}, i8* ${oldKeysI8}, i64 ${oldKeysSize}, i1 false)`,
     );
-    this.emit(`store double* ${newKeysPtr}, double** ${keysFieldPtr}`);
+    this.ctx.emitStore("double*", newKeysPtr, keysFieldPtr);
     const newValuesSize = this.nextTemp();
     this.emit(`${newValuesSize} = mul i64 ${newCapI64}, ${doubleSize}`);
-    const newValuesMem = this.nextTemp();
-    this.emit(`${newValuesMem} = call i8* @GC_malloc_atomic(i64 ${newValuesSize})`);
-    const newValuesPtr = this.nextTemp();
-    this.emit(`${newValuesPtr} = bitcast i8* ${newValuesMem} to double*`);
-    const oldValuesI8 = this.nextTemp();
-    this.emit(`${oldValuesI8} = bitcast double* ${valuesPtr} to i8*`);
+    const newValuesMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newValuesSize}`);
+    const newValuesPtr = this.ctx.emitBitcast(newValuesMem, "i8*", "double*");
+    const oldValuesI8 = this.ctx.emitBitcast(valuesPtr, "double*", "i8*");
     this.emit(
       `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newValuesMem}, i8* ${oldValuesI8}, i64 ${oldKeysSize}, i1 false)`,
     );
-    this.emit(`store double* ${newValuesPtr}, double** ${valuesFieldPtr}`);
-    this.emit(`store i32 ${newCapacity}, i32* ${capacityFieldPtr}`);
-    this.emit(`br label %${doInsertLabel}`);
+    this.ctx.emitStore("double*", newValuesPtr, valuesFieldPtr);
+    this.ctx.emitStore("i32", newCapacity, capacityFieldPtr);
+    this.ctx.emitBr(doInsertLabel);
 
-    this.emit(`${doInsertLabel}:`);
-    const insertKeysPtr = this.nextTemp();
-    this.emit(`${insertKeysPtr} = load double*, double** ${keysFieldPtr}`);
-    const insertValuesPtr = this.nextTemp();
-    this.emit(`${insertValuesPtr} = load double*, double** ${valuesFieldPtr}`);
+    this.ctx.emitLabel(doInsertLabel);
+    const insertKeysPtr = this.ctx.emitLoad("double*", keysFieldPtr);
+    const insertValuesPtr = this.ctx.emitLoad("double*", valuesFieldPtr);
     const keyElemPtr = this.nextTemp();
     this.emit(
       `${keyElemPtr} = getelementptr inbounds double, double* ${insertKeysPtr}, i32 ${currentSize}`,
     );
-    this.emit(`store double ${this.ctx.ensureDouble(keyValue)}, double* ${keyElemPtr}`);
+    this.ctx.emitStore("double", this.ctx.ensureDouble(keyValue), keyElemPtr);
 
     const valueElemPtr = this.nextTemp();
     this.emit(
       `${valueElemPtr} = getelementptr inbounds double, double* ${insertValuesPtr}, i32 ${currentSize}`,
     );
-    this.emit(`store double ${this.ctx.ensureDouble(valueValue)}, double* ${valueElemPtr}`);
+    this.ctx.emitStore("double", this.ctx.ensureDouble(valueValue), valueElemPtr);
 
     const newSize = this.nextTemp();
     this.emit(`${newSize} = add i32 ${currentSize}, 1`);
-    this.emit(`store i32 ${newSize}, i32* ${sizeFieldPtr}`);
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitStore("i32", newSize, sizeFieldPtr);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return mapPtr;
   }
@@ -279,24 +257,21 @@ export class MapGenerator {
     // Load arrays and size
     const keysFieldPtr = this.nextTemp();
     this.emit(`${keysFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 0`);
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load double*, double** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("double*", keysFieldPtr);
 
     const valuesFieldPtr = this.nextTemp();
     this.emit(`${valuesFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 1`);
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load double*, double** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("double*", valuesFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
-    const mapSize = this.nextTemp();
-    this.emit(`${mapSize} = load i32, i32* ${sizeFieldPtr}`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     // For simplicity, linear search (in production, use hash table)
     // We'll just return the first matching key's value, or 0 if not found
     const resultReg = this.nextTemp();
     this.emit(`${resultReg} = alloca double`);
-    this.emit(`store double 0.0, double* ${resultReg}`); // Default to 0
+    this.ctx.emitStore("double", "0.0", resultReg); // Default to 0
 
     // Generate loop to search for key
     const loopLabel = this.nextLabel("map_has_loop");
@@ -306,47 +281,42 @@ export class MapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${loopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const cond = this.nextTemp();
-    this.emit(`${cond} = icmp slt i32 ${currentIndex}, ${mapSize}`);
-    this.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     const keyElemPtr = this.nextTemp();
     this.emit(
       `${keyElemPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${currentIndex}`,
     );
-    const keyValue = this.nextTemp();
-    this.emit(`${keyValue} = load double, double* ${keyElemPtr}`);
+    const keyValue = this.ctx.emitLoad("double", keyElemPtr);
     const dblKeyToFind = this.ctx.ensureDouble(keyToFind);
     const keyMatch = this.nextTemp();
     this.emit(`${keyMatch} = fcmp oeq double ${keyValue}, ${dblKeyToFind}`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${loopLabel}_next`);
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${loopLabel}_next`);
 
-    this.emit(`${foundLabel}:`);
+    this.ctx.emitLabel(foundLabel);
     const valueElemPtr = this.nextTemp();
     this.emit(
       `${valueElemPtr} = getelementptr inbounds double, double* ${valuesPtr}, i32 ${currentIndex}`,
     );
-    const foundValue = this.nextTemp();
-    this.emit(`${foundValue} = load double, double* ${valueElemPtr}`);
-    this.emit(`store double ${foundValue}, double* ${resultReg}`);
-    this.emit(`br label %${endLabel}`);
+    const foundValue = this.ctx.emitLoad("double", valueElemPtr);
+    this.ctx.emitStore("double", foundValue, resultReg);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${loopLabel}_next:`);
+    this.ctx.emitLabel(`${loopLabel}_next`);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${endLabel}:`);
-    const result = this.nextTemp();
-    this.emit(`${result} = load double, double* ${resultReg}`);
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.emitLoad("double", resultReg);
 
     return result;
   }
@@ -366,18 +336,16 @@ export class MapGenerator {
     // Load arrays and size
     const keysFieldPtr = this.nextTemp();
     this.emit(`${keysFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 0`);
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load double*, double** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("double*", keysFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
-    const mapSize = this.nextTemp();
-    this.emit(`${mapSize} = load i32, i32* ${sizeFieldPtr}`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     // Linear search for key
     const resultReg = this.nextTemp();
     this.emit(`${resultReg} = alloca double`);
-    this.emit(`store double 0.0, double* ${resultReg}`);
+    this.ctx.emitStore("double", "0.0", resultReg);
 
     const loopLabel = this.nextLabel("map_get_loop");
     const bodyLabel = this.nextLabel("map_get_body");
@@ -386,41 +354,37 @@ export class MapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${loopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const cond = this.nextTemp();
-    this.emit(`${cond} = icmp slt i32 ${currentIndex}, ${mapSize}`);
-    this.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     const keyElemPtr = this.nextTemp();
     this.emit(
       `${keyElemPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${currentIndex}`,
     );
-    const keyValue = this.nextTemp();
-    this.emit(`${keyValue} = load double, double* ${keyElemPtr}`);
+    const keyValue = this.ctx.emitLoad("double", keyElemPtr);
     const dblKeyToFind = this.ctx.ensureDouble(keyToFind);
     const keyMatch = this.nextTemp();
     this.emit(`${keyMatch} = fcmp oeq double ${keyValue}, ${dblKeyToFind}`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${loopLabel}_next`);
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${loopLabel}_next`);
 
-    this.emit(`${foundLabel}:`);
-    this.emit(`store double 1.0, double* ${resultReg}`);
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitLabel(foundLabel);
+    this.ctx.emitStore("double", "1.0", resultReg);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${loopLabel}_next:`);
+    this.ctx.emitLabel(`${loopLabel}_next`);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${endLabel}:`);
-    const result = this.nextTemp();
-    this.emit(`${result} = load double, double* ${resultReg}`);
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.emitLoad("double", resultReg);
 
     return result;
   }
@@ -429,8 +393,7 @@ export class MapGenerator {
     // Get size field
     const sizeFieldPtr = this.nextTemp();
     this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
-    const size = this.nextTemp();
-    this.emit(`${size} = load i32, i32* ${sizeFieldPtr}`);
+    const size = this.ctx.emitLoad("i32", sizeFieldPtr);
     return size;
   }
 
@@ -438,7 +401,7 @@ export class MapGenerator {
     const mapPtr = this.ctx.generateExpression(expr.object, params);
     const sizeFieldPtr = this.nextTemp();
     this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
-    this.emit(`store i32 0, i32* ${sizeFieldPtr}`);
+    this.ctx.emitStore("i32", "0", sizeFieldPtr);
     return "0.0";
   }
 
@@ -452,22 +415,19 @@ export class MapGenerator {
 
     const keysFieldPtr = this.nextTemp();
     this.emit(`${keysFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 0`);
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load double*, double** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("double*", keysFieldPtr);
 
     const valuesFieldPtr = this.nextTemp();
     this.emit(`${valuesFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 1`);
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load double*, double** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("double*", valuesFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
-    const mapSize = this.nextTemp();
-    this.emit(`${mapSize} = load i32, i32* ${sizeFieldPtr}`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     const resultReg = this.nextTemp();
     this.emit(`${resultReg} = alloca double`);
-    this.emit(`store double 0.0, double* ${resultReg}`);
+    this.ctx.emitStore("double", "0.0", resultReg);
 
     const loopLabel = this.nextLabel("map_del_loop");
     const bodyLabel = this.nextLabel("map_del_body");
@@ -478,76 +438,67 @@ export class MapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${loopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const cond = this.nextTemp();
-    this.emit(`${cond} = icmp slt i32 ${currentIndex}, ${mapSize}`);
-    this.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     const keyElemPtr = this.nextTemp();
     this.emit(
       `${keyElemPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${currentIndex}`,
     );
-    const keyValue = this.nextTemp();
-    this.emit(`${keyValue} = load double, double* ${keyElemPtr}`);
+    const keyValue = this.ctx.emitLoad("double", keyElemPtr);
     const dblKeyToFind = this.ctx.ensureDouble(keyToFind);
     const keyMatch = this.nextTemp();
     this.emit(`${keyMatch} = fcmp oeq double ${keyValue}, ${dblKeyToFind}`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${loopLabel}_next`);
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${loopLabel}_next`);
 
-    this.emit(`${foundLabel}:`);
-    this.emit(`store double 1.0, double* ${resultReg}`);
+    this.ctx.emitLabel(foundLabel);
+    this.ctx.emitStore("double", "1.0", resultReg);
     const newSize = this.nextTemp();
     this.emit(`${newSize} = sub i32 ${mapSize}, 1`);
-    this.emit(`store i32 ${newSize}, i32* ${sizeFieldPtr}`);
+    this.ctx.emitStore("i32", newSize, sizeFieldPtr);
     const shiftIdx = this.nextTemp();
     this.emit(`${shiftIdx} = alloca i32`);
-    const currentIndex2 = this.nextTemp();
-    this.emit(`${currentIndex2} = load i32, i32* ${indexReg}`);
-    this.emit(`store i32 ${currentIndex2}, i32* ${shiftIdx}`);
-    this.emit(`br label %${shiftLabel}`);
+    const currentIndex2 = this.ctx.emitLoad("i32", indexReg);
+    this.ctx.emitStore("i32", currentIndex2, shiftIdx);
+    this.ctx.emitBr(shiftLabel);
 
-    this.emit(`${shiftLabel}:`);
-    const shiftI = this.nextTemp();
-    this.emit(`${shiftI} = load i32, i32* ${shiftIdx}`);
-    const shiftCond = this.nextTemp();
-    this.emit(`${shiftCond} = icmp slt i32 ${shiftI}, ${newSize}`);
-    this.emit(`br i1 ${shiftCond}, label %${shiftBodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(shiftLabel);
+    const shiftI = this.ctx.emitLoad("i32", shiftIdx);
+    const shiftCond = this.ctx.emitIcmp("slt", "i32", shiftI, newSize);
+    this.ctx.emitBrCond(shiftCond, shiftBodyLabel, endLabel);
 
-    this.emit(`${shiftBodyLabel}:`);
+    this.ctx.emitLabel(shiftBodyLabel);
     const nextI = this.nextTemp();
     this.emit(`${nextI} = add i32 ${shiftI}, 1`);
     const nextKeyPtr = this.nextTemp();
     this.emit(`${nextKeyPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${nextI}`);
-    const nextKey = this.nextTemp();
-    this.emit(`${nextKey} = load double, double* ${nextKeyPtr}`);
+    const nextKey = this.ctx.emitLoad("double", nextKeyPtr);
     const currKeyPtr = this.nextTemp();
     this.emit(`${currKeyPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${shiftI}`);
-    this.emit(`store double ${nextKey}, double* ${currKeyPtr}`);
+    this.ctx.emitStore("double", nextKey, currKeyPtr);
     const nextValPtr = this.nextTemp();
     this.emit(`${nextValPtr} = getelementptr inbounds double, double* ${valuesPtr}, i32 ${nextI}`);
-    const nextVal = this.nextTemp();
-    this.emit(`${nextVal} = load double, double* ${nextValPtr}`);
+    const nextVal = this.ctx.emitLoad("double", nextValPtr);
     const currValPtr = this.nextTemp();
     this.emit(`${currValPtr} = getelementptr inbounds double, double* ${valuesPtr}, i32 ${shiftI}`);
-    this.emit(`store double ${nextVal}, double* ${currValPtr}`);
-    this.emit(`store i32 ${nextI}, i32* ${shiftIdx}`);
-    this.emit(`br label %${shiftLabel}`);
+    this.ctx.emitStore("double", nextVal, currValPtr);
+    this.ctx.emitStore("i32", nextI, shiftIdx);
+    this.ctx.emitBr(shiftLabel);
 
-    this.emit(`${loopLabel}_next:`);
+    this.ctx.emitLabel(`${loopLabel}_next`);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${endLabel}:`);
-    const result = this.nextTemp();
-    this.emit(`${result} = load double, double* ${resultReg}`);
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.emitLoad("double", resultReg);
 
     return result;
   }
@@ -574,50 +525,44 @@ export class StringMapGenerator {
     this.emit(`${sizeofPtr} = getelementptr %StringMap, %StringMap* null, i32 1`);
     const structSize = this.nextTemp();
     this.emit(`${structSize} = ptrtoint %StringMap* ${sizeofPtr} to i64`);
-    const mapMem = this.nextTemp();
-    this.emit(`${mapMem} = call i8* @GC_malloc(i64 ${structSize})`);
-    const mapPtr = this.nextTemp();
-    this.emit(`${mapPtr} = bitcast i8* ${mapMem} to %StringMap*`);
+    const mapMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${structSize}`);
+    const mapPtr = this.ctx.emitBitcast(mapMem, "i8*", "%StringMap*");
 
     const initialCapacity = 16;
     const ptrSize = this.getPtrSize();
 
     const keysSize = initialCapacity * ptrSize;
-    const keysMem = this.nextTemp();
-    this.emit(`${keysMem} = call i8* @GC_malloc(i64 ${keysSize})`);
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = bitcast i8* ${keysMem} to i8**`);
+    const keysMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${keysSize}`);
+    const keysPtr = this.ctx.emitBitcast(keysMem, "i8*", "i8**");
 
-    const valuesMem = this.nextTemp();
-    this.emit(`${valuesMem} = call i8* @GC_malloc(i64 ${keysSize})`);
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = bitcast i8* ${valuesMem} to i8**`);
+    const valuesMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${keysSize}`);
+    const valuesPtr = this.ctx.emitBitcast(valuesMem, "i8*", "i8**");
 
     const keysFieldPtr = this.nextTemp();
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    this.emit(`store i8** ${keysPtr}, i8*** ${keysFieldPtr}`);
+    this.ctx.emitStore("i8**", keysPtr, keysFieldPtr);
 
     const valuesFieldPtr = this.nextTemp();
     this.emit(
       `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
     );
-    this.emit(`store i8** ${valuesPtr}, i8*** ${valuesFieldPtr}`);
+    this.ctx.emitStore("i8**", valuesPtr, valuesFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    this.emit(`store i32 0, i32* ${sizeFieldPtr}`);
+    this.ctx.emitStore("i32", "0", sizeFieldPtr);
 
     const capacityFieldPtr = this.nextTemp();
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    this.emit(`store i32 ${initialCapacity}, i32* ${capacityFieldPtr}`);
+    this.ctx.emitStore("i32", `${initialCapacity}`, capacityFieldPtr);
 
-    this.ctx.setVariableType(mapPtr, "%StringMap*");
+    // emitBitcast already set mapPtr type to %StringMap*
     return mapPtr;
   }
 
@@ -639,10 +584,8 @@ export class StringMapGenerator {
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
 
-    const currentSize = this.nextTemp();
-    this.emit(`${currentSize} = load i32, i32* ${sizeFieldPtr}`);
-    const currentCapacity = this.nextTemp();
-    this.emit(`${currentCapacity} = load i32, i32* ${capacityFieldPtr}`);
+    const currentSize = this.ctx.emitLoad("i32", sizeFieldPtr);
+    const currentCapacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
     const resizeCheckLabel = this.nextLabel("strmap_set_resize_check");
     const resizeLabel = this.nextLabel("strmap_set_resize");
@@ -659,53 +602,43 @@ export class StringMapGenerator {
     this.emit(`${sizeTimes10} = mul i32 ${sizeP1}, 10`);
     const capTimes7 = this.nextTemp();
     this.emit(`${capTimes7} = mul i32 ${currentCapacity}, 7`);
-    const needsResize = this.nextTemp();
-    this.emit(`${needsResize} = icmp sge i32 ${sizeTimes10}, ${capTimes7}`);
-    this.emit(`br i1 ${needsResize}, label %${resizeLabel}, label %${resizeCheckLabel}`);
+    const needsResize = this.ctx.emitIcmp("sge", "i32", sizeTimes10, capTimes7);
+    this.ctx.emitBrCond(needsResize, resizeLabel, resizeCheckLabel);
 
     // Resize: double capacity and rehash
-    this.emit(`${resizeLabel}:`);
+    this.ctx.emitLabel(resizeLabel);
     const newCapacity = this.nextTemp();
     this.emit(`${newCapacity} = shl i32 ${currentCapacity}, 1`);
     const newCapI64 = this.nextTemp();
     this.emit(`${newCapI64} = sext i32 ${newCapacity} to i64`);
     const newArrSize = this.nextTemp();
     this.emit(`${newArrSize} = mul i64 ${newCapI64}, 8`);
-    const newKeysMem = this.nextTemp();
-    this.emit(`${newKeysMem} = call i8* @GC_malloc(i64 ${newArrSize})`);
-    const newKeysPtr = this.nextTemp();
-    this.emit(`${newKeysPtr} = bitcast i8* ${newKeysMem} to i8**`);
-    const newValuesMem = this.nextTemp();
-    this.emit(`${newValuesMem} = call i8* @GC_malloc(i64 ${newArrSize})`);
-    const newValuesPtr = this.nextTemp();
-    this.emit(`${newValuesPtr} = bitcast i8* ${newValuesMem} to i8**`);
+    const newKeysMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${newArrSize}`);
+    const newKeysPtr = this.ctx.emitBitcast(newKeysMem, "i8*", "i8**");
+    const newValuesMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${newArrSize}`);
+    const newValuesPtr = this.ctx.emitBitcast(newValuesMem, "i8*", "i8**");
 
-    const oldKeysPtr = this.nextTemp();
-    this.emit(`${oldKeysPtr} = load i8**, i8*** ${keysFieldPtr}`);
-    const oldValuesPtr = this.nextTemp();
-    this.emit(`${oldValuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
+    const oldKeysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
+    const oldValuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
 
-    this.emit(
-      `call void @__strmap_rehash(i8** ${oldKeysPtr}, i8** ${oldValuesPtr}, i32 ${currentCapacity}, i8** ${newKeysPtr}, i8** ${newValuesPtr}, i32 ${newCapacity})`,
+    this.ctx.emitCallVoid(
+      "@__strmap_rehash",
+      `i8** ${oldKeysPtr}, i8** ${oldValuesPtr}, i32 ${currentCapacity}, i8** ${newKeysPtr}, i8** ${newValuesPtr}, i32 ${newCapacity}`,
     );
 
-    this.emit(`store i8** ${newKeysPtr}, i8*** ${keysFieldPtr}`);
-    this.emit(`store i8** ${newValuesPtr}, i8*** ${valuesFieldPtr}`);
-    this.emit(`store i32 ${newCapacity}, i32* ${capacityFieldPtr}`);
-    this.emit(`br label %${resizeCheckLabel}`);
+    this.ctx.emitStore("i8**", newKeysPtr, keysFieldPtr);
+    this.ctx.emitStore("i8**", newValuesPtr, valuesFieldPtr);
+    this.ctx.emitStore("i32", newCapacity, capacityFieldPtr);
+    this.ctx.emitBr(resizeCheckLabel);
 
     // After potential resize, load fresh pointers and capacity
-    this.emit(`${resizeCheckLabel}:`);
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
-    const capacity = this.nextTemp();
-    this.emit(`${capacity} = load i32, i32* ${capacityFieldPtr}`);
+    this.ctx.emitLabel(resizeCheckLabel);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
+    const capacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
     // Hash the key and compute initial slot
-    const hash = this.nextTemp();
-    this.emit(`${hash} = call i32 @__string_hash(i8* ${keyValue})`);
+    const hash = this.ctx.emitCall("i32", "@__string_hash", `i8* ${keyValue}`);
     const mask = this.nextTemp();
     this.emit(`${mask} = sub i32 ${capacity}, 1`);
     const startSlot = this.nextTemp();
@@ -714,63 +647,56 @@ export class StringMapGenerator {
     // Probe loop
     const slotReg = this.nextTemp();
     this.emit(`${slotReg} = alloca i32`);
-    this.emit(`store i32 ${startSlot}, i32* ${slotReg}`);
-    this.emit(`br label %${probeLabel}`);
+    this.ctx.emitStore("i32", startSlot, slotReg);
+    this.ctx.emitBr(probeLabel);
 
-    this.emit(`${probeLabel}:`);
-    const slot = this.nextTemp();
-    this.emit(`${slot} = load i32, i32* ${slotReg}`);
+    this.ctx.emitLabel(probeLabel);
+    const slot = this.ctx.emitLoad("i32", slotReg);
     const keyElemPtr = this.nextTemp();
     this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${slot}`);
-    const keyAtSlot = this.nextTemp();
-    this.emit(`${keyAtSlot} = load i8*, i8** ${keyElemPtr}`);
-    const isNull = this.nextTemp();
-    this.emit(`${isNull} = icmp eq i8* ${keyAtSlot}, null`);
-    this.emit(`br i1 ${isNull}, label %${insertLabel}, label %${probeBodyLabel}`);
+    const keyAtSlot = this.ctx.emitLoad("i8*", keyElemPtr);
+    const isNull = this.ctx.emitIcmp("eq", "i8*", keyAtSlot, "null");
+    this.ctx.emitBrCond(isNull, insertLabel, probeBodyLabel);
 
     // Slot is occupied - check if same key
-    this.emit(`${probeBodyLabel}:`);
-    const cmpResult = this.nextTemp();
-    this.emit(`${cmpResult} = call i32 @strcmp(i8* ${keyAtSlot}, i8* ${keyValue})`);
-    const keyMatch = this.nextTemp();
-    this.emit(`${keyMatch} = icmp eq i32 ${cmpResult}, 0`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${probeLabel}_next`);
+    this.ctx.emitLabel(probeBodyLabel);
+    const cmpResult = this.ctx.emitCall("i32", "@strcmp", `i8* ${keyAtSlot}, i8* ${keyValue}`);
+    const keyMatch = this.ctx.emitIcmp("eq", "i32", cmpResult, "0");
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${probeLabel}_next`);
 
     // Key already exists - update value
-    this.emit(`${foundLabel}:`);
+    this.ctx.emitLabel(foundLabel);
     const valElemPtrFound = this.nextTemp();
     this.emit(`${valElemPtrFound} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${slot}`);
-    this.emit(`store i8* ${valueValue}, i8** ${valElemPtrFound}`);
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitStore("i8*", valueValue, valElemPtrFound);
+    this.ctx.emitBr(endLabel);
 
     // Next probe slot
-    this.emit(`${probeLabel}_next:`);
+    this.ctx.emitLabel(`${probeLabel}_next`);
     const nextSlot = this.nextTemp();
     this.emit(`${nextSlot} = add i32 ${slot}, 1`);
     const wrappedSlot = this.nextTemp();
     this.emit(`${wrappedSlot} = and i32 ${nextSlot}, ${mask}`);
-    this.emit(`store i32 ${wrappedSlot}, i32* ${slotReg}`);
-    this.emit(`br label %${probeLabel}`);
+    this.ctx.emitStore("i32", wrappedSlot, slotReg);
+    this.ctx.emitBr(probeLabel);
 
     // Empty slot found - insert new entry
-    this.emit(`${insertLabel}:`);
-    const insertSlot = this.nextTemp();
-    this.emit(`${insertSlot} = load i32, i32* ${slotReg}`);
+    this.ctx.emitLabel(insertLabel);
+    const insertSlot = this.ctx.emitLoad("i32", slotReg);
     const keyInsertPtr = this.nextTemp();
     this.emit(`${keyInsertPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${insertSlot}`);
-    this.emit(`store i8* ${keyValue}, i8** ${keyInsertPtr}`);
+    this.ctx.emitStore("i8*", keyValue, keyInsertPtr);
     const valInsertPtr = this.nextTemp();
     this.emit(`${valInsertPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${insertSlot}`);
-    this.emit(`store i8* ${valueValue}, i8** ${valInsertPtr}`);
+    this.ctx.emitStore("i8*", valueValue, valInsertPtr);
 
-    const newSize = this.nextTemp();
-    this.emit(`${newSize} = load i32, i32* ${sizeFieldPtr}`);
+    const newSize = this.ctx.emitLoad("i32", sizeFieldPtr);
     const incSize = this.nextTemp();
     this.emit(`${incSize} = add i32 ${newSize}, 1`);
-    this.emit(`store i32 ${incSize}, i32* ${sizeFieldPtr}`);
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitStore("i32", incSize, sizeFieldPtr);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return mapPtr;
   }
@@ -780,27 +706,23 @@ export class StringMapGenerator {
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
     const valuesFieldPtr = this.nextTemp();
     this.emit(
       `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
     );
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
     const capacityFieldPtr = this.nextTemp();
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    const capacity = this.nextTemp();
-    this.emit(`${capacity} = load i32, i32* ${capacityFieldPtr}`);
+    const capacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
     const resultReg = this.nextTemp();
     this.emit(`${resultReg} = alloca i8*`);
-    this.emit(`store i8* null, i8** ${resultReg}`);
+    this.ctx.emitStore("i8*", "null", resultReg);
 
-    const hash = this.nextTemp();
-    this.emit(`${hash} = call i32 @__string_hash(i8* ${keyToFind})`);
+    const hash = this.ctx.emitCall("i32", "@__string_hash", `i8* ${keyToFind}`);
     const mask = this.nextTemp();
     this.emit(`${mask} = sub i32 ${capacity}, 1`);
     const startSlot = this.nextTemp();
@@ -813,47 +735,40 @@ export class StringMapGenerator {
 
     const slotReg = this.nextTemp();
     this.emit(`${slotReg} = alloca i32`);
-    this.emit(`store i32 ${startSlot}, i32* ${slotReg}`);
-    this.emit(`br label %${probeLabel}`);
+    this.ctx.emitStore("i32", startSlot, slotReg);
+    this.ctx.emitBr(probeLabel);
 
-    this.emit(`${probeLabel}:`);
-    const slot = this.nextTemp();
-    this.emit(`${slot} = load i32, i32* ${slotReg}`);
+    this.ctx.emitLabel(probeLabel);
+    const slot = this.ctx.emitLoad("i32", slotReg);
     const keyElemPtr = this.nextTemp();
     this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${slot}`);
-    const keyAtSlot = this.nextTemp();
-    this.emit(`${keyAtSlot} = load i8*, i8** ${keyElemPtr}`);
-    const isNull = this.nextTemp();
-    this.emit(`${isNull} = icmp eq i8* ${keyAtSlot}, null`);
-    this.emit(`br i1 ${isNull}, label %${endLabel}, label %${probeBodyLabel}`);
+    const keyAtSlot = this.ctx.emitLoad("i8*", keyElemPtr);
+    const isNull = this.ctx.emitIcmp("eq", "i8*", keyAtSlot, "null");
+    this.ctx.emitBrCond(isNull, endLabel, probeBodyLabel);
 
-    this.emit(`${probeBodyLabel}:`);
-    const cmpResult = this.nextTemp();
-    this.emit(`${cmpResult} = call i32 @strcmp(i8* ${keyAtSlot}, i8* ${keyToFind})`);
-    const keyMatch = this.nextTemp();
-    this.emit(`${keyMatch} = icmp eq i32 ${cmpResult}, 0`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${probeLabel}_next`);
+    this.ctx.emitLabel(probeBodyLabel);
+    const cmpResult = this.ctx.emitCall("i32", "@strcmp", `i8* ${keyAtSlot}, i8* ${keyToFind}`);
+    const keyMatch = this.ctx.emitIcmp("eq", "i32", cmpResult, "0");
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${probeLabel}_next`);
 
-    this.emit(`${foundLabel}:`);
+    this.ctx.emitLabel(foundLabel);
     const valueElemPtr = this.nextTemp();
     this.emit(`${valueElemPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${slot}`);
-    const foundValue = this.nextTemp();
-    this.emit(`${foundValue} = load i8*, i8** ${valueElemPtr}`);
-    this.emit(`store i8* ${foundValue}, i8** ${resultReg}`);
-    this.emit(`br label %${endLabel}`);
+    const foundValue = this.ctx.emitLoad("i8*", valueElemPtr);
+    this.ctx.emitStore("i8*", foundValue, resultReg);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${probeLabel}_next:`);
+    this.ctx.emitLabel(`${probeLabel}_next`);
     const nextSlot = this.nextTemp();
     this.emit(`${nextSlot} = add i32 ${slot}, 1`);
     const wrappedSlot = this.nextTemp();
     this.emit(`${wrappedSlot} = and i32 ${nextSlot}, ${mask}`);
-    this.emit(`store i32 ${wrappedSlot}, i32* ${slotReg}`);
-    this.emit(`br label %${probeLabel}`);
+    this.ctx.emitStore("i32", wrappedSlot, slotReg);
+    this.ctx.emitBr(probeLabel);
 
-    this.emit(`${endLabel}:`);
-    const result = this.nextTemp();
-    this.emit(`${result} = load i8*, i8** ${resultReg}`);
-    this.ctx.setVariableType(result, "i8*");
+    this.ctx.emitLabel(endLabel);
+    // emitLoad auto-sets type to i8*
+    const result = this.ctx.emitLoad("i8*", resultReg);
 
     return result;
   }
@@ -863,21 +778,18 @@ export class StringMapGenerator {
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
     const capacityFieldPtr = this.nextTemp();
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    const capacity = this.nextTemp();
-    this.emit(`${capacity} = load i32, i32* ${capacityFieldPtr}`);
+    const capacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
     const resultReg = this.nextTemp();
     this.emit(`${resultReg} = alloca double`);
-    this.emit(`store double 0.0, double* ${resultReg}`);
+    this.ctx.emitStore("double", "0.0", resultReg);
 
-    const hash = this.nextTemp();
-    this.emit(`${hash} = call i32 @__string_hash(i8* ${keyToFind})`);
+    const hash = this.ctx.emitCall("i32", "@__string_hash", `i8* ${keyToFind}`);
     const mask = this.nextTemp();
     this.emit(`${mask} = sub i32 ${capacity}, 1`);
     const startSlot = this.nextTemp();
@@ -890,42 +802,36 @@ export class StringMapGenerator {
 
     const slotReg = this.nextTemp();
     this.emit(`${slotReg} = alloca i32`);
-    this.emit(`store i32 ${startSlot}, i32* ${slotReg}`);
-    this.emit(`br label %${probeLabel}`);
+    this.ctx.emitStore("i32", startSlot, slotReg);
+    this.ctx.emitBr(probeLabel);
 
-    this.emit(`${probeLabel}:`);
-    const slot = this.nextTemp();
-    this.emit(`${slot} = load i32, i32* ${slotReg}`);
+    this.ctx.emitLabel(probeLabel);
+    const slot = this.ctx.emitLoad("i32", slotReg);
     const keyElemPtr = this.nextTemp();
     this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${slot}`);
-    const keyAtSlot = this.nextTemp();
-    this.emit(`${keyAtSlot} = load i8*, i8** ${keyElemPtr}`);
-    const isNull = this.nextTemp();
-    this.emit(`${isNull} = icmp eq i8* ${keyAtSlot}, null`);
-    this.emit(`br i1 ${isNull}, label %${endLabel}, label %${probeBodyLabel}`);
+    const keyAtSlot = this.ctx.emitLoad("i8*", keyElemPtr);
+    const isNull = this.ctx.emitIcmp("eq", "i8*", keyAtSlot, "null");
+    this.ctx.emitBrCond(isNull, endLabel, probeBodyLabel);
 
-    this.emit(`${probeBodyLabel}:`);
-    const cmpResult = this.nextTemp();
-    this.emit(`${cmpResult} = call i32 @strcmp(i8* ${keyAtSlot}, i8* ${keyToFind})`);
-    const keyMatch = this.nextTemp();
-    this.emit(`${keyMatch} = icmp eq i32 ${cmpResult}, 0`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${probeLabel}_next`);
+    this.ctx.emitLabel(probeBodyLabel);
+    const cmpResult = this.ctx.emitCall("i32", "@strcmp", `i8* ${keyAtSlot}, i8* ${keyToFind}`);
+    const keyMatch = this.ctx.emitIcmp("eq", "i32", cmpResult, "0");
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${probeLabel}_next`);
 
-    this.emit(`${foundLabel}:`);
-    this.emit(`store double 1.0, double* ${resultReg}`);
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitLabel(foundLabel);
+    this.ctx.emitStore("double", "1.0", resultReg);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${probeLabel}_next:`);
+    this.ctx.emitLabel(`${probeLabel}_next`);
     const nextSlot = this.nextTemp();
     this.emit(`${nextSlot} = add i32 ${slot}, 1`);
     const wrappedSlot = this.nextTemp();
     this.emit(`${wrappedSlot} = and i32 ${nextSlot}, ${mask}`);
-    this.emit(`store i32 ${wrappedSlot}, i32* ${slotReg}`);
-    this.emit(`br label %${probeLabel}`);
+    this.ctx.emitStore("i32", wrappedSlot, slotReg);
+    this.ctx.emitBr(probeLabel);
 
-    this.emit(`${endLabel}:`);
-    const result = this.nextTemp();
-    this.emit(`${result} = load double, double* ${resultReg}`);
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.emitLoad("double", resultReg);
 
     return result;
   }
@@ -935,8 +841,7 @@ export class StringMapGenerator {
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    const size = this.nextTemp();
-    this.emit(`${size} = load i32, i32* ${sizeFieldPtr}`);
+    const size = this.ctx.emitLoad("i32", sizeFieldPtr);
     return size;
   }
 
@@ -953,31 +858,26 @@ export class StringMapGenerator {
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    const capacity = this.nextTemp();
-    this.emit(`${capacity} = load i32, i32* ${capacityFieldPtr}`);
+    const capacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
     const capI64 = this.nextTemp();
     this.emit(`${capI64} = sext i32 ${capacity} to i64`);
     const arrSize = this.nextTemp();
     this.emit(`${arrSize} = mul i64 ${capI64}, 8`);
 
-    const newKeysMem = this.nextTemp();
-    this.emit(`${newKeysMem} = call i8* @GC_malloc(i64 ${arrSize})`);
-    const newKeysPtr = this.nextTemp();
-    this.emit(`${newKeysPtr} = bitcast i8* ${newKeysMem} to i8**`);
-    this.emit(`store i8** ${newKeysPtr}, i8*** ${keysFieldPtr}`);
+    const newKeysMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${arrSize}`);
+    const newKeysPtr = this.ctx.emitBitcast(newKeysMem, "i8*", "i8**");
+    this.ctx.emitStore("i8**", newKeysPtr, keysFieldPtr);
 
-    const newValuesMem = this.nextTemp();
-    this.emit(`${newValuesMem} = call i8* @GC_malloc(i64 ${arrSize})`);
-    const newValuesPtr = this.nextTemp();
-    this.emit(`${newValuesPtr} = bitcast i8* ${newValuesMem} to i8**`);
-    this.emit(`store i8** ${newValuesPtr}, i8*** ${valuesFieldPtr}`);
+    const newValuesMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${arrSize}`);
+    const newValuesPtr = this.ctx.emitBitcast(newValuesMem, "i8*", "i8**");
+    this.ctx.emitStore("i8**", newValuesPtr, valuesFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    this.emit(`store i32 0, i32* ${sizeFieldPtr}`);
+    this.ctx.emitStore("i32", "0", sizeFieldPtr);
     return "0.0";
   }
 
@@ -986,14 +886,12 @@ export class StringMapGenerator {
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
     const valuesFieldPtr = this.nextTemp();
     this.emit(
       `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
     );
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
     const sizeFieldPtr = this.nextTemp();
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
@@ -1002,15 +900,13 @@ export class StringMapGenerator {
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    const capacity = this.nextTemp();
-    this.emit(`${capacity} = load i32, i32* ${capacityFieldPtr}`);
+    const capacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
     const resultReg = this.nextTemp();
     this.emit(`${resultReg} = alloca double`);
-    this.emit(`store double 0.0, double* ${resultReg}`);
+    this.ctx.emitStore("double", "0.0", resultReg);
 
-    const hash = this.nextTemp();
-    this.emit(`${hash} = call i32 @__string_hash(i8* ${keyToFind})`);
+    const hash = this.ctx.emitCall("i32", "@__string_hash", `i8* ${keyToFind}`);
     const mask = this.nextTemp();
     this.emit(`${mask} = sub i32 ${capacity}, 1`);
     const startSlot = this.nextTemp();
@@ -1028,51 +924,44 @@ export class StringMapGenerator {
 
     const slotReg = this.nextTemp();
     this.emit(`${slotReg} = alloca i32`);
-    this.emit(`store i32 ${startSlot}, i32* ${slotReg}`);
-    this.emit(`br label %${probeLabel}`);
+    this.ctx.emitStore("i32", startSlot, slotReg);
+    this.ctx.emitBr(probeLabel);
 
-    this.emit(`${probeLabel}:`);
-    const slot = this.nextTemp();
-    this.emit(`${slot} = load i32, i32* ${slotReg}`);
+    this.ctx.emitLabel(probeLabel);
+    const slot = this.ctx.emitLoad("i32", slotReg);
     const keyElemPtr = this.nextTemp();
     this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${slot}`);
-    const keyAtSlot = this.nextTemp();
-    this.emit(`${keyAtSlot} = load i8*, i8** ${keyElemPtr}`);
-    const isNull = this.nextTemp();
-    this.emit(`${isNull} = icmp eq i8* ${keyAtSlot}, null`);
-    this.emit(`br i1 ${isNull}, label %${endLabel}, label %${probeBodyLabel}`);
+    const keyAtSlot = this.ctx.emitLoad("i8*", keyElemPtr);
+    const isNull = this.ctx.emitIcmp("eq", "i8*", keyAtSlot, "null");
+    this.ctx.emitBrCond(isNull, endLabel, probeBodyLabel);
 
-    this.emit(`${probeBodyLabel}:`);
-    const cmpResult = this.nextTemp();
-    this.emit(`${cmpResult} = call i32 @strcmp(i8* ${keyAtSlot}, i8* ${keyToFind})`);
-    const keyMatch = this.nextTemp();
-    this.emit(`${keyMatch} = icmp eq i32 ${cmpResult}, 0`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${probeLabel}_next`);
+    this.ctx.emitLabel(probeBodyLabel);
+    const cmpResult = this.ctx.emitCall("i32", "@strcmp", `i8* ${keyAtSlot}, i8* ${keyToFind}`);
+    const keyMatch = this.ctx.emitIcmp("eq", "i32", cmpResult, "0");
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${probeLabel}_next`);
 
-    this.emit(`${probeLabel}_next:`);
+    this.ctx.emitLabel(`${probeLabel}_next`);
     const nextSlotDel = this.nextTemp();
     this.emit(`${nextSlotDel} = add i32 ${slot}, 1`);
     const wrappedSlotDel = this.nextTemp();
     this.emit(`${wrappedSlotDel} = and i32 ${nextSlotDel}, ${mask}`);
-    this.emit(`store i32 ${wrappedSlotDel}, i32* ${slotReg}`);
-    this.emit(`br label %${probeLabel}`);
+    this.ctx.emitStore("i32", wrappedSlotDel, slotReg);
+    this.ctx.emitBr(probeLabel);
 
     // Found - remove entry and backward-shift rehash
-    this.emit(`${foundLabel}:`);
-    this.emit(`store double 1.0, double* ${resultReg}`);
-    const foundSlot = this.nextTemp();
-    this.emit(`${foundSlot} = load i32, i32* ${slotReg}`);
+    this.ctx.emitLabel(foundLabel);
+    this.ctx.emitStore("double", "1.0", resultReg);
+    const foundSlot = this.ctx.emitLoad("i32", slotReg);
     const foundKeyPtr = this.nextTemp();
     this.emit(`${foundKeyPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${foundSlot}`);
-    this.emit(`store i8* null, i8** ${foundKeyPtr}`);
+    this.ctx.emitStore("i8*", "null", foundKeyPtr);
     const foundValPtr = this.nextTemp();
     this.emit(`${foundValPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${foundSlot}`);
-    this.emit(`store i8* null, i8** ${foundValPtr}`);
-    const curSize = this.nextTemp();
-    this.emit(`${curSize} = load i32, i32* ${sizeFieldPtr}`);
+    this.ctx.emitStore("i8*", "null", foundValPtr);
+    const curSize = this.ctx.emitLoad("i32", sizeFieldPtr);
     const decSize = this.nextTemp();
     this.emit(`${decSize} = sub i32 ${curSize}, 1`);
-    this.emit(`store i32 ${decSize}, i32* ${sizeFieldPtr}`);
+    this.ctx.emitStore("i32", decSize, sizeFieldPtr);
 
     // Backward-shift rehash: fix up subsequent entries displaced by linear probing
     const rehashIdx = this.nextTemp();
@@ -1081,77 +970,67 @@ export class StringMapGenerator {
     this.emit(`${nextAfterFound} = add i32 ${foundSlot}, 1`);
     const wrappedNext = this.nextTemp();
     this.emit(`${wrappedNext} = and i32 ${nextAfterFound}, ${mask}`);
-    this.emit(`store i32 ${wrappedNext}, i32* ${rehashIdx}`);
-    this.emit(`br label %${rehashLabel}`);
+    this.ctx.emitStore("i32", wrappedNext, rehashIdx);
+    this.ctx.emitBr(rehashLabel);
 
-    this.emit(`${rehashLabel}:`);
-    const ri = this.nextTemp();
-    this.emit(`${ri} = load i32, i32* ${rehashIdx}`);
+    this.ctx.emitLabel(rehashLabel);
+    const ri = this.ctx.emitLoad("i32", rehashIdx);
     const riKeyPtr = this.nextTemp();
     this.emit(`${riKeyPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${ri}`);
-    const riKey = this.nextTemp();
-    this.emit(`${riKey} = load i8*, i8** ${riKeyPtr}`);
-    const riIsNull = this.nextTemp();
-    this.emit(`${riIsNull} = icmp eq i8* ${riKey}, null`);
-    this.emit(`br i1 ${riIsNull}, label %${endLabel}, label %${rehashBodyLabel}`);
+    const riKey = this.ctx.emitLoad("i8*", riKeyPtr);
+    const riIsNull = this.ctx.emitIcmp("eq", "i8*", riKey, "null");
+    this.ctx.emitBrCond(riIsNull, endLabel, rehashBodyLabel);
 
-    this.emit(`${rehashBodyLabel}:`);
-    const riHash = this.nextTemp();
-    this.emit(`${riHash} = call i32 @__string_hash(i8* ${riKey})`);
+    this.ctx.emitLabel(rehashBodyLabel);
+    const riHash = this.ctx.emitCall("i32", "@__string_hash", `i8* ${riKey}`);
     const riDesired = this.nextTemp();
     this.emit(`${riDesired} = and i32 ${riHash}, ${mask}`);
     // Remove current entry
-    this.emit(`store i8* null, i8** ${riKeyPtr}`);
+    this.ctx.emitStore("i8*", "null", riKeyPtr);
     const riValPtr = this.nextTemp();
     this.emit(`${riValPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${ri}`);
-    const riVal = this.nextTemp();
-    this.emit(`${riVal} = load i8*, i8** ${riValPtr}`);
-    this.emit(`store i8* null, i8** ${riValPtr}`);
+    const riVal = this.ctx.emitLoad("i8*", riValPtr);
+    this.ctx.emitStore("i8*", "null", riValPtr);
     // Re-insert from desired position
     const riSlotReg = this.nextTemp();
     this.emit(`${riSlotReg} = alloca i32`);
-    this.emit(`store i32 ${riDesired}, i32* ${riSlotReg}`);
-    this.emit(`br label %${rehashProbeLabel}`);
+    this.ctx.emitStore("i32", riDesired, riSlotReg);
+    this.ctx.emitBr(rehashProbeLabel);
 
-    this.emit(`${rehashProbeLabel}:`);
-    const riSlot = this.nextTemp();
-    this.emit(`${riSlot} = load i32, i32* ${riSlotReg}`);
+    this.ctx.emitLabel(rehashProbeLabel);
+    const riSlot = this.ctx.emitLoad("i32", riSlotReg);
     const riSlotKeyPtr = this.nextTemp();
     this.emit(`${riSlotKeyPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${riSlot}`);
-    const riSlotKey = this.nextTemp();
-    this.emit(`${riSlotKey} = load i8*, i8** ${riSlotKeyPtr}`);
-    const riSlotEmpty = this.nextTemp();
-    this.emit(`${riSlotEmpty} = icmp eq i8* ${riSlotKey}, null`);
-    this.emit(`br i1 ${riSlotEmpty}, label %${rehashPlaceLabel}, label %${rehashProbeLabel}_next`);
+    const riSlotKey = this.ctx.emitLoad("i8*", riSlotKeyPtr);
+    const riSlotEmpty = this.ctx.emitIcmp("eq", "i8*", riSlotKey, "null");
+    this.ctx.emitBrCond(riSlotEmpty, rehashPlaceLabel, `${rehashProbeLabel}_next`);
 
-    this.emit(`${rehashProbeLabel}_next:`);
+    this.ctx.emitLabel(`${rehashProbeLabel}_next`);
     const riNextSlot = this.nextTemp();
     this.emit(`${riNextSlot} = add i32 ${riSlot}, 1`);
     const riWrapped = this.nextTemp();
     this.emit(`${riWrapped} = and i32 ${riNextSlot}, ${mask}`);
-    this.emit(`store i32 ${riWrapped}, i32* ${riSlotReg}`);
-    this.emit(`br label %${rehashProbeLabel}`);
+    this.ctx.emitStore("i32", riWrapped, riSlotReg);
+    this.ctx.emitBr(rehashProbeLabel);
 
-    this.emit(`${rehashPlaceLabel}:`);
-    const placeSlot = this.nextTemp();
-    this.emit(`${placeSlot} = load i32, i32* ${riSlotReg}`);
+    this.ctx.emitLabel(rehashPlaceLabel);
+    const placeSlot = this.ctx.emitLoad("i32", riSlotReg);
     const placeKeyPtr = this.nextTemp();
     this.emit(`${placeKeyPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${placeSlot}`);
-    this.emit(`store i8* ${riKey}, i8** ${placeKeyPtr}`);
+    this.ctx.emitStore("i8*", riKey, placeKeyPtr);
     const placeValPtr = this.nextTemp();
     this.emit(`${placeValPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${placeSlot}`);
-    this.emit(`store i8* ${riVal}, i8** ${placeValPtr}`);
+    this.ctx.emitStore("i8*", riVal, placeValPtr);
 
     const riNext = this.nextTemp();
     this.emit(`${riNext} = add i32 ${ri}, 1`);
     const riNextWrapped = this.nextTemp();
     this.emit(`${riNextWrapped} = and i32 ${riNext}, ${mask}`);
-    this.emit(`store i32 ${riNextWrapped}, i32* ${rehashIdx}`);
-    this.emit(`br label %${rehashLabel}`);
+    this.ctx.emitStore("i32", riNextWrapped, rehashIdx);
+    this.ctx.emitBr(rehashLabel);
 
-    this.emit(`${endLabel}:`);
-    const result = this.nextTemp();
-    this.emit(`${result} = load double, double* ${resultReg}`);
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.emitLoad("double", resultReg);
 
     return result;
   }
@@ -1161,55 +1040,46 @@ export class StringMapGenerator {
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
 
     const valuesFieldPtr = this.nextTemp();
     this.emit(
       `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
     );
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    const mapSize = this.nextTemp();
-    this.emit(`${mapSize} = load i32, i32* ${sizeFieldPtr}`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     const capacityFieldPtr = this.nextTemp();
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    const mapCapacity = this.nextTemp();
-    this.emit(`${mapCapacity} = load i32, i32* ${capacityFieldPtr}`);
+    const mapCapacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
-    const arrayMem = this.nextTemp();
-    this.emit(`${arrayMem} = call i8* @GC_malloc(i64 24)`);
-    const arrayPtr = this.nextTemp();
-    this.emit(`${arrayPtr} = bitcast i8* ${arrayMem} to %Array*`);
+    const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
 
     const mapSizeI64 = this.nextTemp();
     this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
-    const dataMem = this.nextTemp();
-    this.emit(`${dataMem} = call i8* @GC_malloc(i64 ${dataSize})`);
-    const dataPtr = this.nextTemp();
-    this.emit(`${dataPtr} = bitcast i8* ${dataMem} to i8**`);
+    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
+    const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
 
     const lenFieldPtr = this.nextTemp();
     this.emit(`${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
-    this.emit(`store i32 ${mapSize}, i32* ${lenFieldPtr}`);
+    this.ctx.emitStore("i32", mapSize, lenFieldPtr);
     const capFieldPtr = this.nextTemp();
     this.emit(`${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
-    this.emit(`store i32 ${mapSize}, i32* ${capFieldPtr}`);
+    this.ctx.emitStore("i32", mapSize, capFieldPtr);
     const dataFieldPtr = this.nextTemp();
     this.emit(`${dataFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`);
-    const dataCast = this.nextTemp();
-    this.emit(`${dataCast} = bitcast i8** ${dataPtr} to double*`);
-    this.emit(`store double* ${dataCast}, double** ${dataFieldPtr}`);
+    const dataCast = this.ctx.emitBitcast(dataPtr, "i8**", "double*");
+    this.ctx.emitStore("double*", dataCast, dataFieldPtr);
 
     const loopLabel = this.nextLabel("strmap_entries_loop");
     const bodyLabel = this.nextLabel("strmap_entries_body");
@@ -1218,68 +1088,60 @@ export class StringMapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
+    this.ctx.emitStore("i32", "0", indexReg);
     const outIdxReg = this.nextTemp();
     this.emit(`${outIdxReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${outIdxReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", "0", outIdxReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${loopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const cond = this.nextTemp();
-    this.emit(`${cond} = icmp slt i32 ${currentIndex}, ${mapCapacity}`);
-    this.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapCapacity);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     const keyElemPtr = this.nextTemp();
     this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`);
-    const keyValue = this.nextTemp();
-    this.emit(`${keyValue} = load i8*, i8** ${keyElemPtr}`);
-    const keyIsNull = this.nextTemp();
-    this.emit(`${keyIsNull} = icmp eq i8* ${keyValue}, null`);
-    this.emit(`br i1 ${keyIsNull}, label %${skipLabel}, label %${bodyLabel}_store`);
+    const keyValue = this.ctx.emitLoad("i8*", keyElemPtr);
+    const keyIsNull = this.ctx.emitIcmp("eq", "i8*", keyValue, "null");
+    this.ctx.emitBrCond(keyIsNull, skipLabel, `${bodyLabel}_store`);
 
-    this.emit(`${bodyLabel}_store:`);
+    this.ctx.emitLabel(`${bodyLabel}_store`);
     const valueElemPtr = this.nextTemp();
     this.emit(
       `${valueElemPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${currentIndex}`,
     );
-    const valueValue = this.nextTemp();
-    this.emit(`${valueValue} = load i8*, i8** ${valueElemPtr}`);
+    const valueValue = this.ctx.emitLoad("i8*", valueElemPtr);
 
-    const entryMem = this.nextTemp();
-    this.emit(`${entryMem} = call i8* @GC_malloc(i64 16)`);
-    const entryKvPtr = this.nextTemp();
-    this.emit(`${entryKvPtr} = bitcast i8* ${entryMem} to { i8*, i8* }*`);
+    const entryMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 16");
+    const entryKvPtr = this.ctx.emitBitcast(entryMem, "i8*", "{ i8*, i8* }*");
     const keySlot = this.nextTemp();
     this.emit(
       `${keySlot} = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* ${entryKvPtr}, i32 0, i32 0`,
     );
-    this.emit(`store i8* ${keyValue}, i8** ${keySlot}`);
+    this.ctx.emitStore("i8*", keyValue, keySlot);
     const valueSlot = this.nextTemp();
     this.emit(
       `${valueSlot} = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* ${entryKvPtr}, i32 0, i32 1`,
     );
-    this.emit(`store i8* ${valueValue}, i8** ${valueSlot}`);
+    this.ctx.emitStore("i8*", valueValue, valueSlot);
 
-    const outIdx = this.nextTemp();
-    this.emit(`${outIdx} = load i32, i32* ${outIdxReg}`);
+    const outIdx = this.ctx.emitLoad("i32", outIdxReg);
     const entrySlot = this.nextTemp();
     this.emit(`${entrySlot} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${outIdx}`);
-    this.emit(`store i8* ${entryMem}, i8** ${entrySlot}`);
+    this.ctx.emitStore("i8*", entryMem, entrySlot);
     const nextOut = this.nextTemp();
     this.emit(`${nextOut} = add i32 ${outIdx}, 1`);
-    this.emit(`store i32 ${nextOut}, i32* ${outIdxReg}`);
-    this.emit(`br label %${skipLabel}`);
+    this.ctx.emitStore("i32", nextOut, outIdxReg);
+    this.ctx.emitBr(skipLabel);
 
-    this.emit(`${skipLabel}:`);
+    this.ctx.emitLabel(skipLabel);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return arrayPtr;
   }
@@ -1289,55 +1151,46 @@ export class StringMapGenerator {
     this.emit(
       `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
     );
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
 
     const keysFieldPtr = this.nextTemp();
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    const mapSize = this.nextTemp();
-    this.emit(`${mapSize} = load i32, i32* ${sizeFieldPtr}`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     const capacityFieldPtr = this.nextTemp();
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    const mapCapacity = this.nextTemp();
-    this.emit(`${mapCapacity} = load i32, i32* ${capacityFieldPtr}`);
+    const mapCapacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
-    const arrayMem = this.nextTemp();
-    this.emit(`${arrayMem} = call i8* @GC_malloc(i64 24)`);
-    const arrayPtr = this.nextTemp();
-    this.emit(`${arrayPtr} = bitcast i8* ${arrayMem} to %Array*`);
+    const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
 
     const mapSizeI64 = this.nextTemp();
     this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
-    const dataMem = this.nextTemp();
-    this.emit(`${dataMem} = call i8* @GC_malloc(i64 ${dataSize})`);
-    const dataPtr = this.nextTemp();
-    this.emit(`${dataPtr} = bitcast i8* ${dataMem} to i8**`);
+    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
+    const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
 
     const lenFieldPtr = this.nextTemp();
     this.emit(`${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
-    this.emit(`store i32 ${mapSize}, i32* ${lenFieldPtr}`);
+    this.ctx.emitStore("i32", mapSize, lenFieldPtr);
     const capFieldPtr = this.nextTemp();
     this.emit(`${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
-    this.emit(`store i32 ${mapSize}, i32* ${capFieldPtr}`);
+    this.ctx.emitStore("i32", mapSize, capFieldPtr);
     const dataFieldPtr = this.nextTemp();
     this.emit(`${dataFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`);
-    const dataCast = this.nextTemp();
-    this.emit(`${dataCast} = bitcast i8** ${dataPtr} to double*`);
-    this.emit(`store double* ${dataCast}, double** ${dataFieldPtr}`);
+    const dataCast = this.ctx.emitBitcast(dataPtr, "i8**", "double*");
+    this.ctx.emitStore("double*", dataCast, dataFieldPtr);
 
     const loopLabel = this.nextLabel("strmap_values_loop");
     const bodyLabel = this.nextLabel("strmap_values_body");
@@ -1346,53 +1199,47 @@ export class StringMapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
+    this.ctx.emitStore("i32", "0", indexReg);
     const outIdxReg = this.nextTemp();
     this.emit(`${outIdxReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${outIdxReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", "0", outIdxReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${loopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const cond = this.nextTemp();
-    this.emit(`${cond} = icmp slt i32 ${currentIndex}, ${mapCapacity}`);
-    this.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapCapacity);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     const keyElemPtr = this.nextTemp();
     this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`);
-    const keyValue = this.nextTemp();
-    this.emit(`${keyValue} = load i8*, i8** ${keyElemPtr}`);
-    const keyIsNull = this.nextTemp();
-    this.emit(`${keyIsNull} = icmp eq i8* ${keyValue}, null`);
-    this.emit(`br i1 ${keyIsNull}, label %${skipLabel}, label %${bodyLabel}_store`);
+    const keyValue = this.ctx.emitLoad("i8*", keyElemPtr);
+    const keyIsNull = this.ctx.emitIcmp("eq", "i8*", keyValue, "null");
+    this.ctx.emitBrCond(keyIsNull, skipLabel, `${bodyLabel}_store`);
 
-    this.emit(`${bodyLabel}_store:`);
+    this.ctx.emitLabel(`${bodyLabel}_store`);
     const valueElemPtr = this.nextTemp();
     this.emit(
       `${valueElemPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${currentIndex}`,
     );
-    const valueValue = this.nextTemp();
-    this.emit(`${valueValue} = load i8*, i8** ${valueElemPtr}`);
+    const valueValue = this.ctx.emitLoad("i8*", valueElemPtr);
 
-    const outIdx = this.nextTemp();
-    this.emit(`${outIdx} = load i32, i32* ${outIdxReg}`);
+    const outIdx = this.ctx.emitLoad("i32", outIdxReg);
     const valueSlot = this.nextTemp();
     this.emit(`${valueSlot} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${outIdx}`);
-    this.emit(`store i8* ${valueValue}, i8** ${valueSlot}`);
+    this.ctx.emitStore("i8*", valueValue, valueSlot);
     const nextOut = this.nextTemp();
     this.emit(`${nextOut} = add i32 ${outIdx}, 1`);
-    this.emit(`store i32 ${nextOut}, i32* ${outIdxReg}`);
-    this.emit(`br label %${skipLabel}`);
+    this.ctx.emitStore("i32", nextOut, outIdxReg);
+    this.ctx.emitBr(skipLabel);
 
-    this.emit(`${skipLabel}:`);
+    this.ctx.emitLabel(skipLabel);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return arrayPtr;
   }
@@ -1402,52 +1249,45 @@ export class StringMapGenerator {
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    const mapSize = this.nextTemp();
-    this.emit(`${mapSize} = load i32, i32* ${sizeFieldPtr}`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     const capacityFieldPtr = this.nextTemp();
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    const mapCapacity = this.nextTemp();
-    this.emit(`${mapCapacity} = load i32, i32* ${capacityFieldPtr}`);
+    const mapCapacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
-    const arrayMem = this.nextTemp();
-    this.emit(`${arrayMem} = call i8* @GC_malloc(i64 24)`);
-    const arrayPtr = this.nextTemp();
-    this.emit(`${arrayPtr} = bitcast i8* ${arrayMem} to %StringArray*`);
+    const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%StringArray*");
 
     const mapSizeI64 = this.nextTemp();
     this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
-    const dataMem = this.nextTemp();
-    this.emit(`${dataMem} = call i8* @GC_malloc(i64 ${dataSize})`);
-    const dataPtr = this.nextTemp();
-    this.emit(`${dataPtr} = bitcast i8* ${dataMem} to i8**`);
+    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
+    const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
 
     const dataPtrField = this.nextTemp();
     this.emit(
       `${dataPtrField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
     );
-    this.emit(`store i8** ${dataPtr}, i8*** ${dataPtrField}`);
+    this.ctx.emitStore("i8**", dataPtr, dataPtrField);
     const lenFieldPtr = this.nextTemp();
     this.emit(
       `${lenFieldPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
     );
-    this.emit(`store i32 ${mapSize}, i32* ${lenFieldPtr}`);
+    this.ctx.emitStore("i32", mapSize, lenFieldPtr);
     const capFieldPtr = this.nextTemp();
     this.emit(
       `${capFieldPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 2`,
     );
-    this.emit(`store i32 ${mapSize}, i32* ${capFieldPtr}`);
+    this.ctx.emitStore("i32", mapSize, capFieldPtr);
 
     const loopLabel = this.nextLabel("strmap_keys_loop");
     const bodyLabel = this.nextLabel("strmap_keys_body");
@@ -1456,48 +1296,43 @@ export class StringMapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
+    this.ctx.emitStore("i32", "0", indexReg);
     const outIdxReg = this.nextTemp();
     this.emit(`${outIdxReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${outIdxReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", "0", outIdxReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${loopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const cond = this.nextTemp();
-    this.emit(`${cond} = icmp slt i32 ${currentIndex}, ${mapCapacity}`);
-    this.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapCapacity);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     const keyElemPtr = this.nextTemp();
     this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`);
-    const keyVal = this.nextTemp();
-    this.emit(`${keyVal} = load i8*, i8** ${keyElemPtr}`);
-    const keyIsNull = this.nextTemp();
-    this.emit(`${keyIsNull} = icmp eq i8* ${keyVal}, null`);
-    this.emit(`br i1 ${keyIsNull}, label %${skipLabel}, label %${bodyLabel}_store`);
+    const keyVal = this.ctx.emitLoad("i8*", keyElemPtr);
+    const keyIsNull = this.ctx.emitIcmp("eq", "i8*", keyVal, "null");
+    this.ctx.emitBrCond(keyIsNull, skipLabel, `${bodyLabel}_store`);
 
-    this.emit(`${bodyLabel}_store:`);
-    const outIdx = this.nextTemp();
-    this.emit(`${outIdx} = load i32, i32* ${outIdxReg}`);
+    this.ctx.emitLabel(`${bodyLabel}_store`);
+    const outIdx = this.ctx.emitLoad("i32", outIdxReg);
     const destElemPtr = this.nextTemp();
     this.emit(`${destElemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${outIdx}`);
-    this.emit(`store i8* ${keyVal}, i8** ${destElemPtr}`);
+    this.ctx.emitStore("i8*", keyVal, destElemPtr);
     const nextOut = this.nextTemp();
     this.emit(`${nextOut} = add i32 ${outIdx}, 1`);
-    this.emit(`store i32 ${nextOut}, i32* ${outIdxReg}`);
-    this.emit(`br label %${skipLabel}`);
+    this.ctx.emitStore("i32", nextOut, outIdxReg);
+    this.ctx.emitBr(skipLabel);
 
-    this.emit(`${skipLabel}:`);
+    this.ctx.emitLabel(skipLabel);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
-    this.ctx.setVariableType(arrayPtr, "%StringArray*");
+    // emitBitcast already set arrayPtr type to %StringArray*
     return arrayPtr;
   }
 }
@@ -1520,26 +1355,23 @@ export class PointerMapGenerator {
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
 
     const valuesFieldPtr = this.nextTemp();
     this.emit(
       `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
     );
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    const mapSize = this.nextTemp();
-    this.emit(`${mapSize} = load i32, i32* ${sizeFieldPtr}`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     const resultReg = this.nextTemp();
     this.emit(`${resultReg} = alloca i8*`);
-    this.emit(`store i8* null, i8** ${resultReg}`);
+    this.ctx.emitStore("i8*", "null", resultReg);
 
     const loopLabel = this.nextLabel("ptrmap_get_loop");
     const bodyLabel = this.nextLabel("ptrmap_get_body");
@@ -1548,47 +1380,40 @@ export class PointerMapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${loopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const cond = this.nextTemp();
-    this.emit(`${cond} = icmp slt i32 ${currentIndex}, ${mapSize}`);
-    this.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-    this.emit(`${bodyLabel}:`);
+    this.ctx.emitLabel(bodyLabel);
     const keyElemPtr = this.nextTemp();
     this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`);
-    const keyValue = this.nextTemp();
-    this.emit(`${keyValue} = load i8*, i8** ${keyElemPtr}`);
-    const keyCmp = this.nextTemp();
-    this.emit(`${keyCmp} = call i32 @strcmp(i8* ${keyValue}, i8* ${keyToFind})`);
-    const keyMatch = this.nextTemp();
-    this.emit(`${keyMatch} = icmp eq i32 ${keyCmp}, 0`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${loopLabel}_next`);
+    const keyValue = this.ctx.emitLoad("i8*", keyElemPtr);
+    const keyCmp = this.ctx.emitCall("i32", "@strcmp", `i8* ${keyValue}, i8* ${keyToFind}`);
+    const keyMatch = this.ctx.emitIcmp("eq", "i32", keyCmp, "0");
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${loopLabel}_next`);
 
-    this.emit(`${foundLabel}:`);
+    this.ctx.emitLabel(foundLabel);
     const valueElemPtr = this.nextTemp();
     this.emit(
       `${valueElemPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${currentIndex}`,
     );
-    const foundValue = this.nextTemp();
-    this.emit(`${foundValue} = load i8*, i8** ${valueElemPtr}`);
-    this.emit(`store i8* ${foundValue}, i8** ${resultReg}`);
-    this.emit(`br label %${endLabel}`);
+    const foundValue = this.ctx.emitLoad("i8*", valueElemPtr);
+    this.ctx.emitStore("i8*", foundValue, resultReg);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${loopLabel}_next:`);
+    this.ctx.emitLabel(`${loopLabel}_next`);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${loopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
 
-    this.emit(`${endLabel}:`);
-    const result = this.nextTemp();
-    this.emit(`${result} = load i8*, i8** ${resultReg}`);
-    this.ctx.setVariableType(result, "i8*");
+    this.ctx.emitLabel(endLabel);
+    // emitLoad auto-sets type to i8*
+    const result = this.ctx.emitLoad("i8*", resultReg);
 
     return result;
   }
@@ -1598,22 +1423,19 @@ export class PointerMapGenerator {
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
     );
-    const keysPtr = this.nextTemp();
-    this.emit(`${keysPtr} = load i8**, i8*** ${keysFieldPtr}`);
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
 
     const valuesFieldPtr = this.nextTemp();
     this.emit(
       `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
     );
-    const valuesPtr = this.nextTemp();
-    this.emit(`${valuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
 
     const sizeFieldPtr = this.nextTemp();
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    const currentSize = this.nextTemp();
-    this.emit(`${currentSize} = load i32, i32* ${sizeFieldPtr}`);
+    const currentSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     const searchLoopLabel = this.nextLabel("ptrmap_set_search");
     const searchBodyLabel = this.nextLabel("ptrmap_set_body");
@@ -1624,62 +1446,54 @@ export class PointerMapGenerator {
 
     const indexReg = this.nextTemp();
     this.emit(`${indexReg} = alloca i32`);
-    this.emit(`store i32 0, i32* ${indexReg}`);
-    this.emit(`br label %${searchLoopLabel}`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(searchLoopLabel);
 
-    this.emit(`${searchLoopLabel}:`);
-    const currentIndex = this.nextTemp();
-    this.emit(`${currentIndex} = load i32, i32* ${indexReg}`);
-    const searchCond = this.nextTemp();
-    this.emit(`${searchCond} = icmp slt i32 ${currentIndex}, ${currentSize}`);
-    this.emit(`br i1 ${searchCond}, label %${searchBodyLabel}, label %${notFoundLabel}`);
+    this.ctx.emitLabel(searchLoopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const searchCond = this.ctx.emitIcmp("slt", "i32", currentIndex, currentSize);
+    this.ctx.emitBrCond(searchCond, searchBodyLabel, notFoundLabel);
 
-    this.emit(`${searchBodyLabel}:`);
+    this.ctx.emitLabel(searchBodyLabel);
     const keyElemPtrSearch = this.nextTemp();
     this.emit(
       `${keyElemPtrSearch} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`,
     );
-    const keyAtIndex = this.nextTemp();
-    this.emit(`${keyAtIndex} = load i8*, i8** ${keyElemPtrSearch}`);
-    const keyCmp = this.nextTemp();
-    this.emit(`${keyCmp} = call i32 @strcmp(i8* ${keyAtIndex}, i8* ${keyValue})`);
-    const keyMatch = this.nextTemp();
-    this.emit(`${keyMatch} = icmp eq i32 ${keyCmp}, 0`);
-    this.emit(`br i1 ${keyMatch}, label %${foundLabel}, label %${searchLoopLabel}_next`);
+    const keyAtIndex = this.ctx.emitLoad("i8*", keyElemPtrSearch);
+    const keyCmp = this.ctx.emitCall("i32", "@strcmp", `i8* ${keyAtIndex}, i8* ${keyValue}`);
+    const keyMatch = this.ctx.emitIcmp("eq", "i32", keyCmp, "0");
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${searchLoopLabel}_next`);
 
-    this.emit(`${searchLoopLabel}_next:`);
+    this.ctx.emitLabel(`${searchLoopLabel}_next`);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
-    this.emit(`store i32 ${nextIndex}, i32* ${indexReg}`);
-    this.emit(`br label %${searchLoopLabel}`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(searchLoopLabel);
 
-    this.emit(`${foundLabel}:`);
-    const foundIdx = this.nextTemp();
-    this.emit(`${foundIdx} = load i32, i32* ${indexReg}`);
+    this.ctx.emitLabel(foundLabel);
+    const foundIdx = this.ctx.emitLoad("i32", indexReg);
     const valueElemPtrFound = this.nextTemp();
     this.emit(
       `${valueElemPtrFound} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${foundIdx}`,
     );
-    this.emit(`store i8* ${valueValue}, i8** ${valueElemPtrFound}`);
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitStore("i8*", valueValue, valueElemPtrFound);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${notFoundLabel}:`);
-    this.emit(`br label %${insertLabel}`);
+    this.ctx.emitLabel(notFoundLabel);
+    this.ctx.emitBr(insertLabel);
 
-    this.emit(`${insertLabel}:`);
+    this.ctx.emitLabel(insertLabel);
     const capacityFieldPtr = this.nextTemp();
     this.emit(
       `${capacityFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
     );
-    const currentCapacity = this.nextTemp();
-    this.emit(`${currentCapacity} = load i32, i32* ${capacityFieldPtr}`);
-    const needsResize = this.nextTemp();
-    this.emit(`${needsResize} = icmp sge i32 ${currentSize}, ${currentCapacity}`);
+    const currentCapacity = this.ctx.emitLoad("i32", capacityFieldPtr);
+    const needsResize = this.ctx.emitIcmp("sge", "i32", currentSize, currentCapacity);
     const resizeLabel = this.nextLabel("ptrmap_set_resize");
     const doInsertLabel = this.nextLabel("ptrmap_set_doinsert");
-    this.emit(`br i1 ${needsResize}, label %${resizeLabel}, label %${doInsertLabel}`);
+    this.ctx.emitBrCond(needsResize, resizeLabel, doInsertLabel);
 
-    this.emit(`${resizeLabel}:`);
+    this.ctx.emitLabel(resizeLabel);
     const newCapacity = this.nextTemp();
     this.emit(`${newCapacity} = mul i32 ${currentCapacity}, 2`);
     const newCapI64 = this.nextTemp();
@@ -1687,12 +1501,9 @@ export class PointerMapGenerator {
     const ptrSize = 8;
     const newKeysSize = this.nextTemp();
     this.emit(`${newKeysSize} = mul i64 ${newCapI64}, ${ptrSize}`);
-    const newKeysMem = this.nextTemp();
-    this.emit(`${newKeysMem} = call i8* @GC_malloc(i64 ${newKeysSize})`);
-    const newKeysPtr = this.nextTemp();
-    this.emit(`${newKeysPtr} = bitcast i8* ${newKeysMem} to i8**`);
-    const oldKeysI8 = this.nextTemp();
-    this.emit(`${oldKeysI8} = bitcast i8** ${keysPtr} to i8*`);
+    const newKeysMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${newKeysSize}`);
+    const newKeysPtr = this.ctx.emitBitcast(newKeysMem, "i8*", "i8**");
+    const oldKeysI8 = this.ctx.emitBitcast(keysPtr, "i8**", "i8*");
     const oldCapI64 = this.nextTemp();
     this.emit(`${oldCapI64} = zext i32 ${currentCapacity} to i64`);
     const oldKeysSize = this.nextTemp();
@@ -1700,45 +1511,40 @@ export class PointerMapGenerator {
     this.emit(
       `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newKeysMem}, i8* ${oldKeysI8}, i64 ${oldKeysSize}, i1 false)`,
     );
-    this.emit(`store i8** ${newKeysPtr}, i8*** ${keysFieldPtr}`);
+    this.ctx.emitStore("i8**", newKeysPtr, keysFieldPtr);
     const newValuesSize = this.nextTemp();
     this.emit(`${newValuesSize} = mul i64 ${newCapI64}, ${ptrSize}`);
-    const newValuesMem = this.nextTemp();
-    this.emit(`${newValuesMem} = call i8* @GC_malloc(i64 ${newValuesSize})`);
-    const newValuesPtr = this.nextTemp();
-    this.emit(`${newValuesPtr} = bitcast i8* ${newValuesMem} to i8**`);
-    const oldValuesI8 = this.nextTemp();
-    this.emit(`${oldValuesI8} = bitcast i8** ${valuesPtr} to i8*`);
+    const newValuesMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${newValuesSize}`);
+    const newValuesPtr = this.ctx.emitBitcast(newValuesMem, "i8*", "i8**");
+    const oldValuesI8 = this.ctx.emitBitcast(valuesPtr, "i8**", "i8*");
     this.emit(
       `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newValuesMem}, i8* ${oldValuesI8}, i64 ${oldKeysSize}, i1 false)`,
     );
-    this.emit(`store i8** ${newValuesPtr}, i8*** ${valuesFieldPtr}`);
-    this.emit(`store i32 ${newCapacity}, i32* ${capacityFieldPtr}`);
-    this.emit(`br label %${doInsertLabel}`);
+    this.ctx.emitStore("i8**", newValuesPtr, valuesFieldPtr);
+    this.ctx.emitStore("i32", newCapacity, capacityFieldPtr);
+    this.ctx.emitBr(doInsertLabel);
 
-    this.emit(`${doInsertLabel}:`);
-    const insertKeysPtr = this.nextTemp();
-    this.emit(`${insertKeysPtr} = load i8**, i8*** ${keysFieldPtr}`);
-    const insertValuesPtr = this.nextTemp();
-    this.emit(`${insertValuesPtr} = load i8**, i8*** ${valuesFieldPtr}`);
+    this.ctx.emitLabel(doInsertLabel);
+    const insertKeysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
+    const insertValuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
     const keyElemPtr = this.nextTemp();
     this.emit(
       `${keyElemPtr} = getelementptr inbounds i8*, i8** ${insertKeysPtr}, i32 ${currentSize}`,
     );
-    this.emit(`store i8* ${keyValue}, i8** ${keyElemPtr}`);
+    this.ctx.emitStore("i8*", keyValue, keyElemPtr);
 
     const valueElemPtr = this.nextTemp();
     this.emit(
       `${valueElemPtr} = getelementptr inbounds i8*, i8** ${insertValuesPtr}, i32 ${currentSize}`,
     );
-    this.emit(`store i8* ${valueValue}, i8** ${valueElemPtr}`);
+    this.ctx.emitStore("i8*", valueValue, valueElemPtr);
 
     const newSize = this.nextTemp();
     this.emit(`${newSize} = add i32 ${currentSize}, 1`);
-    this.emit(`store i32 ${newSize}, i32* ${sizeFieldPtr}`);
-    this.emit(`br label %${endLabel}`);
+    this.ctx.emitStore("i32", newSize, sizeFieldPtr);
+    this.ctx.emitBr(endLabel);
 
-    this.emit(`${endLabel}:`);
+    this.ctx.emitLabel(endLabel);
 
     return mapPtr;
   }
@@ -1748,7 +1554,7 @@ export class PointerMapGenerator {
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    this.emit(`store i32 0, i32* ${sizeFieldPtr}`);
+    this.ctx.emitStore("i32", "0", sizeFieldPtr);
     return "0.0";
   }
 }

--- a/src/codegen/types/collections/string/manipulation.ts
+++ b/src/codegen/types/collections/string/manipulation.ts
@@ -1,5 +1,6 @@
-// NOTE: This file uses raw ctx.emit() extensively. Prefer structured IR builders
-// (emitStore, emitLoad, emitCall, etc.) when modifying — see .claude/rules.md.
+// String manipulation IR generators: substring, slice, repeat, pad, trim, replace, case conversion.
+// Uses structured IR builders (emitCall, emitLoad, emitStore, etc.) where possible;
+// raw emit() kept for instructions without builders (phi, select, add, sub, alloca, inbounds GEP, etc.).
 
 import { IGeneratorContext } from "../../../infrastructure/generator-context.js";
 
@@ -13,8 +14,7 @@ export function generateSubstr(
   startIndex: string,
   length: string | null,
 ): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
@@ -31,14 +31,12 @@ export function generateSubstr(
   const remainingLen = ctx.nextTemp();
   ctx.emit(`${remainingLen} = sub i32 ${strLenI32}, ${startI32}`);
 
-  const isLenTooLarge = ctx.nextTemp();
-  ctx.emit(`${isLenTooLarge} = icmp sgt i32 ${substrLen}, ${remainingLen}`);
+  const isLenTooLarge = ctx.emitIcmp("sgt", "i32", substrLen, remainingLen);
 
   const clampedLen = ctx.nextTemp();
   ctx.emit(`${clampedLen} = select i1 ${isLenTooLarge}, i32 ${remainingLen}, i32 ${substrLen}`);
 
-  const isNegative = ctx.nextTemp();
-  ctx.emit(`${isNegative} = icmp slt i32 ${clampedLen}, 0`);
+  const isNegative = ctx.emitIcmp("slt", "i32", clampedLen, "0");
 
   const finalLen = ctx.nextTemp();
   ctx.emit(`${finalLen} = select i1 ${isNegative}, i32 0, i32 ${clampedLen}`);
@@ -49,8 +47,7 @@ export function generateSubstr(
   const allocLen = ctx.nextTemp();
   ctx.emit(`${allocLen} = add i64 ${finalLenI64}, 1`);
 
-  const resultPtr = ctx.nextTemp();
-  ctx.emit(`${resultPtr} = call i8* @GC_malloc_atomic(i64 ${allocLen})`);
+  const resultPtr = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen}`);
 
   const startI64 = ctx.nextTemp();
   ctx.emit(`${startI64} = sext i32 ${startI32} to i64`);
@@ -64,14 +61,13 @@ export function generateSubstr(
 
   const nullPtr = ctx.nextTemp();
   ctx.emit(`${nullPtr} = getelementptr inbounds i8, i8* ${resultPtr}, i64 ${finalLenI64}`);
-  ctx.emit(`store i8 0, i8* ${nullPtr}`);
+  ctx.emitStore("i8", "0", nullPtr);
 
   return resultPtr;
 }
 
 export function generateRepeat(ctx: IGeneratorContext, strPtr: string, count: string): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
 
   const countI64 = ctx.nextTemp();
   ctx.emit(`${countI64} = sext i32 ${count} to i64`);
@@ -82,10 +78,9 @@ export function generateRepeat(ctx: IGeneratorContext, strPtr: string, count: st
   const allocLen = ctx.nextTemp();
   ctx.emit(`${allocLen} = add i64 ${totalLen}, 1`);
 
-  const resultPtr = ctx.nextTemp();
-  ctx.emit(`${resultPtr} = call i8* @GC_malloc_atomic(i64 ${allocLen})`);
+  const resultPtr = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen}`);
 
-  ctx.emit(`store i8 0, i8* ${resultPtr}`);
+  ctx.emitStore("i8", "0", resultPtr);
 
   const loopLabel = ctx.nextLabel("repeat_loop");
   const loopBodyLabel = ctx.nextLabel("repeat_body");
@@ -93,27 +88,25 @@ export function generateRepeat(ctx: IGeneratorContext, strPtr: string, count: st
 
   const counterPtr = ctx.nextTemp();
   ctx.emit(`${counterPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${counterPtr}`);
+  ctx.emitStore("i32", "0", counterPtr);
 
-  ctx.emit(`br label %${loopLabel}`);
+  ctx.emitBr(loopLabel);
 
-  ctx.emit(`${loopLabel}:`);
-  const counterVal = ctx.nextTemp();
-  ctx.emit(`${counterVal} = load i32, i32* ${counterPtr}`);
-  const loopCond = ctx.nextTemp();
-  ctx.emit(`${loopCond} = icmp slt i32 ${counterVal}, ${count}`);
-  ctx.emit(`br i1 ${loopCond}, label %${loopBodyLabel}, label %${loopEndLabel}`);
+  ctx.emitLabel(loopLabel);
+  const counterVal = ctx.emitLoad("i32", counterPtr);
+  const loopCond = ctx.emitIcmp("slt", "i32", counterVal, count);
+  ctx.emitBrCond(loopCond, loopBodyLabel, loopEndLabel);
 
-  ctx.emit(`${loopBodyLabel}:`);
-  const strcatResult = ctx.nextTemp();
-  ctx.emit(`${strcatResult} = call i8* @strcat(i8* ${resultPtr}, i8* ${strPtr})`);
+  ctx.emitLabel(loopBodyLabel);
+  const strcatResult = ctx.emitCall("i8*", "@strcat", `i8* ${resultPtr}, i8* ${strPtr}`);
+  // strcatResult unused but call has side effects
 
   const nextCounter = ctx.nextTemp();
   ctx.emit(`${nextCounter} = add i32 ${counterVal}, 1`);
-  ctx.emit(`store i32 ${nextCounter}, i32* ${counterPtr}`);
-  ctx.emit(`br label %${loopLabel}`);
+  ctx.emitStore("i32", nextCounter, counterPtr);
+  ctx.emitBr(loopLabel);
 
-  ctx.emit(`${loopEndLabel}:`);
+  ctx.emitLabel(loopEndLabel);
 
   return resultPtr;
 }
@@ -124,48 +117,42 @@ export function generatePadStart(
   targetLength: string,
   padString: string,
 ): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
-  const padLen = ctx.nextTemp();
-  ctx.emit(`${padLen} = call i64 @strlen(i8* ${padString})`);
+  const padLen = ctx.emitCall("i64", "@strlen", `i8* ${padString}`);
   const padLenI32 = ctx.nextTemp();
   ctx.emit(`${padLenI32} = trunc i64 ${padLen} to i32`);
 
   const paddingNeeded = ctx.nextTemp();
   ctx.emit(`${paddingNeeded} = sub i32 ${targetLength}, ${strLenI32}`);
 
-  const needsPadding = ctx.nextTemp();
-  ctx.emit(`${needsPadding} = icmp sgt i32 ${paddingNeeded}, 0`);
+  const needsPadding = ctx.emitIcmp("sgt", "i32", paddingNeeded, "0");
 
   const noPadLabel = ctx.nextLabel("padstart_nopad");
   const doPadLabel = ctx.nextLabel("padstart_dopad");
   const endLabel = ctx.nextLabel("padstart_end");
 
-  ctx.emit(`br i1 ${needsPadding}, label %${doPadLabel}, label %${noPadLabel}`);
+  ctx.emitBrCond(needsPadding, doPadLabel, noPadLabel);
 
-  ctx.emit(`${noPadLabel}:`);
+  ctx.emitLabel(noPadLabel);
   const targetLenI64NoPad = ctx.nextTemp();
   ctx.emit(`${targetLenI64NoPad} = sext i32 ${targetLength} to i64`);
   const allocLen1 = ctx.nextTemp();
   ctx.emit(`${allocLen1} = add i64 ${targetLenI64NoPad}, 1`);
-  const noPadResult = ctx.nextTemp();
-  ctx.emit(`${noPadResult} = call i8* @GC_malloc_atomic(i64 ${allocLen1})`);
-  const strcpyResult1 = ctx.nextTemp();
-  ctx.emit(`${strcpyResult1} = call i8* @strcpy(i8* ${noPadResult}, i8* ${strPtr})`);
-  ctx.emit(`br label %${endLabel}`);
+  const noPadResult = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen1}`);
+  const strcpyResult1 = ctx.emitCall("i8*", "@strcpy", `i8* ${noPadResult}, i8* ${strPtr}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${doPadLabel}:`);
+  ctx.emitLabel(doPadLabel);
   const targetLenI64Pad = ctx.nextTemp();
   ctx.emit(`${targetLenI64Pad} = sext i32 ${targetLength} to i64`);
   const allocLen2 = ctx.nextTemp();
   ctx.emit(`${allocLen2} = add i64 ${targetLenI64Pad}, 1`);
-  const padResult = ctx.nextTemp();
-  ctx.emit(`${padResult} = call i8* @GC_malloc_atomic(i64 ${allocLen2})`);
+  const padResult = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen2}`);
 
-  ctx.emit(`store i8 0, i8* ${padResult}`);
+  ctx.emitStore("i8", "0", padResult);
 
   const fullPads = ctx.nextTemp();
   ctx.emit(`${fullPads} = sdiv i32 ${paddingNeeded}, ${padLenI32}`);
@@ -179,47 +166,45 @@ export function generatePadStart(
 
   const padCounterPtr = ctx.nextTemp();
   ctx.emit(`${padCounterPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${padCounterPtr}`);
-  ctx.emit(`br label %${padLoopLabel}`);
+  ctx.emitStore("i32", "0", padCounterPtr);
+  ctx.emitBr(padLoopLabel);
 
-  ctx.emit(`${padLoopLabel}:`);
-  const padCounterVal = ctx.nextTemp();
-  ctx.emit(`${padCounterVal} = load i32, i32* ${padCounterPtr}`);
-  const padLoopCond = ctx.nextTemp();
-  ctx.emit(`${padLoopCond} = icmp slt i32 ${padCounterVal}, ${fullPads}`);
-  ctx.emit(`br i1 ${padLoopCond}, label %${padLoopBodyLabel}, label %${padLoopEndLabel}`);
+  ctx.emitLabel(padLoopLabel);
+  const padCounterVal = ctx.emitLoad("i32", padCounterPtr);
+  const padLoopCond = ctx.emitIcmp("slt", "i32", padCounterVal, fullPads);
+  ctx.emitBrCond(padLoopCond, padLoopBodyLabel, padLoopEndLabel);
 
-  ctx.emit(`${padLoopBodyLabel}:`);
-  const strcatPad = ctx.nextTemp();
-  ctx.emit(`${strcatPad} = call i8* @strcat(i8* ${padResult}, i8* ${padString})`);
+  ctx.emitLabel(padLoopBodyLabel);
+  const strcatPad = ctx.emitCall("i8*", "@strcat", `i8* ${padResult}, i8* ${padString}`);
   const nextPadCounter = ctx.nextTemp();
   ctx.emit(`${nextPadCounter} = add i32 ${padCounterVal}, 1`);
-  ctx.emit(`store i32 ${nextPadCounter}, i32* ${padCounterPtr}`);
-  ctx.emit(`br label %${padLoopLabel}`);
+  ctx.emitStore("i32", nextPadCounter, padCounterPtr);
+  ctx.emitBr(padLoopLabel);
 
-  ctx.emit(`${padLoopEndLabel}:`);
+  ctx.emitLabel(padLoopEndLabel);
 
-  const hasRemaining = ctx.nextTemp();
-  ctx.emit(`${hasRemaining} = icmp sgt i32 ${remainingPad}, 0`);
+  const hasRemaining = ctx.emitIcmp("sgt", "i32", remainingPad, "0");
 
   const addRemainingLabel = ctx.nextLabel("padstart_add_remaining");
   const skipRemainingLabel = ctx.nextLabel("padstart_skip_remaining");
 
-  ctx.emit(`br i1 ${hasRemaining}, label %${addRemainingLabel}, label %${skipRemainingLabel}`);
+  ctx.emitBrCond(hasRemaining, addRemainingLabel, skipRemainingLabel);
 
-  ctx.emit(`${addRemainingLabel}:`);
+  ctx.emitLabel(addRemainingLabel);
   const remainingSubstr = generateSubstr(ctx, padString, "0", remainingPad);
-  const strcatRemaining = ctx.nextTemp();
-  ctx.emit(`${strcatRemaining} = call i8* @strcat(i8* ${padResult}, i8* ${remainingSubstr})`);
-  ctx.emit(`br label %${skipRemainingLabel}`);
+  const strcatRemaining = ctx.emitCall(
+    "i8*",
+    "@strcat",
+    `i8* ${padResult}, i8* ${remainingSubstr}`,
+  );
+  ctx.emitBr(skipRemainingLabel);
 
-  ctx.emit(`${skipRemainingLabel}:`);
+  ctx.emitLabel(skipRemainingLabel);
 
-  const finalResult = ctx.nextTemp();
-  ctx.emit(`${finalResult} = call i8* @strcat(i8* ${padResult}, i8* ${strPtr})`);
-  ctx.emit(`br label %${endLabel}`);
+  const finalResult = ctx.emitCall("i8*", "@strcat", `i8* ${padResult}, i8* ${strPtr}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const result = ctx.nextTemp();
   ctx.emit(
     `${result} = phi i8* [ ${noPadResult}, %${noPadLabel} ], [ ${padResult}, %${skipRemainingLabel} ]`,
@@ -235,49 +220,42 @@ export function generatePadEnd(
   targetLength: string,
   padString: string,
 ): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
-  const padLen = ctx.nextTemp();
-  ctx.emit(`${padLen} = call i64 @strlen(i8* ${padString})`);
+  const padLen = ctx.emitCall("i64", "@strlen", `i8* ${padString}`);
   const padLenI32 = ctx.nextTemp();
   ctx.emit(`${padLenI32} = trunc i64 ${padLen} to i32`);
 
   const paddingNeeded = ctx.nextTemp();
   ctx.emit(`${paddingNeeded} = sub i32 ${targetLength}, ${strLenI32}`);
 
-  const needsPadding = ctx.nextTemp();
-  ctx.emit(`${needsPadding} = icmp sgt i32 ${paddingNeeded}, 0`);
+  const needsPadding = ctx.emitIcmp("sgt", "i32", paddingNeeded, "0");
 
   const noPadLabel = ctx.nextLabel("padend_nopad");
   const doPadLabel = ctx.nextLabel("padend_dopad");
   const endLabel = ctx.nextLabel("padend_end");
 
-  ctx.emit(`br i1 ${needsPadding}, label %${doPadLabel}, label %${noPadLabel}`);
+  ctx.emitBrCond(needsPadding, doPadLabel, noPadLabel);
 
-  ctx.emit(`${noPadLabel}:`);
+  ctx.emitLabel(noPadLabel);
   const strLenI64NoPad = ctx.nextTemp();
   ctx.emit(`${strLenI64NoPad} = sext i32 ${strLenI32} to i64`);
   const allocLen1 = ctx.nextTemp();
   ctx.emit(`${allocLen1} = add i64 ${strLenI64NoPad}, 1`);
-  const noPadResult = ctx.nextTemp();
-  ctx.emit(`${noPadResult} = call i8* @GC_malloc_atomic(i64 ${allocLen1})`);
-  const strcpyResult1 = ctx.nextTemp();
-  ctx.emit(`${strcpyResult1} = call i8* @strcpy(i8* ${noPadResult}, i8* ${strPtr})`);
-  ctx.emit(`br label %${endLabel}`);
+  const noPadResult = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen1}`);
+  const strcpyResult1 = ctx.emitCall("i8*", "@strcpy", `i8* ${noPadResult}, i8* ${strPtr}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${doPadLabel}:`);
+  ctx.emitLabel(doPadLabel);
   const targetLenI64Pad = ctx.nextTemp();
   ctx.emit(`${targetLenI64Pad} = sext i32 ${targetLength} to i64`);
   const allocLen2 = ctx.nextTemp();
   ctx.emit(`${allocLen2} = add i64 ${targetLenI64Pad}, 1`);
-  const padResult = ctx.nextTemp();
-  ctx.emit(`${padResult} = call i8* @GC_malloc_atomic(i64 ${allocLen2})`);
+  const padResult = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen2}`);
 
-  const strcpyOrig = ctx.nextTemp();
-  ctx.emit(`${strcpyOrig} = call i8* @strcpy(i8* ${padResult}, i8* ${strPtr})`);
+  const strcpyOrig = ctx.emitCall("i8*", "@strcpy", `i8* ${padResult}, i8* ${strPtr}`);
 
   const fullPads = ctx.nextTemp();
   ctx.emit(`${fullPads} = sdiv i32 ${paddingNeeded}, ${padLenI32}`);
@@ -291,44 +269,43 @@ export function generatePadEnd(
 
   const padCounterPtr = ctx.nextTemp();
   ctx.emit(`${padCounterPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${padCounterPtr}`);
-  ctx.emit(`br label %${padLoopLabel}`);
+  ctx.emitStore("i32", "0", padCounterPtr);
+  ctx.emitBr(padLoopLabel);
 
-  ctx.emit(`${padLoopLabel}:`);
-  const padCounterVal = ctx.nextTemp();
-  ctx.emit(`${padCounterVal} = load i32, i32* ${padCounterPtr}`);
-  const padLoopCond = ctx.nextTemp();
-  ctx.emit(`${padLoopCond} = icmp slt i32 ${padCounterVal}, ${fullPads}`);
-  ctx.emit(`br i1 ${padLoopCond}, label %${padLoopBodyLabel}, label %${padLoopEndLabel}`);
+  ctx.emitLabel(padLoopLabel);
+  const padCounterVal = ctx.emitLoad("i32", padCounterPtr);
+  const padLoopCond = ctx.emitIcmp("slt", "i32", padCounterVal, fullPads);
+  ctx.emitBrCond(padLoopCond, padLoopBodyLabel, padLoopEndLabel);
 
-  ctx.emit(`${padLoopBodyLabel}:`);
-  const strcatPad = ctx.nextTemp();
-  ctx.emit(`${strcatPad} = call i8* @strcat(i8* ${padResult}, i8* ${padString})`);
+  ctx.emitLabel(padLoopBodyLabel);
+  const strcatPad = ctx.emitCall("i8*", "@strcat", `i8* ${padResult}, i8* ${padString}`);
   const nextPadCounter = ctx.nextTemp();
   ctx.emit(`${nextPadCounter} = add i32 ${padCounterVal}, 1`);
-  ctx.emit(`store i32 ${nextPadCounter}, i32* ${padCounterPtr}`);
-  ctx.emit(`br label %${padLoopLabel}`);
+  ctx.emitStore("i32", nextPadCounter, padCounterPtr);
+  ctx.emitBr(padLoopLabel);
 
-  ctx.emit(`${padLoopEndLabel}:`);
+  ctx.emitLabel(padLoopEndLabel);
 
-  const hasRemaining = ctx.nextTemp();
-  ctx.emit(`${hasRemaining} = icmp sgt i32 ${remainingPad}, 0`);
+  const hasRemaining = ctx.emitIcmp("sgt", "i32", remainingPad, "0");
 
   const addRemainingLabel = ctx.nextLabel("padend_add_remaining");
   const skipRemainingLabel = ctx.nextLabel("padend_skip_remaining");
 
-  ctx.emit(`br i1 ${hasRemaining}, label %${addRemainingLabel}, label %${skipRemainingLabel}`);
+  ctx.emitBrCond(hasRemaining, addRemainingLabel, skipRemainingLabel);
 
-  ctx.emit(`${addRemainingLabel}:`);
+  ctx.emitLabel(addRemainingLabel);
   const remainingSubstr = generateSubstr(ctx, padString, "0", remainingPad);
-  const strcatRemaining = ctx.nextTemp();
-  ctx.emit(`${strcatRemaining} = call i8* @strcat(i8* ${padResult}, i8* ${remainingSubstr})`);
-  ctx.emit(`br label %${skipRemainingLabel}`);
+  const strcatRemaining = ctx.emitCall(
+    "i8*",
+    "@strcat",
+    `i8* ${padResult}, i8* ${remainingSubstr}`,
+  );
+  ctx.emitBr(skipRemainingLabel);
 
-  ctx.emit(`${skipRemainingLabel}:`);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitLabel(skipRemainingLabel);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const result = ctx.nextTemp();
   ctx.emit(
     `${result} = phi i8* [ ${noPadResult}, %${noPadLabel} ], [ ${padResult}, %${skipRemainingLabel} ]`,
@@ -344,13 +321,11 @@ export function generateSlice(
   startIndex: string,
   endIndex: string | null,
 ): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
-  const startIsNegative = ctx.nextTemp();
-  ctx.emit(`${startIsNegative} = icmp slt i32 ${startIndex}, 0`);
+  const startIsNegative = ctx.emitIcmp("slt", "i32", startIndex, "0");
 
   const adjustedStart1 = ctx.nextTemp();
   ctx.emit(`${adjustedStart1} = add i32 ${strLenI32}, ${startIndex}`);
@@ -360,13 +335,11 @@ export function generateSlice(
     `${adjustedStart2} = select i1 ${startIsNegative}, i32 ${adjustedStart1}, i32 ${startIndex}`,
   );
 
-  const startTooSmall = ctx.nextTemp();
-  ctx.emit(`${startTooSmall} = icmp slt i32 ${adjustedStart2}, 0`);
+  const startTooSmall = ctx.emitIcmp("slt", "i32", adjustedStart2, "0");
   const clampedStart1 = ctx.nextTemp();
   ctx.emit(`${clampedStart1} = select i1 ${startTooSmall}, i32 0, i32 ${adjustedStart2}`);
 
-  const startTooBig = ctx.nextTemp();
-  ctx.emit(`${startTooBig} = icmp sgt i32 ${clampedStart1}, ${strLenI32}`);
+  const startTooBig = ctx.emitIcmp("sgt", "i32", clampedStart1, strLenI32);
   const finalStart = ctx.nextTemp();
   ctx.emit(`${finalStart} = select i1 ${startTooBig}, i32 ${strLenI32}, i32 ${clampedStart1}`);
 
@@ -374,8 +347,7 @@ export function generateSlice(
   if (endIndex === null) {
     finalEnd = strLenI32;
   } else {
-    const endIsNegative = ctx.nextTemp();
-    ctx.emit(`${endIsNegative} = icmp slt i32 ${endIndex}, 0`);
+    const endIsNegative = ctx.emitIcmp("slt", "i32", endIndex, "0");
 
     const adjustedEnd1 = ctx.nextTemp();
     ctx.emit(`${adjustedEnd1} = add i32 ${strLenI32}, ${endIndex}`);
@@ -383,13 +355,11 @@ export function generateSlice(
     const adjustedEnd2 = ctx.nextTemp();
     ctx.emit(`${adjustedEnd2} = select i1 ${endIsNegative}, i32 ${adjustedEnd1}, i32 ${endIndex}`);
 
-    const endTooSmall = ctx.nextTemp();
-    ctx.emit(`${endTooSmall} = icmp slt i32 ${adjustedEnd2}, 0`);
+    const endTooSmall = ctx.emitIcmp("slt", "i32", adjustedEnd2, "0");
     const clampedEnd1 = ctx.nextTemp();
     ctx.emit(`${clampedEnd1} = select i1 ${endTooSmall}, i32 0, i32 ${adjustedEnd2}`);
 
-    const endTooBig = ctx.nextTemp();
-    ctx.emit(`${endTooBig} = icmp sgt i32 ${clampedEnd1}, ${strLenI32}`);
+    const endTooBig = ctx.emitIcmp("sgt", "i32", clampedEnd1, strLenI32);
     finalEnd = ctx.nextTemp();
     ctx.emit(`${finalEnd} = select i1 ${endTooBig}, i32 ${strLenI32}, i32 ${clampedEnd1}`);
   }
@@ -397,8 +367,7 @@ export function generateSlice(
   const sliceLen = ctx.nextTemp();
   ctx.emit(`${sliceLen} = sub i32 ${finalEnd}, ${finalStart}`);
 
-  const lenIsNegative = ctx.nextTemp();
-  ctx.emit(`${lenIsNegative} = icmp slt i32 ${sliceLen}, 0`);
+  const lenIsNegative = ctx.emitIcmp("slt", "i32", sliceLen, "0");
   const finalLen = ctx.nextTemp();
   ctx.emit(`${finalLen} = select i1 ${lenIsNegative}, i32 0, i32 ${sliceLen}`);
 
@@ -406,47 +375,42 @@ export function generateSlice(
 }
 
 export function generateTrim(ctx: IGeneratorContext, strPtr: string): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
-  const isEmpty = ctx.nextTemp();
-  ctx.emit(`${isEmpty} = icmp eq i32 ${strLenI32}, 0`);
+  const isEmpty = ctx.emitIcmp("eq", "i32", strLenI32, "0");
 
   const emptyLabel = ctx.nextLabel("trim_empty");
   const notEmptyLabel = ctx.nextLabel("trim_notempty");
   const endLabel = ctx.nextLabel("trim_end");
 
-  ctx.emit(`br i1 ${isEmpty}, label %${emptyLabel}, label %${notEmptyLabel}`);
+  ctx.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
-  ctx.emit(`${emptyLabel}:`);
-  const emptyResult = ctx.nextTemp();
-  ctx.emit(`${emptyResult} = call i8* @GC_malloc_atomic(i64 1)`);
-  ctx.emit(`store i8 0, i8* ${emptyResult}`);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitLabel(emptyLabel);
+  const emptyResult = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  ctx.emitStore("i8", "0", emptyResult);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${notEmptyLabel}:`);
+  ctx.emitLabel(notEmptyLabel);
 
   const startPtr = ctx.nextTemp();
   ctx.emit(`${startPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${startPtr}`);
+  ctx.emitStore("i32", "0", startPtr);
 
   const findStartLabel = ctx.nextLabel("trim_find_start");
   const findStartBodyLabel = ctx.nextLabel("trim_find_start_body");
   const findStartCheckLabel = ctx.nextLabel("trim_find_start_check");
   const findStartEndLabel = ctx.nextLabel("trim_find_start_end");
 
-  ctx.emit(`br label %${findStartLabel}`);
+  ctx.emitBr(findStartLabel);
 
-  ctx.emit(`${findStartLabel}:`);
-  const start = ctx.nextTemp();
-  ctx.emit(`${start} = load i32, i32* ${startPtr}`);
-  const startCond = ctx.nextTemp();
-  ctx.emit(`${startCond} = icmp slt i32 ${start}, ${strLenI32}`);
-  ctx.emit(`br i1 ${startCond}, label %${findStartBodyLabel}, label %${findStartEndLabel}`);
+  ctx.emitLabel(findStartLabel);
+  const start = ctx.emitLoad("i32", startPtr);
+  const startCond = ctx.emitIcmp("slt", "i32", start, strLenI32);
+  ctx.emitBrCond(startCond, findStartBodyLabel, findStartEndLabel);
 
-  ctx.emit(`${findStartBodyLabel}:`);
+  ctx.emitLabel(findStartBodyLabel);
   const startI64 = ctx.nextTemp();
   ctx.emit(`${startI64} = sext i32 ${start} to i64`);
   const charPtr1 = ctx.nextTemp();
@@ -454,14 +418,10 @@ export function generateTrim(ctx: IGeneratorContext, strPtr: string): string {
   const char1 = ctx.nextTemp();
   ctx.emit(`${char1} = load i8, i8* ${charPtr1}`);
 
-  const isSpace = ctx.nextTemp();
-  ctx.emit(`${isSpace} = icmp eq i8 ${char1}, 32`);
-  const isTab = ctx.nextTemp();
-  ctx.emit(`${isTab} = icmp eq i8 ${char1}, 9`);
-  const isNewline = ctx.nextTemp();
-  ctx.emit(`${isNewline} = icmp eq i8 ${char1}, 10`);
-  const isCR = ctx.nextTemp();
-  ctx.emit(`${isCR} = icmp eq i8 ${char1}, 13`);
+  const isSpace = ctx.emitIcmp("eq", "i8", char1, "32");
+  const isTab = ctx.emitIcmp("eq", "i8", char1, "9");
+  const isNewline = ctx.emitIcmp("eq", "i8", char1, "10");
+  const isCR = ctx.emitIcmp("eq", "i8", char1, "13");
 
   const isWS1 = ctx.nextTemp();
   ctx.emit(`${isWS1} = or i1 ${isSpace}, ${isTab}`);
@@ -470,54 +430,49 @@ export function generateTrim(ctx: IGeneratorContext, strPtr: string): string {
   const isWhitespace = ctx.nextTemp();
   ctx.emit(`${isWhitespace} = or i1 ${isWS2}, ${isCR}`);
 
-  ctx.emit(`br i1 ${isWhitespace}, label %${findStartCheckLabel}, label %${findStartEndLabel}`);
+  ctx.emitBrCond(isWhitespace, findStartCheckLabel, findStartEndLabel);
 
-  ctx.emit(`${findStartCheckLabel}:`);
+  ctx.emitLabel(findStartCheckLabel);
   const nextStart = ctx.nextTemp();
   ctx.emit(`${nextStart} = add i32 ${start}, 1`);
-  ctx.emit(`store i32 ${nextStart}, i32* ${startPtr}`);
-  ctx.emit(`br label %${findStartLabel}`);
+  ctx.emitStore("i32", nextStart, startPtr);
+  ctx.emitBr(findStartLabel);
 
-  ctx.emit(`${findStartEndLabel}:`);
-  const finalStart = ctx.nextTemp();
-  ctx.emit(`${finalStart} = load i32, i32* ${startPtr}`);
+  ctx.emitLabel(findStartEndLabel);
+  const finalStart = ctx.emitLoad("i32", startPtr);
 
-  const allWhitespace = ctx.nextTemp();
-  ctx.emit(`${allWhitespace} = icmp eq i32 ${finalStart}, ${strLenI32}`);
+  const allWhitespace = ctx.emitIcmp("eq", "i32", finalStart, strLenI32);
 
   const allWSLabel = ctx.nextLabel("trim_all_ws");
   const findEndLabel = ctx.nextLabel("trim_find_end");
 
-  ctx.emit(`br i1 ${allWhitespace}, label %${allWSLabel}, label %${findEndLabel}`);
+  ctx.emitBrCond(allWhitespace, allWSLabel, findEndLabel);
 
-  ctx.emit(`${allWSLabel}:`);
-  const allWSResult = ctx.nextTemp();
-  ctx.emit(`${allWSResult} = call i8* @GC_malloc_atomic(i64 1)`);
-  ctx.emit(`store i8 0, i8* ${allWSResult}`);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitLabel(allWSLabel);
+  const allWSResult = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  ctx.emitStore("i8", "0", allWSResult);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${findEndLabel}:`);
+  ctx.emitLabel(findEndLabel);
   const endPtr = ctx.nextTemp();
   ctx.emit(`${endPtr} = alloca i32`);
   const initEnd = ctx.nextTemp();
   ctx.emit(`${initEnd} = sub i32 ${strLenI32}, 1`);
-  ctx.emit(`store i32 ${initEnd}, i32* ${endPtr}`);
+  ctx.emitStore("i32", initEnd, endPtr);
 
   const findEndLoopLabel = ctx.nextLabel("trim_find_end_loop");
   const findEndBodyLabel = ctx.nextLabel("trim_find_end_body");
   const findEndCheckLabel = ctx.nextLabel("trim_find_end_check");
   const findEndEndLabel = ctx.nextLabel("trim_find_end_end");
 
-  ctx.emit(`br label %${findEndLoopLabel}`);
+  ctx.emitBr(findEndLoopLabel);
 
-  ctx.emit(`${findEndLoopLabel}:`);
-  const end = ctx.nextTemp();
-  ctx.emit(`${end} = load i32, i32* ${endPtr}`);
-  const endCond = ctx.nextTemp();
-  ctx.emit(`${endCond} = icmp sge i32 ${end}, ${finalStart}`);
-  ctx.emit(`br i1 ${endCond}, label %${findEndBodyLabel}, label %${findEndEndLabel}`);
+  ctx.emitLabel(findEndLoopLabel);
+  const end = ctx.emitLoad("i32", endPtr);
+  const endCond = ctx.emitIcmp("sge", "i32", end, finalStart);
+  ctx.emitBrCond(endCond, findEndBodyLabel, findEndEndLabel);
 
-  ctx.emit(`${findEndBodyLabel}:`);
+  ctx.emitLabel(findEndBodyLabel);
   const endI64 = ctx.nextTemp();
   ctx.emit(`${endI64} = sext i32 ${end} to i64`);
   const charPtr2 = ctx.nextTemp();
@@ -525,14 +480,10 @@ export function generateTrim(ctx: IGeneratorContext, strPtr: string): string {
   const char2 = ctx.nextTemp();
   ctx.emit(`${char2} = load i8, i8* ${charPtr2}`);
 
-  const isSpace2 = ctx.nextTemp();
-  ctx.emit(`${isSpace2} = icmp eq i8 ${char2}, 32`);
-  const isTab2 = ctx.nextTemp();
-  ctx.emit(`${isTab2} = icmp eq i8 ${char2}, 9`);
-  const isNewline2 = ctx.nextTemp();
-  ctx.emit(`${isNewline2} = icmp eq i8 ${char2}, 10`);
-  const isCR2 = ctx.nextTemp();
-  ctx.emit(`${isCR2} = icmp eq i8 ${char2}, 13`);
+  const isSpace2 = ctx.emitIcmp("eq", "i8", char2, "32");
+  const isTab2 = ctx.emitIcmp("eq", "i8", char2, "9");
+  const isNewline2 = ctx.emitIcmp("eq", "i8", char2, "10");
+  const isCR2 = ctx.emitIcmp("eq", "i8", char2, "13");
 
   const isWS3 = ctx.nextTemp();
   ctx.emit(`${isWS3} = or i1 ${isSpace2}, ${isTab2}`);
@@ -541,17 +492,16 @@ export function generateTrim(ctx: IGeneratorContext, strPtr: string): string {
   const isWhitespace2 = ctx.nextTemp();
   ctx.emit(`${isWhitespace2} = or i1 ${isWS4}, ${isCR2}`);
 
-  ctx.emit(`br i1 ${isWhitespace2}, label %${findEndCheckLabel}, label %${findEndEndLabel}`);
+  ctx.emitBrCond(isWhitespace2, findEndCheckLabel, findEndEndLabel);
 
-  ctx.emit(`${findEndCheckLabel}:`);
+  ctx.emitLabel(findEndCheckLabel);
   const nextEnd = ctx.nextTemp();
   ctx.emit(`${nextEnd} = sub i32 ${end}, 1`);
-  ctx.emit(`store i32 ${nextEnd}, i32* ${endPtr}`);
-  ctx.emit(`br label %${findEndLoopLabel}`);
+  ctx.emitStore("i32", nextEnd, endPtr);
+  ctx.emitBr(findEndLoopLabel);
 
-  ctx.emit(`${findEndEndLabel}:`);
-  const finalEnd = ctx.nextTemp();
-  ctx.emit(`${finalEnd} = load i32, i32* ${endPtr}`);
+  ctx.emitLabel(findEndEndLabel);
+  const finalEnd = ctx.emitLoad("i32", endPtr);
 
   const trimmedLen = ctx.nextTemp();
   ctx.emit(`${trimmedLen} = sub i32 ${finalEnd}, ${finalStart}`);
@@ -559,9 +509,9 @@ export function generateTrim(ctx: IGeneratorContext, strPtr: string): string {
   ctx.emit(`${trimmedLenPlus1} = add i32 ${trimmedLen}, 1`);
 
   const trimmedResult = generateSubstr(ctx, strPtr, finalStart, trimmedLenPlus1);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const result = ctx.nextTemp();
   ctx.emit(
     `${result} = phi i8* [ ${emptyResult}, %${emptyLabel} ], [ ${allWSResult}, %${allWSLabel} ], [ ${trimmedResult}, %${findEndEndLabel} ]`,
@@ -572,47 +522,42 @@ export function generateTrim(ctx: IGeneratorContext, strPtr: string): string {
 }
 
 export function generateTrimStart(ctx: IGeneratorContext, strPtr: string): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
-  const isEmpty = ctx.nextTemp();
-  ctx.emit(`${isEmpty} = icmp eq i32 ${strLenI32}, 0`);
+  const isEmpty = ctx.emitIcmp("eq", "i32", strLenI32, "0");
 
   const emptyLabel = ctx.nextLabel("trimstart_empty");
   const notEmptyLabel = ctx.nextLabel("trimstart_notempty");
   const endLabel = ctx.nextLabel("trimstart_end");
 
-  ctx.emit(`br i1 ${isEmpty}, label %${emptyLabel}, label %${notEmptyLabel}`);
+  ctx.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
-  ctx.emit(`${emptyLabel}:`);
-  const emptyResult = ctx.nextTemp();
-  ctx.emit(`${emptyResult} = call i8* @GC_malloc_atomic(i64 1)`);
-  ctx.emit(`store i8 0, i8* ${emptyResult}`);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitLabel(emptyLabel);
+  const emptyResult = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  ctx.emitStore("i8", "0", emptyResult);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${notEmptyLabel}:`);
+  ctx.emitLabel(notEmptyLabel);
 
   const startPtr = ctx.nextTemp();
   ctx.emit(`${startPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${startPtr}`);
+  ctx.emitStore("i32", "0", startPtr);
 
   const findStartLabel = ctx.nextLabel("trimstart_find");
   const findStartBodyLabel = ctx.nextLabel("trimstart_find_body");
   const findStartCheckLabel = ctx.nextLabel("trimstart_find_check");
   const findStartEndLabel = ctx.nextLabel("trimstart_find_end");
 
-  ctx.emit(`br label %${findStartLabel}`);
+  ctx.emitBr(findStartLabel);
 
-  ctx.emit(`${findStartLabel}:`);
-  const start = ctx.nextTemp();
-  ctx.emit(`${start} = load i32, i32* ${startPtr}`);
-  const startCond = ctx.nextTemp();
-  ctx.emit(`${startCond} = icmp slt i32 ${start}, ${strLenI32}`);
-  ctx.emit(`br i1 ${startCond}, label %${findStartBodyLabel}, label %${findStartEndLabel}`);
+  ctx.emitLabel(findStartLabel);
+  const start = ctx.emitLoad("i32", startPtr);
+  const startCond = ctx.emitIcmp("slt", "i32", start, strLenI32);
+  ctx.emitBrCond(startCond, findStartBodyLabel, findStartEndLabel);
 
-  ctx.emit(`${findStartBodyLabel}:`);
+  ctx.emitLabel(findStartBodyLabel);
   const startI64 = ctx.nextTemp();
   ctx.emit(`${startI64} = sext i32 ${start} to i64`);
   const charPtr = ctx.nextTemp();
@@ -620,14 +565,10 @@ export function generateTrimStart(ctx: IGeneratorContext, strPtr: string): strin
   const ch = ctx.nextTemp();
   ctx.emit(`${ch} = load i8, i8* ${charPtr}`);
 
-  const isSpace = ctx.nextTemp();
-  ctx.emit(`${isSpace} = icmp eq i8 ${ch}, 32`);
-  const isTab = ctx.nextTemp();
-  ctx.emit(`${isTab} = icmp eq i8 ${ch}, 9`);
-  const isNewline = ctx.nextTemp();
-  ctx.emit(`${isNewline} = icmp eq i8 ${ch}, 10`);
-  const isCR = ctx.nextTemp();
-  ctx.emit(`${isCR} = icmp eq i8 ${ch}, 13`);
+  const isSpace = ctx.emitIcmp("eq", "i8", ch, "32");
+  const isTab = ctx.emitIcmp("eq", "i8", ch, "9");
+  const isNewline = ctx.emitIcmp("eq", "i8", ch, "10");
+  const isCR = ctx.emitIcmp("eq", "i8", ch, "13");
 
   const isWS1 = ctx.nextTemp();
   ctx.emit(`${isWS1} = or i1 ${isSpace}, ${isTab}`);
@@ -636,39 +577,36 @@ export function generateTrimStart(ctx: IGeneratorContext, strPtr: string): strin
   const isWhitespace = ctx.nextTemp();
   ctx.emit(`${isWhitespace} = or i1 ${isWS2}, ${isCR}`);
 
-  ctx.emit(`br i1 ${isWhitespace}, label %${findStartCheckLabel}, label %${findStartEndLabel}`);
+  ctx.emitBrCond(isWhitespace, findStartCheckLabel, findStartEndLabel);
 
-  ctx.emit(`${findStartCheckLabel}:`);
+  ctx.emitLabel(findStartCheckLabel);
   const nextStart = ctx.nextTemp();
   ctx.emit(`${nextStart} = add i32 ${start}, 1`);
-  ctx.emit(`store i32 ${nextStart}, i32* ${startPtr}`);
-  ctx.emit(`br label %${findStartLabel}`);
+  ctx.emitStore("i32", nextStart, startPtr);
+  ctx.emitBr(findStartLabel);
 
-  ctx.emit(`${findStartEndLabel}:`);
-  const finalStart = ctx.nextTemp();
-  ctx.emit(`${finalStart} = load i32, i32* ${startPtr}`);
+  ctx.emitLabel(findStartEndLabel);
+  const finalStart = ctx.emitLoad("i32", startPtr);
 
-  const allWhitespace = ctx.nextTemp();
-  ctx.emit(`${allWhitespace} = icmp eq i32 ${finalStart}, ${strLenI32}`);
+  const allWhitespace = ctx.emitIcmp("eq", "i32", finalStart, strLenI32);
 
   const allWSLabel = ctx.nextLabel("trimstart_all_ws");
   const substrLabel = ctx.nextLabel("trimstart_substr");
 
-  ctx.emit(`br i1 ${allWhitespace}, label %${allWSLabel}, label %${substrLabel}`);
+  ctx.emitBrCond(allWhitespace, allWSLabel, substrLabel);
 
-  ctx.emit(`${allWSLabel}:`);
-  const allWSResult = ctx.nextTemp();
-  ctx.emit(`${allWSResult} = call i8* @GC_malloc_atomic(i64 1)`);
-  ctx.emit(`store i8 0, i8* ${allWSResult}`);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitLabel(allWSLabel);
+  const allWSResult = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  ctx.emitStore("i8", "0", allWSResult);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${substrLabel}:`);
+  ctx.emitLabel(substrLabel);
   const remainLen = ctx.nextTemp();
   ctx.emit(`${remainLen} = sub i32 ${strLenI32}, ${finalStart}`);
   const trimmedResult = generateSubstr(ctx, strPtr, finalStart, remainLen);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const result = ctx.nextTemp();
   ctx.emit(
     `${result} = phi i8* [ ${emptyResult}, %${emptyLabel} ], [ ${allWSResult}, %${allWSLabel} ], [ ${trimmedResult}, %${substrLabel} ]`,
@@ -679,49 +617,44 @@ export function generateTrimStart(ctx: IGeneratorContext, strPtr: string): strin
 }
 
 export function generateTrimEnd(ctx: IGeneratorContext, strPtr: string): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
-  const isEmpty = ctx.nextTemp();
-  ctx.emit(`${isEmpty} = icmp eq i32 ${strLenI32}, 0`);
+  const isEmpty = ctx.emitIcmp("eq", "i32", strLenI32, "0");
 
   const emptyLabel = ctx.nextLabel("trimend_empty");
   const notEmptyLabel = ctx.nextLabel("trimend_notempty");
   const endLabel = ctx.nextLabel("trimend_end");
 
-  ctx.emit(`br i1 ${isEmpty}, label %${emptyLabel}, label %${notEmptyLabel}`);
+  ctx.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
-  ctx.emit(`${emptyLabel}:`);
-  const emptyResult = ctx.nextTemp();
-  ctx.emit(`${emptyResult} = call i8* @GC_malloc_atomic(i64 1)`);
-  ctx.emit(`store i8 0, i8* ${emptyResult}`);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitLabel(emptyLabel);
+  const emptyResult = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  ctx.emitStore("i8", "0", emptyResult);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${notEmptyLabel}:`);
+  ctx.emitLabel(notEmptyLabel);
 
   const endPtr = ctx.nextTemp();
   ctx.emit(`${endPtr} = alloca i32`);
   const initEnd = ctx.nextTemp();
   ctx.emit(`${initEnd} = sub i32 ${strLenI32}, 1`);
-  ctx.emit(`store i32 ${initEnd}, i32* ${endPtr}`);
+  ctx.emitStore("i32", initEnd, endPtr);
 
   const findEndLabel = ctx.nextLabel("trimend_find");
   const findEndBodyLabel = ctx.nextLabel("trimend_find_body");
   const findEndCheckLabel = ctx.nextLabel("trimend_find_check");
   const findEndEndLabel = ctx.nextLabel("trimend_find_end");
 
-  ctx.emit(`br label %${findEndLabel}`);
+  ctx.emitBr(findEndLabel);
 
-  ctx.emit(`${findEndLabel}:`);
-  const end = ctx.nextTemp();
-  ctx.emit(`${end} = load i32, i32* ${endPtr}`);
-  const endCond = ctx.nextTemp();
-  ctx.emit(`${endCond} = icmp sge i32 ${end}, 0`);
-  ctx.emit(`br i1 ${endCond}, label %${findEndBodyLabel}, label %${findEndEndLabel}`);
+  ctx.emitLabel(findEndLabel);
+  const end = ctx.emitLoad("i32", endPtr);
+  const endCond = ctx.emitIcmp("sge", "i32", end, "0");
+  ctx.emitBrCond(endCond, findEndBodyLabel, findEndEndLabel);
 
-  ctx.emit(`${findEndBodyLabel}:`);
+  ctx.emitLabel(findEndBodyLabel);
   const endI64 = ctx.nextTemp();
   ctx.emit(`${endI64} = sext i32 ${end} to i64`);
   const charPtr = ctx.nextTemp();
@@ -729,14 +662,10 @@ export function generateTrimEnd(ctx: IGeneratorContext, strPtr: string): string 
   const ch = ctx.nextTemp();
   ctx.emit(`${ch} = load i8, i8* ${charPtr}`);
 
-  const isSpace = ctx.nextTemp();
-  ctx.emit(`${isSpace} = icmp eq i8 ${ch}, 32`);
-  const isTab = ctx.nextTemp();
-  ctx.emit(`${isTab} = icmp eq i8 ${ch}, 9`);
-  const isNewline = ctx.nextTemp();
-  ctx.emit(`${isNewline} = icmp eq i8 ${ch}, 10`);
-  const isCR = ctx.nextTemp();
-  ctx.emit(`${isCR} = icmp eq i8 ${ch}, 13`);
+  const isSpace = ctx.emitIcmp("eq", "i8", ch, "32");
+  const isTab = ctx.emitIcmp("eq", "i8", ch, "9");
+  const isNewline = ctx.emitIcmp("eq", "i8", ch, "10");
+  const isCR = ctx.emitIcmp("eq", "i8", ch, "13");
 
   const isWS1 = ctx.nextTemp();
   ctx.emit(`${isWS1} = or i1 ${isSpace}, ${isTab}`);
@@ -745,39 +674,36 @@ export function generateTrimEnd(ctx: IGeneratorContext, strPtr: string): string 
   const isWhitespace = ctx.nextTemp();
   ctx.emit(`${isWhitespace} = or i1 ${isWS2}, ${isCR}`);
 
-  ctx.emit(`br i1 ${isWhitespace}, label %${findEndCheckLabel}, label %${findEndEndLabel}`);
+  ctx.emitBrCond(isWhitespace, findEndCheckLabel, findEndEndLabel);
 
-  ctx.emit(`${findEndCheckLabel}:`);
+  ctx.emitLabel(findEndCheckLabel);
   const nextEnd = ctx.nextTemp();
   ctx.emit(`${nextEnd} = sub i32 ${end}, 1`);
-  ctx.emit(`store i32 ${nextEnd}, i32* ${endPtr}`);
-  ctx.emit(`br label %${findEndLabel}`);
+  ctx.emitStore("i32", nextEnd, endPtr);
+  ctx.emitBr(findEndLabel);
 
-  ctx.emit(`${findEndEndLabel}:`);
-  const finalEnd = ctx.nextTemp();
-  ctx.emit(`${finalEnd} = load i32, i32* ${endPtr}`);
+  ctx.emitLabel(findEndEndLabel);
+  const finalEnd = ctx.emitLoad("i32", endPtr);
 
-  const allWhitespace = ctx.nextTemp();
-  ctx.emit(`${allWhitespace} = icmp slt i32 ${finalEnd}, 0`);
+  const allWhitespace = ctx.emitIcmp("slt", "i32", finalEnd, "0");
 
   const allWSLabel = ctx.nextLabel("trimend_all_ws");
   const substrLabel = ctx.nextLabel("trimend_substr");
 
-  ctx.emit(`br i1 ${allWhitespace}, label %${allWSLabel}, label %${substrLabel}`);
+  ctx.emitBrCond(allWhitespace, allWSLabel, substrLabel);
 
-  ctx.emit(`${allWSLabel}:`);
-  const allWSResult = ctx.nextTemp();
-  ctx.emit(`${allWSResult} = call i8* @GC_malloc_atomic(i64 1)`);
-  ctx.emit(`store i8 0, i8* ${allWSResult}`);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitLabel(allWSLabel);
+  const allWSResult = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  ctx.emitStore("i8", "0", allWSResult);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${substrLabel}:`);
+  ctx.emitLabel(substrLabel);
   const trimmedLen = ctx.nextTemp();
   ctx.emit(`${trimmedLen} = add i32 ${finalEnd}, 1`);
   const trimmedResult = generateSubstr(ctx, strPtr, "0", trimmedLen);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const result = ctx.nextTemp();
   ctx.emit(
     `${result} = phi i8* [ ${emptyResult}, %${emptyLabel} ], [ ${allWSResult}, %${allWSLabel} ], [ ${trimmedResult}, %${substrLabel} ]`,
@@ -793,31 +719,25 @@ export function generateReplace(
   searchPtr: string,
   replacePtr: string,
 ): string {
-  const foundPtr = ctx.nextTemp();
-  ctx.emit(`${foundPtr} = call i8* @strstr(i8* ${strPtr}, i8* ${searchPtr})`);
+  const foundPtr = ctx.emitCall("i8*", "@strstr", `i8* ${strPtr}, i8* ${searchPtr}`);
 
-  const isNull = ctx.nextTemp();
-  ctx.emit(`${isNull} = icmp eq i8* ${foundPtr}, null`);
+  const isNull = ctx.emitIcmp("eq", "i8*", foundPtr, "null");
 
   const foundLabel = ctx.nextLabel("replace_found");
   const notFoundLabel = ctx.nextLabel("replace_not_found");
   const endLabel = ctx.nextLabel("replace_end");
 
-  ctx.emit(`br i1 ${isNull}, label %${notFoundLabel}, label %${foundLabel}`);
+  ctx.emitBrCond(isNull, notFoundLabel, foundLabel);
 
-  ctx.emit(`${notFoundLabel}:`);
-  const originalDup = ctx.nextTemp();
-  ctx.emit(`${originalDup} = call i8* @strdup(i8* ${strPtr})`);
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitLabel(notFoundLabel);
+  const originalDup = ctx.emitCall("i8*", "@strdup", `i8* ${strPtr}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${foundLabel}:`);
+  ctx.emitLabel(foundLabel);
 
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
-  const searchLen = ctx.nextTemp();
-  ctx.emit(`${searchLen} = call i64 @strlen(i8* ${searchPtr})`);
-  const replaceLen = ctx.nextTemp();
-  ctx.emit(`${replaceLen} = call i64 @strlen(i8* ${replacePtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
+  const searchLen = ctx.emitCall("i64", "@strlen", `i8* ${searchPtr}`);
+  const replaceLen = ctx.emitCall("i64", "@strlen", `i8* ${replacePtr}`);
 
   const newLen = ctx.nextTemp();
   ctx.emit(`${newLen} = sub i64 ${strLen}, ${searchLen}`);
@@ -826,8 +746,7 @@ export function generateReplace(
   const allocLen = ctx.nextTemp();
   ctx.emit(`${allocLen} = add i64 ${newLen2}, 1`);
 
-  const resultPtr = ctx.nextTemp();
-  ctx.emit(`${resultPtr} = call i8* @GC_malloc_atomic(i64 ${allocLen})`);
+  const resultPtr = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen}`);
 
   const prefixLen = ctx.nextTemp();
   ctx.emit(`${prefixLen} = ptrtoint i8* ${foundPtr} to i64`);
@@ -840,28 +759,25 @@ export function generateReplace(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${resultPtr}, i8* ${strPtr}, i64 ${prefixBytes}, i1 false)`,
   );
 
-  const insertPos = ctx.nextTemp();
-  ctx.emit(`${insertPos} = getelementptr i8, i8* ${resultPtr}, i64 ${prefixBytes}`);
+  // GEP without inbounds -- use emitGep
+  const insertPos = ctx.emitGep("i8", resultPtr, `i64 ${prefixBytes}`);
   ctx.emit(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${insertPos}, i8* ${replacePtr}, i64 ${replaceLen}, i1 false)`,
   );
 
-  const suffixStart = ctx.nextTemp();
-  ctx.emit(`${suffixStart} = getelementptr i8, i8* ${foundPtr}, i64 ${searchLen}`);
-  const suffixLen = ctx.nextTemp();
-  ctx.emit(`${suffixLen} = call i64 @strlen(i8* ${suffixStart})`);
+  const suffixStart = ctx.emitGep("i8", foundPtr, `i64 ${searchLen}`);
+  const suffixLen = ctx.emitCall("i64", "@strlen", `i8* ${suffixStart}`);
   const suffixLenPlus1 = ctx.nextTemp();
   ctx.emit(`${suffixLenPlus1} = add i64 ${suffixLen}, 1`);
 
-  const suffixDest = ctx.nextTemp();
-  ctx.emit(`${suffixDest} = getelementptr i8, i8* ${insertPos}, i64 ${replaceLen}`);
+  const suffixDest = ctx.emitGep("i8", insertPos, `i64 ${replaceLen}`);
   ctx.emit(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${suffixDest}, i8* ${suffixStart}, i64 ${suffixLenPlus1}, i1 false)`,
   );
 
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const result = ctx.nextTemp();
   ctx.emit(
     `${result} = phi i8* [ ${originalDup}, %${notFoundLabel} ], [ ${resultPtr}, %${foundLabel} ]`,
@@ -879,45 +795,38 @@ export function generateReplaceAll(
 ): string {
   const resultPtr = ctx.nextTemp();
   ctx.emit(`${resultPtr} = alloca i8*`);
-  ctx.emit(`store i8* ${strPtr}, i8** ${resultPtr}`);
+  ctx.emitStore("i8*", strPtr, resultPtr);
 
   const loopLabel = ctx.nextLabel("replaceall_loop");
   const bodyLabel = ctx.nextLabel("replaceall_body");
   const endLabel = ctx.nextLabel("replaceall_end");
 
-  ctx.emit(`br label %${loopLabel}`);
+  ctx.emitBr(loopLabel);
 
-  ctx.emit(`${loopLabel}:`);
-  const currentStr = ctx.nextTemp();
-  ctx.emit(`${currentStr} = load i8*, i8** ${resultPtr}`);
-  const foundPtr = ctx.nextTemp();
-  ctx.emit(`${foundPtr} = call i8* @strstr(i8* ${currentStr}, i8* ${searchPtr})`);
-  const isNull = ctx.nextTemp();
-  ctx.emit(`${isNull} = icmp eq i8* ${foundPtr}, null`);
-  ctx.emit(`br i1 ${isNull}, label %${endLabel}, label %${bodyLabel}`);
+  ctx.emitLabel(loopLabel);
+  const currentStr = ctx.emitLoad("i8*", resultPtr);
+  const foundPtr = ctx.emitCall("i8*", "@strstr", `i8* ${currentStr}, i8* ${searchPtr}`);
+  const isNull = ctx.emitIcmp("eq", "i8*", foundPtr, "null");
+  ctx.emitBrCond(isNull, endLabel, bodyLabel);
 
-  ctx.emit(`${bodyLabel}:`);
+  ctx.emitLabel(bodyLabel);
   const replaced = generateReplace(ctx, currentStr, searchPtr, replacePtr);
-  ctx.emit(`store i8* ${replaced}, i8** ${resultPtr}`);
-  ctx.emit(`br label %${loopLabel}`);
+  ctx.emitStore("i8*", replaced, resultPtr);
+  ctx.emitBr(loopLabel);
 
-  ctx.emit(`${endLabel}:`);
-  const result = ctx.nextTemp();
-  ctx.emit(`${result} = load i8*, i8** ${resultPtr}`);
-  ctx.setVariableType(result, "i8*");
+  ctx.emitLabel(endLabel);
+  const result = ctx.emitLoad("i8*", resultPtr);
 
   return result;
 }
 
 export function generateToUpperCase(ctx: IGeneratorContext, strPtr: string): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
 
   const allocLen = ctx.nextTemp();
   ctx.emit(`${allocLen} = add i64 ${strLen}, 1`);
 
-  const resultPtr = ctx.nextTemp();
-  ctx.emit(`${resultPtr} = call i8* @GC_malloc_atomic(i64 ${allocLen})`);
+  const resultPtr = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen}`);
 
   const idxPtr = ctx.nextTemp();
   ctx.emit(`${idxPtr} = alloca i64, align 8`);
@@ -927,25 +836,24 @@ export function generateToUpperCase(ctx: IGeneratorContext, strPtr: string): str
   const bodyLabel = ctx.nextLabel("toupper_body");
   const endLabel = ctx.nextLabel("toupper_end");
 
-  ctx.emit(`br label %${loopLabel}`);
+  ctx.emitBr(loopLabel);
 
-  ctx.emit(`${loopLabel}:`);
+  ctx.emitLabel(loopLabel);
   const idx = ctx.nextTemp();
+  // Keep raw: alloca with align qualifier -- emitLoad would work for the load itself,
+  // but keeping paired with the aligned alloca for clarity
   ctx.emit(`${idx} = load i64, i64* ${idxPtr}`);
-  const cond = ctx.nextTemp();
-  ctx.emit(`${cond} = icmp slt i64 ${idx}, ${strLen}`);
-  ctx.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+  const cond = ctx.emitIcmp("slt", "i64", idx, strLen);
+  ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-  ctx.emit(`${bodyLabel}:`);
+  ctx.emitLabel(bodyLabel);
   const srcPtr = ctx.nextTemp();
   ctx.emit(`${srcPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${idx}`);
   const ch = ctx.nextTemp();
   ctx.emit(`${ch} = load i8, i8* ${srcPtr}`);
 
-  const isLowerA = ctx.nextTemp();
-  ctx.emit(`${isLowerA} = icmp sge i8 ${ch}, 97`);
-  const isLowerZ = ctx.nextTemp();
-  ctx.emit(`${isLowerZ} = icmp sle i8 ${ch}, 122`);
+  const isLowerA = ctx.emitIcmp("sge", "i8", ch, "97");
+  const isLowerZ = ctx.emitIcmp("sle", "i8", ch, "122");
   const isLower = ctx.nextTemp();
   ctx.emit(`${isLower} = and i1 ${isLowerA}, ${isLowerZ}`);
 
@@ -956,31 +864,29 @@ export function generateToUpperCase(ctx: IGeneratorContext, strPtr: string): str
 
   const dstPtr = ctx.nextTemp();
   ctx.emit(`${dstPtr} = getelementptr inbounds i8, i8* ${resultPtr}, i64 ${idx}`);
-  ctx.emit(`store i8 ${finalCh}, i8* ${dstPtr}`);
+  ctx.emitStore("i8", finalCh, dstPtr);
 
   const nextIdx = ctx.nextTemp();
   ctx.emit(`${nextIdx} = add i64 ${idx}, 1`);
   ctx.emit(`store i64 ${nextIdx}, i64* ${idxPtr}`);
-  ctx.emit(`br label %${loopLabel}`);
+  ctx.emitBr(loopLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const nullPtr = ctx.nextTemp();
   ctx.emit(`${nullPtr} = getelementptr inbounds i8, i8* ${resultPtr}, i64 ${strLen}`);
-  ctx.emit(`store i8 0, i8* ${nullPtr}`);
+  ctx.emitStore("i8", "0", nullPtr);
 
   ctx.setVariableType(resultPtr, "i8*");
   return resultPtr;
 }
 
 export function generateToLowerCase(ctx: IGeneratorContext, strPtr: string): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
 
   const allocLen = ctx.nextTemp();
   ctx.emit(`${allocLen} = add i64 ${strLen}, 1`);
 
-  const resultPtr = ctx.nextTemp();
-  ctx.emit(`${resultPtr} = call i8* @GC_malloc_atomic(i64 ${allocLen})`);
+  const resultPtr = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen}`);
 
   const idxPtr = ctx.nextTemp();
   ctx.emit(`${idxPtr} = alloca i64, align 8`);
@@ -990,25 +896,22 @@ export function generateToLowerCase(ctx: IGeneratorContext, strPtr: string): str
   const bodyLabel = ctx.nextLabel("tolower_body");
   const endLabel = ctx.nextLabel("tolower_end");
 
-  ctx.emit(`br label %${loopLabel}`);
+  ctx.emitBr(loopLabel);
 
-  ctx.emit(`${loopLabel}:`);
+  ctx.emitLabel(loopLabel);
   const idx = ctx.nextTemp();
   ctx.emit(`${idx} = load i64, i64* ${idxPtr}`);
-  const cond = ctx.nextTemp();
-  ctx.emit(`${cond} = icmp slt i64 ${idx}, ${strLen}`);
-  ctx.emit(`br i1 ${cond}, label %${bodyLabel}, label %${endLabel}`);
+  const cond = ctx.emitIcmp("slt", "i64", idx, strLen);
+  ctx.emitBrCond(cond, bodyLabel, endLabel);
 
-  ctx.emit(`${bodyLabel}:`);
+  ctx.emitLabel(bodyLabel);
   const srcPtr = ctx.nextTemp();
   ctx.emit(`${srcPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${idx}`);
   const ch = ctx.nextTemp();
   ctx.emit(`${ch} = load i8, i8* ${srcPtr}`);
 
-  const isUpperA = ctx.nextTemp();
-  ctx.emit(`${isUpperA} = icmp sge i8 ${ch}, 65`);
-  const isUpperZ = ctx.nextTemp();
-  ctx.emit(`${isUpperZ} = icmp sle i8 ${ch}, 90`);
+  const isUpperA = ctx.emitIcmp("sge", "i8", ch, "65");
+  const isUpperZ = ctx.emitIcmp("sle", "i8", ch, "90");
   const isUpper = ctx.nextTemp();
   ctx.emit(`${isUpper} = and i1 ${isUpperA}, ${isUpperZ}`);
 
@@ -1019,17 +922,17 @@ export function generateToLowerCase(ctx: IGeneratorContext, strPtr: string): str
 
   const dstPtr = ctx.nextTemp();
   ctx.emit(`${dstPtr} = getelementptr inbounds i8, i8* ${resultPtr}, i64 ${idx}`);
-  ctx.emit(`store i8 ${finalCh}, i8* ${dstPtr}`);
+  ctx.emitStore("i8", finalCh, dstPtr);
 
   const nextIdx = ctx.nextTemp();
   ctx.emit(`${nextIdx} = add i64 ${idx}, 1`);
   ctx.emit(`store i64 ${nextIdx}, i64* ${idxPtr}`);
-  ctx.emit(`br label %${loopLabel}`);
+  ctx.emitBr(loopLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const nullPtr = ctx.nextTemp();
   ctx.emit(`${nullPtr} = getelementptr inbounds i8, i8* ${resultPtr}, i64 ${strLen}`);
-  ctx.emit(`store i8 0, i8* ${nullPtr}`);
+  ctx.emitStore("i8", "0", nullPtr);
 
   ctx.setVariableType(resultPtr, "i8*");
   return resultPtr;

--- a/src/codegen/types/collections/string/split.ts
+++ b/src/codegen/types/collections/string/split.ts
@@ -1,5 +1,6 @@
-// NOTE: This file uses raw ctx.emit() extensively. Prefer structured IR builders
-// (emitStore, emitLoad, emitCall, etc.) when modifying — see .claude/rules.md.
+// String split IR generator: splits a string by delimiter into a StringArray.
+// Uses structured IR builders where possible; raw emit() for phi, select, add, sub, mul,
+// zext, sext, alloca, inbounds GEP, memcpy intrinsics, and or.
 
 import { IGeneratorContext } from "../../../infrastructure/generator-context.js";
 
@@ -8,26 +9,23 @@ import { IGeneratorContext } from "../../../infrastructure/generator-context.js"
 // ============================================
 
 export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter: string): string {
-  const strLen = ctx.nextTemp();
-  ctx.emit(`${strLen} = call i64 @strlen(i8* ${strPtr})`);
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
-  const delimLen = ctx.nextTemp();
-  ctx.emit(`${delimLen} = call i64 @strlen(i8* ${delimiter})`);
+  const delimLen = ctx.emitCall("i64", "@strlen", `i8* ${delimiter}`);
   const delimLenI32 = ctx.nextTemp();
   ctx.emit(`${delimLenI32} = trunc i64 ${delimLen} to i32`);
 
-  const isEmptyDelim = ctx.nextTemp();
-  ctx.emit(`${isEmptyDelim} = icmp eq i32 ${delimLenI32}, 0`);
+  const isEmptyDelim = ctx.emitIcmp("eq", "i32", delimLenI32, "0");
 
   const emptyDelimLabel = ctx.nextLabel("split_empty_delim");
   const normalSplitLabel = ctx.nextLabel("split_normal");
   const endLabel = ctx.nextLabel("split_end");
 
-  ctx.emit(`br i1 ${isEmptyDelim}, label %${emptyDelimLabel}, label %${normalSplitLabel}`);
+  ctx.emitBrCond(isEmptyDelim, emptyDelimLabel, normalSplitLabel);
 
-  ctx.emit(`${emptyDelimLabel}:`);
+  ctx.emitLabel(emptyDelimLabel);
 
   const emptyArrPtr = ctx.nextTemp();
   ctx.emit(`${emptyArrPtr} = alloca %StringArray`);
@@ -36,10 +34,8 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   ctx.emit(`${emptyDataSize} = mul i32 ${strLenI32}, 8`);
   const emptyDataSizeI64 = ctx.nextTemp();
   ctx.emit(`${emptyDataSizeI64} = zext i32 ${emptyDataSize} to i64`);
-  const emptyDataMem = ctx.nextTemp();
-  ctx.emit(`${emptyDataMem} = call i8* @GC_malloc(i64 ${emptyDataSizeI64})`);
-  const emptyDataPtr = ctx.nextTemp();
-  ctx.emit(`${emptyDataPtr} = bitcast i8* ${emptyDataMem} to i8**`);
+  const emptyDataMem = ctx.emitCall("i8*", "@GC_malloc", `i64 ${emptyDataSizeI64}`);
+  const emptyDataPtr = ctx.emitBitcast(emptyDataMem, "i8*", "i8**");
 
   const emptyLoopLabel = ctx.nextLabel("split_empty_loop");
   const emptyLoopBodyLabel = ctx.nextLabel("split_empty_body");
@@ -47,19 +43,16 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
 
   const emptyCounterPtr = ctx.nextTemp();
   ctx.emit(`${emptyCounterPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${emptyCounterPtr}`);
-  ctx.emit(`br label %${emptyLoopLabel}`);
+  ctx.emitStore("i32", "0", emptyCounterPtr);
+  ctx.emitBr(emptyLoopLabel);
 
-  ctx.emit(`${emptyLoopLabel}:`);
-  const emptyCounterVal = ctx.nextTemp();
-  ctx.emit(`${emptyCounterVal} = load i32, i32* ${emptyCounterPtr}`);
-  const emptyLoopCond = ctx.nextTemp();
-  ctx.emit(`${emptyLoopCond} = icmp slt i32 ${emptyCounterVal}, ${strLenI32}`);
-  ctx.emit(`br i1 ${emptyLoopCond}, label %${emptyLoopBodyLabel}, label %${emptyLoopEndLabel}`);
+  ctx.emitLabel(emptyLoopLabel);
+  const emptyCounterVal = ctx.emitLoad("i32", emptyCounterPtr);
+  const emptyLoopCond = ctx.emitIcmp("slt", "i32", emptyCounterVal, strLenI32);
+  ctx.emitBrCond(emptyLoopCond, emptyLoopBodyLabel, emptyLoopEndLabel);
 
-  ctx.emit(`${emptyLoopBodyLabel}:`);
-  const charStr = ctx.nextTemp();
-  ctx.emit(`${charStr} = call i8* @GC_malloc_atomic(i64 2)`);
+  ctx.emitLabel(emptyLoopBodyLabel);
+  const charStr = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 2");
 
   const charIdx = ctx.nextTemp();
   ctx.emit(`${charIdx} = sext i32 ${emptyCounterVal} to i64`);
@@ -68,45 +61,45 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   const charVal = ctx.nextTemp();
   ctx.emit(`${charVal} = load i8, i8* ${charPtr}`);
 
-  ctx.emit(`store i8 ${charVal}, i8* ${charStr}`);
+  ctx.emitStore("i8", charVal, charStr);
   const nullPtr = ctx.nextTemp();
   ctx.emit(`${nullPtr} = getelementptr inbounds i8, i8* ${charStr}, i64 1`);
-  ctx.emit(`store i8 0, i8* ${nullPtr}`);
+  ctx.emitStore("i8", "0", nullPtr);
 
   const emptyElemPtr = ctx.nextTemp();
   ctx.emit(
     `${emptyElemPtr} = getelementptr inbounds i8*, i8** ${emptyDataPtr}, i32 ${emptyCounterVal}`,
   );
-  ctx.emit(`store i8* ${charStr}, i8** ${emptyElemPtr}`);
+  ctx.emitStore("i8*", charStr, emptyElemPtr);
 
   const emptyNextCounter = ctx.nextTemp();
   ctx.emit(`${emptyNextCounter} = add i32 ${emptyCounterVal}, 1`);
-  ctx.emit(`store i32 ${emptyNextCounter}, i32* ${emptyCounterPtr}`);
-  ctx.emit(`br label %${emptyLoopLabel}`);
+  ctx.emitStore("i32", emptyNextCounter, emptyCounterPtr);
+  ctx.emitBr(emptyLoopLabel);
 
-  ctx.emit(`${emptyLoopEndLabel}:`);
+  ctx.emitLabel(emptyLoopEndLabel);
 
   const emptyDataField = ctx.nextTemp();
   ctx.emit(
     `${emptyDataField} = getelementptr inbounds %StringArray, %StringArray* ${emptyArrPtr}, i32 0, i32 0`,
   );
-  ctx.emit(`store i8** ${emptyDataPtr}, i8*** ${emptyDataField}`);
+  ctx.emitStore("i8**", emptyDataPtr, emptyDataField);
 
   const emptyLenField = ctx.nextTemp();
   ctx.emit(
     `${emptyLenField} = getelementptr inbounds %StringArray, %StringArray* ${emptyArrPtr}, i32 0, i32 1`,
   );
-  ctx.emit(`store i32 ${strLenI32}, i32* ${emptyLenField}`);
+  ctx.emitStore("i32", strLenI32, emptyLenField);
 
   const emptyCapField = ctx.nextTemp();
   ctx.emit(
     `${emptyCapField} = getelementptr inbounds %StringArray, %StringArray* ${emptyArrPtr}, i32 0, i32 2`,
   );
-  ctx.emit(`store i32 ${strLenI32}, i32* ${emptyCapField}`);
+  ctx.emitStore("i32", strLenI32, emptyCapField);
 
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${normalSplitLabel}:`);
+  ctx.emitLabel(normalSplitLabel);
 
   const delimLenI64 = ctx.nextTemp();
   ctx.emit(`${delimLenI64} = zext i32 ${delimLenI32} to i64`);
@@ -118,56 +111,52 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
 
   const partCountPtr = ctx.nextTemp();
   ctx.emit(`${partCountPtr} = alloca i32`);
-  ctx.emit(`store i32 1, i32* ${partCountPtr}`);
+  ctx.emitStore("i32", "1", partCountPtr);
 
   const scanPosPtr = ctx.nextTemp();
   ctx.emit(`${scanPosPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${scanPosPtr}`);
+  ctx.emitStore("i32", "0", scanPosPtr);
 
-  ctx.emit(`br label %${countLabel}`);
+  ctx.emitBr(countLabel);
 
-  ctx.emit(`${countLabel}:`);
-  const scanPos = ctx.nextTemp();
-  ctx.emit(`${scanPos} = load i32, i32* ${scanPosPtr}`);
-  const canContinue = ctx.nextTemp();
-  ctx.emit(`${canContinue} = icmp slt i32 ${scanPos}, ${strLenI32}`);
-  ctx.emit(`br i1 ${canContinue}, label %${countBodyLabel}, label %${countEndLabel}`);
+  ctx.emitLabel(countLabel);
+  const scanPos = ctx.emitLoad("i32", scanPosPtr);
+  const canContinue = ctx.emitIcmp("slt", "i32", scanPos, strLenI32);
+  ctx.emitBrCond(canContinue, countBodyLabel, countEndLabel);
 
-  ctx.emit(`${countBodyLabel}:`);
+  ctx.emitLabel(countBodyLabel);
   const scanPosI64 = ctx.nextTemp();
   ctx.emit(`${scanPosI64} = sext i32 ${scanPos} to i64`);
   const checkPtr = ctx.nextTemp();
   ctx.emit(`${checkPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${scanPosI64}`);
-  const cmpResult = ctx.nextTemp();
-  ctx.emit(
-    `${cmpResult} = call i32 @strncmp(i8* ${checkPtr}, i8* ${delimiter}, i64 ${delimLenI64})`,
+  const cmpResult = ctx.emitCall(
+    "i32",
+    "@strncmp",
+    `i8* ${checkPtr}, i8* ${delimiter}, i64 ${delimLenI64}`,
   );
-  const isMatch = ctx.nextTemp();
-  ctx.emit(`${isMatch} = icmp eq i32 ${cmpResult}, 0`);
+  const isMatch = ctx.emitIcmp("eq", "i32", cmpResult, "0");
 
-  ctx.emit(`br i1 ${isMatch}, label %${countCheckLabel}, label %${countCheckLabel}`);
+  ctx.emitBrCond(isMatch, countCheckLabel, countCheckLabel);
 
-  ctx.emit(`${countCheckLabel}:`);
-  const partCount = ctx.nextTemp();
-  ctx.emit(`${partCount} = load i32, i32* ${partCountPtr}`);
+  ctx.emitLabel(countCheckLabel);
+  const partCount = ctx.emitLoad("i32", partCountPtr);
   const newPartCount = ctx.nextTemp();
   ctx.emit(`${newPartCount} = select i1 ${isMatch}, i32 ${partCount}, i32 ${partCount}`);
   const incPartCount = ctx.nextTemp();
   ctx.emit(`${incPartCount} = add i32 ${newPartCount}, 1`);
   const finalPartCount = ctx.nextTemp();
   ctx.emit(`${finalPartCount} = select i1 ${isMatch}, i32 ${incPartCount}, i32 ${newPartCount}`);
-  ctx.emit(`store i32 ${finalPartCount}, i32* ${partCountPtr}`);
+  ctx.emitStore("i32", finalPartCount, partCountPtr);
 
   const skipAmount = ctx.nextTemp();
   ctx.emit(`${skipAmount} = select i1 ${isMatch}, i32 ${delimLenI32}, i32 1`);
   const nextScanPos = ctx.nextTemp();
   ctx.emit(`${nextScanPos} = add i32 ${scanPos}, ${skipAmount}`);
-  ctx.emit(`store i32 ${nextScanPos}, i32* ${scanPosPtr}`);
-  ctx.emit(`br label %${countLabel}`);
+  ctx.emitStore("i32", nextScanPos, scanPosPtr);
+  ctx.emitBr(countLabel);
 
-  ctx.emit(`${countEndLabel}:`);
-  const totalParts = ctx.nextTemp();
-  ctx.emit(`${totalParts} = load i32, i32* ${partCountPtr}`);
+  ctx.emitLabel(countEndLabel);
+  const totalParts = ctx.emitLoad("i32", partCountPtr);
 
   const arrayPtr = ctx.nextTemp();
   ctx.emit(`${arrayPtr} = alloca %StringArray`);
@@ -176,10 +165,8 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   ctx.emit(`${dataSize} = mul i32 ${totalParts}, 8`);
   const dataSizeI64 = ctx.nextTemp();
   ctx.emit(`${dataSizeI64} = zext i32 ${dataSize} to i64`);
-  const dataMem = ctx.nextTemp();
-  ctx.emit(`${dataMem} = call i8* @GC_malloc(i64 ${dataSizeI64})`);
-  const dataPtr = ctx.nextTemp();
-  ctx.emit(`${dataPtr} = bitcast i8* ${dataMem} to i8**`);
+  const dataMem = ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSizeI64}`);
+  const dataPtr = ctx.emitBitcast(dataMem, "i8*", "i8**");
 
   const extractLabel = ctx.nextLabel("split_extract");
   const extractBodyLabel = ctx.nextLabel("split_extract_body");
@@ -189,48 +176,44 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
 
   const startPosPtr = ctx.nextTemp();
   ctx.emit(`${startPosPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${startPosPtr}`);
+  ctx.emitStore("i32", "0", startPosPtr);
 
   const curPosPtr = ctx.nextTemp();
   ctx.emit(`${curPosPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${curPosPtr}`);
+  ctx.emitStore("i32", "0", curPosPtr);
 
   const partIndexPtr = ctx.nextTemp();
   ctx.emit(`${partIndexPtr} = alloca i32`);
-  ctx.emit(`store i32 0, i32* ${partIndexPtr}`);
+  ctx.emitStore("i32", "0", partIndexPtr);
 
-  ctx.emit(`br label %${extractLabel}`);
+  ctx.emitBr(extractLabel);
 
-  ctx.emit(`${extractLabel}:`);
-  const curPos = ctx.nextTemp();
-  ctx.emit(`${curPos} = load i32, i32* ${curPosPtr}`);
-  const extractCond = ctx.nextTemp();
-  ctx.emit(`${extractCond} = icmp sle i32 ${curPos}, ${strLenI32}`);
-  ctx.emit(`br i1 ${extractCond}, label %${extractBodyLabel}, label %${extractEndLabel}`);
+  ctx.emitLabel(extractLabel);
+  const curPos = ctx.emitLoad("i32", curPosPtr);
+  const extractCond = ctx.emitIcmp("sle", "i32", curPos, strLenI32);
+  ctx.emitBrCond(extractCond, extractBodyLabel, extractEndLabel);
 
-  ctx.emit(`${extractBodyLabel}:`);
-  const atEnd = ctx.nextTemp();
-  ctx.emit(`${atEnd} = icmp eq i32 ${curPos}, ${strLenI32}`);
+  ctx.emitLabel(extractBodyLabel);
+  const atEnd = ctx.emitIcmp("eq", "i32", curPos, strLenI32);
 
   const curPosI64 = ctx.nextTemp();
   ctx.emit(`${curPosI64} = sext i32 ${curPos} to i64`);
   const extractCheckPtr = ctx.nextTemp();
   ctx.emit(`${extractCheckPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${curPosI64}`);
-  const extractCmpResult = ctx.nextTemp();
-  ctx.emit(
-    `${extractCmpResult} = call i32 @strncmp(i8* ${extractCheckPtr}, i8* ${delimiter}, i64 ${delimLenI64})`,
+  const extractCmpResult = ctx.emitCall(
+    "i32",
+    "@strncmp",
+    `i8* ${extractCheckPtr}, i8* ${delimiter}, i64 ${delimLenI64}`,
   );
-  const extractIsMatch = ctx.nextTemp();
-  ctx.emit(`${extractIsMatch} = icmp eq i32 ${extractCmpResult}, 0`);
+  const extractIsMatch = ctx.emitIcmp("eq", "i32", extractCmpResult, "0");
 
   const shouldExtract = ctx.nextTemp();
   ctx.emit(`${shouldExtract} = or i1 ${atEnd}, ${extractIsMatch}`);
 
-  ctx.emit(`br i1 ${shouldExtract}, label %${extractMatchLabel}, label %${extractNoMatchLabel}`);
+  ctx.emitBrCond(shouldExtract, extractMatchLabel, extractNoMatchLabel);
 
-  ctx.emit(`${extractMatchLabel}:`);
-  const startPos = ctx.nextTemp();
-  ctx.emit(`${startPos} = load i32, i32* ${startPosPtr}`);
+  ctx.emitLabel(extractMatchLabel);
+  const startPos = ctx.emitLoad("i32", startPosPtr);
   const partLen = ctx.nextTemp();
   ctx.emit(`${partLen} = sub i32 ${curPos}, ${startPos}`);
 
@@ -238,8 +221,7 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   ctx.emit(`${partLenI64} = sext i32 ${partLen} to i64`);
   const allocLen = ctx.nextTemp();
   ctx.emit(`${allocLen} = add i64 ${partLenI64}, 1`);
-  const partStr = ctx.nextTemp();
-  ctx.emit(`${partStr} = call i8* @GC_malloc_atomic(i64 ${allocLen})`);
+  const partStr = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocLen}`);
   const startI64 = ctx.nextTemp();
   ctx.emit(`${startI64} = sext i32 ${startPos} to i64`);
   const srcPtr = ctx.nextTemp();
@@ -249,56 +231,55 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   );
   const nullTermPtr = ctx.nextTemp();
   ctx.emit(`${nullTermPtr} = getelementptr inbounds i8, i8* ${partStr}, i64 ${partLenI64}`);
-  ctx.emit(`store i8 0, i8* ${nullTermPtr}`);
+  ctx.emitStore("i8", "0", nullTermPtr);
 
-  const partIndex = ctx.nextTemp();
-  ctx.emit(`${partIndex} = load i32, i32* ${partIndexPtr}`);
+  const partIndex = ctx.emitLoad("i32", partIndexPtr);
   const partElemPtr = ctx.nextTemp();
   ctx.emit(`${partElemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${partIndex}`);
-  ctx.emit(`store i8* ${partStr}, i8** ${partElemPtr}`);
+  ctx.emitStore("i8*", partStr, partElemPtr);
 
   const nextPartIndex = ctx.nextTemp();
   ctx.emit(`${nextPartIndex} = add i32 ${partIndex}, 1`);
-  ctx.emit(`store i32 ${nextPartIndex}, i32* ${partIndexPtr}`);
+  ctx.emitStore("i32", nextPartIndex, partIndexPtr);
 
   const newStartPos = ctx.nextTemp();
   ctx.emit(`${newStartPos} = add i32 ${curPos}, ${delimLenI32}`);
-  ctx.emit(`store i32 ${newStartPos}, i32* ${startPosPtr}`);
+  ctx.emitStore("i32", newStartPos, startPosPtr);
 
   const newCurPos = ctx.nextTemp();
   ctx.emit(`${newCurPos} = add i32 ${curPos}, ${delimLenI32}`);
-  ctx.emit(`store i32 ${newCurPos}, i32* ${curPosPtr}`);
-  ctx.emit(`br label %${extractLabel}`);
+  ctx.emitStore("i32", newCurPos, curPosPtr);
+  ctx.emitBr(extractLabel);
 
-  ctx.emit(`${extractNoMatchLabel}:`);
+  ctx.emitLabel(extractNoMatchLabel);
   const incCurPos = ctx.nextTemp();
   ctx.emit(`${incCurPos} = add i32 ${curPos}, 1`);
-  ctx.emit(`store i32 ${incCurPos}, i32* ${curPosPtr}`);
-  ctx.emit(`br label %${extractLabel}`);
+  ctx.emitStore("i32", incCurPos, curPosPtr);
+  ctx.emitBr(extractLabel);
 
-  ctx.emit(`${extractEndLabel}:`);
+  ctx.emitLabel(extractEndLabel);
 
   const dataField = ctx.nextTemp();
   ctx.emit(
     `${dataField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
   );
-  ctx.emit(`store i8** ${dataPtr}, i8*** ${dataField}`);
+  ctx.emitStore("i8**", dataPtr, dataField);
 
   const lenField = ctx.nextTemp();
   ctx.emit(
     `${lenField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
   );
-  ctx.emit(`store i32 ${totalParts}, i32* ${lenField}`);
+  ctx.emitStore("i32", totalParts, lenField);
 
   const capField = ctx.nextTemp();
   ctx.emit(
     `${capField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 2`,
   );
-  ctx.emit(`store i32 ${totalParts}, i32* ${capField}`);
+  ctx.emitStore("i32", totalParts, capField);
 
-  ctx.emit(`br label %${endLabel}`);
+  ctx.emitBr(endLabel);
 
-  ctx.emit(`${endLabel}:`);
+  ctx.emitLabel(endLabel);
   const result = ctx.nextTemp();
   ctx.emit(
     `${result} = phi %StringArray* [ ${emptyArrPtr}, %${emptyLoopEndLabel} ], [ ${arrayPtr}, %${extractEndLabel} ]`,

--- a/tests/fixtures/structs/struct-array-field-access-standalone.ts
+++ b/tests/fixtures/structs/struct-array-field-access-standalone.ts
@@ -1,0 +1,27 @@
+// Standalone function accessing arr[0].type via a struct field
+// Previously only worked in class methods due to missing parameter type resolution
+interface Item {
+  type: string;
+  value: number;
+}
+
+interface Container {
+  type: string;
+  items: Item[];
+}
+
+function getFirstItemType(container: Container): string {
+  const item = container.items[0];
+  if (item.type === "number") {
+    return "number";
+  }
+  return "unknown";
+}
+
+const c: Container = { type: "box", items: [{ type: "number", value: 42 }] };
+const result = getFirstItemType(c);
+if (result === "number") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAILED: got " + result);
+}


### PR DESCRIPTION
## Summary

- Fix standalone function access to array-indexed struct fields (`container.items[0].type` now works outside class methods)
- Migrate ~880 raw `ctx.emit()` calls to structured IR builder methods across 12 files (net -458 lines)

## Changes

### Standalone struct field access fix
- **`variable-allocator.ts`**: Added `getParameterTypeFromAST()` fallback so `getIndexedObjectArrayType()` resolves parameter types via AST annotations when symbol table metadata is absent
- **`struct-array-field-access-standalone.ts`**: New test fixture

### IR builder migration
Replaced raw `ctx.emit()` with structured builders (`emitStore`, `emitLoad`, `emitCall`, `emitBitcast`, `emitIcmp`, `emitBr`, `emitBrCond`, `emitLabel`, `emitGep`) in:
- `map.ts` (~348 calls)
- `string/manipulation.ts` (~155 calls), `string/split.ts` (~72 calls)
- `array/mutators.ts`, `reorder.ts`, `search.ts`, `search-predicate.ts`, `iteration.ts`, `sort.ts` (~81+ calls)
- `statements/control-flow.ts` (~137 calls)
- `expressions/calls.ts` (~89 calls)

## Test plan

- [x] All 341 tests pass (native compiler)
- [x] All 207 tests pass (Node.js compiler)
- [x] `npm run verify:quick` — Stage 0 + Stage 1 self-hosting pass
- [x] New fixture `struct-array-field-access-standalone` passes
