### PR TITLE
fix module-scope variables defaulting to double instead of actual type

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -498,18 +498,16 @@ export class VariableAllocator {
       const globalPtr = this.ctx.symbolTable.getAlloca(stmt.name) || "";
       const llvmType = this.ctx.symbolTable.getType(stmt.name) || "i8*";
       if (llvmType.indexOf("*") !== -1) {
-        this.ctx.emit(`store ${llvmType} ${value}, ${llvmType}* ${globalPtr}`);
-      } else if (
-        llvmType === "%Array" ||
-        llvmType === "%StringArray" ||
-        llvmType === "%Map" ||
-        llvmType === "%StringMap" ||
-        llvmType === "%Set" ||
-        llvmType === "%StringSet"
-      ) {
-        const loadedValue = this.ctx.nextTemp();
-        this.ctx.emit(`${loadedValue} = load ${llvmType}, ${llvmType}* ${value}`);
-        this.ctx.emit(`store ${llvmType} ${loadedValue}, ${llvmType}* ${globalPtr}`);
+        // Bitcast if expression type doesn't match the global's declared pointer type
+        // (e.g. .match() returns i8* but global is %StringArray*)
+        const valueType = this.ctx.getVariableType(value);
+        let storeValue = value;
+        if (valueType && valueType !== llvmType && valueType.indexOf("*") !== -1) {
+          const cast = this.ctx.nextTemp();
+          this.ctx.emit(`${cast} = bitcast ${valueType} ${value} to ${llvmType}`);
+          storeValue = cast;
+        }
+        this.ctx.emit(`store ${llvmType} ${storeValue}, ${llvmType}* ${globalPtr}`);
       } else if (llvmType === "double") {
         const coerced = this.ctx.ensureDouble(value);
         this.ctx.emit(`store double ${coerced}, double* ${globalPtr}`);

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -1873,9 +1873,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           kind = SymbolKind.String;
           defaultValue = "null";
         } else if (isStringArray) {
-          llvmType = "%StringArray";
+          llvmType = "%StringArray*";
           kind = SymbolKind.StringArray;
-          defaultValue = "zeroinitializer";
+          defaultValue = "null";
         } else if (isObjectArray) {
           let elementType = "";
           if (stmt.declaredType) {
@@ -1905,9 +1905,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
           continue;
         } else if (isArray) {
-          llvmType = "%Array";
+          llvmType = "%Array*";
           kind = SymbolKind.Array;
-          defaultValue = "zeroinitializer";
+          defaultValue = "null";
         } else if (isObject) {
           llvmType = "i8*";
           kind = SymbolKind.Object;
@@ -1939,9 +1939,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             }
           }
           if (isStringMap) {
-            llvmType = "%StringMap";
+            llvmType = "%StringMap*";
             kind = SymbolKind.Map;
-            defaultValue = "zeroinitializer";
+            defaultValue = "null";
             ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
             this.globalVariables.set(name, { llvmType, kind, initialized: false });
             this.defineVariableWithMetadata(
@@ -1959,9 +1959,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             );
             continue;
           }
-          llvmType = "%Map";
+          llvmType = "%Map*";
           kind = SymbolKind.Map;
-          defaultValue = "zeroinitializer";
+          defaultValue = "null";
         } else if (isSet) {
           let isStringSet = false;
           if (stmt.declaredType) {
@@ -1976,9 +1976,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             }
           }
           if (isStringSet) {
-            llvmType = "%StringSet";
+            llvmType = "%StringSet*";
             kind = SymbolKind.Set;
-            defaultValue = "zeroinitializer";
+            defaultValue = "null";
             ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
             this.globalVariables.set(name, { llvmType, kind, initialized: false });
             this.defineVariableWithMetadata(
@@ -1994,9 +1994,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             );
             continue;
           }
-          llvmType = "%Set";
+          llvmType = "%Set*";
           kind = SymbolKind.Set;
-          defaultValue = "zeroinitializer";
+          defaultValue = "null";
         } else if (isRegex) {
           llvmType = "i8*";
           kind = SymbolKind.Regex;
@@ -2194,9 +2194,21 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               }
             }
             if (llvmType === "") {
-              llvmType = "double";
-              kind = SymbolKind.Number;
-              defaultValue = "0.0";
+              const exprNodeType = stmt.value ? (stmt.value as { type: string }).type : "";
+              // Number literals are the only unclassified expressions that should default to double.
+              // Everything else is a type inference gap — error so we fix the classifier.
+              if (exprNodeType === "number") {
+                llvmType = "double";
+                kind = SymbolKind.Number;
+                defaultValue = "0.0";
+              } else {
+                const loc = stmt.value ? (stmt.value as { loc?: SourceLocation }).loc : undefined;
+                return this.emitError(
+                  `cannot determine type of module-scope variable '${name}' (expression type: ${exprNodeType || "unknown"}). ` +
+                    `Move the declaration inside a function, or add a type annotation`,
+                  loc,
+                );
+              }
             }
           }
         }

--- a/tests/fixtures/globals/module-scope-function-return.ts
+++ b/tests/fixtures/globals/module-scope-function-return.ts
@@ -1,0 +1,7 @@
+// Module-scope variable from function call — tests global i8* fallback for calls
+function getMessage(): string {
+  return "hello from function";
+}
+const msg = getMessage();
+console.log(msg);
+console.log("TEST_PASSED");

--- a/tests/fixtures/globals/module-scope-split.ts
+++ b/tests/fixtures/globals/module-scope-split.ts
@@ -1,0 +1,4 @@
+// Module-scope string array from .split() — tests global %StringArray* type
+const words = "hello world foo".split(" ");
+console.log(words[0]);
+console.log("TEST_PASSED");

--- a/tests/fixtures/globals/module-scope-string-array.ts
+++ b/tests/fixtures/globals/module-scope-string-array.ts
@@ -1,0 +1,6 @@
+// Module-scope string array from .match() — tests global %StringArray* type
+const parts = "hello world".match(/hello (\w+)/);
+if (parts !== null) {
+  console.log(parts[0]);
+}
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

Fix module-scope variables defaulting to `double` instead of their actual type, causing LLVM `opt` crashes.

### Problem

Top-level variable declarations like `const parts = "hello".match(/re/)` crashed during LLVM optimization with type mismatches:

```
'%1' defined with type 'ptr' but expected 'double'
```

The same code worked fine when wrapped in a function.

### Root cause

Module-scope variables go through a two-phase process:
1. `generateGlobalVariableDeclarations()` emits `@name = global <type> <default>`
2. `allocate()` in `@main` stores the expression result into the pre-declared global

Phase 1 has an incomplete type classifier (~12 cases) compared to the function-local path which handles 25 cases via `classifyVariable()`. When it couldn't determine the type, it fell back to `double` — so `.match()`, `.split()`, function calls returning strings, etc. all became `@name = global double 0.0`. Phase 2 then tried to `store i8* %expr, double* @name`, causing the type mismatch.

Additionally, struct-value globals (`%StringArray`, `%Array`, `%Map`, `%Set`) were declared as by-value structs with `zeroinitializer`, while the function-local path correctly uses pointer types — another source of mismatches.

### Fix

- Convert all struct-value global types to pointer types matching the local path (`%StringArray` -> `%StringArray*`, `%Array` -> `%Array*`, `%Map` -> `%Map*`, etc.)
- Extend the global store path to bitcast when the expression's actual type doesn't match the global's declared pointer type
- Remove the now-unnecessary struct-value load+store branch
- Replace the silent `double` fallback with a **compile error** for unclassified expression types — instead of silently guessing the wrong type and crashing later in `opt`, the compiler now tells you: `cannot determine type of module-scope variable 'x'. Move the declaration inside a function, or add a type annotation`
- Number literals (`const x = 42`) still correctly default to `double`

## Test plan

- [x] Added 3 test fixtures in `tests/fixtures/globals/` (module-scope `.match()`, `.split()`, function return)
- [x] All 355 tests pass (native compiler)
- [x] All 222 tests pass (Node.js compiler)
