### PR TITLE
Worktree staged singing lighthouse

### DIFF
--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -318,3 +318,56 @@ interface MultipartPart {
   data: string;
   dataLen: number;
 }
+
+// ============================================================================
+// stdlib modules (import { ... } from "chadscript/*")
+// ============================================================================
+
+declare module "chadscript/argparse" {
+  export class ArgumentParser {
+    constructor(programName: string, description: string);
+    addFlag(name: string, shortFlag: string, help: string): void;
+    addOption(name: string, shortFlag: string, help: string, defaultVal: string): void;
+    parse(argv: string[]): number;
+    getFlag(name: string): boolean;
+    getOption(name: string): string;
+  }
+}
+
+declare module "chadscript/router" {
+  export class RouterRequest {
+    method: string;
+    path: string;
+    body: string;
+    contentType: string;
+    headers: string;
+    param(name: string): string;
+    header(name: string): string;
+  }
+
+  export class Context {
+    req: RouterRequest;
+    status(code: number): Context;
+    header(name: string, value: string): Context;
+    text(body: string): HttpResponse;
+    json(data: string): HttpResponse;
+    html(body: string): HttpResponse;
+    redirect(url: string): HttpResponse;
+  }
+
+  export class Router {
+    get(pattern: string, handler: (c: Context) => HttpResponse): void;
+    post(pattern: string, handler: (c: Context) => HttpResponse): void;
+    put(pattern: string, handler: (c: Context) => HttpResponse): void;
+    delete(pattern: string, handler: (c: Context) => HttpResponse): void;
+    all(pattern: string, handler: (c: Context) => HttpResponse): void;
+    notFound(handler: (c: Context) => HttpResponse): void;
+    handle(req: HttpRequest): HttpResponse;
+  }
+}
+
+declare module "chadscript/http-utils" {
+  export function getHeader(headersRaw: string, name: string): string;
+  export function parseQueryString(qs: string): Map<string, string>;
+  export function parseCookies(cookieHeader: string): Map<string, string>;
+}

--- a/examples/http-server.ts
+++ b/examples/http-server.ts
@@ -79,8 +79,4 @@ console.log("  curl -X POST -d 'hello' http://localhost:" + port + "/echo");
 console.log("  curl -H 'Authorization: Bearer token' http://localhost:" + port + "/headers");
 console.log("");
 
-function handleRequest(req: HttpRequest): HttpResponse {
-  return app.handle(req);
-}
-
-httpServe(port, handleRequest);
+httpServe(port, (req: HttpRequest) => app.handle(req));

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2449,22 +2449,42 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       let hasHeaders = false;
       let hasBodyLen = false;
       const handlerName = this.httpHandlers[0];
+      let handlerReturnType: string | null = null;
       for (let fi = 0; fi < this.ast.functions.length; fi++) {
         const func = this.ast.functions[fi];
         if (func && func.name === handlerName && func.returnType) {
-          const retIface = this.getInterfaceFromAST(func.returnType);
-          if (retIface) {
-            const fields = (retIface as { fields: { name: string }[] }).fields;
-            for (let fj = 0; fj < fields.length; fj++) {
-              if (fields[fj].name === "headers") {
-                hasHeaders = true;
-              }
-              if (fields[fj].name === "bodyLen") {
-                hasBodyLen = true;
-              }
+          handlerReturnType = func.returnType;
+          break;
+        }
+      }
+      if (!handlerReturnType) {
+        const liftedFuncs = this.exprGen.arrowFunctionGen.getLiftedFunctions();
+        for (let fi = 0; fi < liftedFuncs.length; fi++) {
+          const func = liftedFuncs[fi];
+          const lf = func as {
+            name: string;
+            params: string[];
+            body: BlockStatement;
+            returnType?: string;
+          };
+          if (lf.name === handlerName && lf.returnType) {
+            handlerReturnType = lf.returnType;
+            break;
+          }
+        }
+      }
+      if (handlerReturnType) {
+        const retIface = this.getInterfaceFromAST(handlerReturnType);
+        if (retIface) {
+          const fields = (retIface as { fields: { name: string }[] }).fields;
+          for (let fj = 0; fj < fields.length; fj++) {
+            if (fields[fj].name === "headers") {
+              hasHeaders = true;
+            }
+            if (fields[fj].name === "bodyLen") {
+              hasBodyLen = true;
             }
           }
-          break;
         }
       }
 
@@ -3558,6 +3578,30 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     return ir;
   }
 
+  private inferArrowHandlerReturnType(arrow: ArrowFunctionNode): string | null {
+    const body = arrow.body as { type: string };
+    let expr: { type: string } | null = null;
+    if (body.type === "block") {
+      const stmts = (arrow.body as { statements: { type: string; value?: { type: string } }[] })
+        .statements;
+      for (let i = 0; i < stmts.length; i++) {
+        if (stmts[i].type === "return" && stmts[i].value) {
+          expr = stmts[i].value!;
+          break;
+        }
+      }
+    } else {
+      expr = body;
+    }
+    if (!expr || expr.type !== "method_call") return null;
+    const mc = expr as { type: string; object: Expression; method: string };
+    if ((mc.object as { type: string }).type !== "variable") return null;
+    const varName = (mc.object as VariableNode).name;
+    const className = this.symbolTable.getConcreteClass(varName);
+    if (!className) return null;
+    return this.getMethodReturnType(className, mc.method);
+  }
+
   // Generate HTTP server - creates a TCP server that parses HTTP and calls handler
   public generateHttpServe(expr: CallNode, params: string[]): string {
     if (expr.args.length < 2) {
@@ -3569,10 +3613,22 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
     const portValue = this.generateExpression(expr.args[0], params);
     const handlerArg = expr.args[1];
-    if (handlerArg.type !== "variable") {
-      return this.emitError("httpServe() handler must be a function reference", expr.loc);
+    let handlerName: string;
+    if (handlerArg.type === "variable") {
+      handlerName = (handlerArg as VariableNode).name;
+    } else if (handlerArg.type === "arrow_function") {
+      const arrowExpr = handlerArg as ArrowFunctionNode;
+      const returnTypeName = this.inferArrowHandlerReturnType(arrowExpr);
+      handlerName = this.exprGen.arrowFunctionGen.generateArrowFunction(arrowExpr, params, {
+        paramTypes: ["i8*"],
+        returnType: returnTypeName || "i8*",
+      });
+    } else {
+      return this.emitError(
+        "httpServe() handler must be a function reference or arrow function",
+        expr.loc,
+      );
     }
-    const handlerName = (handlerArg as VariableNode).name;
 
     // Track handler for http server event handler generation
     this.httpHandlers.push(handlerName);


### PR DESCRIPTION
# httpServe Ergonomics: Support Inline Arrow Functions

## Summary

Allow passing arrow functions directly to `httpServe()` instead of requiring a pre-declared named function. Users can now write:

```ts
httpServe(port, (req: HttpRequest) => app.handle(req));
```

Instead of:

```ts
function handleRequest(req: HttpRequest): HttpResponse {
  return app.handle(req);
}
httpServe(port, handleRequest);
```

## Motivation

The pre-declared function pattern is needless boilerplate. Other async/callback-based APIs in ChadScript (Router, Map handlers, etc.) already support inline arrow functions — `httpServe` was the odd one out.

## Implementation

### Changes to `src/codegen/llvm-generator.ts`

1. **`generateHttpServe` method**: Now accepts both:
   - `variable` nodes (existing behavior): `httpServe(port, myHandler)`
   - `arrow_function` nodes (new): `httpServe(port, (req) => app.handle(req))`

2. **New helper `inferArrowHandlerReturnType`**: Analyzes the arrow function body to determine its TypeScript return type:
   - If body is a method call (e.g., `app.handle(req)`), looks up the method's return type via `symbolTable.getConcreteClass()` + `getMethodReturnType()`
   - Returns type name like `"HttpResponse"` for proper interface detection later
   - Falls back to `"i8*"` (opaque pointer) if inference fails

3. **Arrow function lifting**: When an arrow is passed, it's lifted to a top-level function via `arrowFunctionGen.generateArrowFunction()` with type hints:
   - `paramTypes: ["i8*"]` — handler param is always `HttpRequest` (passed as pointer)
   - `returnType` — inferred from body, or `"i8*"` as fallback

4. **Enhanced `hasHeaders`/`hasBodyLen` detection**: Previously only searched `ast.functions` for the handler. Now also searches `liftedFunctions` to correctly identify interface fields (e.g., `headers`) on arrow function handlers.

### Changes to `chadscript.d.ts`

Added three `declare module` blocks so TypeScript knows about imports from `chadscript/*`:

```ts
declare module "chadscript/argparse" { ... }
declare module "chadscript/router" { ... }
declare module "chadscript/http-utils" { ... }
```

Provides IDE autocomplete and type checking for `import { Router } from "chadscript/router"` etc.

### Changes to `examples/http-server.ts`

Simplified from a pre-declared wrapper function to the idiomatic inline form.

## How It Works

1. Parser creates `ArrowFunctionNode` from `(req: HttpRequest) => app.handle(req)`
2. `generateHttpServe` detects it's an arrow function
3. `inferArrowHandlerReturnType` walks the body:
   - Finds method call `app.handle(req)`
   - Looks up `Router.handle()` return type → `"HttpResponse"`
4. Arrow is lifted to a top-level function `__lambda_0` with `returnType: "HttpResponse"`
5. Lifted function is added to `liftedFunctions[]`
6. Later, `hasHeaders`/`hasBodyLen` detection finds the lifted function and correctly identifies that `HttpResponse` has headers
7. Wrapper `@__lws_http_handler` is generated with correct struct field access

## Error Handling

Non-function arguments are rejected with a clear error:

```
error: httpServe() handler must be a function reference or arrow function
```

## Testing

- Updated `examples/http-server.ts` compiles to native binary successfully
- All existing tests pass (pre-existing failures unaffected)
- Arrow function handler correctly reads/writes `HttpResponse` headers via the C bridge

## Benefits

- **Idiomatic**: Matches JavaScript conventions (e.g., `Express.js`, `http.createServer()`)
- **Less boilerplate**: No wrapper function needed
- **Consistent**: Router already supports inline handlers
