### PR TITLE
fix json.stringify for inline object literals with booleans and numbers

### DIFF
--- a/c_bridges/yyjson-bridge.c
+++ b/c_bridges/yyjson-bridge.c
@@ -138,6 +138,15 @@ void csyyjson_obj_add_bool(void *doc, void *obj, const char *key, int val) {
     yyjson_mut_obj_add_bool((yyjson_mut_doc *)doc, (yyjson_mut_val *)obj, key, val ? true : false);
 }
 
+void *csyyjson_obj_add_obj(void *doc, void *parent_obj, const char *key) {
+    if (!doc || !parent_obj || !key) return NULL;
+    yyjson_mut_doc *mdoc = (yyjson_mut_doc *)doc;
+    yyjson_mut_val *child = yyjson_mut_obj(mdoc);
+    if (!child) return NULL;
+    yyjson_mut_obj_add_val(mdoc, (yyjson_mut_val *)parent_obj, key, child);
+    return (void *)child;
+}
+
 char *csyyjson_stringify(void *doc) {
     if (!doc) return NULL;
     size_t len;

--- a/src/codegen/runtime/runtime.ts
+++ b/src/codegen/runtime/runtime.ts
@@ -265,6 +265,7 @@ export class RuntimeGenerator {
     ir += "declare i8* @csyyjson_stringify_pretty(i8*, i32)\n";
     ir += "declare i8* @csyyjson_create_arr()\n";
     ir += "declare i8* @csyyjson_mut_arr_add_obj(i8*, i8*)\n";
+    ir += "declare i8* @csyyjson_obj_add_obj(i8*, i8*, i8*)\n";
     ir += "\n";
 
     ir += "define i32 @csyyjson_get_num_as_int(i8* %item) {\n";

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -743,12 +743,30 @@ export class JsonGenerator {
     this.ctx.setUsesJson(true);
     const jsonDoc = this.ctx.emitCall("i8*", "@csyyjson_create_obj", "");
     const jsonObj = this.ctx.emitCall("i8*", "@csyyjson_mut_get_root", `i8* ${jsonDoc}`);
+    this.buildJsonProperties(obj, params, jsonDoc, jsonObj);
+    const result = this.emitStringify(jsonDoc, spaces);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
+  }
 
+  private buildJsonProperties(
+    obj: ObjectNode,
+    params: string[],
+    jsonDoc: string,
+    jsonObj: string,
+  ): void {
     for (let i = 0; i < obj.properties.length; i++) {
       const prop = obj.properties[i];
       const nameConst = this.ctx.createStringConstant(prop.key);
 
-      if (prop.value.type === "boolean") {
+      if (prop.value.type === "object") {
+        const childObj = this.ctx.emitCall(
+          "i8*",
+          "@csyyjson_obj_add_obj",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}`,
+        );
+        this.buildJsonProperties(prop.value as unknown as ObjectNode, params, jsonDoc, childObj);
+      } else if (prop.value.type === "boolean") {
         const val = this.ctx.generateExpression(prop.value, params);
         const boolI32 = this.ctx.nextTemp();
         this.ctx.emit(`${boolI32} = trunc i64 ${val} to i32`);
@@ -786,10 +804,6 @@ export class JsonGenerator {
         }
       }
     }
-
-    const result = this.emitStringify(jsonDoc, spaces);
-    this.ctx.setVariableType(result, "i8*");
-    return result;
   }
 
   private stringifyNumber(arg: Expression, params: string[]): string {

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -1,4 +1,4 @@
-import { Expression, MethodCallNode } from "../../ast/types.js";
+import { Expression, MethodCallNode, ObjectNode } from "../../ast/types.js";
 
 interface ExprBase {
   type: string;
@@ -507,6 +507,10 @@ export class JsonGenerator {
       return this.stringifyString(arg, params);
     }
 
+    if (arg.type === "object") {
+      return this.stringifyObjectLiteral(arg as unknown as ObjectNode, params, spaces);
+    }
+
     // Check for ObjectArray (e.g. Post[]) before resolveInterfaceType —
     // getRawInterfaceType returns the element type for arrays, which would
     // cause stringifyInterface to treat the array pointer as a single object.
@@ -733,6 +737,59 @@ export class JsonGenerator {
 
     this.ctx.setVariableType(buffer, "i8*");
     return buffer;
+  }
+
+  private stringifyObjectLiteral(obj: ObjectNode, params: string[], spaces: number): string {
+    this.ctx.setUsesJson(true);
+    const jsonDoc = this.ctx.emitCall("i8*", "@csyyjson_create_obj", "");
+    const jsonObj = this.ctx.emitCall("i8*", "@csyyjson_mut_get_root", `i8* ${jsonDoc}`);
+
+    for (let i = 0; i < obj.properties.length; i++) {
+      const prop = obj.properties[i];
+      const nameConst = this.ctx.createStringConstant(prop.key);
+
+      if (prop.value.type === "boolean") {
+        const val = this.ctx.generateExpression(prop.value, params);
+        const boolI32 = this.ctx.nextTemp();
+        this.ctx.emit(`${boolI32} = trunc i64 ${val} to i32`);
+        this.ctx.emitCallVoid(
+          "@csyyjson_obj_add_bool",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i32 ${boolI32}`,
+        );
+      } else if (this.ctx.isStringExpression(prop.value)) {
+        const val = this.ctx.generateExpression(prop.value, params);
+        this.ctx.emitCallVoid(
+          "@csyyjson_obj_add_str",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i8* ${val}`,
+        );
+      } else {
+        const val = this.ctx.generateExpression(prop.value, params);
+        const vt = this.ctx.getVariableType(val);
+        if (vt === "i8*") {
+          this.ctx.emitCallVoid(
+            "@csyyjson_obj_add_str",
+            `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i8* ${val}`,
+          );
+        } else if (vt === "i1") {
+          const boolI32 = this.ctx.nextTemp();
+          this.ctx.emit(`${boolI32} = zext i1 ${val} to i32`);
+          this.ctx.emitCallVoid(
+            "@csyyjson_obj_add_bool",
+            `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i32 ${boolI32}`,
+          );
+        } else {
+          const dbl = this.ctx.ensureDouble(val);
+          this.ctx.emitCallVoid(
+            "@csyyjson_obj_add_num",
+            `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, double ${dbl}`,
+          );
+        }
+      }
+    }
+
+    const result = this.emitStringify(jsonDoc, spaces);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
   }
 
   private stringifyNumber(arg: Expression, params: string[]): string {

--- a/tests/fixtures/builtins/json-stringify-deep-object.ts
+++ b/tests/fixtures/builtins/json-stringify-deep-object.ts
@@ -1,0 +1,14 @@
+// @test-description: json stringify deeply nested inline object literal
+const result = JSON.stringify({
+  user: { name: "chad", meta: { active: true, level: 3 } },
+  count: 42,
+  enabled: true,
+});
+if (
+  result.includes("chad") &&
+  result.includes("active") &&
+  result.includes("42") &&
+  result.includes("true")
+) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/builtins/json-stringify-inline-bool.ts
+++ b/tests/fixtures/builtins/json-stringify-inline-bool.ts
@@ -1,0 +1,6 @@
+// @test-description: json stringify inline object with only boolean fields
+const a = JSON.stringify({ ok: true });
+const b = JSON.stringify({ ok: false });
+if (a.includes("true") && b.includes("false")) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/builtins/json-stringify-inline-object.ts
+++ b/tests/fixtures/builtins/json-stringify-inline-object.ts
@@ -1,0 +1,5 @@
+// @test-description: json stringify inline object literal with boolean and number fields
+const result = JSON.stringify({ success: true, count: 42, name: "chad" });
+if (result.includes("true") && result.includes("42") && result.includes("chad")) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/builtins/json-stringify-spaces.ts
+++ b/tests/fixtures/builtins/json-stringify-spaces.ts
@@ -1,0 +1,7 @@
+// @test-description: json stringify inline object with spaces=2 and spaces=4
+const compact = JSON.stringify({ x: 1, ok: true });
+const spaced2 = JSON.stringify({ x: 1, ok: true }, null, 2);
+const spaced4 = JSON.stringify({ x: 1, ok: true }, null, 4);
+if (spaced2.length > compact.length && spaced4.length > spaced2.length) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
# fix json.stringify for inline object literals

## Summary

- `JSON.stringify({ ... })` with inline object literals previously fell through to unhandled codegen paths, producing incorrect output for boolean and numeric fields
- Added `stringifyObjectLiteral` in `src/codegen/stdlib/json.ts` that walks the `ObjectNode` AST and builds a yyjson document directly, handling strings, numbers, booleans, and nested objects
- Added `csyyjson_obj_add_obj` C bridge function to create and attach child objects to a parent during stringification, enabling recursive nested object support
- Declared the new extern in `src/codegen/runtime/runtime.ts`

## Files Changed

| File | Change |
|------|--------|
| `c_bridges/yyjson-bridge.c` | add `csyyjson_obj_add_obj` for nested object construction |
| `src/codegen/runtime/runtime.ts` | declare `@csyyjson_obj_add_obj` extern |
| `src/codegen/stdlib/json.ts` | add `stringifyObjectLiteral` + `buildJsonProperties` (recursive) |
| `tests/fixtures/builtins/json-stringify-inline-object.ts` | test: mixed string/bool/number fields |
| `tests/fixtures/builtins/json-stringify-inline-bool.ts` | test: boolean-only fields |
| `tests/fixtures/builtins/json-stringify-deep-object.ts` | test: deeply nested objects |
| `tests/fixtures/builtins/json-stringify-spaces.ts` | test: spaces=2 and spaces=4 pretty-printing |
