### PR TITLE
add seeded prng: Math.seedRandom() and lib/random.ts lcg

### DIFF
--- a/lib/random.ts
+++ b/lib/random.ts
@@ -1,0 +1,22 @@
+export class Random {
+  private state: number;
+
+  constructor(seed: number) {
+    this.state = seed % 4294967296.0;
+    if (this.state < 0.0) {
+      this.state = this.state + 4294967296.0;
+    }
+    if (this.state === 0.0) {
+      this.state = 1.0;
+    }
+  }
+
+  next(): number {
+    this.state = (this.state * 1664525.0 + 1013904223.0) % 4294967296.0;
+    return this.state / 4294967296.0;
+  }
+
+  nextInt(min: number, max: number): number {
+    return Math.floor(this.next() * (max - min)) + min;
+  }
+}

--- a/src/codegen/stdlib/math.ts
+++ b/src/codegen/stdlib/math.ts
@@ -53,6 +53,7 @@ export class MathGenerator {
       "cos",
       "sign",
       "random",
+      "seedRandom",
     ];
   }
 
@@ -95,6 +96,8 @@ export class MathGenerator {
         return this.generateSign(expr, params);
       case "random":
         return this.generateRandom(expr);
+      case "seedRandom":
+        return this.generateSeedRandom(expr, params);
       default:
         return this.ctx.emitError(`Unsupported Math method: ${method}`, expr.loc);
     }
@@ -214,6 +217,18 @@ export class MathGenerator {
     const result = this.ctx.nextTemp();
     this.ctx.emit(`${result} = call double @drand48()`);
     return result;
+  }
+
+  private generateSeedRandom(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length !== 1) {
+      return this.ctx.emitError("Math.seedRandom() requires 1 argument", expr.loc);
+    }
+    const seed = this.ctx.generateExpression(expr.args[0], params);
+    const dblSeed = this.ctx.ensureDouble(seed);
+    const i64Seed = this.ctx.nextTemp();
+    this.ctx.emit(`${i64Seed} = fptosi double ${dblSeed} to i64`);
+    this.ctx.emitCallVoid("@srand48", `i64 ${i64Seed}`);
+    return "0.0";
   }
 
   private generateSign(expr: MethodCallNode, params: string[]): string {

--- a/tests/fixtures/math/math-seed-random.ts
+++ b/tests/fixtures/math/math-seed-random.ts
@@ -1,0 +1,27 @@
+Math.seedRandom(42);
+const a1 = Math.random();
+const a2 = Math.random();
+
+Math.seedRandom(42);
+const b1 = Math.random();
+const b2 = Math.random();
+
+if (a1 !== b1 || a2 !== b2) {
+  console.log("FAIL: same seed produced different sequences");
+  process.exit(1);
+}
+
+Math.seedRandom(99);
+const c1 = Math.random();
+
+if (c1 === a1) {
+  console.log("FAIL: different seeds produced same first value");
+  process.exit(1);
+}
+
+if (a1 < 0 || a1 >= 1 || b1 < 0 || b1 >= 1) {
+  console.log("FAIL: values out of [0, 1) range");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/random/random-lib-basic.ts
+++ b/tests/fixtures/random/random-lib-basic.ts
@@ -1,0 +1,41 @@
+import { Random } from "../../../lib/random.js";
+
+const rng1 = new Random(12345);
+const a = rng1.next();
+const b = rng1.next();
+const c = rng1.next();
+
+if (a < 0 || a >= 1 || b < 0 || b >= 1 || c < 0 || c >= 1) {
+  console.log("FAIL: values out of [0, 1) range");
+  process.exit(1);
+}
+
+if (a === b && b === c) {
+  console.log("FAIL: all values identical");
+  process.exit(1);
+}
+
+const rng2 = new Random(12345);
+const d = rng2.next();
+const e = rng2.next();
+const f = rng2.next();
+
+if (a !== d || b !== e || c !== f) {
+  console.log("FAIL: same seed produced different sequences");
+  process.exit(1);
+}
+
+const rng3 = new Random(99999);
+const g = rng3.next();
+if (g === a) {
+  console.log("FAIL: different seeds produced same first value");
+  process.exit(1);
+}
+
+const n = rng1.nextInt(0, 10);
+if (n < 0 || n >= 10) {
+  console.log("FAIL: nextInt out of range");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

- Add `Math.seedRandom(seed)` to codegen — converts double seed to i64 and calls `srand48`, making subsequent `Math.random()` calls deterministic for a given seed
- Add `lib/random.ts` — standalone `Random` class implementing the Numerical Recipes LCG (`state = state * 1664525 + 1013904223 mod 2^32`), safe within double precision

## API

```ts
// Seed the global Math.random()
Math.seedRandom(42);
const r = Math.random(); // deterministic

// Standalone seeded RNG
import { Random } from "../lib/random.js";
const rng = new Random(12345);
rng.next();           // [0, 1)
rng.nextInt(0, 10);   // integer in [0, 10)
```

## Test plan

- [ ] `math seed random` — same seed produces same sequence, different seed produces different value
- [ ] `random lib basic` — reproducibility, range checks, `nextInt` bounds
