### PR TITLE
Json array support

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -135,6 +135,7 @@ export class TypeInference {
         if (varType === "i8*") return this.ctx.typeContext.getArrayType("string");
       }
       if (this.isStringExpression(elements[0])) return this.ctx.typeContext.getArrayType("string");
+      if (firstElem.type === "object") return this.ctx.typeContext.getArrayType("object");
       return this.ctx.typeContext.getArrayType("number");
     }
     if (e.type === "unary") {

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -13,6 +13,7 @@ import {
   InterfaceDeclaration,
   InterfaceField,
   ObjectNode,
+  ArrayNode,
   IndexAccessNode,
   MemberAccessNode,
   VariableNode,
@@ -1986,10 +1987,56 @@ export class VariableAllocator {
       }
     }
 
+    const inlineMeta = this.extractInlineObjectArrayMeta(stmt.value!);
+    if (inlineMeta) {
+      this.ctx.defineVariable(stmt.name, allocaReg, "%ObjectArray*", SymbolKind.ObjectArray, "local");
+      this.ctx.symbolTable.setRawInterfaceType(stmt.name, "object");
+      this.ctx.symbolTable.setObjectArrayMetadata(stmt.name, {
+        elementInterfaceName: "object",
+        elementKeys: inlineMeta.keys,
+        elementTypes: inlineMeta.types,
+        elementTsTypes: inlineMeta.tsTypes,
+      });
+      this.ctx.emit(`${allocaReg} = alloca %ObjectArray*`);
+      const value = this.ctx.generateExpression(stmt.value!, params);
+      this.ctx.emit(`store %ObjectArray* ${value}, %ObjectArray** ${allocaReg}`);
+      return;
+    }
+
     this.ctx.defineVariable(stmt.name, allocaReg, "%ObjectArray*", SymbolKind.ObjectArray, "local");
     this.ctx.emit(`${allocaReg} = alloca %ObjectArray*`);
     const value = this.ctx.generateExpression(stmt.value!, params);
     this.ctx.emit(`store %ObjectArray* ${value}, %ObjectArray** ${allocaReg}`);
+  }
+
+  private extractInlineObjectArrayMeta(
+    expr: Expression,
+  ): { keys: string[]; types: string[]; tsTypes: string[] } | null {
+    const e = expr as ExprBase;
+    if (e.type !== "array") return null;
+    const arrayExpr = expr as unknown as ArrayNode;
+    const elements = arrayExpr.elements || [];
+    if (elements.length === 0) return null;
+    const firstElem = elements[0] as ExprBase;
+    if (firstElem.type !== "object") return null;
+
+    const objNode = elements[0] as unknown as ObjectNode;
+    const keys: string[] = [];
+    const types: string[] = [];
+    const tsTypes: string[] = [];
+
+    for (let i = 0; i < objNode.properties.length; i++) {
+      const prop = objNode.properties[i];
+      keys.push(prop.key);
+      const valType = (prop.value as ExprBase).type;
+      let tsType = "string";
+      if (valType === "number") tsType = "number";
+      else if (valType === "boolean") tsType = "boolean";
+      types.push(this.convertTsType(tsType));
+      tsTypes.push(tsType);
+    }
+
+    return { keys, types, tsTypes };
   }
 
   private allocateRegex(stmt: VariableDeclaration, params: string[]): void {

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1989,7 +1989,13 @@ export class VariableAllocator {
 
     const inlineMeta = this.extractInlineObjectArrayMeta(stmt.value!);
     if (inlineMeta) {
-      this.ctx.defineVariable(stmt.name, allocaReg, "%ObjectArray*", SymbolKind.ObjectArray, "local");
+      this.ctx.defineVariable(
+        stmt.name,
+        allocaReg,
+        "%ObjectArray*",
+        SymbolKind.ObjectArray,
+        "local",
+      );
       this.ctx.symbolTable.setRawInterfaceType(stmt.name, "object");
       this.ctx.symbolTable.setObjectArrayMetadata(stmt.name, {
         elementInterfaceName: "object",

--- a/src/codegen/stdlib/json-array.ts
+++ b/src/codegen/stdlib/json-array.ts
@@ -1,0 +1,193 @@
+import { Expression, ArrayNode, ObjectNode } from "../../ast/types.js";
+import { IGeneratorContext } from "../infrastructure/generator-context.js";
+
+interface ExprBase {
+  type: string;
+}
+
+function buildObjectProperties(
+  ctx: IGeneratorContext,
+  obj: ObjectNode,
+  params: string[],
+  jsonDoc: string,
+  jsonObj: string,
+): void {
+  for (let i = 0; i < obj.properties.length; i++) {
+    const prop = obj.properties[i];
+    const nameConst = ctx.createStringConstant(prop.key);
+
+    if (prop.value.type === "object") {
+      const childObj = ctx.emitCall(
+        "i8*",
+        "@csyyjson_obj_add_obj",
+        `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}`,
+      );
+      buildObjectProperties(ctx, prop.value as unknown as ObjectNode, params, jsonDoc, childObj);
+    } else if (prop.value.type === "boolean") {
+      const val = ctx.generateExpression(prop.value, params);
+      const boolI32 = ctx.nextTemp();
+      ctx.emit(`${boolI32} = trunc i64 ${val} to i32`);
+      ctx.emitCallVoid(
+        "@csyyjson_obj_add_bool",
+        `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i32 ${boolI32}`,
+      );
+    } else if (ctx.isStringExpression(prop.value)) {
+      const val = ctx.generateExpression(prop.value, params);
+      ctx.emitCallVoid(
+        "@csyyjson_obj_add_str",
+        `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i8* ${val}`,
+      );
+    } else {
+      const val = ctx.generateExpression(prop.value, params);
+      const vt = ctx.getVariableType(val);
+      if (vt === "i8*") {
+        ctx.emitCallVoid(
+          "@csyyjson_obj_add_str",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i8* ${val}`,
+        );
+      } else if (vt === "i1") {
+        const boolI32 = ctx.nextTemp();
+        ctx.emit(`${boolI32} = zext i1 ${val} to i32`);
+        ctx.emitCallVoid(
+          "@csyyjson_obj_add_bool",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i32 ${boolI32}`,
+        );
+      } else {
+        const dbl = ctx.ensureDouble(val);
+        ctx.emitCallVoid(
+          "@csyyjson_obj_add_num",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, double ${dbl}`,
+        );
+      }
+    }
+  }
+}
+
+function emitStringify(ctx: IGeneratorContext, jsonDoc: string, spaces: number): string {
+  if (spaces > 0) {
+    return ctx.emitCall(
+      "i8*",
+      "@csyyjson_stringify_pretty",
+      `i8* ${jsonDoc}, i32 ${spaces === 2 ? "2" : "4"}`,
+    );
+  }
+  return ctx.emitCall("i8*", "@csyyjson_stringify", `i8* ${jsonDoc}`);
+}
+
+export function stringifyObjectArrayLiteral(
+  ctx: IGeneratorContext,
+  arrayExpr: ArrayNode,
+  params: string[],
+  spaces: number,
+): string {
+  ctx.setUsesJson(true);
+  const jsonDoc = ctx.emitCall("i8*", "@csyyjson_create_arr", "");
+  const jsonArr = ctx.emitCall("i8*", "@csyyjson_mut_get_root", `i8* ${jsonDoc}`);
+
+  for (let i = 0; i < arrayExpr.elements.length; i++) {
+    const elem = arrayExpr.elements[i];
+    const elemBase = elem as ExprBase;
+    if (elemBase.type === "object") {
+      const subObj = ctx.emitCall(
+        "i8*",
+        "@csyyjson_mut_arr_add_obj",
+        `i8* ${jsonDoc}, i8* ${jsonArr}`,
+      );
+      buildObjectProperties(ctx, elem as unknown as ObjectNode, params, jsonDoc, subObj);
+    }
+  }
+
+  const result = emitStringify(ctx, jsonDoc, spaces);
+  ctx.setVariableType(result, "i8*");
+  return result;
+}
+
+export function stringifyObjectArrayWithMeta(
+  ctx: IGeneratorContext,
+  arg: Expression,
+  params: string[],
+  elementKeys: string[],
+  elementTypes: string[],
+  elementTsTypes: string[],
+  spaces: number,
+): string {
+  const fieldCount = elementKeys.length;
+  const structType = `{ ${elementTypes.join(", ")} }`;
+
+  const arrPtr = ctx.generateExpression(arg, params);
+  ctx.setUsesJson(true);
+
+  const lenPtr = ctx.emitGep("%ObjectArray", arrPtr, "i32 0, i32 1");
+  const len = ctx.emitLoad("i32", lenPtr);
+  const dataRawPtr = ctx.emitGep("%ObjectArray", arrPtr, "i32 0, i32 0");
+  const dataI8 = ctx.emitLoad("i8*", dataRawPtr);
+  const dataPtr = ctx.emitBitcast(dataI8, "i8*", "i8**");
+
+  const jsonDoc = ctx.emitCall("i8*", "@csyyjson_create_arr", "");
+  const jsonArr = ctx.emitCall("i8*", "@csyyjson_mut_get_root", `i8* ${jsonDoc}`);
+
+  const counterAlloca = ctx.nextTemp();
+  ctx.emit(`${counterAlloca} = alloca i32`);
+  ctx.emitStore("i32", "0", counterAlloca);
+
+  const loopCond = ctx.nextLabel("json_meta_arr_cond");
+  const loopBody = ctx.nextLabel("json_meta_arr_body");
+  const loopEnd = ctx.nextLabel("json_meta_arr_end");
+
+  ctx.emitBr(loopCond);
+  ctx.emitLabel(loopCond);
+  const i = ctx.emitLoad("i32", counterAlloca);
+  const cond = ctx.emitIcmp("slt", "i32", i, len);
+  ctx.emitBrCond(cond, loopBody, loopEnd);
+
+  ctx.emitLabel(loopBody);
+  const elemSlot = ctx.emitGep("i8*", dataPtr, `i32 ${i}`);
+  const elemRaw = ctx.emitLoad("i8*", elemSlot);
+  const elemTyped = ctx.emitBitcast(elemRaw, "i8*", `${structType}*`);
+
+  const subObj = ctx.emitCall(
+    "i8*",
+    "@csyyjson_mut_arr_add_obj",
+    `i8* ${jsonDoc}, i8* ${jsonArr}`,
+  );
+
+  for (let fi = 0; fi < fieldCount; fi++) {
+    const fieldPtr = ctx.nextTemp();
+    ctx.emit(
+      `${fieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${elemTyped}, i32 0, i32 ${fi}`,
+    );
+    const nameConst = ctx.createStringConstant(elementKeys[fi]);
+    const tsType = elementTsTypes[fi] || "string";
+    if (tsType === "string") {
+      const val = ctx.emitLoad("i8*", fieldPtr);
+      ctx.emitCallVoid(
+        "@csyyjson_obj_add_str",
+        `i8* ${jsonDoc}, i8* ${subObj}, i8* ${nameConst}, i8* ${val}`,
+      );
+    } else if (tsType === "boolean") {
+      const val = ctx.emitLoad("double", fieldPtr);
+      const boolInt = ctx.nextTemp();
+      ctx.emit(`${boolInt} = fptosi double ${val} to i32`);
+      ctx.emitCallVoid(
+        "@csyyjson_obj_add_bool",
+        `i8* ${jsonDoc}, i8* ${subObj}, i8* ${nameConst}, i32 ${boolInt}`,
+      );
+    } else {
+      const val = ctx.emitLoad("double", fieldPtr);
+      ctx.emitCallVoid(
+        "@csyyjson_obj_add_num",
+        `i8* ${jsonDoc}, i8* ${subObj}, i8* ${nameConst}, double ${val}`,
+      );
+    }
+  }
+
+  const iNext = ctx.nextTemp();
+  ctx.emit(`${iNext} = add i32 ${i}, 1`);
+  ctx.emitStore("i32", iNext, counterAlloca);
+  ctx.emitBr(loopCond);
+
+  ctx.emitLabel(loopEnd);
+  const result = emitStringify(ctx, jsonDoc, spaces);
+  ctx.setVariableType(result, "i8*");
+  return result;
+}

--- a/src/codegen/stdlib/json-array.ts
+++ b/src/codegen/stdlib/json-array.ts
@@ -145,11 +145,7 @@ export function stringifyObjectArrayWithMeta(
   const elemRaw = ctx.emitLoad("i8*", elemSlot);
   const elemTyped = ctx.emitBitcast(elemRaw, "i8*", `${structType}*`);
 
-  const subObj = ctx.emitCall(
-    "i8*",
-    "@csyyjson_mut_arr_add_obj",
-    `i8* ${jsonDoc}, i8* ${jsonArr}`,
-  );
+  const subObj = ctx.emitCall("i8*", "@csyyjson_mut_arr_add_obj", `i8* ${jsonDoc}, i8* ${jsonArr}`);
 
   for (let fi = 0; fi < fieldCount; fi++) {
     const fieldPtr = ctx.nextTemp();

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -1,8 +1,11 @@
-import { Expression, MethodCallNode, ObjectNode, ArrayNode, TypeAssertionNode } from "../../ast/types.js";
 import {
-  stringifyObjectArrayLiteral,
-  stringifyObjectArrayWithMeta,
-} from "./json-array.js";
+  Expression,
+  MethodCallNode,
+  ObjectNode,
+  ArrayNode,
+  TypeAssertionNode,
+} from "../../ast/types.js";
+import { stringifyObjectArrayLiteral, stringifyObjectArrayWithMeta } from "./json-array.js";
 
 interface ExprBase {
   type: string;

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -1,4 +1,8 @@
-import { Expression, MethodCallNode, ObjectNode, TypeAssertionNode } from "../../ast/types.js";
+import { Expression, MethodCallNode, ObjectNode, ArrayNode, TypeAssertionNode } from "../../ast/types.js";
+import {
+  stringifyObjectArrayLiteral,
+  stringifyObjectArrayWithMeta,
+} from "./json-array.js";
 
 interface ExprBase {
   type: string;
@@ -532,6 +536,14 @@ export class JsonGenerator {
       return this.stringifyObjectLiteral(arg as unknown as ObjectNode, params, spaces);
     }
 
+    if (arg.type === "array") {
+      const arrayExpr = arg as unknown as ArrayNode;
+      const elements = arrayExpr.elements || [];
+      if (elements.length > 0 && (elements[0] as ExprBase).type === "object") {
+        return stringifyObjectArrayLiteral(this.ctx, arrayExpr, params, spaces);
+      }
+    }
+
     // Check for ObjectArray (e.g. Post[]) before resolveInterfaceType —
     // getRawInterfaceType returns the element type for arrays, which would
     // cause stringifyInterface to treat the array pointer as a single object.
@@ -699,6 +711,21 @@ export class JsonGenerator {
     spaces: number = 0,
   ): string {
     if (!this.ctx.interfaceStructGenHasInterface(elementType)) {
+      if (arg.type === "variable") {
+        const varName = (arg as unknown as { name: string }).name;
+        const meta = this.ctx.symbolTable.getObjectArrayMetadata(varName);
+        if (meta && meta.elementKeys.length > 0) {
+          return stringifyObjectArrayWithMeta(
+            this.ctx,
+            arg,
+            params,
+            meta.elementKeys,
+            meta.elementTypes,
+            meta.elementTsTypes || [],
+            spaces,
+          );
+        }
+      }
       return this.stringifyNumber(arg, params);
     }
     const fieldCount = this.ctx.interfaceStructGenGetFieldCount(elementType);

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -4,6 +4,7 @@ import {
   ObjectNode,
   ArrayNode,
   TypeAssertionNode,
+  VariableNode,
 } from "../../ast/types.js";
 import { stringifyObjectArrayLiteral, stringifyObjectArrayWithMeta } from "./json-array.js";
 
@@ -715,7 +716,7 @@ export class JsonGenerator {
   ): string {
     if (!this.ctx.interfaceStructGenHasInterface(elementType)) {
       if (arg.type === "variable") {
-        const varName = (arg as unknown as { name: string }).name;
+        const varName = (arg as unknown as VariableNode).name;
         const meta = this.ctx.symbolTable.getObjectArrayMetadata(varName);
         if (meta && meta.elementKeys.length > 0) {
           return stringifyObjectArrayWithMeta(

--- a/tests/fixtures/network/context-json-array.ts
+++ b/tests/fixtures/network/context-json-array.ts
@@ -1,0 +1,45 @@
+// @test-description: c.json() accepts object arrays (literal and variable)
+
+import { Router, Context } from "chadscript/http";
+
+function test(): void {
+  const app = new Router();
+
+  app.get("/literal", (c: Context) => {
+    return c.json([{ name: "Alice", age: 30 }]);
+  });
+
+  app.get("/variable", (c: Context) => {
+    const items = [{ name: "Alice", age: 30 }];
+    return c.json(items);
+  });
+
+  const r1 = app.handle({
+    method: "GET",
+    path: "/literal",
+    body: "",
+    contentType: "",
+    headers: "",
+    bodyLen: 0,
+  });
+  if (r1.body !== '[{"name":"Alice","age":30.0}]') {
+    console.log("FAIL literal: " + r1.body);
+    process.exit(1);
+  }
+
+  const r2 = app.handle({
+    method: "GET",
+    path: "/variable",
+    body: "",
+    contentType: "",
+    headers: "",
+    bodyLen: 0,
+  });
+  if (r2.body !== '[{"name":"Alice","age":30.0}]') {
+    console.log("FAIL variable: " + r2.body);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary

`c.json()` previously failed for object array arguments in two ways:

- **Literal**: `return c.json([{ name: "Alice", age: 30 }])` → compile error: "JSON.stringify: unsupported argument type"
- **Variable**: `const items = [...]; return c.json(items)` → garbage output like `[2.140390922e-314]`

Both cases now produce correct JSON: `[{"name":"Alice","age":30.0}]`

## Root Causes

**Literal arrays**: `generateStringifyArgWithSpaces` had no handler for `arg.type === "array"`, falling through to the unsupported-type error.

**Variable arrays**: `resolveExpressionType` defaulted object-element arrays to `number[]` type. This caused the variable to be allocated as `SymbolKind.Array` instead of `SymbolKind.ObjectArray`, so the JSON serializer read the object pointer as a `double` and printed it as a float.

## Changes

- `type-inference.ts`: detect `firstElem.type === "object"` in array literals and return `getArrayType("object")` so the variable allocator treats them as object arrays
- `variable-allocator.ts`: when allocating an object array variable with no registered interface, extract field metadata from the inline array literal (`extractInlineObjectArrayMeta`) and store it in `ObjectArrayMetadata`
- `json.ts`: add `arg.type === "array"` dispatch for literal object arrays; fall back to metadata-based serialization for variables without a registered interface
- `json-array.ts` (new): standalone helpers `stringifyObjectArrayLiteral` and `stringifyObjectArrayWithMeta` — extracted to a separate file to keep `json.ts` from growing further, and implemented as free functions (not class methods) to avoid Stage 0 closure-over-`this` issues

## Test

`tests/fixtures/network/context-json-array.ts` — covers both the literal and variable cases end-to-end through the HTTP router.
