### PR TITLE
fix examples: http-server and websocket

### DIFF
--- a/examples/http-server-public/index.html
+++ b/examples/http-server-public/index.html
@@ -101,7 +101,7 @@
     <div class="route">
       <span class="method post">POST</span>
       <span>/echo</span>
-      <form method="POST" action="/echo" style="display:flex;gap:8px;align-items:center">
+      <form method="POST" action="/echo" style="display: flex; gap: 8px; align-items: center">
         <input type="text" name="body" value="hello world" />
         <button type="submit">Send</button>
       </form>
@@ -110,7 +110,7 @@
     <div class="route">
       <span class="method post">POST</span>
       <span>/api/users</span>
-      <form method="POST" action="/api/users" style="display:flex;gap:8px">
+      <form method="POST" action="/api/users" style="display: flex; gap: 8px">
         <button type="submit">Send</button>
       </form>
       <span class="desc">201 created</span>

--- a/examples/http-server-public/index.html
+++ b/examples/http-server-public/index.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html>
+  <head>
+    <style>
+      body {
+        font-family: monospace;
+        max-width: 640px;
+        margin: 40px auto;
+        padding: 0 24px;
+        background: #f9f9f9;
+        color: #111;
+      }
+      h2 {
+        margin-bottom: 24px;
+      }
+      .route {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 0;
+        border-bottom: 1px solid #e5e5e5;
+      }
+      .method {
+        font-weight: bold;
+        min-width: 36px;
+      }
+      .get {
+        color: #0070f3;
+      }
+      .post {
+        color: #e67e00;
+      }
+      a {
+        color: #0070f3;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .desc {
+        color: #888;
+        font-size: 12px;
+        margin-left: auto;
+      }
+      input[type="text"] {
+        font-family: monospace;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 4px 8px;
+        font-size: 13px;
+        width: 180px;
+      }
+      button {
+        font-family: monospace;
+        background: #e67e00;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        padding: 5px 10px;
+        cursor: pointer;
+        font-size: 13px;
+      }
+      button:hover {
+        background: #c96d00;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>ChadScript HTTP Server</h2>
+
+    <div class="route">
+      <span class="method get">GET</span>
+      <a href="/json">/json</a>
+      <span class="desc">JSON response</span>
+    </div>
+    <div class="route">
+      <span class="method get">GET</span>
+      <a href="/api/users/42">/api/users/42</a>
+      <span class="desc">user by ID</span>
+    </div>
+    <div class="route">
+      <span class="method get">GET</span>
+      <a href="/api/users/alice/posts/7">/api/users/alice/posts/7</a>
+      <span class="desc">multi-param</span>
+    </div>
+    <div class="route">
+      <span class="method get">GET</span>
+      <a href="/status/418">/status/418</a>
+      <span class="desc">custom status code</span>
+    </div>
+    <div class="route">
+      <span class="method get">GET</span>
+      <a href="/headers">/headers</a>
+      <span class="desc">echo Authorization header</span>
+    </div>
+    <div class="route">
+      <span class="method get">GET</span>
+      <a href="/redirect">/redirect</a>
+      <span class="desc">302 redirect</span>
+    </div>
+    <div class="route">
+      <span class="method post">POST</span>
+      <span>/echo</span>
+      <form method="POST" action="/echo" style="display:flex;gap:8px;align-items:center">
+        <input type="text" name="body" value="hello world" />
+        <button type="submit">Send</button>
+      </form>
+      <span class="desc">echo body</span>
+    </div>
+    <div class="route">
+      <span class="method post">POST</span>
+      <span>/api/users</span>
+      <form method="POST" action="/api/users" style="display:flex;gap:8px">
+        <button type="submit">Send</button>
+      </form>
+      <span class="desc">201 created</span>
+    </div>
+  </body>
+</html>

--- a/examples/http-server.ts
+++ b/examples/http-server.ts
@@ -10,7 +10,7 @@ const port = parseInt(parser.getOption("port"));
 
 const app: Router = new Router();
 
-ChadScript.embedFile("./http-server-public/index.html");
+ChadScript.embedDir("./http-server-public");
 
 app.get("/", (c: Context) => {
   return c.html(ChadScript.getEmbeddedFile("index.html"));

--- a/examples/http-server.ts
+++ b/examples/http-server.ts
@@ -10,35 +10,10 @@ const port = parseInt(parser.getOption("port"));
 
 const app: Router = new Router();
 
+ChadScript.embedFile("./http-server-public/index.html");
+
 app.get("/", (c: Context) => {
-  return c.html(
-    "<!doctype html><html><head><style>" +
-      "body{font-family:monospace;max-width:640px;margin:40px auto;padding:0 24px;background:#f9f9f9;color:#111}" +
-      "h2{margin-bottom:24px}" +
-      ".route{display:flex;align-items:center;gap:12px;padding:10px 0;border-bottom:1px solid #e5e5e5}" +
-      ".method{font-weight:bold;min-width:36px}" +
-      ".get{color:#0070f3}.post{color:#e67e00}" +
-      "a{color:#0070f3;text-decoration:none}.a:hover{text-decoration:underline}" +
-      ".desc{color:#888;font-size:12px;margin-left:auto}" +
-      "input[type=text]{font-family:monospace;border:1px solid #ccc;border-radius:4px;padding:4px 8px;font-size:13px;width:180px}" +
-      "button{font-family:monospace;background:#e67e00;color:#fff;border:none;border-radius:4px;padding:5px 10px;cursor:pointer;font-size:13px}" +
-      "button:hover{background:#c96d00}" +
-      "</style></head><body>" +
-      "<h2>ChadScript HTTP Server</h2>" +
-      "<div class='route'><span class='method get'>GET</span><a href='/json'>/json</a><span class='desc'>JSON response</span></div>" +
-      "<div class='route'><span class='method get'>GET</span><a href='/api/users/42'>/api/users/42</a><span class='desc'>user by ID</span></div>" +
-      "<div class='route'><span class='method get'>GET</span><a href='/api/users/alice/posts/7'>/api/users/alice/posts/7</a><span class='desc'>multi-param</span></div>" +
-      "<div class='route'><span class='method get'>GET</span><a href='/status/418'>/status/418</a><span class='desc'>custom status code</span></div>" +
-      "<div class='route'><span class='method get'>GET</span><a href='/headers'>/headers</a><span class='desc'>echo Authorization header</span></div>" +
-      "<div class='route'><span class='method get'>GET</span><a href='/redirect'>/redirect</a><span class='desc'>302 redirect</span></div>" +
-      "<div class='route'><span class='method post'>POST</span><span>/echo</span>" +
-      "<form method='POST' action='/echo' style='display:flex;gap:8px;align-items:center'><input type='text' name='body' value='hello world'><button type='submit'>Send</button></form>" +
-      "<span class='desc'>echo body</span></div>" +
-      "<div class='route'><span class='method post'>POST</span><span>/api/users</span>" +
-      "<form method='POST' action='/api/users' style='display:flex;gap:8px'><button type='submit'>Send</button></form>" +
-      "<span class='desc'>201 created</span></div>" +
-      "</body></html>",
-  );
+  return c.html(ChadScript.getEmbeddedFile("index.html"));
 });
 
 app.get("/json", (c: Context) => {

--- a/examples/http-server.ts
+++ b/examples/http-server.ts
@@ -12,17 +12,32 @@ const app: Router = new Router();
 
 app.get("/", (c: Context) => {
   return c.html(
-    "<html><body style='font-family:monospace;max-width:600px;margin:40px auto;padding:0 20px'>" +
+    "<!doctype html><html><head><style>" +
+      "body{font-family:monospace;max-width:640px;margin:40px auto;padding:0 24px;background:#f9f9f9;color:#111}" +
+      "h2{margin-bottom:24px}" +
+      ".route{display:flex;align-items:center;gap:12px;padding:10px 0;border-bottom:1px solid #e5e5e5}" +
+      ".method{font-weight:bold;min-width:36px}" +
+      ".get{color:#0070f3}.post{color:#e67e00}" +
+      "a{color:#0070f3;text-decoration:none}.a:hover{text-decoration:underline}" +
+      ".desc{color:#888;font-size:12px;margin-left:auto}" +
+      "input[type=text]{font-family:monospace;border:1px solid #ccc;border-radius:4px;padding:4px 8px;font-size:13px;width:180px}" +
+      "button{font-family:monospace;background:#e67e00;color:#fff;border:none;border-radius:4px;padding:5px 10px;cursor:pointer;font-size:13px}" +
+      "button:hover{background:#c96d00}" +
+      "</style></head><body>" +
       "<h2>ChadScript HTTP Server</h2>" +
-      "<table style='border-collapse:collapse;width:100%'>" +
-      "<tr><td><a href='/json'>GET /json</a></td><td style='color:#888;padding-left:16px'>JSON response</td></tr>" +
-      "<tr><td><a href='/api/users/42'>GET /api/users/42</a></td><td style='color:#888;padding-left:16px'>user by ID</td></tr>" +
-      "<tr><td><a href='/api/users/alice/posts/7'>GET /api/users/alice/posts/7</a></td><td style='color:#888;padding-left:16px'>multi-param</td></tr>" +
-      "<tr><td><a href='/status/418'>GET /status/418</a></td><td style='color:#888;padding-left:16px'>custom status code</td></tr>" +
-      "<tr><td><a href='/redirect'>GET /redirect</a></td><td style='color:#888;padding-left:16px'>302 redirect</td></tr>" +
-      "<tr><td style='color:#aaa'>POST /echo</td><td style='color:#888;padding-left:16px'>echo body</td></tr>" +
-      "<tr><td style='color:#aaa'>POST /api/users</td><td style='color:#888;padding-left:16px'>201 created</td></tr>" +
-      "</table></body></html>",
+      "<div class='route'><span class='method get'>GET</span><a href='/json'>/json</a><span class='desc'>JSON response</span></div>" +
+      "<div class='route'><span class='method get'>GET</span><a href='/api/users/42'>/api/users/42</a><span class='desc'>user by ID</span></div>" +
+      "<div class='route'><span class='method get'>GET</span><a href='/api/users/alice/posts/7'>/api/users/alice/posts/7</a><span class='desc'>multi-param</span></div>" +
+      "<div class='route'><span class='method get'>GET</span><a href='/status/418'>/status/418</a><span class='desc'>custom status code</span></div>" +
+      "<div class='route'><span class='method get'>GET</span><a href='/headers'>/headers</a><span class='desc'>echo Authorization header</span></div>" +
+      "<div class='route'><span class='method get'>GET</span><a href='/redirect'>/redirect</a><span class='desc'>302 redirect</span></div>" +
+      "<div class='route'><span class='method post'>POST</span><span>/echo</span>" +
+      "<form method='POST' action='/echo' style='display:flex;gap:8px;align-items:center'><input type='text' name='body' value='hello world'><button type='submit'>Send</button></form>" +
+      "<span class='desc'>echo body</span></div>" +
+      "<div class='route'><span class='method post'>POST</span><span>/api/users</span>" +
+      "<form method='POST' action='/api/users' style='display:flex;gap:8px'><button type='submit'>Send</button></form>" +
+      "<span class='desc'>201 created</span></div>" +
+      "</body></html>",
   );
 });
 

--- a/examples/http-server.ts
+++ b/examples/http-server.ts
@@ -11,22 +11,34 @@ const port = parseInt(parser.getOption("port"));
 const app: Router = new Router();
 
 app.get("/", (c: Context) => {
-  return c.json('{"name":"ChadScript HTTP Server","status":"running"}');
+  return c.html(
+    "<html><body style='font-family:monospace;max-width:600px;margin:40px auto;padding:0 20px'>" +
+      "<h2>ChadScript HTTP Server</h2>" +
+      "<table style='border-collapse:collapse;width:100%'>" +
+      "<tr><td><a href='/json'>GET /json</a></td><td style='color:#888;padding-left:16px'>JSON response</td></tr>" +
+      "<tr><td><a href='/api/users/42'>GET /api/users/42</a></td><td style='color:#888;padding-left:16px'>user by ID</td></tr>" +
+      "<tr><td><a href='/api/users/alice/posts/7'>GET /api/users/alice/posts/7</a></td><td style='color:#888;padding-left:16px'>multi-param</td></tr>" +
+      "<tr><td><a href='/status/418'>GET /status/418</a></td><td style='color:#888;padding-left:16px'>custom status code</td></tr>" +
+      "<tr><td><a href='/redirect'>GET /redirect</a></td><td style='color:#888;padding-left:16px'>302 redirect</td></tr>" +
+      "<tr><td style='color:#aaa'>POST /echo</td><td style='color:#888;padding-left:16px'>echo body</td></tr>" +
+      "<tr><td style='color:#aaa'>POST /api/users</td><td style='color:#888;padding-left:16px'>201 created</td></tr>" +
+      "</table></body></html>",
+  );
 });
 
 app.get("/json", (c: Context) => {
-  return c.json('{"message":"hello","count":42}');
+  return c.json({ message: "hello", count: 42 });
 });
 
 app.get("/api/users/:id", (c: Context) => {
   const id = c.req.param("id");
-  return c.json('{"id":"' + id + '"}');
+  return c.json({ id });
 });
 
 app.get("/api/users/:name/posts/:pid", (c: Context) => {
   const name = c.req.param("name");
   const pid = c.req.param("pid");
-  return c.json('{"user":"' + name + '","post":"' + pid + '"}');
+  return c.json({ user: name, post: pid });
 });
 
 app.get("/status/:code", (c: Context) => {
@@ -50,12 +62,12 @@ app.post("/echo", (c: Context) => {
 
 app.post("/api/users", (c: Context) => {
   c.status(201);
-  return c.json('{"created":true}');
+  return c.json({ created: true });
 });
 
 app.notFound((c: Context) => {
   c.status(404);
-  return c.json('{"error":"not found","path":"' + c.req.path + '"}');
+  return c.json({ error: "not found", path: c.req.path });
 });
 
 console.log("ChadScript HTTP Server (Router API)");

--- a/examples/websocket/app.ts
+++ b/examples/websocket/app.ts
@@ -17,7 +17,6 @@ function wsHandler(event: WsEvent): string {
   if (event.event === "open") {
     userCount = userCount + 1;
     console.log("  [ws] client connected (" + userCount + " online)");
-    wsBroadcast("sys|a new user joined the chat (" + userCount + " online)");
     return "";
   }
   if (event.event === "close") {

--- a/examples/websocket/app.ts
+++ b/examples/websocket/app.ts
@@ -1,9 +1,9 @@
 // WebSocket Chat - real-time chat with embedded HTML/CSS served statically
 import { ArgumentParser } from "chadscript/argparse";
-import { httpServe, wsBroadcast } from "chadscript/http";
+import { httpServe, wsBroadcast, wsSend } from "chadscript/http";
 
 const parser = new ArgumentParser("websocket-chat", "Real-time WebSocket chat server");
-parser.addOption("port", "p", "Port to listen on (0 = auto)", "0");
+parser.addOption("port", "p", "Port to listen on", "8080");
 parser.parse(process.argv);
 
 const port = parseInt(parser.getOption("port"));
@@ -17,8 +17,9 @@ function wsHandler(event: WsEvent): string {
   if (event.event === "open") {
     userCount = userCount + 1;
     console.log("  [ws] client connected (" + userCount + " online)");
+    wsSend(event.connId, "init|" + event.connId);
     wsBroadcast("sys|a new user joined the chat (" + userCount + " online)");
-    return "init|" + event.connId;
+    return "";
   }
   if (event.event === "close") {
     userCount = userCount - 1;
@@ -48,4 +49,5 @@ function handleRequest(req: HttpRequest): HttpResponse {
 }
 
 console.log("WebSocket Chat Server (HTML/CSS embedded at compile time)");
+console.log("  open http://localhost:" + port + " in two tabs to chat");
 httpServe(port, handleRequest, wsHandler);

--- a/examples/websocket/app.ts
+++ b/examples/websocket/app.ts
@@ -8,24 +8,6 @@ parser.parse(process.argv);
 
 const port = parseInt(parser.getOption("port"));
 
-interface WsEvent {
-  data: string;
-  event: string;
-  connId: string;
-}
-
-interface HttpRequest {
-  method: string;
-  path: string;
-  body: string;
-  contentType: string;
-}
-
-interface HttpResponse {
-  status: number;
-  body: string;
-}
-
 // Embed the public/ directory into the binary at compile time
 ChadScript.embedDir("./public");
 
@@ -35,18 +17,18 @@ function wsHandler(event: WsEvent): string {
   if (event.event === "open") {
     userCount = userCount + 1;
     console.log("  [ws] client connected (" + userCount + " online)");
-    wsBroadcast("a new user joined the chat (" + userCount + " online)");
-    return "";
+    wsBroadcast("sys|a new user joined the chat (" + userCount + " online)");
+    return "init|" + event.connId;
   }
   if (event.event === "close") {
     userCount = userCount - 1;
     console.log("  [ws] client disconnected (" + userCount + " online)");
-    wsBroadcast("a user left the chat (" + userCount + " online)");
+    wsBroadcast("sys|a user left the chat (" + userCount + " online)");
     return "";
   }
   if (event.event === "message") {
     console.log("  [ws] message: " + event.data);
-    wsBroadcast(event.data);
+    wsBroadcast("msg|" + event.connId + "|" + event.data);
     return "";
   }
   return "";

--- a/examples/websocket/app.ts
+++ b/examples/websocket/app.ts
@@ -1,9 +1,9 @@
 // WebSocket Chat - real-time chat with embedded HTML/CSS served statically
 import { ArgumentParser } from "chadscript/argparse";
-import { httpServe, wsBroadcast, wsSend } from "chadscript/http";
+import { httpServe, wsBroadcast } from "chadscript/http";
 
 const parser = new ArgumentParser("websocket-chat", "Real-time WebSocket chat server");
-parser.addOption("port", "p", "Port to listen on", "8080");
+parser.addOption("port", "p", "Port to listen on (0 = auto)", "0");
 parser.parse(process.argv);
 
 const port = parseInt(parser.getOption("port"));
@@ -17,7 +17,6 @@ function wsHandler(event: WsEvent): string {
   if (event.event === "open") {
     userCount = userCount + 1;
     console.log("  [ws] client connected (" + userCount + " online)");
-    wsSend(event.connId, "init|" + event.connId);
     wsBroadcast("sys|a new user joined the chat (" + userCount + " online)");
     return "";
   }
@@ -28,26 +27,22 @@ function wsHandler(event: WsEvent): string {
     return "";
   }
   if (event.event === "message") {
-    console.log("  [ws] message: " + event.data);
-    wsBroadcast("msg|" + event.connId + "|" + event.data);
+    const sep = event.data.indexOf("|");
+    const senderId = event.data.substring(0, sep);
+    const text = event.data.substring(sep + 1);
+    console.log("  [ws] " + senderId + ": " + text);
+    wsBroadcast("msg|" + senderId + "|" + text);
     return "";
   }
   return "";
 }
 
 function handleRequest(req: HttpRequest): HttpResponse {
-  console.log(req.method + " " + req.path);
-
-  // Serve index.html for the root path
   if (req.path === "/") {
     return ChadScript.serveEmbedded("index.html");
   }
-
-  // serveEmbedded strips leading "/" and looks up embedded files automatically.
-  // Returns 200 with content if found, 404 if not.
   return ChadScript.serveEmbedded(req.path);
 }
 
 console.log("WebSocket Chat Server (HTML/CSS embedded at compile time)");
-console.log("  open http://localhost:" + port + " in two tabs to chat");
 httpServe(port, handleRequest, wsHandler);

--- a/examples/websocket/public/chat.js
+++ b/examples/websocket/public/chat.js
@@ -7,11 +7,11 @@ var input = document.getElementById("input");
 var status = document.getElementById("status");
 var sendBtn = document.getElementById("send-btn");
 var ws;
-var myConnId = null;
+var myId = Math.random().toString(36).slice(2, 8);
 var lastSender = null;
 
-function shortName(connId) {
-  return "User " + connId.slice(-4);
+function shortName(id) {
+  return "User " + id.slice(-4);
 }
 
 function addMessage(text, type, senderId) {
@@ -39,15 +39,11 @@ function connect() {
   ws.onopen = function () {
     status.textContent = "connected";
     status.className = "status connected";
+    sendBtn.disabled = input.value.trim().length === 0;
   };
 
   ws.onmessage = function (e) {
     var data = e.data;
-    if (data.startsWith("init|")) {
-      myConnId = data.slice(5);
-      sendBtn.disabled = false;
-      return;
-    }
     if (data.startsWith("sys|")) {
       addMessage(data.slice(4), "system", null);
       return;
@@ -57,7 +53,7 @@ function connect() {
       var sep = rest.indexOf("|");
       var sender = rest.slice(0, sep);
       var msg = rest.slice(sep + 1);
-      addMessage(msg, sender === myConnId ? "sent" : "received", sender);
+      addMessage(msg, sender === myId ? "sent" : "received", sender);
       return;
     }
     addMessage(data, "received", null);
@@ -71,7 +67,6 @@ function connect() {
     status.textContent = "disconnected";
     status.className = "status disconnected";
     sendBtn.disabled = true;
-    myConnId = null;
     lastSender = null;
     addMessage("Disconnected — reconnecting...", "system", null);
     setTimeout(connect, 2000);
@@ -79,14 +74,14 @@ function connect() {
 }
 
 input.addEventListener("input", function () {
-  sendBtn.disabled = !input.value.trim() || !ws || ws.readyState !== 1 || !myConnId;
+  sendBtn.disabled = !input.value.trim() || !ws || ws.readyState !== 1;
 });
 
 form.onsubmit = function (e) {
   e.preventDefault();
   var msg = input.value.trim();
   if (msg.length > 0 && ws && ws.readyState === 1) {
-    ws.send(msg);
+    ws.send(myId + "|" + msg);
     input.value = "";
     sendBtn.disabled = true;
   }

--- a/examples/websocket/public/chat.js
+++ b/examples/websocket/public/chat.js
@@ -1,14 +1,14 @@
 // Client-side WebSocket chat logic.
 // Connects to the server, sends/receives messages, auto-reconnects.
 
-var messages = document.getElementById("messages");
-var form = document.getElementById("form");
-var input = document.getElementById("input");
-var status = document.getElementById("status");
-var sendBtn = document.getElementById("send-btn");
-var ws;
-var myId = Math.random().toString(36).slice(2, 8);
-var lastSender = null;
+const messages = document.getElementById("messages");
+const form = document.getElementById("form");
+const input = document.getElementById("input");
+const statusEl = document.getElementById("status");
+const sendBtn = document.getElementById("send-btn");
+let ws;
+const myId = Math.random().toString(36).slice(2, 8);
+let lastSender = null;
 
 function shortName(id) {
   return "User " + id.slice(-4);
@@ -16,14 +16,14 @@ function shortName(id) {
 
 function addMessage(text, type, senderId) {
   if (type === "received" && senderId && senderId !== lastSender) {
-    var nameEl = document.createElement("div");
+    const nameEl = document.createElement("div");
     nameEl.className = "sender-name";
     nameEl.textContent = shortName(senderId);
     messages.appendChild(nameEl);
   }
   lastSender = type === "system" ? null : senderId || type;
 
-  var div = document.createElement("div");
+  const div = document.createElement("div");
   div.className = "message " + type;
   div.textContent = text;
   messages.appendChild(div);
@@ -31,28 +31,28 @@ function addMessage(text, type, senderId) {
 }
 
 function connect() {
-  status.textContent = "connecting...";
-  status.className = "status";
+  statusEl.textContent = "connecting...";
+  statusEl.className = "status";
   sendBtn.disabled = true;
   ws = new WebSocket("ws://" + location.host + "/ws");
 
   ws.onopen = function () {
-    status.textContent = "connected";
-    status.className = "status connected";
+    statusEl.textContent = "connected";
+    statusEl.className = "status connected";
     sendBtn.disabled = input.value.trim().length === 0;
   };
 
   ws.onmessage = function (e) {
-    var data = e.data;
+    const data = e.data;
     if (data.startsWith("sys|")) {
       addMessage(data.slice(4), "system", null);
       return;
     }
     if (data.startsWith("msg|")) {
-      var rest = data.slice(4);
-      var sep = rest.indexOf("|");
-      var sender = rest.slice(0, sep);
-      var msg = rest.slice(sep + 1);
+      const rest = data.slice(4);
+      const sep = rest.indexOf("|");
+      const sender = rest.slice(0, sep);
+      const msg = rest.slice(sep + 1);
       addMessage(msg, sender === myId ? "sent" : "received", sender);
       return;
     }
@@ -64,8 +64,8 @@ function connect() {
   };
 
   ws.onclose = function () {
-    status.textContent = "disconnected";
-    status.className = "status disconnected";
+    statusEl.textContent = "disconnected";
+    statusEl.className = "status disconnected";
     sendBtn.disabled = true;
     lastSender = null;
     addMessage("Disconnected — reconnecting...", "system", null);
@@ -79,7 +79,7 @@ input.addEventListener("input", function () {
 
 form.onsubmit = function (e) {
   e.preventDefault();
-  var msg = input.value.trim();
+  const msg = input.value.trim();
   if (msg.length > 0 && ws && ws.readyState === 1) {
     ws.send(myId + "|" + msg);
     input.value = "";

--- a/examples/websocket/public/chat.js
+++ b/examples/websocket/public/chat.js
@@ -6,6 +6,7 @@ var form = document.getElementById("form");
 var input = document.getElementById("input");
 var status = document.getElementById("status");
 var ws;
+var myConnId = null;
 
 function addMessage(text, type) {
   var div = document.createElement("div");
@@ -27,7 +28,24 @@ function connect() {
   };
 
   ws.onmessage = function (e) {
-    addMessage(e.data, "received");
+    var data = e.data;
+    if (data.startsWith("init|")) {
+      myConnId = data.slice(5);
+      return;
+    }
+    if (data.startsWith("sys|")) {
+      addMessage(data.slice(4), "system");
+      return;
+    }
+    if (data.startsWith("msg|")) {
+      var rest = data.slice(4);
+      var sep = rest.indexOf("|");
+      var sender = rest.slice(0, sep);
+      var msg = rest.slice(sep + 1);
+      addMessage(msg, sender === myConnId ? "sent" : "received");
+      return;
+    }
+    addMessage(data, "received");
   };
 
   ws.onerror = function () {
@@ -47,7 +65,6 @@ form.onsubmit = function (e) {
   var msg = input.value.trim();
   if (msg.length > 0 && ws && ws.readyState === 1) {
     ws.send(msg);
-    addMessage(msg, "sent");
     input.value = "";
   }
 };

--- a/examples/websocket/public/chat.js
+++ b/examples/websocket/public/chat.js
@@ -5,10 +5,24 @@ var messages = document.getElementById("messages");
 var form = document.getElementById("form");
 var input = document.getElementById("input");
 var status = document.getElementById("status");
+var sendBtn = document.getElementById("send-btn");
 var ws;
 var myConnId = null;
+var lastSender = null;
 
-function addMessage(text, type) {
+function shortName(connId) {
+  return "User " + connId.slice(-4);
+}
+
+function addMessage(text, type, senderId) {
+  if (type === "received" && senderId && senderId !== lastSender) {
+    var nameEl = document.createElement("div");
+    nameEl.className = "sender-name";
+    nameEl.textContent = shortName(senderId);
+    messages.appendChild(nameEl);
+  }
+  lastSender = type === "system" ? null : senderId || type;
+
   var div = document.createElement("div");
   div.className = "message " + type;
   div.textContent = text;
@@ -19,22 +33,23 @@ function addMessage(text, type) {
 function connect() {
   status.textContent = "connecting...";
   status.className = "status";
+  sendBtn.disabled = true;
   ws = new WebSocket("ws://" + location.host + "/ws");
 
   ws.onopen = function () {
     status.textContent = "connected";
     status.className = "status connected";
-    addMessage("Connected to chat server", "system");
   };
 
   ws.onmessage = function (e) {
     var data = e.data;
     if (data.startsWith("init|")) {
       myConnId = data.slice(5);
+      sendBtn.disabled = false;
       return;
     }
     if (data.startsWith("sys|")) {
-      addMessage(data.slice(4), "system");
+      addMessage(data.slice(4), "system", null);
       return;
     }
     if (data.startsWith("msg|")) {
@@ -42,23 +57,30 @@ function connect() {
       var sep = rest.indexOf("|");
       var sender = rest.slice(0, sep);
       var msg = rest.slice(sep + 1);
-      addMessage(msg, sender === myConnId ? "sent" : "received");
+      addMessage(msg, sender === myConnId ? "sent" : "received", sender);
       return;
     }
-    addMessage(data, "received");
+    addMessage(data, "received", null);
   };
 
   ws.onerror = function () {
-    addMessage("Connection error", "system");
+    addMessage("Connection error", "system", null);
   };
 
   ws.onclose = function () {
     status.textContent = "disconnected";
     status.className = "status disconnected";
-    addMessage("Disconnected — reconnecting...", "system");
+    sendBtn.disabled = true;
+    myConnId = null;
+    lastSender = null;
+    addMessage("Disconnected — reconnecting...", "system", null);
     setTimeout(connect, 2000);
   };
 }
+
+input.addEventListener("input", function () {
+  sendBtn.disabled = !input.value.trim() || !ws || ws.readyState !== 1 || !myConnId;
+});
 
 form.onsubmit = function (e) {
   e.preventDefault();
@@ -66,6 +88,7 @@ form.onsubmit = function (e) {
   if (msg.length > 0 && ws && ws.readyState === 1) {
     ws.send(msg);
     input.value = "";
+    sendBtn.disabled = true;
   }
 };
 

--- a/examples/websocket/public/index.html
+++ b/examples/websocket/public/index.html
@@ -17,7 +17,7 @@
         <input
           type="text"
           id="input"
-          placeholder="iMessage"
+          placeholder="Message"
           autocomplete="off"
           autofocus
         />

--- a/examples/websocket/public/index.html
+++ b/examples/websocket/public/index.html
@@ -14,13 +14,7 @@
       </div>
       <div class="messages" id="messages"></div>
       <form class="input-bar" id="form">
-        <input
-          type="text"
-          id="input"
-          placeholder="Message"
-          autocomplete="off"
-          autofocus
-        />
+        <input type="text" id="input" placeholder="Message" autocomplete="off" autofocus />
         <button type="submit" id="send-btn" disabled>↑</button>
       </form>
     </div>

--- a/examples/websocket/public/index.html
+++ b/examples/websocket/public/index.html
@@ -17,11 +17,11 @@
         <input
           type="text"
           id="input"
-          placeholder="Type a message..."
+          placeholder="iMessage"
           autocomplete="off"
           autofocus
         />
-        <button type="submit">Send</button>
+        <button type="submit" id="send-btn" disabled>↑</button>
       </form>
     </div>
     <script src="chat.js"></script>

--- a/examples/websocket/public/style.css
+++ b/examples/websocket/public/style.css
@@ -15,8 +15,6 @@ body {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  max-width: 480px;
-  margin: 0 auto;
   background: #fff;
 }
 
@@ -59,10 +57,14 @@ body {
 .messages {
   flex: 1;
   overflow-y: auto;
-  padding: 12px 16px;
+  padding: 12px 24px;
   display: flex;
   flex-direction: column;
   gap: 2px;
+  max-width: 900px;
+  width: 100%;
+  align-self: center;
+  box-sizing: border-box;
 }
 
 .sender-name {
@@ -109,10 +111,14 @@ body {
 .input-bar {
   display: flex;
   align-items: center;
-  padding: 8px 12px;
+  padding: 8px 24px;
   background: #f5f5f7;
   border-top: 1px solid #d1d1d6;
   gap: 8px;
+  max-width: 900px;
+  width: 100%;
+  align-self: center;
+  box-sizing: border-box;
 }
 
 .input-bar input {

--- a/examples/websocket/public/style.css
+++ b/examples/websocket/public/style.css
@@ -6,16 +6,21 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
-  background: #fff;
+  background: #e5e5ea;
   color: #000;
   height: 100vh;
+  display: flex;
+  justify-content: center;
 }
 
 .container {
   display: flex;
   flex-direction: column;
   height: 100vh;
+  width: 100%;
+  max-width: 900px;
   background: #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08);
 }
 
 .header {
@@ -61,9 +66,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  max-width: 900px;
-  width: 100%;
-  align-self: center;
   box-sizing: border-box;
 }
 
@@ -115,9 +117,6 @@ body {
   background: #f5f5f7;
   border-top: 1px solid #d1d1d6;
   gap: 8px;
-  max-width: 900px;
-  width: 100%;
-  align-self: center;
   box-sizing: border-box;
 }
 

--- a/examples/websocket/public/style.css
+++ b/examples/websocket/public/style.css
@@ -1,4 +1,3 @@
-/* VitePress amber/gold theme — matches docs/.vitepress/theme/style.css palette */
 * {
   margin: 0;
   padding: 0;
@@ -6,9 +5,9 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  background: #1b1b1f;
-  color: #e2e2e5;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  background: #fff;
+  color: #000;
   height: 100vh;
 }
 
@@ -16,116 +15,143 @@ body {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  max-width: 720px;
+  max-width: 480px;
   margin: 0 auto;
+  background: #fff;
 }
 
 .header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 16px 20px;
-  background: #161618;
-  border-bottom: 1px solid #2e2e32;
+  justify-content: center;
+  padding: 12px 16px 10px;
+  background: #f5f5f7;
+  border-bottom: 1px solid #d1d1d6;
+  position: relative;
 }
 
 .header h1 {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 600;
-  color: #fbbf24;
+  color: #000;
 }
 
 .status {
-  font-size: 12px;
-  padding: 4px 10px;
-  border-radius: 12px;
-  background: #2e2e32;
-  color: #888;
+  position: absolute;
+  right: 12px;
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 10px;
+  background: #e5e5ea;
+  color: #8e8e93;
 }
 
 .status.connected {
-  background: rgba(34, 197, 94, 0.15);
-  color: #22c55e;
+  background: rgba(52, 199, 89, 0.15);
+  color: #34c759;
 }
 
 .status.disconnected {
-  background: rgba(239, 68, 68, 0.15);
-  color: #ef4444;
+  background: rgba(255, 59, 48, 0.15);
+  color: #ff3b30;
 }
 
 .messages {
   flex: 1;
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: 12px 16px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 2px;
+}
+
+.sender-name {
+  font-size: 12px;
+  color: #8e8e93;
+  margin-top: 8px;
+  margin-left: 14px;
+  margin-bottom: 2px;
 }
 
 .message {
-  padding: 8px 14px;
-  border-radius: 8px;
-  max-width: 80%;
+  padding: 9px 14px;
+  border-radius: 20px;
+  max-width: 75%;
   word-wrap: break-word;
-  font-size: 14px;
-  line-height: 1.4;
+  font-size: 16px;
+  line-height: 1.35;
 }
 
 .message.sent {
   align-self: flex-end;
-  background: rgba(245, 158, 11, 0.15);
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  color: #e2e2e5;
+  background: #007aff;
+  color: #fff;
+  border-bottom-right-radius: 5px;
 }
 
 .message.received {
   align-self: flex-start;
-  background: #2e2e32;
-  color: #e2e2e5;
+  background: #e9e9eb;
+  color: #000;
+  border-bottom-left-radius: 5px;
 }
 
 .message.system {
   align-self: center;
   background: none;
-  color: #666;
+  color: #8e8e93;
   font-size: 12px;
-  font-style: italic;
+  max-width: 100%;
+  text-align: center;
+  padding: 6px 8px;
 }
 
 .input-bar {
   display: flex;
-  padding: 12px 20px;
-  background: #161618;
-  border-top: 1px solid #2e2e32;
+  align-items: center;
+  padding: 8px 12px;
+  background: #f5f5f7;
+  border-top: 1px solid #d1d1d6;
   gap: 8px;
 }
 
 .input-bar input {
   flex: 1;
-  padding: 10px 14px;
-  border: 1px solid #3e3e42;
-  border-radius: 6px;
-  background: #2e2e32;
-  color: #e2e2e5;
-  font-size: 14px;
+  padding: 8px 14px;
+  border: 1px solid #c7c7cc;
+  border-radius: 20px;
+  background: #fff;
+  color: #000;
+  font-size: 16px;
+  font-family: inherit;
   outline: none;
 }
 
 .input-bar input:focus {
-  border-color: #fbbf24;
+  border-color: #007aff;
 }
 
 .input-bar button {
-  padding: 10px 20px;
+  width: 32px;
+  height: 32px;
   border: none;
-  border-radius: 6px;
-  background: #f59e0b;
-  color: #1b1b1f;
-  font-size: 14px;
-  font-weight: 600;
+  border-radius: 50%;
+  background: #007aff;
+  color: #fff;
+  font-size: 18px;
+  line-height: 1;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .input-bar button:hover {
-  background: #fbbf24;
+  background: #0051d5;
+}
+
+.input-bar button:disabled {
+  background: #c7c7cc;
+  cursor: default;
 }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2554,6 +2554,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               hasBodyLen = true;
             }
           }
+        } else if (handlerReturnType === "HttpResponse") {
+          // HttpResponse is defined in chadscript.d.ts (not in AST), always has headers
+          hasHeaders = true;
         }
       }
 


### PR DESCRIPTION
# fix examples: http-server and websocket

## Summary

- **http-server**: replace raw JSON strings with `c.json()` object literals; serve an embedded HTML homepage with clickable routes and inline POST forms
- **websocket**: fix crash on open (removed `wsBroadcast` call on connect), iMessage-style chat UI (white/blue bubbles, sender names, arrow button), client-generated IDs, structured `sender|text` message protocol, fixed status var shadowing `window.status`, constrained container width on wide screens
- **http redirect fixes**: set `hasHeaders=true` when handler returns `HttpResponse` from `.d.ts`; use `embedDir` not `embedFile` for `getEmbeddedFile` lookup

## Changes

### examples/http-server.ts
- All `c.json()` calls now pass object literals instead of raw JSON strings
- Root route serves embedded `index.html` (HTML homepage with all routes)
- New `examples/http-server-public/index.html` with clickable GET links and inline POST forms

### examples/websocket/
- `app.ts`: remove `wsBroadcast` on open (caused crash), structured `sender|text` protocol, removed redundant interface definitions (use `.d.ts`)
- `public/chat.js`: client-generated UUID, parse structured messages, distinguish sent/received sides
- `public/style.css`: iMessage-style bubbles, full-screen layout, constrained width

### src/codegen/llvm-generator.ts
- Support `embedDir` for embedded file lookup (fixes blank page on redirect)

## Test plan
- [ ] `node dist/chad-node.js run examples/http-server.ts` — homepage loads, all routes return JSON
- [ ] `node dist/chad-node.js run examples/websocket/app.ts` — chat UI loads, messages appear with correct sender/receiver styling, user count updates on leave
- [ ] Multiple browser tabs — broadcast works, leave message shown to remaining users
- [ ] `bash scripts/run-examples.sh` — all 9 example tests pass
