### PR TITLE
add req.queryString, crypto.hmacSha256, btoa/atob, encodeURIComponent…

### DIFF
--- a/c_bridges/base64-bridge.c
+++ b/c_bridges/base64-bridge.c
@@ -1,0 +1,53 @@
+#include <stddef.h>
+#include <string.h>
+
+extern void *GC_malloc_atomic(size_t);
+
+static const char b64_enc[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+char *cs_btoa(const char *src, int len) {
+    int out_len = ((len + 2) / 3) * 4;
+    char *out = (char *)GC_malloc_atomic((size_t)(out_len + 1));
+    int i = 0, j = 0;
+    while (i < len) {
+        unsigned int b0 = (unsigned char)src[i++];
+        unsigned int b1 = i < len ? (unsigned char)src[i++] : 0;
+        unsigned int b2 = i < len ? (unsigned char)src[i++] : 0;
+        out[j++] = b64_enc[(b0 >> 2) & 0x3F];
+        out[j++] = b64_enc[((b0 & 0x3) << 4) | ((b1 >> 4) & 0xF)];
+        out[j++] = (i - 1 < len || (i - 1 == len && b1)) ? b64_enc[((b1 & 0xF) << 2) | ((b2 >> 6) & 0x3)] : '=';
+        out[j++] = (i < len || i == len + 1) ? b64_enc[b2 & 0x3F] : '=';
+    }
+    out[j] = '\0';
+    return out;
+}
+
+static int b64_decode_char(char c) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+') return 62;
+    if (c == '/') return 63;
+    return -1;
+}
+
+char *cs_atob(const char *src, int *out_len) {
+    int src_len = (int)strlen(src);
+    int max_out = (src_len / 4) * 3;
+    char *out = (char *)GC_malloc_atomic((size_t)(max_out + 1));
+    int j = 0;
+    for (int i = 0; i < src_len; i += 4) {
+        int c0 = b64_decode_char(src[i]);
+        int c1 = i + 1 < src_len ? b64_decode_char(src[i + 1]) : 0;
+        int c2 = i + 2 < src_len ? b64_decode_char(src[i + 2]) : 0;
+        int c3 = i + 3 < src_len ? b64_decode_char(src[i + 3]) : 0;
+        if (c0 < 0 || c1 < 0) break;
+        out[j++] = (char)((c0 << 2) | (c1 >> 4));
+        if (i + 2 < src_len && src[i + 2] != '=') out[j++] = (char)((c1 << 4) | (c2 >> 2));
+        if (i + 3 < src_len && src[i + 3] != '=') out[j++] = (char)((c2 << 6) | c3);
+    }
+    out[j] = '\0';
+    if (out_len) *out_len = j;
+    return out;
+}

--- a/c_bridges/lws-bridge.c
+++ b/c_bridges/lws-bridge.c
@@ -381,6 +381,13 @@ static const char *sniff_content_type(const char *path, const char *body) {
 static void dispatch_http_request(http_conn_t *conn) {
     lws_bridge_request req;
     req.method = conn->method_str;
+    char *qmark = strchr(conn->path_str, '?');
+    if (qmark) {
+        *qmark = '\0';
+        req.query_string = qmark + 1;
+    } else {
+        req.query_string = "";
+    }
     req.path = conn->path_str;
     req.body = conn->body ? conn->body : "";
     req.content_type = conn->content_type_str;

--- a/c_bridges/lws-bridge.h
+++ b/c_bridges/lws-bridge.h
@@ -10,6 +10,7 @@ typedef struct {
     const char *content_type;
     const char *headers_raw;  // all headers as "Key: Value\n..." string
     int64_t body_len;         // actual byte count (for binary bodies with embedded nulls)
+    const char *query_string; // query string portion of URL (after ?), or ""
 } lws_bridge_request;
 
 typedef struct {

--- a/c_bridges/uri-bridge.c
+++ b/c_bridges/uri-bridge.c
@@ -1,0 +1,57 @@
+#include <stddef.h>
+#include <string.h>
+
+extern void *GC_malloc_atomic(size_t);
+
+static const char hex[] = "0123456789ABCDEF";
+
+static int is_unreserved(unsigned char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+           (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '!' ||
+           c == '~' || c == '*' || c == '\'' || c == '(' || c == ')';
+}
+
+char *cs_encode_uri_component(const char *src) {
+    int len = (int)strlen(src);
+    char *out = (char *)GC_malloc_atomic((size_t)(len * 3 + 1));
+    int j = 0;
+    for (int i = 0; i < len; i++) {
+        unsigned char c = (unsigned char)src[i];
+        if (is_unreserved(c)) {
+            out[j++] = (char)c;
+        } else {
+            out[j++] = '%';
+            out[j++] = hex[c >> 4];
+            out[j++] = hex[c & 0xF];
+        }
+    }
+    out[j] = '\0';
+    return out;
+}
+
+static int hex_val(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+char *cs_decode_uri_component(const char *src) {
+    int len = (int)strlen(src);
+    char *out = (char *)GC_malloc_atomic((size_t)(len + 1));
+    int j = 0;
+    for (int i = 0; i < len; i++) {
+        if (src[i] == '%' && i + 2 < len) {
+            int hi = hex_val(src[i + 1]);
+            int lo = hex_val(src[i + 2]);
+            if (hi >= 0 && lo >= 0) {
+                out[j++] = (char)((hi << 4) | lo);
+                i += 2;
+                continue;
+            }
+        }
+        out[j++] = src[i];
+    }
+    out[j] = '\0';
+    return out;
+}

--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -135,6 +135,8 @@ declare namespace crypto {
   function sha512(input: string): string;
   function md5(input: string): string;
   function randomBytes(n: number): string;
+  function hmacSha256(key: string, data: string): string;
+  function pbkdf2(password: string, salt: string, iterations: number, keyLen: number): string;
 }
 
 // ============================================================================
@@ -227,6 +229,7 @@ interface HttpRequest {
   contentType: string;
   headers: string;
   bodyLen: number;
+  queryString: string;
 }
 
 interface HttpResponse {
@@ -259,6 +262,10 @@ declare function parseInt(str: string, radix?: number): number;
 declare function parseFloat(str: string): number;
 declare function isNaN(value: any): boolean;
 declare function execSync(command: string): string;
+declare function btoa(data: string): string;
+declare function atob(data: string): string;
+declare function encodeURIComponent(str: string): string;
+declare function decodeURIComponent(str: string): string;
 
 // ============================================================================
 // Low-Level System Calls

--- a/docs/stdlib/crypto.md
+++ b/docs/stdlib/crypto.md
@@ -46,6 +46,24 @@ const id = crypto.randomUUID();
 // "550e8400-e29b-41d4-a716-446655440000"
 ```
 
+## `crypto.hmacSha256(key, message)`
+
+Compute HMAC-SHA256 of `message` using `key`. Returns a 64-character hex string.
+
+```typescript
+const sig = crypto.hmacSha256("secret", "hello");
+// e.g. "88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b"
+```
+
+## `crypto.pbkdf2(password, salt, iterations, keyLen)`
+
+Derive a key from `password` and `salt` using PBKDF2-HMAC-SHA256. Returns a hex string of length `keyLen * 2`.
+
+```typescript
+const key = crypto.pbkdf2("password", "salt", 100000, 32);
+// 64-character hex string
+```
+
 ## Example
 
 ```typescript
@@ -69,3 +87,5 @@ console.log(uuid);
 | `crypto.md5()` | OpenSSL EVP API (`EVP_md5`) |
 | `crypto.randomBytes()` | `RAND_bytes()` |
 | `crypto.randomUUID()` | `RAND_bytes(16)` + version/variant bits + `snprintf` |
+| `crypto.hmacSha256()` | OpenSSL `HMAC()` with `EVP_sha256` |
+| `crypto.pbkdf2()` | OpenSSL `PKCS5_PBKDF2_HMAC()` with `EVP_sha256` |

--- a/docs/stdlib/http-server.md
+++ b/docs/stdlib/http-server.md
@@ -184,10 +184,11 @@ function wsHandler(event: WsEvent): string {
 | Property | Type | Description |
 |----------|------|-------------|
 | `method` | `string` | HTTP method (`"GET"`, `"POST"`, etc.) |
-| `path` | `string` | Request path (`"/"`, `"/api/users"`, etc.) |
+| `path` | `string` | Request path (`"/"`, `"/api/users"`, etc.), without query string |
 | `body` | `string` | Request body |
 | `contentType` | `string` | Content-Type header value |
 | `headers` | `string` | All request headers as `"Key: Value\n..."` string |
+| `queryString` | `string` | Raw query string (e.g. `"page=2&limit=10"`), or `""` if none |
 
 ## HttpResponse Object
 

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -12,6 +12,8 @@ Most APIs are available everywhere with no import:
 console.log("hello");
 const data = fs.readFileSync("file.txt");
 const hash = crypto.createHash("sha256");
+const encoded = btoa("hello world");
+const uri = encodeURIComponent("hello world & foo=bar");
 ```
 
 ## Modules

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -168,6 +168,28 @@ else
   echo "==> watch-bridge already built, skipping"
 fi
 
+# --- base64-bridge ---
+BASE64_BRIDGE_SRC="$C_BRIDGES_DIR/base64-bridge.c"
+BASE64_BRIDGE_OBJ="$C_BRIDGES_DIR/base64-bridge.o"
+if [ ! -f "$BASE64_BRIDGE_OBJ" ] || [ "$BASE64_BRIDGE_SRC" -nt "$BASE64_BRIDGE_OBJ" ]; then
+  echo "==> Building base64-bridge..."
+  cc -c -O2 -fPIC "$BASE64_BRIDGE_SRC" -o "$BASE64_BRIDGE_OBJ"
+  echo "  -> $BASE64_BRIDGE_OBJ"
+else
+  echo "==> base64-bridge already built, skipping"
+fi
+
+# --- uri-bridge ---
+URI_BRIDGE_SRC="$C_BRIDGES_DIR/uri-bridge.c"
+URI_BRIDGE_OBJ="$C_BRIDGES_DIR/uri-bridge.o"
+if [ ! -f "$URI_BRIDGE_OBJ" ] || [ "$URI_BRIDGE_SRC" -nt "$URI_BRIDGE_OBJ" ]; then
+  echo "==> Building uri-bridge..."
+  cc -c -O2 -fPIC "$URI_BRIDGE_SRC" -o "$URI_BRIDGE_OBJ"
+  echo "  -> $URI_BRIDGE_OBJ"
+else
+  echo "==> uri-bridge already built, skipping"
+fi
+
 # --- child-process-bridge (sync only, no libuv dependency) ---
 CP_BRIDGE_SRC="$C_BRIDGES_DIR/child-process-bridge.c"
 CP_BRIDGE_OBJ="$C_BRIDGES_DIR/child-process-bridge.o"

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -194,6 +194,19 @@ export class CallExpressionGenerator {
       return this.generateIsNaN(expr, params);
     }
 
+    if (expr.name === "btoa") {
+      return this.generateBtoa(expr, params);
+    }
+    if (expr.name === "atob") {
+      return this.generateAtob(expr, params);
+    }
+    if (expr.name === "encodeURIComponent") {
+      return this.generateEncodeURIComponent(expr, params);
+    }
+    if (expr.name === "decodeURIComponent") {
+      return this.generateDecodeURIComponent(expr, params);
+    }
+
     // Handle C built-in functions with proper signatures
     if (expr.name === "malloc") {
       return this.generateMalloc(expr, params);
@@ -1212,5 +1225,57 @@ export class CallExpressionGenerator {
       }
     }
     return "i8*";
+  }
+
+  private generateBtoa(expr: CallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("btoa() requires 1 argument", expr.loc);
+    }
+    this.ctx.setUsesBase64(true);
+    const strPtr = this.ctx.generateExpression(expr.args[0], params);
+    const lenTemp = this.ctx.nextTemp();
+    this.ctx.emit(`${lenTemp} = call i64 @strlen(i8* ${strPtr})`);
+    const lenI32 = this.ctx.nextTemp();
+    this.ctx.emit(`${lenI32} = trunc i64 ${lenTemp} to i32`);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = call i8* @cs_btoa(i8* ${strPtr}, i32 ${lenI32})`);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
+  }
+
+  private generateAtob(expr: CallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("atob() requires 1 argument", expr.loc);
+    }
+    this.ctx.setUsesBase64(true);
+    const strPtr = this.ctx.generateExpression(expr.args[0], params);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = call i8* @cs_atob(i8* ${strPtr}, i8* null)`);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
+  }
+
+  private generateEncodeURIComponent(expr: CallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("encodeURIComponent() requires 1 argument", expr.loc);
+    }
+    this.ctx.setUsesUri(true);
+    const strPtr = this.ctx.generateExpression(expr.args[0], params);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = call i8* @cs_encode_uri_component(i8* ${strPtr})`);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
+  }
+
+  private generateDecodeURIComponent(expr: CallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("decodeURIComponent() requires 1 argument", expr.loc);
+    }
+    this.ctx.setUsesUri(true);
+    const strPtr = this.ctx.generateExpression(expr.args[0], params);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = call i8* @cs_decode_uri_component(i8* ${strPtr})`);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
   }
 }

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -828,6 +828,10 @@ export class MethodCallGenerator {
         return this.ctx.cryptoGen.generateRandomBytes(expr, params);
       } else if (method === "randomUUID") {
         return this.ctx.cryptoGen.generateRandomUUID(expr, params);
+      } else if (method === "hmacSha256") {
+        return this.ctx.cryptoGen.generateHmacSha256(expr, params);
+      } else if (method === "pbkdf2") {
+        return this.ctx.cryptoGen.generatePbkdf2(expr, params);
       }
     }
 

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -350,8 +350,16 @@ export class FunctionGenerator {
             let biTypes: string[] = [];
             const ptype = paramTypes[i];
             if (ptype === "HttpRequest") {
-              biKeys = ["method", "path", "body", "contentType", "headers", "bodyLen"];
-              biTypes = ["i8*", "i8*", "i8*", "i8*", "i8*", "double"];
+              biKeys = [
+                "method",
+                "path",
+                "body",
+                "contentType",
+                "headers",
+                "bodyLen",
+                "queryString",
+              ];
+              biTypes = ["i8*", "i8*", "i8*", "i8*", "i8*", "double", "i8*"];
             } else if (ptype === "HttpResponse") {
               biKeys = ["status", "body", "headers"];
               biTypes = ["double", "i8*", "i8*"];

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -195,6 +195,8 @@ export interface ICryptoGenerator {
   generateSha512(expr: MethodCallNode, params: string[]): string;
   generateRandomBytes(expr: MethodCallNode, params: string[]): string;
   generateRandomUUID(expr: MethodCallNode, params: string[]): string;
+  generateHmacSha256(expr: MethodCallNode, params: string[]): string;
+  generatePbkdf2(expr: MethodCallNode, params: string[]): string;
 }
 
 export interface ISqliteGenerator {
@@ -940,6 +942,9 @@ export interface IGeneratorContext {
   lastTypeAssertionSourceVar: string | null;
   getLastTypeAssertionSourceVar(): string | null;
   setLastTypeAssertionSourceVar(name: string | null): void;
+
+  setUsesBase64(value: boolean): void;
+  setUsesUri(value: boolean): void;
 }
 
 /**
@@ -991,6 +996,8 @@ export class MockGeneratorContext implements IGeneratorContext {
   public usesJson: number = 0;
   public usesHttpServer: number = 0;
   public usesRegex: number = 0;
+  public usesBase64: number = 0;
+  public usesUri: number = 0;
   public usesTestRunner: number = 0;
   public usesAsyncFs: number = 0;
   public currentFunction: string | null = null;
@@ -1208,6 +1215,12 @@ export class MockGeneratorContext implements IGeneratorContext {
   }
   setUsesRegex(value: boolean): void {
     this.usesRegex = value ? 1 : 0;
+  }
+  setUsesBase64(value: boolean): void {
+    this.usesBase64 = value ? 1 : 0;
+  }
+  setUsesUri(value: boolean): void {
+    this.usesUri = value ? 1 : 0;
   }
   setUsesTestRunner(value: boolean): void {
     this.usesTestRunner = value ? 1 : 0;
@@ -1913,6 +1926,9 @@ export class MockGeneratorContext implements IGeneratorContext {
       "%mock_crypto_random_bytes",
     generateRandomUUID: (_expr: MethodCallNode, _params: string[]): string =>
       "%mock_crypto_random_uuid",
+    generateHmacSha256: (_expr: MethodCallNode, _params: string[]): string =>
+      "%mock_crypto_hmac_sha256",
+    generatePbkdf2: (_expr: MethodCallNode, _params: string[]): string => "%mock_crypto_pbkdf2",
   };
   sqliteGen: ISqliteGenerator = {
     canHandle: (_expr: MethodCallNode): boolean => false,

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -3,6 +3,8 @@ export interface DeclConfig {
   crypto?: boolean;
   sqlite?: boolean;
   testRunner?: boolean;
+  base64?: boolean;
+  uri?: boolean;
   targetOS?: string;
 }
 
@@ -224,6 +226,8 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
     ir += "declare i8* @EVP_md5()\n";
     ir += "declare i8* @EVP_sha512()\n";
     ir += "declare i32 @RAND_bytes(i8*, i32)\n";
+    ir += "declare i8* @HMAC(i8*, i8*, i32, i8*, i64, i8*, i32*)\n";
+    ir += "declare i32 @PKCS5_PBKDF2_HMAC(i8*, i32, i8*, i32, i32, i8*, i32, i8*)\n";
     ir += "\n";
   }
 
@@ -263,6 +267,20 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
       '@.str.assert_deep_idx = private unnamed_addr constant [31 x i8] c"    arrays differ at index %d\\0A\\00", align 1\n';
     ir += '@.str.describe_header = private unnamed_addr constant [4 x i8] c"%s\\0A\\00", align 1\n';
     ir += '@.str.indent_unit = private unnamed_addr constant [3 x i8] c"  \\00", align 1\n';
+    ir += "\n";
+  }
+
+  if (config && config.base64) {
+    ir += "; base64 encode/decode (base64-bridge)\n";
+    ir += "declare i8* @cs_btoa(i8*, i32)\n";
+    ir += "declare i8* @cs_atob(i8*, i8*)\n";
+    ir += "\n";
+  }
+
+  if (config && config.uri) {
+    ir += "; URI encode/decode (uri-bridge)\n";
+    ir += "declare i8* @cs_encode_uri_component(i8*)\n";
+    ir += "declare i8* @cs_decode_uri_component(i8*)\n";
     ir += "\n";
   }
 

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -159,6 +159,13 @@ export class TypeInference {
       if (callExpr.name === "fetch") return this.ctx.typeContext.resolve("Promise");
       if (callExpr.name === "__ts_node_type" || callExpr.name === "__ts_node_text")
         return this.ctx.typeContext.stringType;
+      if (
+        callExpr.name === "btoa" ||
+        callExpr.name === "atob" ||
+        callExpr.name === "encodeURIComponent" ||
+        callExpr.name === "decodeURIComponent"
+      )
+        return this.ctx.typeContext.stringType;
       if (callExpr.name) {
         const func = this.getFunction(callExpr.name);
         if (func) {
@@ -397,7 +404,9 @@ export class TypeInference {
           method === "sha256" ||
           method === "md5" ||
           method === "sha512" ||
-          method === "randomBytes"
+          method === "randomBytes" ||
+          method === "hmacSha256" ||
+          method === "pbkdf2"
         ) {
           return this.ctx.typeContext.stringType;
         }

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1050,15 +1050,21 @@ export class VariableAllocator {
       keys.push("body");
       keys.push("contentType");
       keys.push("headers");
+      keys.push("bodyLen");
+      keys.push("queryString");
       types.push("i8*");
       types.push("i8*");
       types.push("i8*");
       types.push("i8*");
+      types.push("i8*");
+      types.push("double");
       types.push("i8*");
       tsTypes.push("string");
       tsTypes.push("string");
       tsTypes.push("string");
       tsTypes.push("string");
+      tsTypes.push("string");
+      tsTypes.push("number");
       tsTypes.push("string");
     } else if (interfaceName === "WsEvent") {
       keys.push("data");

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -219,6 +219,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public usesChildProcess: number = 0;
   public usesSpawn: number = 0;
   public usesStringBuilder: number = 0;
+  public usesBase64: number = 0;
+  public usesUri: number = 0;
   private stringBuilderSlen: Map<string, string> = new Map();
   private stringBuilderScap: Map<string, string> = new Map();
 
@@ -1057,6 +1059,18 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
   public getUsesRegex(): boolean {
     return this.usesRegex !== 0;
+  }
+  public setUsesBase64(value: boolean): void {
+    this.usesBase64 = value ? 1 : 0;
+  }
+  public getUsesBase64(): boolean {
+    return this.usesBase64 !== 0;
+  }
+  public setUsesUri(value: boolean): void {
+    this.usesUri = value ? 1 : 0;
+  }
+  public getUsesUri(): boolean {
+    return this.usesUri !== 0;
   }
   public setUsesTestRunner(value: boolean): void {
     this.usesTestRunner = value ? 1 : 0;
@@ -2698,6 +2712,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           crypto: this.usesCrypto !== 0,
           sqlite: this.usesSqlite !== 0,
           testRunner: this.usesTestRunner !== 0,
+          base64: this.usesBase64 !== 0,
+          uri: this.usesUri !== 0,
           targetOS: this.getTargetOS(),
         }),
       ),

--- a/src/codegen/stdlib/crypto.ts
+++ b/src/codegen/stdlib/crypto.ts
@@ -14,7 +14,15 @@ export class CryptoGenerator {
     if (exprObjBase.type !== "variable") return false;
     const varNode = expr.object as { type: string; name: string };
     if (varNode.name !== "crypto") return false;
-    const supported = ["sha256", "md5", "sha512", "randomBytes", "randomUUID"];
+    const supported = [
+      "sha256",
+      "md5",
+      "sha512",
+      "randomBytes",
+      "randomUUID",
+      "hmacSha256",
+      "pbkdf2",
+    ];
     return supported.indexOf(expr.method) !== -1;
   }
 
@@ -108,6 +116,77 @@ export class CryptoGenerator {
     this.ctx.emit(`${result} = call i8* @__bytes_to_hex(i8* ${buf}, i32 ${countI32})`);
     this.ctx.setVariableType(result, "i8*");
 
+    return result;
+  }
+
+  generateHmacSha256(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length < 2) {
+      return this.ctx.emitError("crypto.hmacSha256() requires 2 arguments (key, data)", expr.loc);
+    }
+    const keyPtr = this.ctx.generateExpression(expr.args[0], params);
+    const dataPtr = this.ctx.generateExpression(expr.args[1], params);
+    const keyLen = this.ctx.nextTemp();
+    this.ctx.emit(`${keyLen} = call i64 @strlen(i8* ${keyPtr})`);
+    const dataLen = this.ctx.nextTemp();
+    this.ctx.emit(`${dataLen} = call i64 @strlen(i8* ${dataPtr})`);
+    const evpMd = this.ctx.nextTemp();
+    this.ctx.emit(`${evpMd} = call i8* @EVP_sha256()`);
+    const outBuf = this.ctx.nextTemp();
+    this.ctx.emit(`${outBuf} = call i8* @GC_malloc_atomic(i64 32)`);
+    const outLenPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${outLenPtr} = call i8* @GC_malloc_atomic(i64 4)`);
+    const outLenI32Ptr = this.ctx.nextTemp();
+    this.ctx.emit(`${outLenI32Ptr} = bitcast i8* ${outLenPtr} to i32*`);
+    const keyLenI32 = this.ctx.nextTemp();
+    this.ctx.emit(`${keyLenI32} = trunc i64 ${keyLen} to i32`);
+    const hmacRet = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${hmacRet} = call i8* @HMAC(i8* ${evpMd}, i8* ${keyPtr}, i32 ${keyLenI32}, i8* ${dataPtr}, i64 ${dataLen}, i8* ${outBuf}, i32* ${outLenI32Ptr})`,
+    );
+    const outLen = this.ctx.nextTemp();
+    this.ctx.emit(`${outLen} = load i32, i32* ${outLenI32Ptr}`);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = call i8* @__bytes_to_hex(i8* ${outBuf}, i32 ${outLen})`);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
+  }
+
+  generatePbkdf2(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length < 4) {
+      return this.ctx.emitError(
+        "crypto.pbkdf2() requires 4 arguments (password, salt, iterations, keyLen)",
+        expr.loc,
+      );
+    }
+    const passPtr = this.ctx.generateExpression(expr.args[0], params);
+    const saltPtr = this.ctx.generateExpression(expr.args[1], params);
+    const itersDouble = this.ctx.generateExpression(expr.args[2], params);
+    const keyLenDouble = this.ctx.generateExpression(expr.args[3], params);
+    const passLen = this.ctx.nextTemp();
+    this.ctx.emit(`${passLen} = call i64 @strlen(i8* ${passPtr})`);
+    const saltLen = this.ctx.nextTemp();
+    this.ctx.emit(`${saltLen} = call i64 @strlen(i8* ${saltPtr})`);
+    const itersI32 = this.ctx.nextTemp();
+    this.ctx.emit(`${itersI32} = fptosi double ${itersDouble} to i32`);
+    const keyLenI32 = this.ctx.nextTemp();
+    this.ctx.emit(`${keyLenI32} = fptosi double ${keyLenDouble} to i32`);
+    const keyLenI64 = this.ctx.nextTemp();
+    this.ctx.emit(`${keyLenI64} = sext i32 ${keyLenI32} to i64`);
+    const outBuf = this.ctx.nextTemp();
+    this.ctx.emit(`${outBuf} = call i8* @GC_malloc_atomic(i64 ${keyLenI64})`);
+    const evpMd = this.ctx.nextTemp();
+    this.ctx.emit(`${evpMd} = call i8* @EVP_sha256()`);
+    const passLenI32 = this.ctx.nextTemp();
+    this.ctx.emit(`${passLenI32} = trunc i64 ${passLen} to i32`);
+    const saltLenI32 = this.ctx.nextTemp();
+    this.ctx.emit(`${saltLenI32} = trunc i64 ${saltLen} to i32`);
+    const pbkdf2Ret = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${pbkdf2Ret} = call i32 @PKCS5_PBKDF2_HMAC(i8* ${passPtr}, i32 ${passLenI32}, i8* ${saltPtr}, i32 ${saltLenI32}, i32 ${itersI32}, i8* ${evpMd}, i32 ${keyLenI32}, i8* ${outBuf})`,
+    );
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = call i8* @__bytes_to_hex(i8* ${outBuf}, i32 ${keyLenI32})`);
+    this.ctx.setVariableType(result, "i8*");
     return result;
   }
 

--- a/src/codegen/stdlib/http-server.ts
+++ b/src/codegen/stdlib/http-server.ts
@@ -17,7 +17,7 @@ export class HttpServerGenerator {
     let ir = "; libwebsockets HTTP server declarations (via lws-bridge)\n\n";
 
     ir += "; lws bridge types (match lws-bridge.h structs)\n";
-    ir += "%struct.lws_bridge_request = type { i8*, i8*, i8*, i8*, i8*, i64 }\n";
+    ir += "%struct.lws_bridge_request = type { i8*, i8*, i8*, i8*, i8*, i64, i8* }\n";
     ir += "%struct.lws_bridge_response = type { i32, i8*, i64, i8* }\n\n";
 
     ir += "; lws bridge functions\n";

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -401,6 +401,8 @@ export function compile(
     ? `${bridgePath}/lws-bridge.o ${picoPath}/picohttpparser.o ${bridgePath}/multipart-bridge.o`
     : "";
   const regexBridgeObj = generator.usesRegex ? `${bridgePath}/regex-bridge.o` : "";
+  const base64BridgeObj = generator.usesBase64 ? `${bridgePath}/base64-bridge.o` : "";
+  const uriBridgeObj = generator.usesUri ? `${bridgePath}/uri-bridge.o` : "";
   const cpBridgeObj = `${bridgePath}/child-process-bridge.o`;
   const osBridgeObj = `${bridgePath}/os-bridge.o`;
   const dotenvBridgeObj = fs.existsSync(`${bridgePath}/dotenv-bridge.o`)
@@ -486,7 +488,7 @@ export function compile(
   const userObjs = extraLinkObjs.length > 0 ? " " + extraLinkObjs.join(" ") : "";
   const userPaths = extraLinkPaths.map((p) => ` -L${p}`).join("");
   const userLibs = extraLinkLibs.map((l) => ` -l${l}`).join("");
-  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${cpSpawnObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
+  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${base64BridgeObj} ${uriBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${cpSpawnObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
   logger.info(` ${linkCmd}`);
   const linkStdio = logger.getLevel() >= LogLevel.Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -502,6 +502,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
       "/multipart-bridge.o"
     : "";
   const regexBridgeObj = generator.getUsesRegex() ? effectiveBridgePath + "/regex-bridge.o" : "";
+  const base64BridgeObj = generator.getUsesBase64() ? effectiveBridgePath + "/base64-bridge.o" : "";
+  const uriBridgeObj = generator.getUsesUri() ? effectiveBridgePath + "/uri-bridge.o" : "";
   const cpBridgeObj = effectiveBridgePath + "/child-process-bridge.o";
   const osBridgeObj = effectiveBridgePath + "/os-bridge.o";
   const dotenvBridgePath = effectiveBridgePath + "/dotenv-bridge.o";
@@ -573,6 +575,10 @@ export function compileNative(inputFile: string, outputFile: string): void {
     lwsBridgeObj +
     " " +
     regexBridgeObj +
+    " " +
+    base64BridgeObj +
+    " " +
+    uriBridgeObj +
     " " +
     cpBridgeObj +
     " " +

--- a/tests/fixtures/crypto/hmac.ts
+++ b/tests/fixtures/crypto/hmac.ts
@@ -1,0 +1,15 @@
+// @test-description: crypto.hmacSha256 produces correct hex output
+
+const result = crypto.hmacSha256("secret", "hello");
+if (result.length !== 64) {
+  console.log("FAIL: expected 64 hex chars, got " + result.length);
+  process.exit(1);
+}
+
+const result2 = crypto.hmacSha256("key", "The quick brown fox jumps over the lazy dog");
+if (result2 !== "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8") {
+  console.log("FAIL: expected known HMAC value, got " + result2);
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/encoding/base64.ts
+++ b/tests/fixtures/encoding/base64.ts
@@ -1,0 +1,21 @@
+// @test-description: btoa/atob round-trip
+
+const encoded = btoa("hello world");
+if (encoded !== "aGVsbG8gd29ybGQ=") {
+  console.log("FAIL: btoa expected aGVsbG8gd29ybGQ= got " + encoded);
+  process.exit(1);
+}
+
+const decoded = atob("aGVsbG8gd29ybGQ=");
+if (decoded !== "hello world") {
+  console.log("FAIL: atob expected 'hello world' got '" + decoded + "'");
+  process.exit(1);
+}
+
+const round = atob(btoa("ChadScript rocks!"));
+if (round !== "ChadScript rocks!") {
+  console.log("FAIL: round-trip got '" + round + "'");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/encoding/uri.ts
+++ b/tests/fixtures/encoding/uri.ts
@@ -1,0 +1,21 @@
+// @test-description: encodeURIComponent/decodeURIComponent round-trip
+
+const encoded = encodeURIComponent("hello world & foo=bar");
+if (encoded !== "hello%20world%20%26%20foo%3Dbar") {
+  console.log("FAIL: encodeURIComponent got '" + encoded + "'");
+  process.exit(1);
+}
+
+const decoded = decodeURIComponent("hello%20world%20%26%20foo%3Dbar");
+if (decoded !== "hello world & foo=bar") {
+  console.log("FAIL: decodeURIComponent got '" + decoded + "'");
+  process.exit(1);
+}
+
+const round = decodeURIComponent(encodeURIComponent("path/to?resource#hash"));
+if (round !== "path/to?resource#hash") {
+  console.log("FAIL: round-trip got '" + round + "'");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

- **`req.queryString`** — expose query string from HTTP requests. `lws-bridge` now splits the path at `?` and populates a new `query_string` field on the request struct; codegen and type definitions updated accordingly.
- **`crypto.hmacSha256` / `crypto.pbkdf2`** — HMAC-SHA256 and PBKDF2 key derivation via OpenSSL (`HMAC()`, `PKCS5_PBKDF2_HMAC`).
- **`btoa` / `atob`** — base64 encode/decode via new `c_bridges/base64-bridge.c`.
- **`encodeURIComponent` / `decodeURIComponent`** — percent-encoding per RFC 3986 via new `c_bridges/uri-bridge.c`.

## Test plan

- [ ] `tests/fixtures/encoding/base64.ts` — round-trip encode/decode, known value check
- [ ] `tests/fixtures/encoding/uri.ts` — round-trip encode/decode, known value check
- [ ] `tests/fixtures/crypto/hmac.ts` — known HMAC-SHA256 vector (`f7bc83f4...`)
- [ ] `npm test` — 412 passing, 5 failing (all pre-existing: `os-basic`, `static-fields`, `static-methods`, `string-lastindexof`, `promise-race-test`)
