### PR TITLE
json stringify with mixed-type variables and type assertions

### DIFF
--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -1,4 +1,4 @@
-import { Expression, MethodCallNode, ObjectNode } from "../../ast/types.js";
+import { Expression, MethodCallNode, ObjectNode, TypeAssertionNode } from "../../ast/types.js";
 
 interface ExprBase {
   type: string;
@@ -500,8 +500,12 @@ export class JsonGenerator {
       return this.ctx.emitError("JSON.stringify() requires 1 argument", expr.loc);
     }
 
-    const arg = expr.args[0];
+    let arg = expr.args[0];
     const spaces = this.getSpaces(expr);
+
+    if ((arg as { type: string }).type === "type_assertion") {
+      arg = (arg as unknown as TypeAssertionNode).expression;
+    }
 
     if (this.ctx.isStringExpression(arg)) {
       return this.stringifyString(arg, params);
@@ -759,29 +763,34 @@ export class JsonGenerator {
       const prop = obj.properties[i];
       const nameConst = this.ctx.createStringConstant(prop.key);
 
-      if (prop.value.type === "object") {
+      let propValue = prop.value;
+      if ((propValue as { type: string }).type === "type_assertion") {
+        propValue = (propValue as unknown as TypeAssertionNode).expression;
+      }
+
+      if (propValue.type === "object") {
         const childObj = this.ctx.emitCall(
           "i8*",
           "@csyyjson_obj_add_obj",
           `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}`,
         );
-        this.buildJsonProperties(prop.value as unknown as ObjectNode, params, jsonDoc, childObj);
-      } else if (prop.value.type === "boolean") {
-        const val = this.ctx.generateExpression(prop.value, params);
+        this.buildJsonProperties(propValue as unknown as ObjectNode, params, jsonDoc, childObj);
+      } else if (propValue.type === "boolean") {
+        const val = this.ctx.generateExpression(propValue, params);
         const boolI32 = this.ctx.nextTemp();
         this.ctx.emit(`${boolI32} = trunc i64 ${val} to i32`);
         this.ctx.emitCallVoid(
           "@csyyjson_obj_add_bool",
           `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i32 ${boolI32}`,
         );
-      } else if (this.ctx.isStringExpression(prop.value)) {
-        const val = this.ctx.generateExpression(prop.value, params);
+      } else if (this.ctx.isStringExpression(propValue)) {
+        const val = this.ctx.generateExpression(propValue, params);
         this.ctx.emitCallVoid(
           "@csyyjson_obj_add_str",
           `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i8* ${val}`,
         );
       } else {
-        const val = this.ctx.generateExpression(prop.value, params);
+        const val = this.ctx.generateExpression(propValue, params);
         const vt = this.ctx.getVariableType(val);
         if (vt === "i8*") {
           this.ctx.emitCallVoid(

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -1,4 +1,4 @@
-import { Expression, MethodCallNode, ObjectNode } from "../../ast/types.js";
+import { Expression, MethodCallNode, ObjectNode, TypeAssertionNode } from "../../ast/types.js";
 
 interface ExprBase {
   type: string;
@@ -500,11 +500,17 @@ export class JsonGenerator {
       return this.ctx.emitError("JSON.stringify() requires 1 argument", expr.loc);
     }
 
-    const rawArg = expr.args[0];
-    const arg =
-      (rawArg as { type: string }).type === "type_assertion"
-        ? (rawArg as { type: string; expression: Expression }).expression
-        : rawArg;
+    if (expr.args[0].type === "type_assertion") {
+      return this.generateStringifyArg(
+        (expr.args[0] as unknown as TypeAssertionNode).expression,
+        expr,
+        params,
+      );
+    }
+    return this.generateStringifyArg(expr.args[0], expr, params);
+  }
+
+  private generateStringifyArg(arg: Expression, expr: MethodCallNode, params: string[]): string {
     const spaces = this.getSpaces(expr);
 
     if (this.ctx.isStringExpression(arg)) {

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -1,4 +1,4 @@
-import { Expression, MethodCallNode, ObjectNode, TypeAssertionNode } from "../../ast/types.js";
+import { Expression, MethodCallNode, ObjectNode } from "../../ast/types.js";
 
 interface ExprBase {
   type: string;
@@ -500,12 +500,12 @@ export class JsonGenerator {
       return this.ctx.emitError("JSON.stringify() requires 1 argument", expr.loc);
     }
 
-    let arg = expr.args[0];
+    const rawArg = expr.args[0];
+    const arg =
+      (rawArg as { type: string }).type === "type_assertion"
+        ? (rawArg as { type: string; expression: Expression }).expression
+        : rawArg;
     const spaces = this.getSpaces(expr);
-
-    if ((arg as { type: string }).type === "type_assertion") {
-      arg = (arg as unknown as TypeAssertionNode).expression;
-    }
 
     if (this.ctx.isStringExpression(arg)) {
       return this.stringifyString(arg, params);
@@ -763,34 +763,29 @@ export class JsonGenerator {
       const prop = obj.properties[i];
       const nameConst = this.ctx.createStringConstant(prop.key);
 
-      let propValue = prop.value;
-      if ((propValue as { type: string }).type === "type_assertion") {
-        propValue = (propValue as unknown as TypeAssertionNode).expression;
-      }
-
-      if (propValue.type === "object") {
+      if (prop.value.type === "object") {
         const childObj = this.ctx.emitCall(
           "i8*",
           "@csyyjson_obj_add_obj",
           `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}`,
         );
-        this.buildJsonProperties(propValue as unknown as ObjectNode, params, jsonDoc, childObj);
-      } else if (propValue.type === "boolean") {
-        const val = this.ctx.generateExpression(propValue, params);
+        this.buildJsonProperties(prop.value as unknown as ObjectNode, params, jsonDoc, childObj);
+      } else if (prop.value.type === "boolean") {
+        const val = this.ctx.generateExpression(prop.value, params);
         const boolI32 = this.ctx.nextTemp();
         this.ctx.emit(`${boolI32} = trunc i64 ${val} to i32`);
         this.ctx.emitCallVoid(
           "@csyyjson_obj_add_bool",
           `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i32 ${boolI32}`,
         );
-      } else if (this.ctx.isStringExpression(propValue)) {
-        const val = this.ctx.generateExpression(propValue, params);
+      } else if (this.ctx.isStringExpression(prop.value)) {
+        const val = this.ctx.generateExpression(prop.value, params);
         this.ctx.emitCallVoid(
           "@csyyjson_obj_add_str",
           `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i8* ${val}`,
         );
       } else {
-        const val = this.ctx.generateExpression(propValue, params);
+        const val = this.ctx.generateExpression(prop.value, params);
         const vt = this.ctx.getVariableType(val);
         if (vt === "i8*") {
           this.ctx.emitCallVoid(

--- a/tests/fixtures/builtins/json-stringify-mixed-vars.ts
+++ b/tests/fixtures/builtins/json-stringify-mixed-vars.ts
@@ -1,0 +1,8 @@
+// @test-description: json stringify inline object with mixed string and number variable values
+const name = "hello";
+const count = 42;
+const ts = 1234567890;
+const result = JSON.stringify({ name: name, count: count, ts: ts });
+if (result.includes("hello") && result.includes("42") && result.includes("1234567890")) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/builtins/json-stringify-type-assertion.ts
+++ b/tests/fixtures/builtins/json-stringify-type-assertion.ts
@@ -1,0 +1,8 @@
+// @test-description: json stringify inline object with type assertion does not crash
+const name = "hello";
+const count = 42;
+const ts = 1234567890;
+const result = JSON.stringify({ name: name, count: count, ts: ts } as any);
+if (result.includes("hello") && result.includes("42") && result.includes("1234567890")) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
# fix: json stringify with mixed-type variables and type assertions

## Summary

- `JSON.stringify({ ... } as any)` crashed at LLVM opt: the `as` type assertion wraps the object in a `TypeAssertionNode`, so `arg.type === "type_assertion"` instead of `"object"`, bypassing `stringifyObjectLiteral` and falling through to `stringifyNumber`. That called `generateExpression` on the whole object, bitcast the struct pointer to `i8*`, then passed it as `double` to `sprintf` — a type mismatch that `opt -O2` rejects.
- Fix: unwrap `type_assertion` nodes in `generateStringify` before dispatch, using a named `TypeAssertionNode` cast (avoids phi node metadata loss from inline `as { ... }` struct assertions); extract `generateStringifyArg()` helper.
- Two regression tests added: mixed string+number variable values, and an inline object with a type assertion.

## Test plan

- [ ] `json stringify inline object with mixed string and number variable values` passes
- [ ] `json stringify inline object with type assertion does not crash` passes
- [ ] All pre-existing JSON stringify tests still pass
