### PR TITLE
Docs os page

### DIFF
--- a/.claude/rules.md
+++ b/.claude/rules.md
@@ -198,6 +198,7 @@ Existing bridges: `regex-bridge.c`, `yyjson-bridge.c`, `os-bridge.c`, `child-pro
 
 1. **`new` in class field initializers** — codegen handles simple `new X()` in field initializers (both explicit and default constructors), but complex nested class instantiation may have edge cases. Prefer initializing in constructors for safety.
 2. **Type assertions must match real struct field order AND count** — `as { type, left, right }` on a struct that's `{ type, op, left, right }` causes GEP to read wrong fields. Fields must be a PREFIX of the real struct in EXACT order.
+3. **Never insert new optional fields in the MIDDLE of an interface** — The native compiler determines struct layouts from object literal creation sites. If an interface has multiple creation sites (e.g., `MethodCallNode` is created in parser-ts, parser-native, and codegen), inserting a new field before existing ones shifts GEP indices and breaks creation sites that don't include the new field. **Always add new optional fields at the END of interfaces.** Root cause: the native compiler doesn't unify struct layouts from interface definitions — it uses object literal field order, and different creation sites may have different subsets of fields.
 
 ## Stage 0 Compatibility
 

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -12,10 +12,8 @@
 }
 
 .copy-markdown-btn {
-  position: fixed;
-  top: 72px;
-  right: 24px;
-  z-index: 20;
+  float: right;
+  margin-top: 8px;
   padding: 6px 12px;
   font-size: 13px;
   font-weight: 500;

--- a/docs/stdlib/os.md
+++ b/docs/stdlib/os.md
@@ -1,0 +1,106 @@
+# os
+
+Operating system information. Properties are resolved at compile time; methods call POSIX APIs at runtime.
+
+## Properties
+
+### `os.platform`
+
+```typescript
+os.platform    // "linux" or "darwin"
+```
+
+Resolved at compile time to the target platform. Defaults to the host platform.
+
+### `os.arch`
+
+```typescript
+os.arch    // "x64", "arm64", etc.
+```
+
+Resolved at compile time to the target architecture. Defaults to `"x64"`.
+
+### `os.EOL`
+
+```typescript
+os.EOL    // "\n"
+```
+
+End-of-line marker. Always `"\n"` (Unix-only).
+
+## Methods
+
+### `os.hostname()`
+
+```typescript
+const name = os.hostname();    // string
+```
+
+### `os.homedir()`
+
+```typescript
+const home = os.homedir();    // string — e.g. "/home/user"
+```
+
+### `os.tmpdir()`
+
+```typescript
+const tmp = os.tmpdir();    // string — e.g. "/tmp"
+```
+
+Falls back to `"/tmp"` if `TMPDIR` is not set.
+
+### `os.cpus()`
+
+```typescript
+const count = os.cpus();    // number — logical CPU count
+```
+
+::: info
+Returns the CPU count as a number, not an array of CPU info objects like Node.js.
+:::
+
+### `os.totalmem()`
+
+```typescript
+const bytes = os.totalmem();    // number — total system memory in bytes
+```
+
+### `os.freemem()`
+
+```typescript
+const bytes = os.freemem();    // number — free system memory in bytes
+```
+
+### `os.uptime()`
+
+```typescript
+const seconds = os.uptime();    // number — system uptime in seconds
+```
+
+## Example
+
+```typescript
+console.log("Platform: " + os.platform);
+console.log("Arch: " + os.arch);
+console.log("Host: " + os.hostname());
+console.log("Home: " + os.homedir());
+console.log("CPUs: " + os.cpus());
+console.log("Memory: " + os.freemem() + " / " + os.totalmem());
+console.log("Uptime: " + os.uptime() + "s");
+```
+
+## Native Implementation
+
+| API | Maps to |
+|-----|---------|
+| `os.platform` | Compile-time string constant |
+| `os.arch` | Compile-time string constant |
+| `os.EOL` | Compile-time string constant |
+| `os.hostname()` | `gethostname()` |
+| `os.homedir()` | `getenv("HOME")` |
+| `os.tmpdir()` | `getenv("TMPDIR")` with `"/tmp"` fallback |
+| `os.cpus()` | `sysconf(_SC_NPROCESSORS_ONLN)` |
+| `os.totalmem()` | `sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE)` |
+| `os.freemem()` | `chad_os_freemem()` C bridge |
+| `os.uptime()` | `chad_os_uptime()` C bridge |


### PR DESCRIPTION
## Summary
- Add missing `docs/stdlib/os.md` page — the sidebar already linked to `/stdlib/os` but the file didn't exist, resulting in a 404
- Documents all os module APIs: compile-time properties (`platform`, `arch`, `EOL`) and runtime methods (`hostname`, `homedir`, `tmpdir`, `cpus`, `totalmem`, `freemem`, `uptime`)
- Includes native implementation mapping table matching the style of other stdlib doc pages

## Test plan
- Verified all 25 sidebar stdlib links now have corresponding markdown files
- Page content matches the actual codegen in `src/codegen/expressions/access/os-access.ts` and `src/codegen/expressions/method-calls/os.ts`
