### PR TITLE
Type keyword support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Requires LLVM (`brew install llvm` / `apt install llvm clang`).
 ```typescript
 import { httpServe, Router, Context } from "chadscript/http";
 
-interface Post {
+type Post = {
   id: number;
   title: string;
-}
+};
 
 const posts: Post[] = [
   { id: 1, title: "ChadScript ships v1" },

--- a/docs/language/classes.md
+++ b/docs/language/classes.md
@@ -25,16 +25,16 @@ Classes and interfaces work like standard TypeScript with a few differences.
 | Abstract classes | Not yet supported |
 | Decorators | Not supported |
 
-## Interface Field Ordering
+## Field Ordering
 
-One ChadScript-specific detail: object literals are automatically reordered to match the interface's declared field order. You can write fields in any order:
+One ChadScript-specific detail: object literals are automatically reordered to match the declared field order. You can write fields in any order:
 
 ```typescript
-interface Person {
+type Person = {
   name: string;
   age: number;
   city: string;
-}
+};
 
 const p: Person = { age: 30, city: "NYC", name: "Alice" }; // works fine
 ```

--- a/docs/language/features.md
+++ b/docs/language/features.md
@@ -59,7 +59,7 @@ The tables below describe the full feature set and support status.
 | `number`, `string`, `boolean`, `null`, `undefined` | Supported |
 | `number[]`, `string[]` (typed arrays) | Supported |
 | `Uint8Array` | Supported |
-| Object literals / interfaces (fixed-layout structs) | Supported |
+| Object literals / interfaces / type aliases (fixed-layout structs) | Supported |
 | `Map<K, V>`, `Set<T>` | Supported |
 | Enums (numeric and string) | Supported |
 | Type aliases | Supported |
@@ -75,13 +75,13 @@ The tables below describe the full feature set and support status.
 
 ## Classes & Interfaces
 
-Classes and interfaces work like standard TypeScript with a few differences.
+Classes, interfaces, and type aliases work like standard TypeScript with a few differences. `type Foo = { ... }` and `interface Foo { ... }` are interchangeable for defining object shapes.
 
 **Key differences from TypeScript:**
 
 - **No `instanceof`** — there are no runtime type tags
 - **Static dispatch** — method calls are resolved at compile time, not dynamically
-- **Interfaces are data-only** — interfaces define fields, not methods. To attach methods to a type, use a class.
+- **Interfaces/types are data-only** — they define fields, not methods. To attach methods to a type, use a class.
 - **Access modifiers not enforced at runtime** — `private`/`protected` are parsed but all fields are accessible in the compiled output. Run `chad init` to get TypeScript type-checking in your editor, which will flag access violations before you compile.
 
 | Feature | Status |
@@ -99,14 +99,14 @@ Classes and interfaces work like standard TypeScript with a few differences.
 | Private class fields (`#field`) | Not supported |
 | Decorators | Not supported |
 
-**Interface field ordering** — object literals are automatically reordered to match the interface's declared field order. You can write fields in any order:
+**Field ordering** — object literals are automatically reordered to match the declared field order. You can write fields in any order:
 
 ```typescript
-interface Person {
+type Person = {
   name: string;
   age: number;
   city: string;
-}
+};
 
 const p: Person = { age: 30, city: "NYC", name: "Alice" }; // works fine
 ```

--- a/docs/stdlib/fetch.md
+++ b/docs/stdlib/fetch.md
@@ -29,10 +29,10 @@ async function main(): any {
 ## Examples
 
 ```typescript
-interface Repo {
+type Repo = {
   name: string;
   description: string;
-}
+};
 
 async function main(): any {
   const response = await fetch("https://api.github.com/repos/cs01/ChadScript");
@@ -45,9 +45,9 @@ async function main(): any {
 ### Parallel fetches with `Promise.all`
 
 ```typescript
-interface Repo {
+type Repo = {
   stargazers_count: number;
-}
+};
 
 async function main(): Promise<void> {
   const results = await Promise.all([

--- a/docs/stdlib/json.md
+++ b/docs/stdlib/json.md
@@ -4,13 +4,13 @@ JSON parsing and serialization via the yyjson library.
 
 ## `JSON.parse<T>(str)`
 
-Parse a JSON string into a typed struct. The type parameter `T` is **required** — ChadScript generates a specialized parser at compile time based on the interface's field names and types. Calling `JSON.parse()` without a type parameter is a compile error.
+Parse a JSON string into a typed struct. The type parameter `T` is **required** — ChadScript generates a specialized parser at compile time based on the type's field names and types. Calling `JSON.parse()` without a type parameter is a compile error.
 
 ```typescript
-interface Config {
+type Config = {
   host: string;
   port: number;
-}
+};
 
 const config = JSON.parse<Config>('{"host":"localhost","port":8080}');
 console.log(config.host);
@@ -28,10 +28,10 @@ Missing or wrong-typed fields get safe zero values instead of crashing:
 | Invalid JSON string | Returns struct with all defaults |
 
 ```typescript
-interface User {
+type User = {
   name: string;
   age: number;
-}
+};
 
 const partial = JSON.parse<User>('{"name":"Alice"}');
 // partial.age === 0 (safe default, no crash)

--- a/docs/stdlib/object.md
+++ b/docs/stdlib/object.md
@@ -7,10 +7,10 @@ Static methods for working with objects and interfaces.
 Returns an array of the object's own property names.
 
 ```typescript
-interface User {
+type User = {
   name: string;
   age: number;
-}
+};
 
 const user: User = { name: "Alice", age: 30 };
 const keys = Object.keys(user);

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -2976,18 +2976,35 @@ function transformObjectTypeAlias(node: TreeSitterNode): InterfaceDeclaration | 
   if ((valueNode as NodeBase).type !== "object_type") return null;
   const name = (nameNode as NodeBase).text;
   const fields: { name: string; type: string }[] = [];
+  const methods: { name: string; params: string[]; paramTypes: string[]; returnType: string }[] =
+    [];
   const vn = valueNode as NodeBase;
   for (let i = 0; i < vn.namedChildCount; i++) {
     const member = getNamedChild(valueNode, i);
     if (!member) continue;
-    if ((member as NodeBase).type !== "property_signature") continue;
-    const propNameNode = getChildByFieldName(member, "name");
-    const propTypeNode = getChildByFieldName(member, "type");
-    const fieldName = propNameNode ? (propNameNode as NodeBase).text : "";
-    const fieldType = propTypeNode ? extractTypeString(propTypeNode) : "any";
-    fields.push({ name: fieldName, type: fieldType });
+    const m = member as NodeBase;
+    if (m.type === "property_signature") {
+      const propNameNode = getChildByFieldName(member, "name");
+      const propTypeNode = getChildByFieldName(member, "type");
+      const fieldName = propNameNode ? (propNameNode as NodeBase).text : "";
+      const fieldType = propTypeNode ? extractTypeString(propTypeNode) : "any";
+      fields.push({ name: fieldName, type: fieldType });
+    } else if (m.type === "method_signature") {
+      const methodNameNode = getChildByFieldName(member, "name");
+      if (!methodNameNode) continue;
+      const methodName = (methodNameNode as NodeBase).text;
+      const paramsNode = getChildByFieldName(member, "parameters");
+      const params = paramsNode ? extractFunctionParams(paramsNode) : [];
+      const paramTypes = paramsNode ? extractParamTypes(paramsNode) || [] : [];
+      const returnTypeNode = getChildByFieldName(member, "return_type");
+      let returnType = "void";
+      if (returnTypeNode) {
+        returnType = extractTypeString(returnTypeNode);
+      }
+      methods.push({ name: methodName, params, paramTypes, returnType });
+    }
   }
-  return { name, extends: [], fields, methods: [] };
+  return { name, extends: [], fields, methods };
 }
 
 function transformTypeAliasDeclaration(node: TreeSitterNode): TypeAliasDeclaration | null {

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -140,8 +140,12 @@ function transformTopLevelStatement(
       const taNode = node as ts.TypeAliasDeclaration;
       if (ts.isTypeLiteralNode(taNode.type)) {
         const fields: { name: string; type: string }[] = [];
-        const methods: { name: string; params: string[]; paramTypes: string[]; returnType: string }[] =
-          [];
+        const methods: {
+          name: string;
+          params: string[];
+          paramTypes: string[];
+          returnType: string;
+        }[] = [];
         for (const m of taNode.type.members) {
           if (ts.isPropertySignature(m) && ts.isIdentifier(m.name)) {
             fields.push({ name: m.name.text, type: m.type ? m.type.getText() : "any" });

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -140,12 +140,19 @@ function transformTopLevelStatement(
       const taNode = node as ts.TypeAliasDeclaration;
       if (ts.isTypeLiteralNode(taNode.type)) {
         const fields: { name: string; type: string }[] = [];
+        const methods: { name: string; params: string[]; paramTypes: string[]; returnType: string }[] =
+          [];
         for (const m of taNode.type.members) {
           if (ts.isPropertySignature(m) && ts.isIdentifier(m.name)) {
             fields.push({ name: m.name.text, type: m.type ? m.type.getText() : "any" });
+          } else if (ts.isMethodSignature(m) && ts.isIdentifier(m.name)) {
+            const params = m.parameters.map((p) => (ts.isIdentifier(p.name) ? p.name.text : ""));
+            const paramTypes = m.parameters.map((p) => (p.type ? p.type.getText() : "any"));
+            const returnType = m.type ? m.type.getText() : "void";
+            methods.push({ name: m.name.text, params, paramTypes, returnType });
           }
         }
-        ast.interfaces.push({ name: taNode.name.text, extends: [], fields, methods: [] });
+        ast.interfaces.push({ name: taNode.name.text, extends: [], fields, methods });
       } else {
         const typeAlias = transformTypeAliasDeclaration(taNode);
         if (typeAlias) {

--- a/tests/fixtures/interfaces/type-alias-json-parse.ts
+++ b/tests/fixtures/interfaces/type-alias-json-parse.ts
@@ -1,0 +1,12 @@
+type Repo = {
+  stargazers_count: number;
+  name: string;
+};
+
+const json = '{"stargazers_count":42,"name":"vue"}';
+const repo = JSON.parse<Repo>(json);
+if (repo.stargazers_count === 42 && repo.name === "vue") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: " + repo.stargazers_count.toString() + " " + repo.name);
+}

--- a/tests/fixtures/interfaces/type-alias-object.ts
+++ b/tests/fixtures/interfaces/type-alias-object.ts
@@ -1,0 +1,16 @@
+type Inner = {
+  value: number;
+};
+
+type Outer = {
+  inner: Inner;
+  name: string;
+};
+
+const obj: Outer = { inner: { value: 42 }, name: "test" };
+const v = obj.inner.value;
+if (v === 42 && obj.name === "test") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: expected 42/test, got " + v.toString() + "/" + obj.name);
+}

--- a/tests/fixtures/interfaces/type-alias-optional.ts
+++ b/tests/fixtures/interfaces/type-alias-optional.ts
@@ -1,0 +1,11 @@
+type Config = {
+  host: string;
+  port?: number;
+};
+
+const cfg: Config = { host: "localhost" };
+if (cfg.host === "localhost") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL");
+}


### PR DESCRIPTION
## Summary

- `type Foo = { ... }` now fully supported as an equivalent to `interface Foo { ... }` for defining object shapes — including method signatures, which were previously silently dropped from type aliases in both parsers
- Docs updated to prefer `type` syntax in all examples (README, fetch, json, object, classes, features)

## Changes

**Parser fixes** (`src/parser-native/transformer.ts`, `src/parser-ts/transformer.ts`):
- `type Foo = { method(): void }` — method signatures in type aliases now parsed and registered, matching `interface` behavior
- Both the TS and native parsers updated

**Tests** (`tests/fixtures/interfaces/`):
- `type-alias-object.ts` — nested type alias access
- `type-alias-json-parse.ts` — `JSON.parse<T>()` with a type alias
- `type-alias-optional.ts` — optional fields in type aliases

## Test plan

- [ ] All 276 unit tests pass (`npm test`)
- [ ] `type Foo = { ... }` works interchangeably with `interface Foo { ... }` for field access, `JSON.parse<T>()`, optional fields, and method signatures
