### PR TITLE
fix cross-function exception propagation by removing nounwind

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -290,7 +290,9 @@ export class FunctionGenerator {
       paramStrings.push(`${llvmType} %arg${i}`);
     }
     ir += paramStrings.join(", ");
-    const funcAttrs = this.hasTryStatement(funcBody) ? ") noinline optnone" : ") nounwind";
+    // noinline optnone for try functions (protects setjmp); no nounwind for others
+    // because any function may transitively call throw (longjmp) — nounwind + longjmp is UB
+    const funcAttrs = this.hasTryStatement(funcBody) ? ") noinline optnone" : ")";
     ir += funcAttrs + this.ctx.getSubprogramDbgRef() + " {\n";
     ir += "entry:\n";
     this.ctx.setCurrentLabel("entry");
@@ -900,7 +902,7 @@ export class FunctionGenerator {
     topLevelObjectVariables: Map<string, { ptr: string; keys: string[]; types: string[] }>,
     hasTry?: boolean,
   ): string {
-    const mainAttrs = hasTry ? "noinline optnone" : "nounwind";
+    const mainAttrs = hasTry ? "noinline optnone" : "";
     let ir =
       "define i32 @main(i32 %argc, i8** %argv) " +
       mainAttrs +

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -487,7 +487,7 @@ export class ClassGenerator {
       paramParts.push(paramLLVMTypes[argIdx] + " %arg" + argIdx);
     }
     ir += paramParts.join(", ");
-    ir += ") nounwind {\n";
+    ir += ") {\n";
     ir += "entry:\n";
     this.ctx.setCurrentLabel("entry");
 

--- a/tests/fixtures/error-handling/try-catch-cross-function.js
+++ b/tests/fixtures/error-handling/try-catch-cross-function.js
@@ -1,0 +1,17 @@
+// @test-description: cross-function exception propagation via longjmp
+function throwError() {
+  throw new Error("from inner");
+}
+
+function testCrossFunctionCatch() {
+  let caught = "";
+  try {
+    throwError();
+  } catch (e) {
+    caught = "caught:" + e;
+  }
+  console.log(caught);
+}
+
+testCrossFunctionCatch();
+console.log("TEST_PASSED");

--- a/tests/fixtures/error-handling/try-catch-deep-propagation.js
+++ b/tests/fixtures/error-handling/try-catch-deep-propagation.js
@@ -1,0 +1,21 @@
+// @test-description: deep cross-function exception propagation through multiple call frames
+function level3() {
+  throw new Error("deep");
+}
+function level2() {
+  level3();
+}
+function level1() {
+  level2();
+}
+
+function testDeep() {
+  try {
+    level1();
+  } catch (e) {
+    console.log("caught:" + e);
+  }
+}
+
+testDeep();
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

Fix cross-function exception propagation — `throw` inside a called function was not caught by `try/catch` in the caller.

### Problem

A `throw` inside a function called from within a `try` block was never caught:

```typescript
function throwError() { throw new Error("boom"); }
try {
  throwError(); // exception not caught — program aborted
} catch (e) {
  console.log(e); // never reached
}
```

The same `throw` worked fine when placed directly inside the `try` block.

### Root cause

ChadScript implements exceptions via `setjmp`/`longjmp`. Functions containing `try` were correctly marked `noinline optnone` to protect `setjmp` semantics, but **all other functions** were marked `nounwind`.

`nounwind` is an LLVM attribute that promises the function will never unwind — it tells the optimizer "this function has no exceptional control flow." When a `nounwind` function calls `longjmp` (which is how `throw` works), LLVM considers that undefined behavior. In practice, the optimizer could remove or reorder code around the call, and the `longjmp` either crashed or silently failed to reach the `setjmp` in the caller.

This affected:
- Regular functions (`function-generator.ts`)
- Class constructors (`class.ts`)
- `@main` when it didn't contain a direct `try`

### Fix

Remove `nounwind` from all function definitions. Any function may transitively call `throw` (i.e., `longjmp`), so none can promise `nounwind`. Functions with `try` statements keep `noinline optnone` to protect `setjmp`.

**Changed files:**
- `src/codegen/infrastructure/function-generator.ts` — remove `nounwind` from regular functions and `@main`
- `src/codegen/types/objects/class.ts` — remove `nounwind` from class constructors

## Test plan

- [x] Added `try-catch-cross-function.js` — verifies `throw` in a called function is caught by caller's `try/catch`
- [x] Added `try-catch-deep-propagation.js` — verifies exception propagation through 3 levels of call depth
- [ ] All tests pass (`npm test`)
- [ ] Self-hosting passes (`npm run verify:quick`)
