### PR TITLE
consolidate http apis into chadscript/http module

### DIFF
--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -241,16 +241,6 @@ interface WsEvent {
   connId: string;
 }
 
-declare function httpServe(port: number, handler: (req: HttpRequest) => HttpResponse): void;
-declare function httpServe(
-  port: number,
-  handler: (req: HttpRequest) => HttpResponse,
-  wsHandler: (event: WsEvent) => string,
-): void;
-
-declare function wsBroadcast(message: string): void;
-declare function wsSend(connId: string, message: string): void;
-
 // ============================================================================
 // Async / Timers
 // ============================================================================
@@ -308,7 +298,7 @@ declare namespace ChadScript {
   function embedFile(path: string): string;
   function embedDir(path: string): void;
   function getEmbeddedFile(key: string): string;
-  function parseMultipart(req: HttpRequest): MultipartPart[];
+  function serveEmbedded(req: HttpRequest): HttpResponse;
 }
 
 interface MultipartPart {
@@ -366,8 +356,17 @@ declare module "chadscript/router" {
   }
 }
 
-declare module "chadscript/http-utils" {
+declare module "chadscript/http" {
   export function getHeader(headersRaw: string, name: string): string;
   export function parseQueryString(qs: string): Map<string, string>;
   export function parseCookies(cookieHeader: string): Map<string, string>;
+  export function httpServe(port: number, handler: (req: HttpRequest) => HttpResponse): void;
+  export function httpServe(
+    port: number,
+    handler: (req: HttpRequest) => HttpResponse,
+    wsHandler: (event: WsEvent) => string,
+  ): void;
+  export function wsBroadcast(message: string): void;
+  export function wsSend(connId: string, message: string): void;
+  export function parseMultipart(req: HttpRequest): MultipartPart[];
 }

--- a/docs/stdlib/http-server.md
+++ b/docs/stdlib/http-server.md
@@ -2,11 +2,19 @@
 
 Built-in HTTP server with websocket support compiled to native code via libuv TCP + picohttpparser.
 
+All HTTP server APIs are imported from `chadscript/http`:
+
+```typescript
+import { httpServe, wsBroadcast, wsSend, parseMultipart,
+         getHeader, parseQueryString, parseCookies } from "chadscript/http";
+```
+
 ## Router (recommended)
 
 For most servers, use the `Router` class from `chadscript/router`. It provides an Express/Hono-style API with URL parameter extraction, method matching, and chainable response helpers.
 
 ```typescript
+import { httpServe } from "chadscript/http";
 import { Router, Context } from "chadscript/router";
 
 const app = new Router();
@@ -86,10 +94,10 @@ app.get("/example", (c: Context) => {
 
 ### HTTP utility functions
 
-`chadscript/http-utils` provides helpers for parsing common request data:
+`chadscript/http` includes helpers for parsing common request data:
 
 ```typescript
-import { getHeader, parseQueryString, parseCookies } from "chadscript/http-utils";
+import { getHeader, parseQueryString, parseCookies } from "chadscript/http";
 
 // Parse a single request header by name (case-insensitive)
 const auth = getHeader(req.headers, "Authorization"); // "Bearer abc"
@@ -108,11 +116,11 @@ cookies.get("session"); // "abc123"
 
 ## `httpServe(port, handler)`
 
-## `httpServe(port, handler)`
-
 Start an HTTP server on the given port. The handler function receives an `HttpRequest` and returns an `HttpResponse`.
 
 ```typescript
+import { httpServe } from "chadscript/http";
+
 function handleRequest(req: HttpRequest): HttpResponse {
   if (req.path == "/") {
     return { status: 200, body: "Hello!", headers: "" };
@@ -130,11 +138,7 @@ Start an HTTP server with WebSocket support. The third argument is a WebSocket h
 Any HTTP request with an `Upgrade: websocket` header is automatically upgraded when a wsHandler is registered.
 
 ```typescript
-interface WsEvent {
-  data: string;
-  event: string;  // "open", "message", "close"
-  connId: string; // hex pointer identifying this connection
-}
+import { httpServe, wsBroadcast } from "chadscript/http";
 
 function wsHandler(event: WsEvent): string {
   if (event.event == "message") {
@@ -152,6 +156,8 @@ httpServe(3000, handleRequest, wsHandler);
 Send a message to all connected WebSocket clients. Only available when a wsHandler is registered.
 
 ```typescript
+import { wsBroadcast } from "chadscript/http";
+
 wsBroadcast("hello everyone");
 ```
 
@@ -160,6 +166,8 @@ wsBroadcast("hello everyone");
 Send a message to a specific WebSocket connection identified by its `connId`. The `connId` is available on every `WsEvent`.
 
 ```typescript
+import { wsSend } from "chadscript/http";
+
 function wsHandler(event: WsEvent): string {
   if (event.event == "message") {
     wsSend(event.connId, "echo: " + event.data);  // reply to sender only
@@ -202,6 +210,8 @@ If `headers` contains a `Content-Type:` line, it overrides the auto-detected con
 A full HTTP server with routing:
 
 ```typescript
+import { httpServe } from "chadscript/http";
+
 function homeHandler(req: HttpRequest): HttpResponse {
   return { status: 200, body: "<h1>Hello from ChadScript</h1>", headers: "" };
 }
@@ -233,25 +243,7 @@ $ curl http://localhost:3000/json
 A chat server with HTTP homepage and WebSocket messaging:
 
 ```typescript
-interface WsEvent {
-  data: string;
-  event: string;
-  connId: string;
-}
-
-interface HttpRequest {
-  method: string;
-  path: string;
-  body: string;
-  contentType: string;
-  headers: string;
-}
-
-interface HttpResponse {
-  status: number;
-  body: string;
-  headers: string;
-}
+import { httpServe, wsBroadcast } from "chadscript/http";
 
 function wsHandler(event: WsEvent): string {
   if (event.event == "message") {
@@ -297,9 +289,11 @@ Multiple headers are separated by `\n`. The server normalizes them to `\r\n` in 
 
 ## Multipart Form Data
 
-Parse `multipart/form-data` request bodies (file uploads, form submissions) using `ChadScript.parseMultipart()`:
+Parse `multipart/form-data` request bodies (file uploads, form submissions) using `parseMultipart()`:
 
 ```typescript
+import { httpServe, parseMultipart } from "chadscript/http";
+
 interface MultipartPart {
   name: string;        // field name
   filename: string;    // original filename (empty string if not a file upload)
@@ -310,7 +304,7 @@ interface MultipartPart {
 
 function handleRequest(req: HttpRequest): HttpResponse {
   if (req.method == "POST" && req.path == "/upload") {
-    const parts: MultipartPart[] = ChadScript.parseMultipart(req);
+    const parts: MultipartPart[] = parseMultipart(req);
 
     for (let i = 0; i < parts.length; i++) {
       console.log("field: " + parts[i].name);

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -1,10 +1,36 @@
 # Standard Library
 
-Everything is built in. No `npm install`, no `node_modules`, no bundler. All APIs are available as globals — no imports needed.
+Everything is built in. No `npm install`, no `node_modules`, no bundler. All APIs compile to native code — no runtime overhead.
 
-API names match Node.js where applicable (`fs.readFileSync`, `process.argv`, `path.join`, `console.log`, etc.), so the code you write looks like standard TypeScript. The main difference is that these APIs compile to native code instead of calling into V8.
+API names match Node.js where applicable (`fs.readFileSync`, `process.argv`, `path.join`, `console.log`, etc.), so the code you write looks like standard TypeScript.
 
 Browse the sidebar for the full API reference.
+
+## Globals vs. Modules
+
+Most APIs are available as globals with no import required:
+
+```typescript
+console.log("hello");
+const data = fs.readFileSync("file.txt");
+const hash = crypto.createHash("sha256");
+```
+
+Some APIs live in named stdlib modules and must be imported:
+
+| Module | Contents |
+|--------|----------|
+| `chadscript/http` | `httpServe`, `wsBroadcast`, `wsSend`, `parseMultipart`, `getHeader`, `parseQueryString`, `parseCookies` |
+| `chadscript/router` | `Router`, `Context`, `RouterRequest` |
+| `chadscript/argparse` | `ArgumentParser` |
+
+```typescript
+import { httpServe, getHeader } from "chadscript/http";
+import { Router, Context } from "chadscript/router";
+import { ArgumentParser } from "chadscript/argparse";
+```
+
+The `chadscript/` prefix works like Node's `node:` prefix — unambiguous and collision-free.
 
 ## Editor Support
 

--- a/examples/hackernews/app.ts
+++ b/examples/hackernews/app.ts
@@ -1,5 +1,6 @@
 // Hacker News Clone - full-stack app with SQLite, embedded files, and a JSON API
 import { ArgumentParser } from "chadscript/argparse";
+import { httpServe } from "chadscript/http";
 
 const parser = new ArgumentParser(
   "hackernews",

--- a/examples/http-server.ts
+++ b/examples/http-server.ts
@@ -1,6 +1,6 @@
 import { ArgumentParser } from "chadscript/argparse";
 import { Router, Context } from "chadscript/router";
-import { getHeader, parseQueryString } from "chadscript/http-utils";
+import { httpServe, getHeader, parseQueryString } from "chadscript/http";
 
 const parser = new ArgumentParser("http-server", "HTTP server with Router API");
 parser.addOption("port", "p", "Port to listen on", "3000");

--- a/examples/websocket/app.ts
+++ b/examples/websocket/app.ts
@@ -1,5 +1,6 @@
 // WebSocket Chat - real-time chat with embedded HTML/CSS served statically
 import { ArgumentParser } from "chadscript/argparse";
+import { httpServe, wsBroadcast } from "chadscript/http";
 
 const parser = new ArgumentParser("websocket-chat", "Real-time WebSocket chat server");
 parser.addOption("port", "p", "Port to listen on (0 = auto)", "0");

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -45,3 +45,10 @@ export function parseCookies(cookieHeader: string): Map<string, string> {
   }
   return result;
 }
+
+export function httpServe(port: number, handler: (req: HttpRequest) => HttpResponse): void {}
+export function wsBroadcast(message: string): void {}
+export function wsSend(connId: string, message: string): void {}
+export function parseMultipart(req: HttpRequest): MultipartPart[] {
+  return [];
+}

--- a/lib/router.ts
+++ b/lib/router.ts
@@ -1,4 +1,4 @@
-import { getHeader } from "chadscript/http-utils";
+import { getHeader } from "chadscript/http";
 
 interface HttpRequest {
   method: string;

--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -17,7 +17,7 @@ import {
 const dtsContent = ChadScript.embedFile("../chadscript.d.ts");
 registerStdlib("router.ts", ChadScript.embedFile("../lib/router.ts"));
 registerStdlib("argparse.ts", ChadScript.embedFile("../lib/argparse.ts"));
-registerStdlib("http-utils.ts", ChadScript.embedFile("../lib/http-utils.ts"));
+registerStdlib("http.ts", ChadScript.embedFile("../lib/http.ts"));
 import { ArgumentParser } from "chadscript/argparse";
 
 declare const fs: {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -111,6 +111,10 @@ export class CallExpressionGenerator {
       return this.ctx.generateWsSend(expr, params);
     }
 
+    if (expr.name === "parseMultipart") {
+      return this.ctx.generateParseMultipart(expr, params);
+    }
+
     // Handle setTimeout() - libuv timer (one-shot)
     if (expr.name === "setTimeout") {
       return this.generateSetTimeout(expr, params);

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -480,8 +480,6 @@ export class MethodCallGenerator {
         return this.ctx.embedGen.generateGetEmbeddedFileAsUint8Array(expr, params);
       } else if (method === "serveEmbedded") {
         return this.ctx.embedGen.generateServeEmbedded(expr, params);
-      } else if (method === "parseMultipart") {
-        return this.handleParseMultipart(expr, params);
       }
       return this.ctx.emitError(`ChadScript.${method}() is not a supported method`, expr.loc);
     }
@@ -1462,60 +1460,5 @@ export class MethodCallGenerator {
       return true;
     }
     return false;
-  }
-
-  /**
-   * Handle ChadScript.parseMultipart(req) — extracts content_type, body, and
-   * body_len from the request struct and calls the C bridge parser.
-   * Returns %ObjectArray* of MultipartPart interface structs.
-   */
-  private handleParseMultipart(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length < 1) {
-      return this.ctx.emitError(
-        "ChadScript.parseMultipart() requires a request argument",
-        expr.loc,
-      );
-    }
-
-    // Mark that we use the multipart parser (for declaration emission)
-    this.ctx.setUsesMultipart(true);
-
-    const reqValue = this.ctx.generateExpression(expr.args[0], params);
-    const reqType = "%struct.lws_bridge_request";
-
-    // Cast i8* request to struct pointer
-    const reqPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${reqPtr} = bitcast i8* ${reqValue} to ${reqType}*`);
-
-    // Load content_type (field 3)
-    const ctGep = this.ctx.nextTemp();
-    this.ctx.emit(`${ctGep} = getelementptr ${reqType}, ${reqType}* ${reqPtr}, i32 0, i32 3`);
-    const ctVal = this.ctx.nextTemp();
-    this.ctx.emit(`${ctVal} = load i8*, i8** ${ctGep}`);
-
-    // Load body (field 2)
-    const bodyGep = this.ctx.nextTemp();
-    this.ctx.emit(`${bodyGep} = getelementptr ${reqType}, ${reqType}* ${reqPtr}, i32 0, i32 2`);
-    const bodyVal = this.ctx.nextTemp();
-    this.ctx.emit(`${bodyVal} = load i8*, i8** ${bodyGep}`);
-
-    // Load body_len (field 5)
-    const lenGep = this.ctx.nextTemp();
-    this.ctx.emit(`${lenGep} = getelementptr ${reqType}, ${reqType}* ${reqPtr}, i32 0, i32 5`);
-    const lenVal = this.ctx.nextTemp();
-    this.ctx.emit(`${lenVal} = load i64, i64* ${lenGep}`);
-
-    // Call C bridge: cs_parse_multipart_to_array(content_type, body, body_len) -> i8*
-    const rawResult = this.ctx.nextTemp();
-    this.ctx.emit(
-      `${rawResult} = call i8* @cs_parse_multipart_to_array(i8* ${ctVal}, i8* ${bodyVal}, i64 ${lenVal})`,
-    );
-
-    // Cast to %ObjectArray*
-    const objArr = this.ctx.nextTemp();
-    this.ctx.emit(`${objArr} = bitcast i8* ${rawResult} to %ObjectArray*`);
-    this.ctx.setVariableType(objArr, "%ObjectArray*");
-
-    return objArr;
   }
 }

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -808,6 +808,8 @@ export interface IGeneratorContext {
    */
   generateWsSend(expr: CallNode, params: string[]): string;
 
+  generateParseMultipart(expr: CallNode, params: string[]): string;
+
   /**
    * Look up an interface definition by name from the AST
    */
@@ -1703,6 +1705,10 @@ export class MockGeneratorContext implements IGeneratorContext {
 
   generateWsSend(_expr: CallNode, _params: string[]): string {
     return "0.0";
+  }
+
+  generateParseMultipart(_expr: CallNode, _params: string[]): string {
+    return this.nextTemp();
   }
 
   getInterfaceFromAST(

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -3684,6 +3684,37 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     return "0.0";
   }
 
+  public generateParseMultipart(expr: CallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.emitError("parseMultipart() requires a request argument", expr.loc);
+    }
+    this.setUsesMultipart(true);
+    const reqValue = this.generateExpression(expr.args[0], params);
+    const reqType = "%struct.lws_bridge_request";
+    const reqPtr = this.nextTemp();
+    this.emit(`${reqPtr} = bitcast i8* ${reqValue} to ${reqType}*`);
+    const ctGep = this.nextTemp();
+    this.emit(`${ctGep} = getelementptr ${reqType}, ${reqType}* ${reqPtr}, i32 0, i32 3`);
+    const ctVal = this.nextTemp();
+    this.emit(`${ctVal} = load i8*, i8** ${ctGep}`);
+    const bodyGep = this.nextTemp();
+    this.emit(`${bodyGep} = getelementptr ${reqType}, ${reqType}* ${reqPtr}, i32 0, i32 2`);
+    const bodyVal = this.nextTemp();
+    this.emit(`${bodyVal} = load i8*, i8** ${bodyGep}`);
+    const lenGep = this.nextTemp();
+    this.emit(`${lenGep} = getelementptr ${reqType}, ${reqType}* ${reqPtr}, i32 0, i32 5`);
+    const lenVal = this.nextTemp();
+    this.emit(`${lenVal} = load i64, i64* ${lenGep}`);
+    const rawResult = this.nextTemp();
+    this.emit(
+      `${rawResult} = call i8* @cs_parse_multipart_to_array(i8* ${ctVal}, i8* ${bodyVal}, i64 ${lenVal})`,
+    );
+    const objArr = this.nextTemp();
+    this.emit(`${objArr} = bitcast i8* ${rawResult} to %ObjectArray*`);
+    this.setVariableType(objArr, "%ObjectArray*");
+    return objArr;
+  }
+
   public getInterfaceFromAST(
     name: string,
   ): { name: string; fields: { name: string; type: string }[] } | null {

--- a/tests/fixtures/network/http-headers-test.ts
+++ b/tests/fixtures/network/http-headers-test.ts
@@ -1,6 +1,7 @@
 // @test-skip
 // HTTP headers fixture used by http-headers.test.ts (needs external test orchestration)
 // Tests: custom response headers, Content-Type override, request header access
+import { httpServe } from "chadscript/http";
 
 interface Request {
   method: string;

--- a/tests/fixtures/network/http-route-isolation-test.ts
+++ b/tests/fixtures/network/http-route-isolation-test.ts
@@ -1,5 +1,6 @@
 // @test-skip
 // HTTP route isolation fixture used by http-routes.test.ts (needs external test orchestration)
+import { httpServe } from "chadscript/http";
 
 interface Request {
   method: string;

--- a/tests/fixtures/network/http-server-test.ts
+++ b/tests/fixtures/network/http-server-test.ts
@@ -1,5 +1,6 @@
 // @test-skip
 // HTTP server fixture used by network.test.ts (needs external test orchestration)
+import { httpServe } from "chadscript/http";
 
 interface Request {
   method: string;

--- a/tests/fixtures/network/multipart-test.ts
+++ b/tests/fixtures/network/multipart-test.ts
@@ -1,6 +1,7 @@
 // @test-skip
 // Multipart form-data parser test server — used by multipart.test.ts
-// Tests ChadScript.parseMultipart(req) for field/file extraction
+// Tests parseMultipart(req) for field/file extraction
+import { httpServe, parseMultipart } from "chadscript/http";
 
 interface Request {
   method: string;
@@ -26,7 +27,7 @@ interface MultipartPart {
 
 function handleRequest(req: Request): Response {
   if (req.path == "/upload" && req.method == "POST") {
-    const parts: MultipartPart[] = ChadScript.parseMultipart(req);
+    const parts: MultipartPart[] = parseMultipart(req);
     let result = "count=" + parts.length.toString();
 
     for (let i = 0; i < parts.length; i++) {


### PR DESCRIPTION
- create lib/http.ts with getHeader, parseQueryString, parseCookies, plus stubs for httpServe, wsBroadcast, wsSend, parseMultipart
- delete lib/http-utils.ts
- move parseMultipart codegen from ChadScript.parseMultipart (method-calls.ts) to standalone parseMultipart() call (calls.ts via llvm-generator.ts)
- remove global httpServe/wsBroadcast/wsSend declarations from chadscript.d.ts
- remove ChadScript.parseMultipart from chadscript.d.ts
- add chadscript/http module declaration with all 7 functions
- update lib/router.ts, examples, and test fixtures to import from chadscript/http