### PR TITLE
add named type assertion checker to catch wrong-indexed subset types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,15 @@
 # ChadScript Rules
 
+## Worktree Rule
+
+**ALWAYS work on a git worktree and branch. NEVER modify files directly on `main`.** `main` must always remain clean. Every piece of work — features, bug fixes, docs, even CLAUDE.md edits — must happen on a dedicated branch in a worktree:
+
+```bash
+git worktree add .worktrees/<name> -b <branch-name>
+cd .worktrees/<name>
+# do work, commit, then open a PR
+```
+
 ## Testing & Commit Workflow
 
 After completing each todo:

--- a/src/semantic/type-assertion-checker.ts
+++ b/src/semantic/type-assertion-checker.ts
@@ -133,6 +133,7 @@ class TypeAssertionChecker {
     if (etype === "type_assertion") {
       const ta = expr as TypeAssertionNode;
       this.validateInlineAssertion(ta);
+      this.validateNamedAssertion(ta);
       this.checkExpr(ta.expression);
     } else if (etype === "binary") {
       // BinaryNode: { type, op, left, right }
@@ -341,6 +342,144 @@ class TypeAssertionChecker {
 
     if (anyMatchingInterface && !anyValidPrefix && bestMatchIface !== null) {
       this.reportError(ta, bestMatchIface, bestMatchFields!, assertedNames, bestMatchReason!);
+    }
+  }
+
+  private validateNamedAssertion(ta: TypeAssertionNode): void {
+    const assertedType = ta.assertedType;
+    if (assertedType.startsWith("{")) return;
+
+    const innerBase = ta.expression as { type: string };
+    if (innerBase.type === "type_assertion") {
+      const inner = ta.expression as TypeAssertionNode;
+      if (inner.assertedType === "unknown" || inner.assertedType === "any") return;
+    }
+
+    const tiface = this.getInterface(assertedType);
+    if (!tiface) return;
+
+    const tFields = this.getAllFields(tiface);
+    const reqNames: string[] = [];
+    const reqIdx: number[] = [];
+    for (let i = 0; i < tFields.length; i++) {
+      const f = tFields[i] as InterfaceField;
+      if (!f.name.endsWith("?")) {
+        reqNames.push(f.name);
+        reqIdx.push(i);
+      }
+    }
+    if (reqNames.length < 2) return;
+    if (reqNames[0] === "type") return;
+
+    if (!this.ast.interfaces) return;
+
+    let anyMismatch = false;
+    let anyValid = false;
+    let mismatchIface: InterfaceDeclaration | null = null;
+    let mismatchReason = "";
+
+    for (let i = 0; i < this.ast.interfaces.length; i++) {
+      const uIface = this.ast.interfaces[i] as InterfaceDeclaration;
+      if (uIface.name === assertedType) continue;
+
+      const uFields = this.getAllFields(uIface);
+
+      let allFound = true;
+      for (let j = 0; j < reqNames.length; j++) {
+        let found = false;
+        for (let k = 0; k < uFields.length; k++) {
+          if (this.stripOpt((uFields[k] as InterfaceField).name) === reqNames[j]) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          allFound = false;
+          break;
+        }
+      }
+      if (!allFound) continue;
+
+      let orderOk = true;
+      let nonLastMismatch = false;
+      let reason = "";
+      for (let j = 0; j < reqNames.length; j++) {
+        let uIdx = -1;
+        for (let k = 0; k < uFields.length; k++) {
+          if (this.stripOpt((uFields[k] as InterfaceField).name) === reqNames[j]) {
+            uIdx = k;
+            break;
+          }
+        }
+        if (uIdx !== reqIdx[j]) {
+          orderOk = false;
+          const offset = uIdx >= 0 ? uIdx - reqIdx[j] : -2;
+          if (j < reqNames.length - 1 && (offset > 1 || offset < -1)) {
+            nonLastMismatch = true;
+            reason =
+              "field '" +
+              reqNames[j] +
+              "' is at index " +
+              reqIdx[j] +
+              " in '" +
+              assertedType +
+              "' but index " +
+              uIdx +
+              " in '" +
+              uIface.name +
+              "'";
+          }
+          break;
+        }
+      }
+
+      if (orderOk) {
+        anyValid = true;
+        break;
+      } else if (nonLastMismatch && mismatchIface === null) {
+        anyMismatch = true;
+        mismatchIface = uIface;
+        mismatchReason = reason;
+      }
+    }
+
+    if (anyMismatch && !anyValid && mismatchIface !== null) {
+      let msg = "";
+      if (ta.loc) {
+        const file = ta.loc.file || "<input>";
+        msg += file + ":" + ta.loc.line + ":" + (ta.loc.column + 1) + ": error: ";
+      } else {
+        msg += "error: ";
+      }
+      msg +=
+        "named type assertion '" +
+        assertedType +
+        "' has wrong field indices relative to '" +
+        mismatchIface.name +
+        "': " +
+        mismatchReason +
+        "\n";
+      const tNames: string[] = [];
+      for (let i = 0; i < tFields.length; i++) {
+        tNames.push(this.stripOpt((tFields[i] as InterfaceField).name));
+      }
+      msg += "  asserted type '" + assertedType + "': { " + tNames.join("; ") + " }\n";
+      const uF = this.getAllFields(mismatchIface);
+      const uNames: string[] = [];
+      for (let i = 0; i < uF.length; i++) {
+        uNames.push((uF[i] as InterfaceField).name);
+      }
+      msg += "  interface '" + mismatchIface.name + "': { " + uNames.join("; ") + " }\n";
+      msg +=
+        "  note: GEP indices in native code are determined by field position in the asserted type\n";
+      msg +=
+        "  hint: '" +
+        assertedType +
+        "' fields must appear at the same positions as in '" +
+        mismatchIface.name +
+        "'\n";
+      console.error(msg);
+      process.exit(1);
     }
   }
 

--- a/src/semantic/type-assertion-checker.ts
+++ b/src/semantic/type-assertion-checker.ts
@@ -410,9 +410,9 @@ class TypeAssertionChecker {
       let badReason = "";
       for (let j = 0; j < tIndices.length; j++) {
         if (tIndices[j] !== uIndices[j]) {
+          orderOk = false;
           const diff = uIndices[j] - tIndices[j];
           if (diff > 1 || diff < -1) {
-            orderOk = false;
             badReason =
               "field '" +
               reqNames[j] +

--- a/src/semantic/type-assertion-checker.ts
+++ b/src/semantic/type-assertion-checker.ts
@@ -360,22 +360,17 @@ class TypeAssertionChecker {
 
     const tFields = this.getAllFields(tiface);
     const reqNames: string[] = [];
-    const reqIdx: number[] = [];
     for (let i = 0; i < tFields.length; i++) {
       const f = tFields[i] as InterfaceField;
-      if (!f.name.endsWith("?")) {
-        reqNames.push(f.name);
-        reqIdx.push(i);
-      }
+      if (!f.name.endsWith("?")) reqNames.push(this.stripOpt(f.name));
     }
     if (reqNames.length < 2) return;
     if (reqNames[0] === "type") return;
-
     if (!this.ast.interfaces) return;
 
-    let anyMismatch = false;
     let anyValid = false;
-    let mismatchIface: InterfaceDeclaration | null = null;
+    let anyMismatch = false;
+    let mismatchIfaceName = "";
     let mismatchReason = "";
 
     for (let i = 0; i < this.ast.interfaces.length; i++) {
@@ -384,47 +379,49 @@ class TypeAssertionChecker {
 
       const uFields = this.getAllFields(uIface);
 
+      // Build parallel index arrays: tIndices[j] = T-GEP-index, uIndices[j] = U-GEP-index
+      // for the j-th required (non-optional) T-field. Both are pushed as doubles (number[]).
+      const tIndices: number[] = [];
+      const uIndices: number[] = [];
       let allFound = true;
-      for (let j = 0; j < reqNames.length; j++) {
-        let found = false;
-        for (let k = 0; k < uFields.length; k++) {
-          if (this.stripOpt((uFields[k] as InterfaceField).name) === reqNames[j]) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          allFound = false;
-          break;
-        }
-      }
-      if (!allFound) continue;
-
-      let orderOk = true;
-      let nonLastMismatch = false;
-      let reason = "";
-      for (let j = 0; j < reqNames.length; j++) {
+      for (let ti = 0; ti < tFields.length; ti++) {
+        const tf = tFields[ti] as InterfaceField;
+        if (tf.name.endsWith("?")) continue;
+        const reqName = this.stripOpt(tf.name);
         let uIdx = -1;
         for (let k = 0; k < uFields.length; k++) {
-          if (this.stripOpt((uFields[k] as InterfaceField).name) === reqNames[j]) {
+          if (this.stripOpt((uFields[k] as InterfaceField).name) === reqName) {
             uIdx = k;
             break;
           }
         }
-        if (uIdx !== reqIdx[j]) {
-          orderOk = false;
-          const offset = uIdx >= 0 ? uIdx - reqIdx[j] : -2;
-          if (j < reqNames.length - 1 && (offset > 1 || offset < -1)) {
-            nonLastMismatch = true;
-            reason =
+        if (uIdx === -1) {
+          allFound = false;
+          break;
+        }
+        tIndices.push(ti);
+        uIndices.push(uIdx);
+      }
+      if (!allFound) continue;
+      if (tIndices.length < 2) continue;
+
+      // Check T-GEP-index === U-GEP-index for each required field (both arrays are double[]).
+      let orderOk = true;
+      let badReason = "";
+      for (let j = 0; j < tIndices.length; j++) {
+        if (tIndices[j] !== uIndices[j]) {
+          const diff = uIndices[j] - tIndices[j];
+          if (diff > 1 || diff < -1) {
+            orderOk = false;
+            badReason =
               "field '" +
               reqNames[j] +
               "' is at index " +
-              reqIdx[j] +
+              tIndices[j] +
               " in '" +
               assertedType +
               "' but index " +
-              uIdx +
+              uIndices[j] +
               " in '" +
               uIface.name +
               "'";
@@ -436,14 +433,14 @@ class TypeAssertionChecker {
       if (orderOk) {
         anyValid = true;
         break;
-      } else if (nonLastMismatch && mismatchIface === null) {
+      } else if (!anyMismatch && badReason !== "") {
         anyMismatch = true;
-        mismatchIface = uIface;
-        mismatchReason = reason;
+        mismatchIfaceName = uIface.name;
+        mismatchReason = badReason;
       }
     }
 
-    if (anyMismatch && !anyValid && mismatchIface !== null) {
+    if (anyMismatch && !anyValid) {
       let msg = "";
       if (ta.loc) {
         const file = ta.loc.file || "<input>";
@@ -455,7 +452,7 @@ class TypeAssertionChecker {
         "named type assertion '" +
         assertedType +
         "' has wrong field indices relative to '" +
-        mismatchIface.name +
+        mismatchIfaceName +
         "': " +
         mismatchReason +
         "\n";
@@ -464,19 +461,22 @@ class TypeAssertionChecker {
         tNames.push(this.stripOpt((tFields[i] as InterfaceField).name));
       }
       msg += "  asserted type '" + assertedType + "': { " + tNames.join("; ") + " }\n";
-      const uF = this.getAllFields(mismatchIface);
-      const uNames: string[] = [];
-      for (let i = 0; i < uF.length; i++) {
-        uNames.push((uF[i] as InterfaceField).name);
+      const mismatchIface = this.getInterface(mismatchIfaceName);
+      if (mismatchIface !== null) {
+        const uF = this.getAllFields(mismatchIface);
+        const uNames: string[] = [];
+        for (let i = 0; i < uF.length; i++) {
+          uNames.push((uF[i] as InterfaceField).name);
+        }
+        msg += "  interface '" + mismatchIfaceName + "': { " + uNames.join("; ") + " }\n";
       }
-      msg += "  interface '" + mismatchIface.name + "': { " + uNames.join("; ") + " }\n";
       msg +=
         "  note: GEP indices in native code are determined by field position in the asserted type\n";
       msg +=
         "  hint: '" +
         assertedType +
         "' fields must appear at the same positions as in '" +
-        mismatchIface.name +
+        mismatchIfaceName +
         "'\n";
       console.error(msg);
       process.exit(1);

--- a/tests/fixtures/types/type-assertion-named-bad.ts
+++ b/tests/fixtures/types/type-assertion-named-bad.ts
@@ -1,0 +1,34 @@
+// @test-compile-error: named type assertion 'FunctionMeta' has wrong field indices
+
+interface FunctionNode {
+  name: string;
+  params: string[];
+  body: string;
+  returnType: string;
+  isAsync: boolean;
+  isExported: boolean;
+  parameters: string[];
+}
+
+interface FunctionMeta {
+  name: string;
+  returnType: string;
+  parameters: string[];
+}
+
+function process(node: FunctionNode): string {
+  const meta = node as FunctionMeta;
+  return meta.name;
+}
+
+console.log(
+  process({
+    name: "foo",
+    params: [],
+    body: "",
+    returnType: "void",
+    isAsync: false,
+    isExported: false,
+    parameters: [],
+  }),
+);


### PR DESCRIPTION
## Summary

- Extends `TypeAssertionChecker` in `src/semantic/type-assertion-checker.ts` to validate **named** type assertions (`as FunctionMeta`) in addition to the existing inline assertion check (`as { field: type }`)
- Catches the class of bugs where an invented subset interface has field positions that don't match the real struct layout, causing wrong GEP indices in native code → silent data corruption or SIGSEGV
- Adds `tests/fixtures/types/type-assertion-named-bad.ts` to assert the compiler rejects a known-bad named assertion at compile time

## How it works

`validateNamedAssertion(ta)` looks up the asserted type T in `ast.interfaces`, then for each other interface U that contains all of T's required field names, builds two parallel `number[]` arrays — T-side GEP indices and U-side GEP indices for the same fields. If any required field has a significantly different index (offset > 1) in U and no interface validates T's layout perfectly, the compiler exits with a descriptive error.

Three guards prevent false positives:
1. **`as unknown as T` / `as any as T`** — skip (intentional class-to-interface bypass)
2. **`type` as first required field** — skip (AST discriminant types are always narrowed before casting)
3. **Offset ≤ 1** — don't flag (adjacent-field near-misses between unrelated interfaces)

## Test plan

- [x] `npm test` — 277 tests, 0 failures
- [x] `npm run verify:quick` — Stage 0, Stage 1 self-hosting, and all tests pass
- [x] `tests/fixtures/types/type-assertion-named-bad.ts` passes as a `@test-compile-error` fixture (caught by both JS and native compilers)
