### PR TITLE
Fix linker warnings and hn upvote

### DIFF
--- a/examples/hackernews/public/index.html
+++ b/examples/hackernews/public/index.html
@@ -22,5 +22,17 @@
       <p>Powered by ChadScript &mdash; compiled from TypeScript to a native ELF binary via LLVM.</p>
       <p>HTML, CSS, and data are all embedded in a single binary. Zero runtime dependencies.</p>
     </div>
+    <script>
+      document.addEventListener("submit", function (e) {
+        var form = e.target;
+        if (form.action && form.action.indexOf("/upvote/") !== -1) {
+          e.preventDefault();
+          fetch(form.action, { method: "POST" });
+          var meta = form.closest(".post").nextElementSibling;
+          var pts = parseInt(meta.textContent, 10);
+          meta.textContent = pts + 1 + " points";
+        }
+      });
+    </script>
   </body>
 </html>

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2509,8 +2509,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     const finalParts: string[] = [];
 
     if (this.targetInfo) {
-      finalParts.push('target triple = "' + this.targetInfo.triple + '"\n');
+      // datalayout must come before triple — LLVM opt validates this order
       finalParts.push('target datalayout = "' + this.targetInfo.dataLayout + '"\n');
+      finalParts.push('target triple = "' + this.targetInfo.triple + '"\n');
       finalParts.push("\n");
     }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -362,7 +362,8 @@ export function compile(
       linkLibs = `-L${brewPrefix}/zstd/lib ` + linkLibs;
     }
     const sdkPath = execSync("xcrun --show-sdk-path", { stdio: "pipe", encoding: "utf8" }).trim();
-    linkLibs = `-Wl,-syslibroot,${sdkPath} -L/usr/local/lib ` + linkLibs;
+    const usrLocalLib = fs.existsSync("/usr/local/lib") ? " -L/usr/local/lib" : "";
+    linkLibs = `-Wl,-syslibroot,${sdkPath}${usrLocalLib} ` + linkLibs;
   }
 
   // Bridge object files

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -410,16 +410,29 @@ export function compileNative(inputFile: string, outputFile: string): void {
   if (hasSDK && sdkSysroot.length > 0) {
     linkLibs = "--sysroot=" + sdkSysroot + " " + linkLibs;
   } else if (!crossCompiling && isMac) {
+    // Only add -L flags for paths that actually exist to avoid ld warnings.
+    // Both prefixes are checked because we can't detect arch at runtime in native code.
     if (generator.getUsesCrypto()) {
-      linkLibs = "-L/opt/homebrew/opt/openssl/lib -L/usr/local/opt/openssl/lib " + linkLibs;
+      if (fs.existsSync("/opt/homebrew/opt/openssl/lib"))
+        linkLibs = "-L/opt/homebrew/opt/openssl/lib " + linkLibs;
+      if (fs.existsSync("/usr/local/opt/openssl/lib"))
+        linkLibs = "-L/usr/local/opt/openssl/lib " + linkLibs;
     }
     if (generator.getUsesSqlite()) {
-      linkLibs = "-L/opt/homebrew/opt/sqlite/lib -L/usr/local/opt/sqlite/lib " + linkLibs;
+      if (fs.existsSync("/opt/homebrew/opt/sqlite/lib"))
+        linkLibs = "-L/opt/homebrew/opt/sqlite/lib " + linkLibs;
+      if (fs.existsSync("/usr/local/opt/sqlite/lib"))
+        linkLibs = "-L/usr/local/opt/sqlite/lib " + linkLibs;
     }
     if (generator.getUsesMongoose()) {
-      linkLibs = "-L/opt/homebrew/opt/zstd/lib -L/usr/local/opt/zstd/lib " + linkLibs;
+      if (fs.existsSync("/opt/homebrew/opt/zstd/lib"))
+        linkLibs = "-L/opt/homebrew/opt/zstd/lib " + linkLibs;
+      if (fs.existsSync("/usr/local/opt/zstd/lib"))
+        linkLibs = "-L/usr/local/opt/zstd/lib " + linkLibs;
     }
-    linkLibs = "-Wl,-syslibroot,$(xcrun --show-sdk-path) -L/usr/local/lib " + linkLibs;
+    let macLinkPrefix = "-Wl,-syslibroot,$(xcrun --show-sdk-path)";
+    if (fs.existsSync("/usr/local/lib")) macLinkPrefix = macLinkPrefix + " -L/usr/local/lib";
+    linkLibs = macLinkPrefix + " " + linkLibs;
   }
 
   const shouldStatic = false;


### PR DESCRIPTION
## Summary
- Suppress macOS linker warnings for non-existent Homebrew library paths by adding `fs.existsSync` checks before emitting `-L` flags in both `native-compiler-lib.ts` and `compiler.ts`
- Fix cross-compilation (`--target=linux-x64`) by emitting `target datalayout` before `target triple` in generated LLVM IR, matching the order LLVM `opt` expects
- Add client-side upvote to HackerNews example so clicking the arrow updates points in-place via `fetch()` instead of triggering a full page refresh

## Test plan
- TypeScript build passes cleanly
- Linker warning fix: checked that `fs.existsSync` is already used extensively in `native-compiler-lib.ts`, same pattern applied
- Cross-compilation fix: the datalayout/triple order now matches LLVM convention and what `clang -S -emit-llvm` produces
- HackerNews upvote: JS intercepts form submit, does background POST, increments points client-side; non-JS browsers fall back to original form behavior
