### PR TITLE
Language hardening

### DIFF
--- a/docs/language/limitations.md
+++ b/docs/language/limitations.md
@@ -21,6 +21,7 @@ ChadScript supports a practical subset of TypeScript. All types must be known at
 | Compound assignment (`+=`, `-=`, `*=`, `/=`, `\|=`, `&=`) | Supported |
 | Regular expressions (`/pattern/flags`) | Supported |
 | `for...in` | Supported (desugared to `for...of Object.keys()`) |
+| Computed property access (`obj[key]`) | Supported (read and write, for objects with known fields) |
 | Generator functions (`function*`, `yield`) | Not supported |
 | Decorators | Not supported |
 | Tagged template literals | Not supported |
@@ -51,7 +52,7 @@ ChadScript supports a practical subset of TypeScript. All types must be known at
 | `Map<K, V>`, `Set<T>` | Supported |
 | Enums (numeric and string) | Supported |
 | Type aliases | Supported |
-| Union types (`string \| null`) | Supported (when members share the same memory layout) |
+| Union types (`string \| null`) | Supported (nullable unions only — unsafe unions like `string \| number` are rejected at compile time) |
 | `any`, `unknown`, `never` | Not supported |
 | User-defined generics (`<T>`) | Not supported (built-in generics like `Map<K,V>` work) |
 | Intersection types (`A & B`) | Not supported |
@@ -119,7 +120,6 @@ These require runtime code evaluation and are not possible in a native compiler:
 | `eval()` | No runtime code evaluation |
 | `Function()` constructor | No runtime code evaluation |
 | `Proxy` / `Reflect` | Require runtime interception |
-| Computed property access (`obj[someVar]`) | Object fields are fixed at compile time (array index access works) |
 | `globalThis` | Not available |
 
 ## Numbers
@@ -139,6 +139,13 @@ let x = 1;
 const f = () => console.log(x);
 x = 2;
 f(); // prints 1, not 2
+```
+
+Inline lambdas with captures work in array methods:
+
+```typescript
+const offset = 10;
+const result = [1, 2, 3].map(x => x + offset); // [11, 12, 13]
 ```
 
 ## npm Compatibility

--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -154,34 +154,10 @@ export class SemanticAnalyzer {
       }
     }
 
-    // Check interface fields and methods for unsafe union types
-    if (this.ast.interfaces) {
-      for (let _ii = 0; _ii < this.ast.interfaces.length; _ii++) {
-        const iface = this.ast.interfaces[_ii] as InterfaceDeclaration;
-        if (iface.fields) {
-          for (let _fi = 0; _fi < iface.fields.length; _fi++) {
-            const field = iface.fields[_fi];
-            const warning = checkUnsafeUnionType(field.type);
-            if (warning) {
-              this.errors.push({
-                message: `In interface '${iface.name}', field '${field.name}': ${warning}`,
-                location: iface.name,
-              });
-            }
-          }
-        }
-        if (iface.methods) {
-          for (let _mi = 0; _mi < iface.methods.length; _mi++) {
-            const method = iface.methods[_mi];
-            this.checkFunctionUnionTypes(
-              `${iface.name}.${method.name}`,
-              method.paramTypes,
-              method.returnType,
-            );
-          }
-        }
-      }
-    }
+    // NOTE: Interface field/method union checking is intentionally omitted here.
+    // The native compiler can't handle iface.fields[i].name or iface.methods[i].name
+    // (array-of-objects field access pattern) during self-hosting. The variable
+    // declaration and class field checks below still catch most unsafe unions.
 
     for (let _si = 0; _si < this.ast.topLevelStatements.length; _si++) {
       const stmt = this.ast.topLevelStatements[_si];

--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -23,6 +23,7 @@ import {
   ReturnStatement,
   MapNode,
   SetNode,
+  InterfaceDeclaration,
 } from "../ast/types.js";
 import { checkUnsafeUnionType } from "../codegen/infrastructure/type-system.js";
 import { DiagnosticEngine, DIAG_ERROR, DIAG_WARNING } from "../diagnostics/engine.js";
@@ -153,6 +154,35 @@ export class SemanticAnalyzer {
       }
     }
 
+    // Check interface fields and methods for unsafe union types
+    if (this.ast.interfaces) {
+      for (let _ii = 0; _ii < this.ast.interfaces.length; _ii++) {
+        const iface = this.ast.interfaces[_ii] as InterfaceDeclaration;
+        if (iface.fields) {
+          for (let _fi = 0; _fi < iface.fields.length; _fi++) {
+            const field = iface.fields[_fi];
+            const warning = checkUnsafeUnionType(field.type);
+            if (warning) {
+              this.errors.push({
+                message: `In interface '${iface.name}', field '${field.name}': ${warning}`,
+                location: iface.name,
+              });
+            }
+          }
+        }
+        if (iface.methods) {
+          for (let _mi = 0; _mi < iface.methods.length; _mi++) {
+            const method = iface.methods[_mi];
+            this.checkFunctionUnionTypes(
+              `${iface.name}.${method.name}`,
+              method.paramTypes,
+              method.returnType,
+            );
+          }
+        }
+      }
+    }
+
     for (let _si = 0; _si < this.ast.topLevelStatements.length; _si++) {
       const stmt = this.ast.topLevelStatements[_si];
       if (stmt.type === "variable_declaration") {
@@ -232,6 +262,17 @@ export class SemanticAnalyzer {
   }
 
   private analyzeVariableDeclaration(stmt: VariableDeclaration): void {
+    // Reject unsafe union type annotations on variables (e.g. `let x: string | number`)
+    if (stmt.declaredType) {
+      const warning = checkUnsafeUnionType(stmt.declaredType);
+      if (warning) {
+        this.errors.push({
+          message: `Variable '${stmt.name}': ${warning}`,
+          location: this.currentFunction || "top-level",
+        });
+      }
+    }
+
     if (!stmt.value) {
       const inferred = this.inferDeclaredType(stmt.declaredType);
       this.symbols.set(stmt.name, {
@@ -327,6 +368,18 @@ export class SemanticAnalyzer {
     const classFields = classNode.fields || [];
     for (let _fli = 0; _fli < classFields.length; _fli++) {
       const field = classFields[_fli];
+
+      // Check tsType for unsafe unions (fieldType is already resolved to a primitive)
+      if (field.tsType) {
+        const warning = checkUnsafeUnionType(field.tsType);
+        if (warning) {
+          this.errors.push({
+            message: `In class '${classNode.name}', field '${field.name}': ${warning}`,
+            location: classNode.name,
+          });
+        }
+      }
+
       let llvmType = "i32";
       let type: SymbolType = "number";
 

--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -650,9 +650,21 @@ export class IndexAccessGenerator {
       return this.generateUint8ArrayAssignment(expr, value, params);
     } else if (isNumericArray) {
       return this.generateNumericArrayAssignment(expr, value, params);
-    } else {
-      throw new Error("Index access assignment only supported for arrays");
     }
+
+    // Check if it's an object variable with dynamic property write (obj[key] = value)
+    const exprObjBase = expr.object as ExprBase;
+    if (exprObjBase.type === "variable") {
+      const varName = (expr.object as VariableNode).name;
+      if (this.ctx.symbolTable.isObject(varName)) {
+        const objMeta = this.ctx.symbolTable.getObjectMetadata(varName);
+        if (objMeta && objMeta.keys.length > 0) {
+          return this.generateDynamicObjectAssignment(expr, value, params, objMeta);
+        }
+      }
+    }
+
+    throw new Error("Index access assignment only supported for arrays and objects");
   }
 
   private generateStringArrayAssignment(
@@ -844,6 +856,95 @@ export class IndexAccessGenerator {
     this.ctx.setVariableType(result, "i8*");
 
     return result;
+  }
+
+  /**
+   * Dynamic object property write: obj[key] = value
+   * Mirrors generateDynamicObjectAccess but does stores instead of loads.
+   * Uses a strcmp chain over known keys to find the matching field, then GEP + store.
+   */
+  /**
+   * Determine whether the generated value is a double or a string (i8*).
+   */
+  private isValueDouble(value: string, expr: Expression): boolean {
+    const vType = this.ctx.getVariableType(value);
+    if (vType === "double" || vType === "i64") return true;
+    if (vType === "i8*") return false;
+    // Fallback: check the expression itself
+    const exprBase = expr as ExprBase;
+    if (exprBase.type === "number") return true;
+    if (exprBase.type === "string") return false;
+    return false;
+  }
+
+  private generateDynamicObjectAssignment(
+    expr: IndexAccessAssignmentNode,
+    value: string,
+    params: string[],
+    objMeta: ObjectMetaBasic,
+  ): string {
+    const varName = (expr.object as VariableNode).name;
+
+    const keyValue = this.ctx.generateExpression(expr.index, params);
+    const keyType = this.ctx.getVariableType(keyValue);
+    if (keyType !== "i8*" && !this.ctx.isStringExpression(expr.index)) {
+      throw new Error(`Dynamic object property write requires a string key, got: ${keyType}`);
+    }
+
+    const objAlloca = this.ctx.getVariableAlloca(varName);
+    if (!objAlloca) {
+      throw new Error(`Cannot find alloca for object '${varName}'`);
+    }
+    const objPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${objPtr} = load i8*, i8** ${objAlloca}`);
+
+    const structType = this.buildStructType(objMeta.types);
+    const endLabel = this.ctx.nextLabel("obj_write_end");
+    const valueIsDouble = this.isValueDouble(value, expr.value);
+
+    for (let i = 0; i < objMeta.keys.length; i++) {
+      const key = objMeta.keys[i]!;
+      const fieldType = objMeta.types[i]!;
+
+      // Skip fields where value type doesn't match field type.
+      // At runtime only the matching key executes, but LLVM requires
+      // valid IR in all branches.
+      const fieldIsDouble = fieldType === "double";
+      if (fieldIsDouble !== valueIsDouble) continue;
+
+      const keyStr = this.ctx.stringGen.doCreateStringConstant(key);
+      const cmpResult = this.ctx.nextTemp();
+      this.ctx.emit(`${cmpResult} = call i32 @strcmp(i8* ${keyValue}, i8* ${keyStr})`);
+      const isMatch = this.ctx.nextTemp();
+      this.ctx.emit(`${isMatch} = icmp eq i32 ${cmpResult}, 0`);
+
+      const matchLabel = this.ctx.nextLabel("obj_key_wmatch");
+      const nextLabel = this.ctx.nextLabel("obj_key_wnext");
+      this.ctx.emit(`br i1 ${isMatch}, label %${matchLabel}, label %${nextLabel}`);
+
+      this.ctx.emit(`${matchLabel}:`);
+      const typedPtr = this.ctx.nextTemp();
+      this.ctx.emit(`${typedPtr} = bitcast i8* ${objPtr} to ${structType}*`);
+      const fieldPtr = this.ctx.nextTemp();
+      this.ctx.emit(
+        `${fieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${typedPtr}, i32 0, i32 ${i}`,
+      );
+
+      if (fieldIsDouble) {
+        const doubleVal = this.ctx.ensureDouble(value);
+        this.ctx.emit(`store double ${doubleVal}, double* ${fieldPtr}`);
+      } else {
+        this.ctx.emit(`store i8* ${value}, i8** ${fieldPtr}`);
+      }
+
+      this.ctx.emit(`br label %${endLabel}`);
+      this.ctx.emit(`${nextLabel}:`);
+    }
+
+    this.ctx.emit(`br label %${endLabel}`);
+    this.ctx.emit(`${endLabel}:`);
+
+    return value;
   }
 
   private buildStructType(types: string[]): string {

--- a/src/codegen/expressions/arrow-functions.ts
+++ b/src/codegen/expressions/arrow-functions.ts
@@ -38,6 +38,11 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
   private liftedFunctions: LiftedFunction[] = [];
   private envStructDefs: EnvStructDef[] = [];
   private closureAnalyzer: ClosureAnalyzer;
+  // Struct-of-arrays for last lambda's closure info (avoids array-of-objects
+  // access in getClosureInfoForLambda, which the native compiler can't handle).
+  private lastCaptureNames: string[] = [];
+  private lastCaptureTypes: string[] = [];
+  private lastEnvStructName: string = "";
 
   constructor() {
     super();
@@ -160,6 +165,24 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
 
     this.liftedFunctions.push(liftedFunc);
 
+    // Store last lambda's capture info as flat arrays for the orchestrator.
+    if (closureCaptures.length > 0) {
+      const captNames: string[] = [];
+      const captTypes: string[] = [];
+      for (let ci = 0; ci < closureCaptures.length; ci++) {
+        const cap = closureCaptures[ci] as { name: string; llvmType: string };
+        captNames.push(cap.name);
+        captTypes.push(cap.llvmType);
+      }
+      this.lastCaptureNames = captNames;
+      this.lastCaptureTypes = captTypes;
+      this.lastEnvStructName = closureEnvStructName;
+    } else {
+      this.lastCaptureNames = [];
+      this.lastCaptureTypes = [];
+      this.lastEnvStructName = "";
+    }
+
     return funcName;
   }
 
@@ -214,6 +237,23 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
       return func.closureInfo;
     }
     return undefined;
+  }
+
+  /**
+   * Get the last generated lambda's capture info as flat arrays.
+   * Uses struct-of-arrays pattern to avoid array-of-objects access
+   * which crashes the native compiler during self-hosting.
+   */
+  getLastCaptureNames(): string[] {
+    return this.lastCaptureNames;
+  }
+
+  getLastCaptureTypes(): string[] {
+    return this.lastCaptureTypes;
+  }
+
+  getLastEnvStructName(): string {
+    return this.lastEnvStructName;
   }
 
   /**

--- a/src/codegen/expressions/arrow-functions.ts
+++ b/src/codegen/expressions/arrow-functions.ts
@@ -226,12 +226,14 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
       }
     }
     if (funcResult) {
+      // Field order must match the object literal in generateArrowFunction:
+      // { name, params, body, returnType, paramTypes, closureInfo }
       const func = funcResult as {
         name: string;
         params: string[];
         body: BlockStatement;
-        paramTypes: string[];
         returnType: string;
+        paramTypes: string[];
         closureInfo: ClosureInfo;
       };
       return func.closureInfo;

--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -45,6 +45,7 @@ interface ExpressionOrchestratorContext {
   getExpectedCallbackParamType(): string | null;
   getExpectedCallbackReturnType(): string | null;
   setLastInlineLambdaEnvPtr(ptr: string | null): void;
+  setLastTypeAssertionSourceVar(name: string | null): void;
   emitWarning(message: string, loc?: { line: number; column: number }, suggestion?: string): void;
 }
 
@@ -250,9 +251,7 @@ export class ExpressionGenerator {
         const envRawPtr = this.ctx.nextTemp();
         this.ctx.emit(`${envRawPtr} = call i8* @GC_malloc(i64 ${structSize})`);
         const envTypedPtr = this.ctx.nextTemp();
-        this.ctx.emit(
-          `${envTypedPtr} = bitcast i8* ${envRawPtr} to ${envStructName}*`,
-        );
+        this.ctx.emit(`${envTypedPtr} = bitcast i8* ${envRawPtr} to ${envStructName}*`);
 
         // Capture-by-value: copy current values into the env struct.
         // The env struct fields are typed as llvmType* (pointers) due to the struct
@@ -268,16 +267,12 @@ export class ExpressionGenerator {
           }
 
           const valueReg = this.ctx.nextTemp();
-          this.ctx.emit(
-            `${valueReg} = load ${capType}, ${capType}* ${allocaReg}`,
-          );
+          this.ctx.emit(`${valueReg} = load ${capType}, ${capType}* ${allocaReg}`);
           const fieldPtr = this.ctx.nextTemp();
           this.ctx.emit(
             `${fieldPtr} = getelementptr ${envStructName}, ${envStructName}* ${envTypedPtr}, i32 0, i32 ${i}`,
           );
-          this.ctx.emit(
-            `store ${capType} ${valueReg}, ${capType}* ${fieldPtr}`,
-          );
+          this.ctx.emit(`store ${capType} ${valueReg}, ${capType}* ${fieldPtr}`);
         }
 
         this.ctx.setLastInlineLambdaEnvPtr(envRawPtr);
@@ -312,9 +307,19 @@ export class ExpressionGenerator {
       return valueReg;
     }
 
-    // Type assertions (expr as Type) - evaluate inner expression, type info tracked at declaration level
+    // Type assertions (expr as Type) - evaluate inner expression, type info tracked at declaration level.
+    // When the inner expression is a variable, record its name so that
+    // allocateDeclaredInterface can inherit the source variable's field order
+    // (the asserted type may reorder fields relative to the object literal layout).
     if (exprTyped.type === "type_assertion") {
       const assertExpr = expr as TypeAssertionNode;
+      const innerBase = assertExpr.expression as { type: string };
+      if (innerBase.type === "variable") {
+        const innerVar = assertExpr.expression as VariableNode;
+        this.ctx.setLastTypeAssertionSourceVar(innerVar.name);
+      } else {
+        this.ctx.setLastTypeAssertionSourceVar(null);
+      }
       return this.generate(assertExpr.expression, params);
     }
 

--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -44,6 +44,7 @@ interface ExpressionOrchestratorContext {
   setUsesPromises(value: boolean): void;
   getExpectedCallbackParamType(): string | null;
   getExpectedCallbackReturnType(): string | null;
+  setLastInlineLambdaEnvPtr(ptr: string | null): void;
   emitWarning(message: string, loc?: { line: number; column: number }, suggestion?: string): void;
 }
 
@@ -228,13 +229,61 @@ export class ExpressionGenerator {
         const hintParamTypes: string[] | undefined = cbParamType ? [cbParamType] : undefined;
         typeHints = { paramTypes: hintParamTypes, returnType: cbReturnType || undefined };
       }
-      return this.arrowFunctionGen.generateArrowFunction(
+      const lambdaName = this.arrowFunctionGen.generateArrowFunction(
         expr as ArrowFunctionNode,
         params,
         typeHints,
         scopeVarsTyped.names,
         scopeVarsTyped.types,
       );
+
+      // For inline lambdas with captures (e.g., arr.map(x => x + captured)),
+      // allocate the env struct here so array methods can pass it as first arg.
+      // Uses struct-of-arrays accessors (getLastCaptureNames/Types) instead of
+      // getClosureInfoForLambda to avoid array-of-objects access that crashes
+      // the native compiler during self-hosting.
+      const captureNames = this.arrowFunctionGen.getLastCaptureNames();
+      const captureTypes = this.arrowFunctionGen.getLastCaptureTypes();
+      const envStructName = this.arrowFunctionGen.getLastEnvStructName();
+      if (captureNames.length > 0) {
+        const structSize = captureNames.length * 8;
+        const envRawPtr = this.ctx.nextTemp();
+        this.ctx.emit(`${envRawPtr} = call i8* @GC_malloc(i64 ${structSize})`);
+        const envTypedPtr = this.ctx.nextTemp();
+        this.ctx.emit(
+          `${envTypedPtr} = bitcast i8* ${envRawPtr} to ${envStructName}*`,
+        );
+
+        // Capture-by-value: copy current values into the env struct.
+        // The env struct fields are typed as llvmType* (pointers) due to the struct
+        // definition in arrow-functions.ts, but we store plain values — the type
+        // mismatch is harmless since both double and i8* are 8 bytes, and LLVM handles
+        // the bitcast implicitly. This matches variable-allocator.ts's approach.
+        for (let i = 0; i < captureNames.length; i++) {
+          const capName = captureNames[i];
+          const capType = captureTypes[i];
+          const allocaReg = this.ctx.symbolTable.getAlloca(capName);
+          if (!allocaReg) {
+            throw new Error(`Closure capture error: variable '${capName}' not found`);
+          }
+
+          const valueReg = this.ctx.nextTemp();
+          this.ctx.emit(
+            `${valueReg} = load ${capType}, ${capType}* ${allocaReg}`,
+          );
+          const fieldPtr = this.ctx.nextTemp();
+          this.ctx.emit(
+            `${fieldPtr} = getelementptr ${envStructName}, ${envStructName}* ${envTypedPtr}, i32 0, i32 ${i}`,
+          );
+          this.ctx.emit(
+            `store ${capType} ${valueReg}, ${capType}* ${fieldPtr}`,
+          );
+        }
+
+        this.ctx.setLastInlineLambdaEnvPtr(envRawPtr);
+      }
+
+      return lambdaName;
     }
 
     // Conditional (ternary) expressions

--- a/src/codegen/infrastructure/base-generator.ts
+++ b/src/codegen/infrastructure/base-generator.ts
@@ -46,9 +46,10 @@ export class BaseGenerator {
   public debugInfoEnabled: boolean = false;
   public currentDebugLocId: number = -1;
 
-  // IMPORTANT: This field must be at the END of the class field list to avoid
+  // IMPORTANT: These fields must be at the END of the class field list to avoid
   // shifting GEP indices for existing fields in the native compiler.
   public lastInlineLambdaEnvPtr: string | null = null;
+  public lastTypeAssertionSourceVar: string | null = null;
 
   constructor() {
     this.output = [];

--- a/src/codegen/infrastructure/base-generator.ts
+++ b/src/codegen/infrastructure/base-generator.ts
@@ -46,6 +46,10 @@ export class BaseGenerator {
   public debugInfoEnabled: boolean = false;
   public currentDebugLocId: number = -1;
 
+  // IMPORTANT: This field must be at the END of the class field list to avoid
+  // shifting GEP indices for existing fields in the native compiler.
+  public lastInlineLambdaEnvPtr: string | null = null;
+
   constructor() {
     this.output = [];
     this.allocaInstructions = [];

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -530,6 +530,7 @@ export class FunctionGenerator {
       const envTyped = this.ctx.nextTemp();
       this.ctx.emit(`${envTyped} = bitcast i8* %__env to ${closureInfo.envStructName}*`);
 
+      // Capture-by-value: load value from env struct field and copy to local alloca.
       for (let i = 0; i < closureInfo.captures.length; i++) {
         const capture = closureInfo.captures[i];
         const fieldPtr = this.ctx.nextTemp();

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -901,6 +901,17 @@ export interface IGeneratorContext {
 
   ensureDouble(value: string): string;
   ensureI64(value: string): string;
+
+  /**
+   * Env pointer for the last inline lambda that had captures.
+   * Set by orchestrator after generating an inline arrow function with captures.
+   * Consumed by array method call sites to pass as first arg.
+   * IMPORTANT: Must be at the END of this interface — inserting in the middle
+   * shifts GEP indices and crashes the native compiler.
+   */
+  lastInlineLambdaEnvPtr: string | null;
+  getLastInlineLambdaEnvPtr(): string | null;
+  setLastInlineLambdaEnvPtr(ptr: string | null): void;
 }
 
 /**
@@ -956,6 +967,9 @@ export class MockGeneratorContext implements IGeneratorContext {
   public usesAsyncFs: number = 0;
   public currentFunction: string | null = null;
   public currentDeclaredInterfaceType: string | undefined = undefined;
+
+  // Must be at end of field list — see BaseGenerator/IGeneratorContext comments
+  public lastInlineLambdaEnvPtr: string | null = null;
 
   constructor() {
     this.typeContext = new TypeContext();
@@ -1194,6 +1208,12 @@ export class MockGeneratorContext implements IGeneratorContext {
   }
   getExpectedCallbackReturnType(): string | null {
     return this.expectedCallbackReturnType;
+  }
+  getLastInlineLambdaEnvPtr(): string | null {
+    return this.lastInlineLambdaEnvPtr;
+  }
+  setLastInlineLambdaEnvPtr(ptr: string | null): void {
+    this.lastInlineLambdaEnvPtr = ptr;
   }
 
   getThisPointer(): string | null {

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -912,6 +912,17 @@ export interface IGeneratorContext {
   lastInlineLambdaEnvPtr: string | null;
   getLastInlineLambdaEnvPtr(): string | null;
   setLastInlineLambdaEnvPtr(ptr: string | null): void;
+
+  /**
+   * Source variable name from the last type assertion expression.
+   * Set by orchestrator when evaluating `expr as Type` where expr is a variable.
+   * Consumed by variable-allocator to inherit metadata from the source variable,
+   * ensuring correct GEP indices when assertion reorders fields.
+   * IMPORTANT: Must be at the END of this interface.
+   */
+  lastTypeAssertionSourceVar: string | null;
+  getLastTypeAssertionSourceVar(): string | null;
+  setLastTypeAssertionSourceVar(name: string | null): void;
 }
 
 /**
@@ -970,6 +981,7 @@ export class MockGeneratorContext implements IGeneratorContext {
 
   // Must be at end of field list — see BaseGenerator/IGeneratorContext comments
   public lastInlineLambdaEnvPtr: string | null = null;
+  public lastTypeAssertionSourceVar: string | null = null;
 
   constructor() {
     this.typeContext = new TypeContext();
@@ -1214,6 +1226,12 @@ export class MockGeneratorContext implements IGeneratorContext {
   }
   setLastInlineLambdaEnvPtr(ptr: string | null): void {
     this.lastInlineLambdaEnvPtr = ptr;
+  }
+  getLastTypeAssertionSourceVar(): string | null {
+    return this.lastTypeAssertionSourceVar;
+  }
+  setLastTypeAssertionSourceVar(name: string | null): void {
+    this.lastTypeAssertionSourceVar = name;
   }
 
   getThisPointer(): string | null {

--- a/src/codegen/infrastructure/symbol-table.ts
+++ b/src/codegen/infrastructure/symbol-table.ts
@@ -670,6 +670,17 @@ export class SymbolTable {
   }
 
   /**
+   * Redirect a variable's alloca register to a new location (e.g., heap cell for closure capture).
+   * Subsequent loads/stores to this variable will use the new alloca.
+   */
+  redefineAlloca(name: string, newAlloca: string): void {
+    const symbol = this.symbols.get(name);
+    if (symbol) {
+      symbol.allocaRegister = newAlloca;
+    }
+  }
+
+  /**
    * Get symbol kind for a variable
    */
   getKind(name: string): number | undefined {

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2259,12 +2259,19 @@ export class VariableAllocator {
 
     if (closureInfoResult && closureInfo.captures.length > 0) {
       const captures = closureInfo.captures as CaptureInfo[];
+
+      // Capture by value: allocate env struct and copy current variable values into it.
+      // Note: this means mutations in the closure don't affect the outer scope.
+      // Capture-by-reference (heap boxing) is deferred — the native compiler can't
+      // handle the heap boxing code path correctly in self-hosting yet.
       const structSize = captures.length * 8;
       const envMemReg = this.ctx.nextTemp();
       this.ctx.emit(`${envMemReg} = call i8* @GC_malloc(i64 ${structSize})`);
 
       const envTypedReg = this.ctx.nextTemp();
-      this.ctx.emit(`${envTypedReg} = bitcast i8* ${envMemReg} to ${closureInfo.envStructName}*`);
+      this.ctx.emit(
+        `${envTypedReg} = bitcast i8* ${envMemReg} to ${closureInfo.envStructName}*`,
+      );
 
       for (let i = 0; i < captures.length; i++) {
         const captureItem = captures[i] as CaptureInfo;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -222,6 +222,8 @@ export interface VariableAllocatorContext {
   isUint8ArrayExpression(expr: Expression): boolean;
   setWantsBinaryReturn(value: boolean): void;
   getWantsBinaryReturn(): boolean;
+  getLastTypeAssertionSourceVar(): string | null;
+  setLastTypeAssertionSourceVar(name: string | null): void;
 }
 
 export class VariableAllocator {
@@ -1163,8 +1165,70 @@ export class VariableAllocator {
     );
     this.ctx.emit(`${allocaReg} = alloca i8*`);
     this.ctx.setCurrentDeclaredInterfaceType(interfaceName);
+    // Clear stale state — the orchestrator sets lastTypeAssertionSourceVar for ALL
+    // type assertions, not just ones in variable declarations.
+    this.ctx.setLastTypeAssertionSourceVar(null);
     const objPtr = this.ctx.generateExpression(stmt.value!, params);
     this.ctx.setCurrentDeclaredInterfaceType(undefined);
+
+    // When a type assertion wraps an existing object variable (e.g., obj as { age: number; name: string }),
+    // the memory layout is fixed by the object literal's creation-site field order — not the
+    // assertion's field order. Reorder OUR keys/types to match the source's field order so GEP
+    // indices align with the actual struct layout. We reorder rather than copy to ensure we always
+    // use our correctly-converted LLVM types (source metadata may have TS types in some cases).
+    if (stmt.value && stmt.value.type === "type_assertion" && keys.length > 0) {
+      const sourceVar = this.ctx.getLastTypeAssertionSourceVar();
+      this.ctx.setLastTypeAssertionSourceVar(null);
+      if (sourceVar && this.ctx.symbolTable.isObject(sourceVar)) {
+        const srcMeta = this.ctx.symbolTable.getObjectMetadata(sourceVar);
+        if (srcMeta && srcMeta.keys.length > 0) {
+          // Check that source has ALL of our keys (possibly reordered, possibly with extras)
+          let allKeysPresent = true;
+          for (let i = 0; i < keys.length; i++) {
+            if (srcMeta.keys.indexOf(keys[i]) === -1) {
+              allKeysPresent = false;
+              break;
+            }
+          }
+          if (allKeysPresent) {
+            // Reorder our keys/types/tsTypes to match source's field order.
+            // Use source's field order but our LLVM type mappings.
+            const reorderedKeys: string[] = [];
+            const reorderedTypes: string[] = [];
+            const reorderedTsTypes: string[] = [];
+            for (let si = 0; si < srcMeta.keys.length; si++) {
+              const srcKey = srcMeta.keys[si];
+              const ourIdx = keys.indexOf(srcKey);
+              if (ourIdx !== -1) {
+                reorderedKeys.push(srcKey);
+                reorderedTypes.push(types[ourIdx]);
+                reorderedTsTypes.push(tsTypes[ourIdx]);
+              } else {
+                // Source has extra fields not in our assertion — include them for correct
+                // GEP indexing. Convert types through convertTsType since source metadata
+                // may have TS types in the types array in some code paths.
+                reorderedKeys.push(srcKey);
+                const srcTs = srcMeta.tsTypes || srcMeta.types;
+                reorderedTypes.push(this.convertTsType(srcTs[si]));
+                reorderedTsTypes.push(srcTs[si]);
+              }
+            }
+            this.ctx.defineVariableWithMetadata(
+              stmt.name,
+              allocaReg,
+              "i8*",
+              SymbolKind.Object,
+              "local",
+              createObjectMetadataWithInterface(
+                { keys: reorderedKeys, types: reorderedTypes, tsTypes: reorderedTsTypes },
+                interfaceName,
+              ),
+            );
+          }
+        }
+      }
+    }
+
     this.ctx.emit(`store i8* ${objPtr}, i8** ${allocaReg}`);
   }
 
@@ -2269,9 +2333,7 @@ export class VariableAllocator {
       this.ctx.emit(`${envMemReg} = call i8* @GC_malloc(i64 ${structSize})`);
 
       const envTypedReg = this.ctx.nextTemp();
-      this.ctx.emit(
-        `${envTypedReg} = bitcast i8* ${envMemReg} to ${closureInfo.envStructName}*`,
-      );
+      this.ctx.emit(`${envTypedReg} = bitcast i8* ${envMemReg} to ${closureInfo.envStructName}*`);
 
       for (let i = 0; i < captures.length; i++) {
         const captureItem = captures[i] as CaptureInfo;

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -1069,6 +1069,12 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public getExpectedCallbackReturnType(): string | null {
     return this.expectedCallbackReturnType;
   }
+  public getLastInlineLambdaEnvPtr(): string | null {
+    return this.lastInlineLambdaEnvPtr;
+  }
+  public setLastInlineLambdaEnvPtr(ptr: string | null): void {
+    this.lastInlineLambdaEnvPtr = ptr;
+  }
   public setIsAsyncFunction(value: boolean): void {
     this.isAsyncFunction = value;
   }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -1075,6 +1075,12 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public setLastInlineLambdaEnvPtr(ptr: string | null): void {
     this.lastInlineLambdaEnvPtr = ptr;
   }
+  public getLastTypeAssertionSourceVar(): string | null {
+    return this.lastTypeAssertionSourceVar;
+  }
+  public setLastTypeAssertionSourceVar(name: string | null): void {
+    this.lastTypeAssertionSourceVar = name;
+  }
   public setIsAsyncFunction(value: boolean): void {
     this.isAsyncFunction = value;
   }

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -8,6 +8,16 @@ interface ExprBase {
   type: string;
 }
 
+/** Build call args, prepending env pointer for inline lambdas with captures.
+ *  Does NOT clear the env ptr — caller must clear after the loop completes. */
+function buildIterCallArgs(gen: IGeneratorContext, baseArgs: string): string {
+  const envPtr = gen.getLastInlineLambdaEnvPtr();
+  if (envPtr) {
+    return `i8* ${envPtr}, ${baseArgs}`;
+  }
+  return baseArgs;
+}
+
 // ============================================
 // filter
 // ============================================
@@ -38,10 +48,14 @@ export function generateArrayFilter(
     throw new Error("filter() argument must be a function name or inline function");
   }
 
+  let result: string;
   if (isStringArray || isObjectArray) {
-    return generateStringArrayFilter(gen, arrayPtr, predicateFn);
+    result = generateStringArrayFilter(gen, arrayPtr, predicateFn);
+  } else {
+    result = generateNumericArrayFilter(gen, arrayPtr, predicateFn);
   }
-  return generateNumericArrayFilter(gen, arrayPtr, predicateFn);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 function generateNumericArrayFilter(
@@ -111,7 +125,7 @@ function generateNumericArrayFilter(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `double ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildIterCallArgs(gen, `double ${elem}`));
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -209,7 +223,7 @@ function generateStringArrayFilter(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `i8* ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildIterCallArgs(gen, `i8* ${elem}`));
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -268,10 +282,14 @@ export function generateArrayForEach(
     throw new Error("forEach() argument must be a function name or inline function");
   }
 
+  let result: string;
   if (isStringArray || isObjectArray) {
-    return generateStringArrayForEach(gen, arrayPtr, callbackFn);
+    result = generateStringArrayForEach(gen, arrayPtr, callbackFn);
+  } else {
+    result = generateNumericArrayForEach(gen, arrayPtr, callbackFn);
   }
-  return generateNumericArrayForEach(gen, arrayPtr, callbackFn);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 function generateNumericArrayForEach(
@@ -304,7 +322,7 @@ function generateNumericArrayForEach(
   const elem = gen.emitLoad("double", elemPtr);
 
   // Call callback (discard return value)
-  gen.emitCall("double", `@${callbackFn}`, `double ${elem}`);
+  gen.emitCall("double", `@${callbackFn}`, buildIterCallArgs(gen, `double ${elem}`));
 
   const nextCounter = gen.nextTemp();
   gen.emit(`${nextCounter} = add i32 ${counter}, 1`);
@@ -354,7 +372,7 @@ function generateStringArrayForEach(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  gen.emitCall("double", `@${callbackFn}`, `i8* ${elem}`);
+  gen.emitCall("double", `@${callbackFn}`, buildIterCallArgs(gen, `i8* ${elem}`));
 
   const nextCounter = gen.nextTemp();
   gen.emit(`${nextCounter} = add i32 ${counter}, 1`);
@@ -411,10 +429,14 @@ export function generateArrayReduce(
     initialValue = gen.generateExpression(expr.args[1], params);
   }
 
+  let result: string;
   if (isStringArray) {
-    return generateStringArrayReduce(gen, arrayPtr, callbackFn, initialValue);
+    result = generateStringArrayReduce(gen, arrayPtr, callbackFn, initialValue);
+  } else {
+    result = generateNumericArrayReduce(gen, arrayPtr, callbackFn, initialValue);
   }
-  return generateNumericArrayReduce(gen, arrayPtr, callbackFn, initialValue);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 function generateNumericArrayReduce(
@@ -463,7 +485,7 @@ function generateNumericArrayReduce(
 
   const acc = gen.emitLoad("double", accPtr);
 
-  const newAcc = gen.emitCall("double", `@${callbackFn}`, `double ${acc}, double ${elem}`);
+  const newAcc = gen.emitCall("double", `@${callbackFn}`, buildIterCallArgs(gen, `double ${acc}, double ${elem}`));
   gen.emitStore("double", newAcc, accPtr);
 
   const nextCounter = gen.nextTemp();
@@ -533,7 +555,7 @@ function generateStringArrayReduce(
   const acc = gen.nextTemp();
   gen.emit(`${acc} = load i8*, i8** ${accPtr}`);
 
-  const newAcc = gen.emitCall("i8*", `@${callbackFn}`, `i8* ${acc}, i8* ${elem}`);
+  const newAcc = gen.emitCall("i8*", `@${callbackFn}`, buildIterCallArgs(gen, `i8* ${acc}, i8* ${elem}`));
   gen.emit(`store i8* ${newAcc}, i8** ${accPtr}`);
 
   const nextCounter = gen.nextTemp();
@@ -581,10 +603,14 @@ export function generateArrayMap(
     throw new Error("map() argument must be a function name or inline function");
   }
 
+  let result: string;
   if (isStringArray || isObjectArray) {
-    return generateStringArrayMapImpl(gen, arrayPtr, callbackFn);
+    result = generateStringArrayMapImpl(gen, arrayPtr, callbackFn);
+  } else {
+    result = generateNumericArrayMap(gen, arrayPtr, callbackFn);
   }
-  return generateNumericArrayMap(gen, arrayPtr, callbackFn);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 export function generateStringArrayMap(
@@ -612,7 +638,9 @@ export function generateStringArrayMap(
     throw new Error("map() argument must be a function name or inline function");
   }
 
-  return generateStringArrayMapImpl(gen, arrayPtr, callbackFn);
+  const result = generateStringArrayMapImpl(gen, arrayPtr, callbackFn);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 function generateNumericArrayMap(
@@ -679,7 +707,7 @@ function generateNumericArrayMap(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const result = gen.emitCall("double", `@${callbackFn}`, `double ${elem}`);
+  const result = gen.emitCall("double", `@${callbackFn}`, buildIterCallArgs(gen, `double ${elem}`));
 
   const resultElemPtr = gen.nextTemp();
   gen.emit(
@@ -764,7 +792,7 @@ function generateStringArrayMapImpl(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const result = gen.emitCall("i8*", `@${callbackFn}`, `i8* ${elem}`);
+  const result = gen.emitCall("i8*", `@${callbackFn}`, buildIterCallArgs(gen, `i8* ${elem}`));
 
   const resultElemPtr = gen.nextTemp();
   gen.emit(`${resultElemPtr} = getelementptr inbounds i8*, i8** ${resultDataPtr}, i32 ${counter}`);

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -125,7 +125,11 @@ function generateNumericArrayFilter(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildIterCallArgs(gen, `double ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildIterCallArgs(gen, `double ${elem}`),
+  );
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -223,7 +227,11 @@ function generateStringArrayFilter(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildIterCallArgs(gen, `i8* ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildIterCallArgs(gen, `i8* ${elem}`),
+  );
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -485,7 +493,11 @@ function generateNumericArrayReduce(
 
   const acc = gen.emitLoad("double", accPtr);
 
-  const newAcc = gen.emitCall("double", `@${callbackFn}`, buildIterCallArgs(gen, `double ${acc}, double ${elem}`));
+  const newAcc = gen.emitCall(
+    "double",
+    `@${callbackFn}`,
+    buildIterCallArgs(gen, `double ${acc}, double ${elem}`),
+  );
   gen.emitStore("double", newAcc, accPtr);
 
   const nextCounter = gen.nextTemp();
@@ -555,7 +567,11 @@ function generateStringArrayReduce(
   const acc = gen.nextTemp();
   gen.emit(`${acc} = load i8*, i8** ${accPtr}`);
 
-  const newAcc = gen.emitCall("i8*", `@${callbackFn}`, buildIterCallArgs(gen, `i8* ${acc}, i8* ${elem}`));
+  const newAcc = gen.emitCall(
+    "i8*",
+    `@${callbackFn}`,
+    buildIterCallArgs(gen, `i8* ${acc}, i8* ${elem}`),
+  );
   gen.emit(`store i8* ${newAcc}, i8** ${accPtr}`);
 
   const nextCounter = gen.nextTemp();

--- a/src/codegen/types/collections/array/search-predicate.ts
+++ b/src/codegen/types/collections/array/search-predicate.ts
@@ -8,6 +8,16 @@ interface ExprBase {
   type: string;
 }
 
+/** Build call args, prepending env pointer for inline lambdas with captures.
+ *  Does NOT clear the env ptr — caller must clear after the loop completes. */
+function buildPredicateCallArgs(gen: IGeneratorContext, baseArgs: string): string {
+  const envPtr = gen.getLastInlineLambdaEnvPtr();
+  if (envPtr) {
+    return `i8* ${envPtr}, ${baseArgs}`;
+  }
+  return baseArgs;
+}
+
 // ============================================
 // find
 // ============================================
@@ -38,10 +48,14 @@ export function generateArrayFind(
     throw new Error("find() argument must be a function name or inline function");
   }
 
+  let result: string;
   if (isStringArray || isObjectArray) {
-    return generateStringArrayFind(gen, arrayPtr, predicateFn);
+    result = generateStringArrayFind(gen, arrayPtr, predicateFn);
+  } else {
+    result = generateNumericArrayFind(gen, arrayPtr, predicateFn);
   }
-  return generateNumericArrayFind(gen, arrayPtr, predicateFn);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 function generateNumericArrayFind(
@@ -79,7 +93,7 @@ function generateNumericArrayFind(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `double ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `double ${elem}`));
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -145,7 +159,7 @@ function generateStringArrayFind(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `i8* ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `i8* ${elem}`));
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -198,10 +212,14 @@ export function generateArraySome(
     throw new Error("some() argument must be a function name or inline function");
   }
 
+  let result: string;
   if (isStringArray || isObjectArray) {
-    return generateStringArraySome(gen, arrayPtr, predicateFn);
+    result = generateStringArraySome(gen, arrayPtr, predicateFn);
+  } else {
+    result = generateNumericArraySome(gen, arrayPtr, predicateFn);
   }
-  return generateNumericArraySome(gen, arrayPtr, predicateFn);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 function generateNumericArraySome(
@@ -239,7 +257,7 @@ function generateNumericArraySome(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `double ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `double ${elem}`));
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -307,7 +325,7 @@ function generateStringArraySome(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `i8* ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `i8* ${elem}`));
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -360,10 +378,14 @@ export function generateArrayEvery(
     throw new Error("every() argument must be a function name or inline function");
   }
 
+  let result: string;
   if (isStringArray || isObjectArray) {
-    return generateStringArrayEvery(gen, arrayPtr, predicateFn);
+    result = generateStringArrayEvery(gen, arrayPtr, predicateFn);
+  } else {
+    result = generateNumericArrayEvery(gen, arrayPtr, predicateFn);
   }
-  return generateNumericArrayEvery(gen, arrayPtr, predicateFn);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 function generateNumericArrayEvery(
@@ -401,7 +423,7 @@ function generateNumericArrayEvery(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `double ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `double ${elem}`));
 
   const isFalsy = gen.nextTemp();
   gen.emit(`${isFalsy} = fcmp oeq double ${predicateResult}, 0.0`);
@@ -469,7 +491,7 @@ function generateStringArrayEvery(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `i8* ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `i8* ${elem}`));
 
   const isFalsy = gen.nextTemp();
   gen.emit(`${isFalsy} = fcmp oeq double ${predicateResult}, 0.0`);

--- a/src/codegen/types/collections/array/search-predicate.ts
+++ b/src/codegen/types/collections/array/search-predicate.ts
@@ -93,7 +93,11 @@ function generateNumericArrayFind(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `double ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildPredicateCallArgs(gen, `double ${elem}`),
+  );
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -159,7 +163,11 @@ function generateStringArrayFind(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `i8* ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildPredicateCallArgs(gen, `i8* ${elem}`),
+  );
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -257,7 +265,11 @@ function generateNumericArraySome(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `double ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildPredicateCallArgs(gen, `double ${elem}`),
+  );
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -325,7 +337,11 @@ function generateStringArraySome(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `i8* ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildPredicateCallArgs(gen, `i8* ${elem}`),
+  );
 
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
@@ -423,7 +439,11 @@ function generateNumericArrayEvery(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `double ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildPredicateCallArgs(gen, `double ${elem}`),
+  );
 
   const isFalsy = gen.nextTemp();
   gen.emit(`${isFalsy} = fcmp oeq double ${predicateResult}, 0.0`);
@@ -491,7 +511,11 @@ function generateStringArrayEvery(
   const elem = gen.nextTemp();
   gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildPredicateCallArgs(gen, `i8* ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildPredicateCallArgs(gen, `i8* ${elem}`),
+  );
 
   const isFalsy = gen.nextTemp();
   gen.emit(`${isFalsy} = fcmp oeq double ${predicateResult}, 0.0`);

--- a/src/codegen/types/collections/array/search.ts
+++ b/src/codegen/types/collections/array/search.ts
@@ -4,6 +4,16 @@
 import { MethodCallNode, VariableNode } from "../../../../ast/types.js";
 import { IGeneratorContext } from "./context.js";
 
+/** Build call args, prepending env pointer for inline lambdas with captures.
+ *  Does NOT clear the env ptr — caller must clear after the loop completes. */
+function buildSearchCallArgs(gen: IGeneratorContext, baseArgs: string): string {
+  const envPtr = gen.getLastInlineLambdaEnvPtr();
+  if (envPtr) {
+    return `i8* ${envPtr}, ${baseArgs}`;
+  }
+  return baseArgs;
+}
+
 interface ExprBase {
   type: string;
 }
@@ -200,10 +210,14 @@ export function generateArrayFindIndex(
     throw new Error("findIndex() argument must be a function name or inline function");
   }
 
+  let result: string;
   if (isStringArray) {
-    return generateStringArrayFindIndex(gen, arrayPtr, predicateFn);
+    result = generateStringArrayFindIndex(gen, arrayPtr, predicateFn);
+  } else {
+    result = generateNumericArrayFindIndex(gen, arrayPtr, predicateFn);
   }
-  return generateNumericArrayFindIndex(gen, arrayPtr, predicateFn);
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
 }
 
 function generateNumericArrayFindIndex(
@@ -247,7 +261,7 @@ function generateNumericArrayFindIndex(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${i}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `double ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildSearchCallArgs(gen, `double ${elem}`));
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
   gen.emitBrCond(isTruthy, foundLabel, nextLabel);
@@ -314,7 +328,7 @@ function generateStringArrayFindIndex(
   gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${i}`);
   const elem = gen.emitLoad("i8*", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, `i8* ${elem}`);
+  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildSearchCallArgs(gen, `i8* ${elem}`));
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
   gen.emitBrCond(isTruthy, foundLabel, nextLabel);

--- a/src/codegen/types/collections/array/search.ts
+++ b/src/codegen/types/collections/array/search.ts
@@ -261,7 +261,11 @@ function generateNumericArrayFindIndex(
   gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${i}`);
   const elem = gen.emitLoad("double", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildSearchCallArgs(gen, `double ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildSearchCallArgs(gen, `double ${elem}`),
+  );
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
   gen.emitBrCond(isTruthy, foundLabel, nextLabel);
@@ -328,7 +332,11 @@ function generateStringArrayFindIndex(
   gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${i}`);
   const elem = gen.emitLoad("i8*", elemPtr);
 
-  const predicateResult = gen.emitCall("double", `@${predicateFn}`, buildSearchCallArgs(gen, `i8* ${elem}`));
+  const predicateResult = gen.emitCall(
+    "double",
+    `@${predicateFn}`,
+    buildSearchCallArgs(gen, `i8* ${elem}`),
+  );
   const isTruthy = gen.nextTemp();
   gen.emit(`${isTruthy} = fcmp one double ${predicateResult}, 0.0`);
   gen.emitBrCond(isTruthy, foundLabel, nextLabel);

--- a/src/codegen/types/collections/array/sort.ts
+++ b/src/codegen/types/collections/array/sort.ts
@@ -92,7 +92,10 @@ export function generateArraySort(
     throw new Error("sort() comparator must be a function name or inline function");
   }
 
-  return generateNumericSortWithFn(gen, arrayPtr, compareFn);
+  // Capture env ptr for inline lambda closures, then clear it
+  const sortEnvPtr = gen.getLastInlineLambdaEnvPtr();
+  gen.setLastInlineLambdaEnvPtr(null);
+  return generateNumericSortWithFn(gen, arrayPtr, compareFn, sortEnvPtr);
 }
 
 function generateDefaultNumericSort(gen: ArraySortContext, arrayPtr: string): string {
@@ -151,6 +154,7 @@ function generateNumericSortWithFn(
   gen: ArraySortContext,
   arrayPtr: string,
   compareFn: string,
+  envPtr?: string | null,
 ): string {
   const lenPtr = gen.nextTemp();
   gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
@@ -219,7 +223,8 @@ function generateNumericSortWithFn(
   gen.emit(`${valB} = load double, double* ${ptrB}`);
 
   const cmpResult = gen.nextTemp();
-  gen.emit(`${cmpResult} = call double @${compareFn}(double ${valA}, double ${valB})`);
+  const cmpArgs = envPtr ? `i8* ${envPtr}, double ${valA}, double ${valB}` : `double ${valA}, double ${valB}`;
+  gen.emit(`${cmpResult} = call double @${compareFn}(${cmpArgs})`);
   const shouldSwap = gen.nextTemp();
   gen.emit(`${shouldSwap} = fcmp ogt double ${cmpResult}, 0.0`);
   gen.emit(`br i1 ${shouldSwap}, label %${swapLabel}, label %${noSwapLabel}`);

--- a/src/codegen/types/collections/array/sort.ts
+++ b/src/codegen/types/collections/array/sort.ts
@@ -223,7 +223,9 @@ function generateNumericSortWithFn(
   gen.emit(`${valB} = load double, double* ${ptrB}`);
 
   const cmpResult = gen.nextTemp();
-  const cmpArgs = envPtr ? `i8* ${envPtr}, double ${valA}, double ${valB}` : `double ${valA}, double ${valB}`;
+  const cmpArgs = envPtr
+    ? `i8* ${envPtr}, double ${valA}, double ${valB}`
+    : `double ${valA}, double ${valB}`;
   gen.emit(`${cmpResult} = call double @${compareFn}(${cmpArgs})`);
   const shouldSwap = gen.nextTemp();
   gen.emit(`${shouldSwap} = fcmp ogt double ${cmpResult}, 0.0`);

--- a/tests/fixtures/closures/closure-capture-in-filter.ts
+++ b/tests/fixtures/closures/closure-capture-in-filter.ts
@@ -1,0 +1,7 @@
+// @test-description: inline lambda with capture in array filter
+const threshold = 3;
+const nums = [1, 2, 3, 4, 5];
+const result = nums.filter(x => x > threshold);
+if (result.length === 2 && result[0] === 4 && result[1] === 5) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/closures/closure-capture-in-filter.ts
+++ b/tests/fixtures/closures/closure-capture-in-filter.ts
@@ -1,7 +1,7 @@
 // @test-description: inline lambda with capture in array filter
 const threshold = 3;
 const nums = [1, 2, 3, 4, 5];
-const result = nums.filter(x => x > threshold);
+const result = nums.filter((x) => x > threshold);
 if (result.length === 2 && result[0] === 4 && result[1] === 5) {
   console.log("TEST_PASSED");
 }

--- a/tests/fixtures/closures/closure-capture-in-foreach.ts
+++ b/tests/fixtures/closures/closure-capture-in-foreach.ts
@@ -1,0 +1,8 @@
+// @test-description: inline lambda with capture in array forEach
+const prefix = 100;
+const nums = [1, 2, 3];
+const results: number[] = [];
+nums.forEach(x => { results.push(x + prefix); });
+if (results.length === 3 && results[0] === 101 && results[1] === 102 && results[2] === 103) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/closures/closure-capture-in-foreach.ts
+++ b/tests/fixtures/closures/closure-capture-in-foreach.ts
@@ -2,7 +2,9 @@
 const prefix = 100;
 const nums = [1, 2, 3];
 const results: number[] = [];
-nums.forEach(x => { results.push(x + prefix); });
+nums.forEach((x) => {
+  results.push(x + prefix);
+});
 if (results.length === 3 && results[0] === 101 && results[1] === 102 && results[2] === 103) {
   console.log("TEST_PASSED");
 }

--- a/tests/fixtures/closures/closure-capture-in-map.ts
+++ b/tests/fixtures/closures/closure-capture-in-map.ts
@@ -1,7 +1,7 @@
 // @test-description: inline lambda with capture in array map
 const offset = 10;
 const nums = [1, 2, 3];
-const result = nums.map(x => x + offset);
+const result = nums.map((x) => x + offset);
 if (result[0] === 11 && result[1] === 12 && result[2] === 13) {
   console.log("TEST_PASSED");
 }

--- a/tests/fixtures/closures/closure-capture-in-map.ts
+++ b/tests/fixtures/closures/closure-capture-in-map.ts
@@ -1,0 +1,7 @@
+// @test-description: inline lambda with capture in array map
+const offset = 10;
+const nums = [1, 2, 3];
+const result = nums.map(x => x + offset);
+if (result[0] === 11 && result[1] === 12 && result[2] === 13) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/objects/computed-property-write-number.ts
+++ b/tests/fixtures/objects/computed-property-write-number.ts
@@ -1,0 +1,7 @@
+// @test-description: computed property write with numeric value
+const obj = { x: 10, y: 20 };
+const key = "x";
+obj[key] = 42;
+if (obj.x === 42 && obj.y === 20) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/objects/computed-property-write.ts
+++ b/tests/fixtures/objects/computed-property-write.ts
@@ -1,0 +1,7 @@
+// @test-description: computed property write via dynamic key
+const obj = { name: "alice", age: 30 };
+const key = "name";
+obj[key] = "bob";
+if (obj.name === "bob" && obj.age === 30) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/objects/type-assertion-field-order.ts
+++ b/tests/fixtures/objects/type-assertion-field-order.ts
@@ -1,0 +1,11 @@
+// @test-description: type assertion with reordered fields
+// Verifies that `as { ... }` with fields in different order than the
+// object literal doesn't cause wrong field access or segfault.
+function testAssertOrder(): void {
+  const obj = { name: "alice", age: 30 };
+  const typed = obj as { age: number; name: string };
+  if (typed.age === 30 && typed.name === "alice") {
+    console.log("TEST_PASSED");
+  }
+}
+testAssertOrder();

--- a/tests/unit/type-system.test.ts
+++ b/tests/unit/type-system.test.ts
@@ -11,6 +11,8 @@ import {
   tsTypeToLlvmJson,
   checkUnsafeUnionType,
 } from "../../src/codegen/infrastructure/type-system.js";
+import { SemanticAnalyzer } from "../../src/analysis/semantic-analyzer.js";
+import { AST } from "../../src/ast/types.js";
 
 describe("stripOptional", () => {
   it("should return empty string for null/undefined/empty input", () => {
@@ -342,5 +344,156 @@ describe("checkUnsafeUnionType", () => {
 
   it("should ignore unions nested inside generic types", () => {
     assert.strictEqual(checkUnsafeUnionType("Map<string, number | string>"), null);
+  });
+});
+
+// Helper to create a minimal AST for SemanticAnalyzer tests
+function makeAST(overrides: Partial<AST> = {}): AST {
+  return {
+    imports: [],
+    functions: [],
+    classes: [],
+    exports: [],
+    interfaces: [],
+    typeAliases: [],
+    enums: [],
+    topLevelStatements: [],
+    topLevelExpressions: [],
+    ...overrides,
+  } as AST;
+}
+
+describe("SemanticAnalyzer unsafe union checks", () => {
+  it("should reject unsafe union in variable declaration type", () => {
+    const ast = makeAST({
+      topLevelStatements: [
+        {
+          type: "variable_declaration",
+          kind: "let",
+          name: "x",
+          value: { type: "number", value: 42 },
+          declaredType: "string | number",
+        } as any,
+      ],
+    });
+    const analyzer = new SemanticAnalyzer(ast);
+    const ok = analyzer.analyze();
+    assert.strictEqual(ok, false);
+    const errors = analyzer.getErrors();
+    assert.ok(errors.length > 0);
+    assert.ok(errors[0].message.indexOf("string | number") !== -1);
+    assert.ok(errors[0].message.indexOf("Variable 'x'") !== -1);
+  });
+
+  it("should allow nullable union in variable declaration", () => {
+    const ast = makeAST({
+      topLevelStatements: [
+        {
+          type: "variable_declaration",
+          kind: "let",
+          name: "x",
+          value: { type: "string", value: "hello" },
+          declaredType: "string | null",
+        } as any,
+      ],
+    });
+    const analyzer = new SemanticAnalyzer(ast);
+    const ok = analyzer.analyze();
+    assert.strictEqual(ok, true);
+  });
+
+  it("should reject unsafe union in interface field type", () => {
+    const ast = makeAST({
+      interfaces: [
+        {
+          name: "MyInterface",
+          fields: [{ name: "data", type: "string | number" }],
+        },
+      ],
+    });
+    const analyzer = new SemanticAnalyzer(ast);
+    const ok = analyzer.analyze();
+    assert.strictEqual(ok, false);
+    const errors = analyzer.getErrors();
+    assert.ok(errors.length > 0);
+    assert.ok(errors[0].message.indexOf("MyInterface") !== -1);
+    assert.ok(errors[0].message.indexOf("data") !== -1);
+  });
+
+  it("should reject unsafe union in interface method params", () => {
+    const ast = makeAST({
+      interfaces: [
+        {
+          name: "MyInterface",
+          fields: [],
+          methods: [
+            {
+              name: "process",
+              params: ["input"],
+              paramTypes: ["string | number"],
+              returnType: "void",
+            },
+          ],
+        },
+      ],
+    });
+    const analyzer = new SemanticAnalyzer(ast);
+    const ok = analyzer.analyze();
+    assert.strictEqual(ok, false);
+    const errors = analyzer.getErrors();
+    assert.ok(errors.length > 0);
+    assert.ok(errors[0].message.indexOf("MyInterface.process") !== -1);
+  });
+
+  it("should reject unsafe union in class field tsType", () => {
+    const ast = makeAST({
+      classes: [
+        {
+          name: "MyClass",
+          fields: [
+            {
+              name: "data",
+              fieldType: "double",
+              tsType: "string | number",
+            },
+          ],
+          methods: [],
+        } as any,
+      ],
+    });
+    const analyzer = new SemanticAnalyzer(ast);
+    const ok = analyzer.analyze();
+    assert.strictEqual(ok, false);
+    const errors = analyzer.getErrors();
+    assert.ok(errors.length > 0);
+    assert.ok(errors[0].message.indexOf("MyClass") !== -1);
+    assert.ok(errors[0].message.indexOf("data") !== -1);
+  });
+
+  it("should pass when no unsafe unions exist", () => {
+    const ast = makeAST({
+      interfaces: [
+        {
+          name: "SafeInterface",
+          fields: [
+            { name: "name", type: "string" },
+            { name: "age", type: "number" },
+            { name: "optional", type: "string | null" },
+          ],
+        },
+      ],
+      topLevelStatements: [
+        {
+          type: "variable_declaration",
+          kind: "const",
+          name: "y",
+          value: { type: "number", value: 1 },
+          declaredType: "number",
+        } as any,
+      ],
+    });
+    const analyzer = new SemanticAnalyzer(ast);
+    const ok = analyzer.analyze();
+    assert.strictEqual(ok, true);
   });
 });

--- a/tests/unit/type-system.test.ts
+++ b/tests/unit/type-system.test.ts
@@ -402,48 +402,8 @@ describe("SemanticAnalyzer unsafe union checks", () => {
     assert.strictEqual(ok, true);
   });
 
-  it("should reject unsafe union in interface field type", () => {
-    const ast = makeAST({
-      interfaces: [
-        {
-          name: "MyInterface",
-          fields: [{ name: "data", type: "string | number" }],
-        },
-      ],
-    });
-    const analyzer = new SemanticAnalyzer(ast);
-    const ok = analyzer.analyze();
-    assert.strictEqual(ok, false);
-    const errors = analyzer.getErrors();
-    assert.ok(errors.length > 0);
-    assert.ok(errors[0].message.indexOf("MyInterface") !== -1);
-    assert.ok(errors[0].message.indexOf("data") !== -1);
-  });
-
-  it("should reject unsafe union in interface method params", () => {
-    const ast = makeAST({
-      interfaces: [
-        {
-          name: "MyInterface",
-          fields: [],
-          methods: [
-            {
-              name: "process",
-              params: ["input"],
-              paramTypes: ["string | number"],
-              returnType: "void",
-            },
-          ],
-        },
-      ],
-    });
-    const analyzer = new SemanticAnalyzer(ast);
-    const ok = analyzer.analyze();
-    assert.strictEqual(ok, false);
-    const errors = analyzer.getErrors();
-    assert.ok(errors.length > 0);
-    assert.ok(errors[0].message.indexOf("MyInterface.process") !== -1);
-  });
+  // NOTE: Interface field/method union checking tests removed — the native compiler
+  // can't handle array-of-objects field access (iface.fields[i].name) during self-hosting.
 
   it("should reject unsafe union in class field tsType", () => {
     const ast = makeAST({


### PR DESCRIPTION
## Language hardening: closures, computed writes, type safety

Fixes several crash-inducing codegen issues and adds compile-time guardrails for unsafe type patterns.

### Unsafe union type rejection

The semantic analyzer now rejects union types where members have incompatible memory layouts (e.g. `string | number`) in variable declarations and class fields. Nullable unions (`string | null`) remain allowed since null shares the pointer representation. This prevents silent memory corruption at runtime.

Interface field checking is intentionally omitted — the native compiler can't handle the `iface.fields[i].name` array-of-objects access pattern during self-hosting.

### Inline lambda captures in array methods

`arr.map(x => x + captured)`, `arr.filter(...)`, and `arr.forEach(...)` now correctly capture outer variables. Previously, inline lambdas passed to array methods lost their closure environment, causing undefined values or segfaults.

The fix uses a struct-of-arrays pattern (`getLastCaptureNames()`/`getLastCaptureTypes()`) instead of array-of-objects to remain self-hosting compatible. The orchestrator allocates the env struct immediately after generating the arrow function, so array iteration codegen can pass it as the first argument.

### Computed property write (`obj[key] = value`)

Extends computed property access (read) with write support. Uses the same strcmp chain over known object keys, but emits `store` instead of `load`. Both string and numeric field values are handled, with type matching to skip incompatible branches.

### Type assertion field order fix

`const typed = obj as { age: number; name: string }` where the asserted type reorders fields relative to the object literal now works correctly. Previously, the GEP indices followed the assertion's field order instead of the actual struct layout, reading wrong fields and causing segfaults.

The fix records the source variable name during type assertion codegen (`setLastTypeAssertionSourceVar`) so that `allocateDeclaredInterface` can inherit the original field order.

### Changes

- `src/analysis/semantic-analyzer.ts` — union type checks for variable decls and class fields
- `src/codegen/expressions/access/index.ts` — `generateDynamicObjectAssignment` for `obj[key] = value`
- `src/codegen/expressions/arrow-functions.ts` — struct-of-arrays capture info accessors
- `src/codegen/expressions/orchestrator.ts` — env struct allocation for inline lambdas; type assertion source tracking
- `src/codegen/infrastructure/` — new context methods for env ptr and assertion source var
- `src/codegen/types/collections/array/` — pass closure env through iteration/search/sort codegen
- `src/codegen/llvm-generator.ts` — plumb new context methods
- `docs/language/limitations.md` — updated for computed property write, closures, union restrictions
- 6 new test fixtures (closures, computed writes, type assertions)
- New unit tests for `SemanticAnalyzer` unsafe union rejection

### Test plan

- `npm test` — all unit and compiler tests pass
- `npm run verify` — full 3-stage self-hosting succeeds
