### PR TITLE
readme: accuracy fixes + timeval platform fix + float i64 promotion fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/time-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -114,6 +114,7 @@ jobs:
           cp c_bridges/child-process-bridge.o release/lib/
           cp c_bridges/child-process-spawn.o release/lib/
           cp c_bridges/os-bridge.o release/lib/
+          cp c_bridges/time-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
           cp c_bridges/watch-bridge.o release/lib/
           tar -czf chadscript-linux-x64.tar.gz -C release chad lib
@@ -158,7 +159,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/time-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -221,6 +222,7 @@ jobs:
           cp c_bridges/child-process-bridge.o release/lib/
           cp c_bridges/child-process-spawn.o release/lib/
           cp c_bridges/os-bridge.o release/lib/
+          cp c_bridges/time-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
           cp c_bridges/watch-bridge.o release/lib/
           tar -czf chadscript-macos-arm64.tar.gz -C release chad lib
@@ -291,6 +293,7 @@ jobs:
             child-process-bridge.o \
             child-process-spawn.o \
             os-bridge.o \
+            time-bridge.o \
             dotenv-bridge.o \
             watch-bridge.o \
             tree-sitter-typescript-parser.o \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The compiler is self-hosting: tens of thousands of lines of TypeScript that comp
 > | Self-hosting                        | ✅          |
 > | Performance improvements            | ✅          |
 > | Testing & hardening                 | In progress |
-> | GC → Reference Counting             | Planned     |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ChadScript's goal:
 
-> As fast as C, as safe as Rust, as ergonomic as TypeScript.
+> As fast as C, as ergonomic as TypeScript.
 
 ChadScript is a natively-compiled systems language with TypeScript syntax. Write familiar TypeScript, run `chad build`, get a standalone ELF or Mach-O binary via LLVM — no Node.js, no JVM, no runtime.
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ The same LLVM backend used by Clang, Rust, and Swift. Direct calls into C librar
 
 TypeScript is my favorite language to write and the type system is terse and intuitive. It's familiar to tens of millions of developers and LLMs are well trained on it. ChadScript uses a statically-safe subset where every type is known at compile time, enabling:
 
-- **Null safety** — `string` is never null. `string | null` must be checked before use. The type system enforces it.
-- **No undefined behavior** — no dangling pointers, no uninitialized reads.
+- **Null safety** — `string` is never null. Use `string | null` to express optional values and `?.` for safe access.
+- **GC-managed memory** — Boehm GC handles allocation; no use-after-free or double-frees.
 - **IDE support** — run `chad init` to get `tsconfig.json` pointing at ChadScript types and standard library. Language services in VS Code work.
 
 ---
@@ -97,10 +97,10 @@ No `npm install`. Everything ships with the compiler:
 | `Router`, `httpServe` | HTTP server with routing   |
 | `fs`                  | File system                |
 | `sqlite`              | Embedded SQLite database   |
-| `crypto`              | Hashing, encryption        |
+| `crypto`              | Hashing, random bytes      |
 | `JSON`                | Typed JSON parse/stringify |
 | `child_process`       | Spawn subprocesses         |
-| `WebSocket`           | WebSocket client + server  |
+| `WebSocket`           | WebSocket server           |
 
 ---
 

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -53,15 +53,23 @@ bench_compute() {
     fi
 }
 
+now_ns() {
+    if command -v gdate &>/dev/null; then
+        gdate +%s%N
+    else
+        python3 -c 'import time; print(int(time.time_ns()))'
+    fi
+}
+
 bench_startup() {
     local name="$1"
     local lang="$2"
     shift 2
-    local start_ns=$(date +%s%N)
+    local start_ns=$(now_ns)
     for i in $(seq 1 $STARTUP_RUNS); do
         "$@" > /dev/null 2>&1
     done
-    local end_ns=$(date +%s%N)
+    local end_ns=$(now_ns)
     local avg_us=$(( (end_ns - start_ns) / STARTUP_RUNS / 1000 ))
     local avg_ms_int=$(( avg_us / 1000 ))
     local avg_ms_frac=$(( (avg_us % 1000) / 100 ))
@@ -74,7 +82,7 @@ bench_startup() {
 wait_port_free() {
     local port=$1
     for i in $(seq 1 30); do
-        if ! ss -tln 2>/dev/null | grep -q ":${port} "; then
+        if ! (ss -tln 2>/dev/null || lsof -i ":${port}" 2>/dev/null) | grep -q ":${port}"; then
             return 0
         fi
         sleep 0.2
@@ -339,7 +347,7 @@ echo "  ChadScript Binary Trees built"
 $CHAD build "$DIR/json/chadscript.ts" -o /tmp/bench-json-chad
 echo "  ChadScript JSON built"
 
-$CHAD "$DIR/stringsearch/chadscript.ts" -o /tmp/bench-stringsearch-chad
+$CHAD build "$DIR/stringsearch/chadscript.ts" -o /tmp/bench-stringsearch-chad
 echo "  ChadScript String Search built"
 
 clang -O2 -march=native -o /tmp/bench-startup-c "$DIR/startup/hello.c"

--- a/c_bridges/time-bridge.c
+++ b/c_bridges/time-bridge.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+
+#ifdef __APPLE__
+#include <sys/time.h>
+#else
+#include <time.h>
+#endif
+
+// Returns current time in milliseconds (double for sub-ms precision).
+// Uses clock_gettime(CLOCK_REALTIME) on Linux, gettimeofday on macOS.
+// Avoids any struct timeval layout differences between platforms.
+double cs_time_ms(void) {
+#ifdef __APPLE__
+    struct timeval tv;
+    gettimeofday(&tv, 0);
+    return (double)tv.tv_sec * 1000.0 + (double)tv.tv_usec / 1000.0;
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1000000.0;
+#endif
+}

--- a/scripts/build-target-sdk.sh
+++ b/scripts/build-target-sdk.sh
@@ -69,7 +69,7 @@ fi
 
 # Copy C bridge object files
 echo "  Copying bridge objects..."
-for bridge in child-process-bridge.o os-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o; do
+for bridge in child-process-bridge.o os-bridge.o time-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o; do
   if [ -f "$C_BRIDGES_DIR/$bridge" ]; then
     cp "$C_BRIDGES_DIR/$bridge" "$SDK_DIR/bridges/"
   fi

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -179,6 +179,17 @@ else
   echo "==> child-process-bridge already built, skipping"
 fi
 
+# --- time-bridge (platform-abstracted high-resolution time) ---
+TIME_BRIDGE_SRC="$C_BRIDGES_DIR/time-bridge.c"
+TIME_BRIDGE_OBJ="$C_BRIDGES_DIR/time-bridge.o"
+if [ ! -f "$TIME_BRIDGE_OBJ" ] || [ "$TIME_BRIDGE_SRC" -nt "$TIME_BRIDGE_OBJ" ]; then
+  echo "==> Building time-bridge..."
+  cc -c -O2 -fPIC "$TIME_BRIDGE_SRC" -o "$TIME_BRIDGE_OBJ"
+  echo "  -> $TIME_BRIDGE_OBJ"
+else
+  echo "==> time-bridge already built, skipping"
+fi
+
 # --- os-bridge (platform-abstracted os.freemem/os.uptime) ---
 OS_BRIDGE_SRC="$C_BRIDGES_DIR/os-bridge.c"
 OS_BRIDGE_OBJ="$C_BRIDGES_DIR/os-bridge.o"

--- a/src/codegen/expressions/literals.ts
+++ b/src/codegen/expressions/literals.ts
@@ -29,7 +29,6 @@ export interface LiteralGeneratorContext {
   getCurrentDeclaredSetType(): string | undefined;
   classGenGenerateNewExpression(className: string, args: Expression[], params: string[]): string;
   ensureDouble(value: string): string;
-  getTargetOS?(): string;
   readonly stringGen: IStringGenerator;
   readonly stringMapGen: IStringMapGenerator;
   readonly arrayGen: IArrayGenerator;
@@ -302,42 +301,8 @@ export class LiteralExpressionGenerator {
 
     let msValue: string;
     if (args.length === 0) {
-      const tvAlloca = this.ctx.nextTemp();
-      this.ctx.emit(`${tvAlloca} = alloca %struct.timeval`);
-      const gettimResult = this.ctx.nextTemp();
-      this.ctx.emit(
-        `${gettimResult} = call i32 @gettimeofday(%struct.timeval* ${tvAlloca}, i8* null)`,
-      );
-      const secPtr = this.ctx.nextTemp();
-      this.ctx.emit(
-        `${secPtr} = getelementptr inbounds %struct.timeval, %struct.timeval* ${tvAlloca}, i32 0, i32 0`,
-      );
-      const secVal = this.ctx.nextTemp();
-      this.ctx.emit(`${secVal} = load i64, i64* ${secPtr}`);
-      const usecPtr = this.ctx.nextTemp();
-      this.ctx.emit(
-        `${usecPtr} = getelementptr inbounds %struct.timeval, %struct.timeval* ${tvAlloca}, i32 0, i32 1`,
-      );
-      let usecVal: string;
-      if (this.ctx.getTargetOS?.() === "darwin") {
-        const usecRaw = this.ctx.nextTemp();
-        this.ctx.emit(`${usecRaw} = load i32, i32* ${usecPtr}`);
-        usecVal = this.ctx.nextTemp();
-        this.ctx.emit(`${usecVal} = zext i32 ${usecRaw} to i64`);
-      } else {
-        usecVal = this.ctx.nextTemp();
-        this.ctx.emit(`${usecVal} = load i64, i64* ${usecPtr}`);
-      }
-      const secDbl = this.ctx.nextTemp();
-      this.ctx.emit(`${secDbl} = sitofp i64 ${secVal} to double`);
-      const usecDbl = this.ctx.nextTemp();
-      this.ctx.emit(`${usecDbl} = sitofp i64 ${usecVal} to double`);
-      const secMs = this.ctx.nextTemp();
-      this.ctx.emit(`${secMs} = fmul fast double ${secDbl}, 1.000000e+03`);
-      const usecMs = this.ctx.nextTemp();
-      this.ctx.emit(`${usecMs} = fdiv fast double ${usecDbl}, 1.000000e+03`);
       msValue = this.ctx.nextTemp();
-      this.ctx.emit(`${msValue} = fadd fast double ${secMs}, ${usecMs}`);
+      this.ctx.emit(`${msValue} = call double @cs_time_ms()`);
     } else {
       msValue = this.ctx.ensureDouble(this.ctx.generateExpression(args[0], params));
     }

--- a/src/codegen/expressions/literals.ts
+++ b/src/codegen/expressions/literals.ts
@@ -29,6 +29,7 @@ export interface LiteralGeneratorContext {
   getCurrentDeclaredSetType(): string | undefined;
   classGenGenerateNewExpression(className: string, args: Expression[], params: string[]): string;
   ensureDouble(value: string): string;
+  getTargetOS?(): string;
   readonly stringGen: IStringGenerator;
   readonly stringMapGen: IStringMapGenerator;
   readonly arrayGen: IArrayGenerator;
@@ -317,10 +318,16 @@ export class LiteralExpressionGenerator {
       this.ctx.emit(
         `${usecPtr} = getelementptr inbounds %struct.timeval, %struct.timeval* ${tvAlloca}, i32 0, i32 1`,
       );
-      const usecRaw = this.ctx.nextTemp();
-      this.ctx.emit(`${usecRaw} = load i32, i32* ${usecPtr}`);
-      const usecVal = this.ctx.nextTemp();
-      this.ctx.emit(`${usecVal} = zext i32 ${usecRaw} to i64`);
+      let usecVal: string;
+      if (this.ctx.getTargetOS?.() === "darwin") {
+        const usecRaw = this.ctx.nextTemp();
+        this.ctx.emit(`${usecRaw} = load i32, i32* ${usecPtr}`);
+        usecVal = this.ctx.nextTemp();
+        this.ctx.emit(`${usecVal} = zext i32 ${usecRaw} to i64`);
+      } else {
+        usecVal = this.ctx.nextTemp();
+        this.ctx.emit(`${usecVal} = load i64, i64* ${usecPtr}`);
+      }
       const secDbl = this.ctx.nextTemp();
       this.ctx.emit(`${secDbl} = sitofp i64 ${secVal} to double`);
       const usecDbl = this.ctx.nextTemp();

--- a/src/codegen/expressions/literals.ts
+++ b/src/codegen/expressions/literals.ts
@@ -317,8 +317,10 @@ export class LiteralExpressionGenerator {
       this.ctx.emit(
         `${usecPtr} = getelementptr inbounds %struct.timeval, %struct.timeval* ${tvAlloca}, i32 0, i32 1`,
       );
+      const usecRaw = this.ctx.nextTemp();
+      this.ctx.emit(`${usecRaw} = load i32, i32* ${usecPtr}`);
       const usecVal = this.ctx.nextTemp();
-      this.ctx.emit(`${usecVal} = load i64, i64* ${usecPtr}`);
+      this.ctx.emit(`${usecVal} = zext i32 ${usecRaw} to i64`);
       const secDbl = this.ctx.nextTemp();
       this.ctx.emit(`${secDbl} = sitofp i64 ${secVal} to double`);
       const usecDbl = this.ctx.nextTemp();

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -1051,13 +1051,15 @@ export class FunctionGenerator {
       ir += "  %__start_sec = load i64, i64* %__start_sec_ptr\n";
       ir +=
         "  %__start_usec_ptr = getelementptr %struct.timeval, %struct.timeval* %__start_tv, i32 0, i32 1\n";
-      ir += "  %__start_usec = load i64, i64* %__start_usec_ptr\n";
+      ir += "  %__start_usec_raw = load i32, i32* %__start_usec_ptr\n";
+      ir += "  %__start_usec = zext i32 %__start_usec_raw to i64\n";
       ir +=
         "  %__end_sec_ptr = getelementptr %struct.timeval, %struct.timeval* %__end_tv, i32 0, i32 0\n";
       ir += "  %__end_sec = load i64, i64* %__end_sec_ptr\n";
       ir +=
         "  %__end_usec_ptr = getelementptr %struct.timeval, %struct.timeval* %__end_tv, i32 0, i32 1\n";
-      ir += "  %__end_usec = load i64, i64* %__end_usec_ptr\n";
+      ir += "  %__end_usec_raw = load i32, i32* %__end_usec_ptr\n";
+      ir += "  %__end_usec = zext i32 %__end_usec_raw to i64\n";
       ir += "  %__diff_sec = sub i64 %__end_sec, %__start_sec\n";
       ir += "  %__diff_usec = sub i64 %__end_usec, %__start_usec\n";
       ir += "  %__sec_ms = mul i64 %__diff_sec, 1000\n";

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -965,8 +965,7 @@ export class FunctionGenerator {
     ir += "  call void @GC_init()\n";
     ir += "  %__seed_time = call i64 @time(i8* null)\n";
     ir += "  call void @srand48(i64 %__seed_time)\n";
-    ir += "  %__start_tv = alloca %struct.timeval\n";
-    ir += "  %__gtod_start = call i32 @gettimeofday(%struct.timeval* %__start_tv, i8* null)\n";
+    ir += "  %__start_ms = call double @cs_time_ms()\n";
     ir += "\n";
 
     const effectiveOS = this.ctx.getTargetOS();
@@ -1044,33 +1043,9 @@ export class FunctionGenerator {
 
     if (this.ctx.getUsesTestRunner()) {
       ir += "  ; Test runner summary\n";
-      ir += "  %__end_tv = alloca %struct.timeval\n";
-      ir += "  %__gtod_end = call i32 @gettimeofday(%struct.timeval* %__end_tv, i8* null)\n";
-      ir +=
-        "  %__start_sec_ptr = getelementptr %struct.timeval, %struct.timeval* %__start_tv, i32 0, i32 0\n";
-      ir += "  %__start_sec = load i64, i64* %__start_sec_ptr\n";
-      ir +=
-        "  %__start_usec_ptr = getelementptr %struct.timeval, %struct.timeval* %__start_tv, i32 0, i32 1\n";
-      ir +=
-        "  %__end_sec_ptr = getelementptr %struct.timeval, %struct.timeval* %__end_tv, i32 0, i32 0\n";
-      ir += "  %__end_sec = load i64, i64* %__end_sec_ptr\n";
-      ir +=
-        "  %__end_usec_ptr = getelementptr %struct.timeval, %struct.timeval* %__end_tv, i32 0, i32 1\n";
-      if (effectiveOS === "darwin") {
-        ir += "  %__start_usec_raw = load i32, i32* %__start_usec_ptr\n";
-        ir += "  %__start_usec = zext i32 %__start_usec_raw to i64\n";
-        ir += "  %__end_usec_raw = load i32, i32* %__end_usec_ptr\n";
-        ir += "  %__end_usec = zext i32 %__end_usec_raw to i64\n";
-      } else {
-        ir += "  %__start_usec = load i64, i64* %__start_usec_ptr\n";
-        ir += "  %__end_usec = load i64, i64* %__end_usec_ptr\n";
-      }
-      ir += "  %__diff_sec = sub i64 %__end_sec, %__start_sec\n";
-      ir += "  %__diff_usec = sub i64 %__end_usec, %__start_usec\n";
-      ir += "  %__sec_ms = mul i64 %__diff_sec, 1000\n";
-      ir += "  %__usec_ms = sdiv i64 %__diff_usec, 1000\n";
-      ir += "  %__elapsed_i64 = add i64 %__sec_ms, %__usec_ms\n";
-      ir += "  %__elapsed_ms = trunc i64 %__elapsed_i64 to i32\n";
+      ir += "  %__end_ms = call double @cs_time_ms()\n";
+      ir += "  %__diff_ms = fsub double %__end_ms, %__start_ms\n";
+      ir += "  %__elapsed_ms = fptosi double %__diff_ms to i32\n";
       ir += "  %__tr_passed = load i32, i32* @__test_passed\n";
       ir += "  %__tr_failed = load i32, i32* @__test_failed\n";
       ir += "  %__tr_total = load i32, i32* @__test_total\n";

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -1051,15 +1051,20 @@ export class FunctionGenerator {
       ir += "  %__start_sec = load i64, i64* %__start_sec_ptr\n";
       ir +=
         "  %__start_usec_ptr = getelementptr %struct.timeval, %struct.timeval* %__start_tv, i32 0, i32 1\n";
-      ir += "  %__start_usec_raw = load i32, i32* %__start_usec_ptr\n";
-      ir += "  %__start_usec = zext i32 %__start_usec_raw to i64\n";
       ir +=
         "  %__end_sec_ptr = getelementptr %struct.timeval, %struct.timeval* %__end_tv, i32 0, i32 0\n";
       ir += "  %__end_sec = load i64, i64* %__end_sec_ptr\n";
       ir +=
         "  %__end_usec_ptr = getelementptr %struct.timeval, %struct.timeval* %__end_tv, i32 0, i32 1\n";
-      ir += "  %__end_usec_raw = load i32, i32* %__end_usec_ptr\n";
-      ir += "  %__end_usec = zext i32 %__end_usec_raw to i64\n";
+      if (effectiveOS === "darwin") {
+        ir += "  %__start_usec_raw = load i32, i32* %__start_usec_ptr\n";
+        ir += "  %__start_usec = zext i32 %__start_usec_raw to i64\n";
+        ir += "  %__end_usec_raw = load i32, i32* %__end_usec_ptr\n";
+        ir += "  %__end_usec = zext i32 %__end_usec_raw to i64\n";
+      } else {
+        ir += "  %__start_usec = load i64, i64* %__start_usec_ptr\n";
+        ir += "  %__end_usec = load i64, i64* %__end_usec_ptr\n";
+      }
       ir += "  %__diff_sec = sub i64 %__end_sec, %__start_sec\n";
       ir += "  %__diff_usec = sub i64 %__end_usec, %__start_usec\n";
       ir += "  %__sec_ms = mul i64 %__diff_sec, 1000\n";

--- a/src/codegen/infrastructure/integer-analysis.ts
+++ b/src/codegen/infrastructure/integer-analysis.ts
@@ -16,6 +16,50 @@ function isIntegerLiteral(val: object): boolean {
   return v % 1 === 0;
 }
 
+function getBlockStatements(block: object): object[] {
+  const b = block as { type: string; statements: object[] };
+  return b.statements;
+}
+
+function collectNestedAssignments(stmts: object[], out: object[]): void {
+  for (let i = 0; i < stmts.length; i++) {
+    const stmt = stmts[i];
+    if (!stmt) continue;
+    const stmtBase = stmt as { type: string };
+    if (!stmtBase.type) continue;
+
+    if (stmtBase.type === "assignment") {
+      out.push(stmt);
+    } else if (stmtBase.type === "while" || stmtBase.type === "do_while") {
+      // WhileStatement: { type, condition, body, loc } — body at field index 2
+      const asWhile = stmt as { type: string; condition: object; body: object };
+      collectNestedAssignments(getBlockStatements(asWhile.body), out);
+    } else if (stmtBase.type === "if") {
+      // IfStatement: { type, condition, thenBlock, elseBlock, loc } — thenBlock=2, elseBlock=3
+      const asIf = stmt as {
+        type: string;
+        condition: object;
+        thenBlock: object;
+        elseBlock: object;
+      };
+      collectNestedAssignments(getBlockStatements(asIf.thenBlock), out);
+      if (asIf.elseBlock) {
+        collectNestedAssignments(getBlockStatements(asIf.elseBlock), out);
+      }
+    } else if (stmtBase.type === "for") {
+      // ForStatement: { type, init, condition, update, body, loc } — body at field index 4
+      const asFor = stmt as {
+        type: string;
+        init: object;
+        condition: object;
+        update: object;
+        body: object;
+      };
+      collectNestedAssignments(getBlockStatements(asFor.body), out);
+    }
+  }
+}
+
 export function findI64EligibleVariables(statements: object[]): string[] {
   if (!statements || !statements.length) return [];
   const len = statements.length;
@@ -39,18 +83,19 @@ export function findI64EligibleVariables(statements: object[]): string[] {
 
   if (candidates.length === 0) return [];
 
-  // Pass 2: Scan assignments to demote let variables with non-integer RHS
+  // Pass 2: Scan all assignments (including inside loops/branches) to demote
+  // variables that are ever assigned a non-integer value.
   const isDemoted: boolean[] = [];
   for (let k = 0; k < candidates.length; k++) {
     isDemoted.push(false);
   }
 
-  for (let i = 0; i < len; i++) {
-    const stmt = statements[i];
-    if (!stmt) continue;
+  const allAssignments: object[] = [];
+  collectNestedAssignments(statements, allAssignments);
+
+  for (let i = 0; i < allAssignments.length; i++) {
+    const stmt = allAssignments[i];
     const stmtTyped = stmt as { type: string; name?: string; value?: unknown };
-    if (!stmtTyped.type) continue;
-    if (stmtTyped.type !== "assignment") continue;
     if (!stmtTyped.name || !stmtTyped.value) continue;
     for (let j = 0; j < candidates.length; j++) {
       if (candidates[j] === stmtTyped.name) {

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -17,7 +17,8 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "%StringMap = type { i8**, i8**, i32, i32 }\n";
   ir += "%Set = type { double*, i32, i32 }\n";
   ir += "%StringSet = type { i8**, i32, i32 }\n";
-  ir += "%struct.timeval = type { i64, i32 }\n";
+  const usevalUsecType = config?.targetOS === "darwin" ? "i32" : "i64";
+  ir += `%struct.timeval = type { i64, ${usevalUsecType} }\n`;
   ir += "%Date = type { double }\n";
   ir += "%struct.tm = type { i32, i32, i32, i32, i32, i32, i32, i32, i32, i64, i8* }\n";
   ir += "%ExceptionFrame = type { [200 x i8], i8*, i8* }\n\n";

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -17,7 +17,7 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "%StringMap = type { i8**, i8**, i32, i32 }\n";
   ir += "%Set = type { double*, i32, i32 }\n";
   ir += "%StringSet = type { i8**, i32, i32 }\n";
-  ir += "%struct.timeval = type { i64, i64 }\n";
+  ir += "%struct.timeval = type { i64, i32 }\n";
   ir += "%Date = type { double }\n";
   ir += "%struct.tm = type { i32, i32, i32, i32, i32, i32, i32, i32, i32, i64, i8* }\n";
   ir += "%ExceptionFrame = type { [200 x i8], i8*, i8* }\n\n";

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -17,8 +17,6 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "%StringMap = type { i8**, i8**, i32, i32 }\n";
   ir += "%Set = type { double*, i32, i32 }\n";
   ir += "%StringSet = type { i8**, i32, i32 }\n";
-  const usevalUsecType = config?.targetOS === "darwin" ? "i32" : "i64";
-  ir += `%struct.timeval = type { i64, ${usevalUsecType} }\n`;
   ir += "%Date = type { double }\n";
   ir += "%struct.tm = type { i32, i32, i32, i32, i32, i32, i32, i32, i32, i64, i8* }\n";
   ir += "%ExceptionFrame = type { [200 x i8], i8*, i8* }\n\n";
@@ -172,6 +170,9 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "declare i32 @gethostname(i8*, i64)\n";
   ir += "declare i64 @sysconf(i32)\n";
   ir += "declare double @atof(i8*)\n";
+  // time-bridge.c — platform-abstracted high-resolution time
+  ir += "declare double @cs_time_ms()\n";
+
   // os-bridge.c — platform-abstracted os helpers
   ir += "declare i64 @chad_os_freemem()\n";
   ir += "declare double @chad_os_uptime()\n";
@@ -187,7 +188,6 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "\n";
 
   ir += "declare i32 @sprintf(i8*, i8*, ...)\n";
-  ir += "declare i32 @gettimeofday(%struct.timeval*, i8*)\n";
   ir += "declare %struct.tm* @localtime_r(i64*, %struct.tm*)\n";
   ir += "declare %struct.tm* @gmtime_r(i64*, %struct.tm*)\n";
   ir += "declare i64 @strftime(i8*, i64, i8*, %struct.tm*)\n";

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2263,7 +2263,7 @@ export class VariableAllocator {
       this.ctx.emit(`store ${valueType} ${value}, ${valueType}* ${allocaReg}`);
     } else {
       const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-      if (valueType === "i64") {
+      if (valueType === "i64" && this.isI64Eligible(stmt.name)) {
         this.ctx.defineVariable(stmt.name, allocaReg, "i64", SymbolKind.Number, "local");
         this.ctx.emit(`${allocaReg} = alloca i64`);
         this.ctx.emit(`store i64 ${value}, i64* ${allocaReg}`);

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -1789,8 +1789,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       return ir;
     }
     const items = this.ast.topLevelStatements;
-    // Find which numeric globals can stay as native i64 instead of double
-    const i64Eligible = findI64EligibleVariables(items);
+    const i64Eligible = findI64EligibleVariables(this.ast.topLevelStatements as object[]);
     for (let stmtIdx = 0; stmtIdx < totalCount; stmtIdx++) {
       const stmt = items[stmtIdx] as {
         type: string;

--- a/src/codegen/stdlib/date.ts
+++ b/src/codegen/stdlib/date.ts
@@ -28,10 +28,15 @@ export class DateGenerator {
     const secVal = this.ctx.emitLoad("i64", secPtr);
 
     const usecPtr = this.ctx.emitGep("%struct.timeval", tvAlloca, "i32 0, i32 1");
-    const usecRaw = this.ctx.nextTemp();
-    this.ctx.emit(`${usecRaw} = load i32, i32* ${usecPtr}`);
-    const usecVal = this.ctx.nextTemp();
-    this.ctx.emit(`${usecVal} = zext i32 ${usecRaw} to i64`);
+    let usecVal: string;
+    if (this.ctx.getTargetOS?.() === "darwin") {
+      const usecRaw = this.ctx.nextTemp();
+      this.ctx.emit(`${usecRaw} = load i32, i32* ${usecPtr}`);
+      usecVal = this.ctx.nextTemp();
+      this.ctx.emit(`${usecVal} = zext i32 ${usecRaw} to i64`);
+    } else {
+      usecVal = this.ctx.emitLoad("i64", usecPtr);
+    }
 
     const secDouble = this.ctx.nextTemp();
     this.ctx.emit(`${secDouble} = sitofp i64 ${secVal} to double`);

--- a/src/codegen/stdlib/date.ts
+++ b/src/codegen/stdlib/date.ts
@@ -19,39 +19,7 @@ export class DateGenerator {
   }
 
   generateNow(): string {
-    const tvAlloca = this.ctx.nextTemp();
-    this.ctx.emit(`${tvAlloca} = alloca %struct.timeval`);
-
-    this.ctx.emitCall("i32", "@gettimeofday", `%struct.timeval* ${tvAlloca}, i8* null`);
-
-    const secPtr = this.ctx.emitGep("%struct.timeval", tvAlloca, "i32 0, i32 0");
-    const secVal = this.ctx.emitLoad("i64", secPtr);
-
-    const usecPtr = this.ctx.emitGep("%struct.timeval", tvAlloca, "i32 0, i32 1");
-    let usecVal: string;
-    if (this.ctx.getTargetOS?.() === "darwin") {
-      const usecRaw = this.ctx.nextTemp();
-      this.ctx.emit(`${usecRaw} = load i32, i32* ${usecPtr}`);
-      usecVal = this.ctx.nextTemp();
-      this.ctx.emit(`${usecVal} = zext i32 ${usecRaw} to i64`);
-    } else {
-      usecVal = this.ctx.emitLoad("i64", usecPtr);
-    }
-
-    const secDouble = this.ctx.nextTemp();
-    this.ctx.emit(`${secDouble} = sitofp i64 ${secVal} to double`);
-    const usecDouble = this.ctx.nextTemp();
-    this.ctx.emit(`${usecDouble} = sitofp i64 ${usecVal} to double`);
-
-    const secMs = this.ctx.nextTemp();
-    this.ctx.emit(`${secMs} = fmul fast double ${secDouble}, 1.000000e+03`);
-    const usecMs = this.ctx.nextTemp();
-    this.ctx.emit(`${usecMs} = fdiv fast double ${usecDouble}, 1.000000e+03`);
-
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = fadd fast double ${secMs}, ${usecMs}`);
-
-    return result;
+    return this.ctx.emitCall("double", "@cs_time_ms", "");
   }
 
   generateDateMethod(datePtr: string, method: string): string {

--- a/src/codegen/stdlib/date.ts
+++ b/src/codegen/stdlib/date.ts
@@ -28,7 +28,10 @@ export class DateGenerator {
     const secVal = this.ctx.emitLoad("i64", secPtr);
 
     const usecPtr = this.ctx.emitGep("%struct.timeval", tvAlloca, "i32 0, i32 1");
-    const usecVal = this.ctx.emitLoad("i64", usecPtr);
+    const usecRaw = this.ctx.nextTemp();
+    this.ctx.emit(`${usecRaw} = load i32, i32* ${usecPtr}`);
+    const usecVal = this.ctx.nextTemp();
+    this.ctx.emit(`${usecVal} = zext i32 ${usecRaw} to i64`);
 
     const secDouble = this.ctx.nextTemp();
     this.ctx.emit(`${secDouble} = sitofp i64 ${secVal} to double`);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -403,6 +403,7 @@ export function compile(
   const regexBridgeObj = generator.usesRegex ? `${bridgePath}/regex-bridge.o` : "";
   const cpBridgeObj = `${bridgePath}/child-process-bridge.o`;
   const osBridgeObj = `${bridgePath}/os-bridge.o`;
+  const timeBridgeObj = `${bridgePath}/time-bridge.o`;
   const dotenvBridgeObj = fs.existsSync(`${bridgePath}/dotenv-bridge.o`)
     ? `${bridgePath}/dotenv-bridge.o`
     : "";
@@ -486,7 +487,7 @@ export function compile(
   const userObjs = extraLinkObjs.length > 0 ? " " + extraLinkObjs.join(" ") : "";
   const userPaths = extraLinkPaths.map((p) => ` -L${p}`).join("");
   const userLibs = extraLinkLibs.map((l) => ` -l${l}`).join("");
-  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${cpSpawnObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
+  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${timeBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${cpSpawnObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
   logger.info(` ${linkCmd}`);
   const linkStdio = logger.getLevel() >= LogLevel.Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -504,6 +504,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const regexBridgeObj = generator.getUsesRegex() ? effectiveBridgePath + "/regex-bridge.o" : "";
   const cpBridgeObj = effectiveBridgePath + "/child-process-bridge.o";
   const osBridgeObj = effectiveBridgePath + "/os-bridge.o";
+  const timeBridgeObj = effectiveBridgePath + "/time-bridge.o";
   const dotenvBridgePath = effectiveBridgePath + "/dotenv-bridge.o";
   const dotenvBridgeObj = fs.existsSync(dotenvBridgePath) ? dotenvBridgePath : "";
   const watchBridgeObj = effectiveBridgePath + "/watch-bridge.o";
@@ -577,6 +578,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
     cpBridgeObj +
     " " +
     osBridgeObj +
+    " " +
+    timeBridgeObj +
     " " +
     dotenvBridgeObj +
     " " +


### PR DESCRIPTION
# readme: accuracy fixes + timeval platform fix + float i64 promotion fix

## Summary

- Remove overstated claims from README (safety/crypto/websocket scope)
- Remove "GC → Reference Counting" planned milestone
- Fix timeval struct layout to be platform-specific (macOS: i32 tv_usec, Linux: i64)
- Replace `gettimeofday` with `cs_time_ms()` C bridge to eliminate platform-specific timeval layout entirely
- Fix float variable incorrectly promoted to i64 (e.g. `let e = 0.0`)
- Fix benchmarks/run.sh for macOS compatibility

## Test plan

- [ ] `npm run verify:quick` passes
- [ ] Date-related tests pass on both macOS and Linux
- [ ] Benchmarks script runs cleanly on macOS
