### PR TITLE
fix cross-compile datalayout

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -108,7 +108,7 @@ import { ExpressionGenerator } from "./expressions/orchestrator.js";
 import type { TypeChecker } from "../typescript/type-checker.js";
 import { InterfaceStructGenerator } from "./types/interface-struct-generator.js";
 import { JsonObjectMeta } from "./expressions/access/member.js";
-import type { TargetInfo } from "../target.js";
+import type { TargetInfo } from "../target-types.js";
 
 export interface SemaSymbolData {
   names: string[];

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -6,6 +6,7 @@ import { transformTree } from "./parser-native/transformer.js";
 import { LLVMGenerator, LLVMGeneratorOptions, SemaSymbolData } from "./codegen/llvm-generator.js";
 import { SemanticAnalyzer } from "./analysis/semantic-analyzer.js";
 import { AST, ImportDeclaration } from "./ast/types.js";
+import { TargetInfo } from "./target-types.js";
 
 declare const child_process: {
   execSync(command: string): number;
@@ -217,11 +218,10 @@ export function compileNative(inputFile: string, outputFile: string): void {
     }
   }
 
-  // Build a minimal TargetInfo for the LLVM generator when cross-compiling.
-  // The generator needs triple, dataLayout, os, and archString.
-  // We cast to any to avoid importing TargetInfo (this file is self-hosted,
-  // can't use Node's os module that target.ts depends on).
-  let targetInfo: any = undefined;
+  // Build a TargetInfo for the LLVM generator when cross-compiling.
+  // TargetInfo is imported from target-types.ts (dependency-free) so the
+  // native compiler sees the interface definition and resolves correct GEP indices.
+  let targetInfo: TargetInfo | undefined = undefined;
   if (crossCompiling) {
     const isDarwin = targetTriple.indexOf("darwin") !== -1 || targetTriple.indexOf("apple") !== -1;
     const isAarch64 =

--- a/src/target-types.ts
+++ b/src/target-types.ts
@@ -1,0 +1,15 @@
+// Target type definitions — dependency-free so both target.ts and
+// native-compiler-lib.ts can import without pulling in Node's os module.
+
+export type LibC = "gnu" | "system";
+
+export interface TargetInfo {
+  triple: string;
+  os: string;
+  arch: string;
+  cpu: string;
+  platformString: string;
+  archString: string;
+  dataLayout: string;
+  libc: LibC;
+}

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,19 +1,9 @@
 // Target triple resolution and host detection for cross-compilation.
 // Cross-compilation currently only supports linux-x64 as a target.
 import * as os from "os";
+import { TargetInfo, LibC } from "./target-types.js";
 
-export type LibC = "gnu" | "system";
-
-export interface TargetInfo {
-  triple: string;
-  os: string;
-  arch: string;
-  cpu: string;
-  platformString: string;
-  archString: string;
-  dataLayout: string;
-  libc: LibC;
-}
+export type { TargetInfo, LibC };
 
 const DATA_LAYOUT_X86_64_LINUX =
   "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128";

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -375,6 +375,14 @@ await main();
           "Should contain target triple",
         );
         assert.ok(ir.includes('target datalayout = "'), "Should contain target datalayout");
+        // Verify datalayout is an actual LLVM data layout (starts with 'e-' for little-endian),
+        // not accidentally set to the target triple
+        const dlMatch = ir.match(/target datalayout = "([^"]+)"/);
+        assert.ok(dlMatch, "Should have parseable target datalayout");
+        assert.ok(
+          dlMatch![1].startsWith("e-"),
+          `Data layout should start with 'e-' (little-endian), got: "${dlMatch![1]}"`,
+        );
       } finally {
         try {
           if (fsSync.existsSync(llFile)) await fs.unlink(llFile);
@@ -404,5 +412,35 @@ await main();
         } catch {}
       }
     });
+
+    // Native binary cross-compilation — this catches self-hosting bugs where
+    // the any-typed targetInfo object produces wrong GEP indices for field access
+    if (fsSync.existsSync(".build/chad")) {
+      it("native binary should emit correct datalayout when cross-compiling", async () => {
+        const fixture = "tests/fixtures/arithmetic/simple-add.js";
+        const outputDir = path.join(".build", path.dirname(fixture));
+        const baseName = path.basename(fixture, ".js");
+        const llFile = path.join(outputDir, `${baseName}.ll`);
+
+        try {
+          await execAsync(`.build/chad ir --target linux-x64 ${fixture}`);
+          const ir = fsSync.readFileSync(llFile, "utf-8");
+          const dlMatch = ir.match(/target datalayout = "([^"]+)"/);
+          assert.ok(dlMatch, "Native binary should emit target datalayout");
+          assert.ok(
+            dlMatch![1].startsWith("e-"),
+            `Native binary data layout should start with 'e-' (little-endian), got: "${dlMatch![1]}"`,
+          );
+          assert.ok(
+            !dlMatch![1].includes("unknown"),
+            "Data layout must not contain the target triple",
+          );
+        } finally {
+          try {
+            if (fsSync.existsSync(llFile)) fsSync.unlinkSync(llFile);
+          } catch {}
+        }
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Fixed `chad build --target linux-x64` failing with `unknown specifier 'x' target datalayout = "x86_64-unknown-linux-gnu"` — the native binary was emitting the target triple as the LLVM data layout string
- Root cause: `native-compiler-lib.ts` typed `targetInfo` as `any` to avoid importing `TargetInfo` from `target.ts` (which depends on Node's `os` module). The native compiler couldn't resolve GEP field indices for the `any`-typed object, so `this.targetInfo.dataLayout` read the wrong struct field (returning the triple instead)
- Fix: extracted `TargetInfo` interface and `LibC` type into a new dependency-free `src/target-types.ts`, allowing the self-hosted path to import proper type info without pulling in Node's `os` module
- Strengthened cross-compilation tests: datalayout assertion now validates actual content (must start with `e-`, not be the triple), and added a native binary cross-compile test that would have caught this bug in CI

## Test plan

- [x] `npm test` — 226 tests pass (225 existing + 1 new native binary cross-compile test)
- [x] `npm run verify:quick` — self-hosting verification passed (Stage 0 + Stage 1)
- [x] `.build/chad ir --target linux-x64` now emits correct `target datalayout = "e-m:e-p270:32:32-..."` instead of the triple
- [x] Node.js path (`node dist/chad-node.js build --target linux-x64`) still works
