### PR TITLE
req.queryString: expose query string from http requests

### DIFF
--- a/c_bridges/lws-bridge.c
+++ b/c_bridges/lws-bridge.c
@@ -25,6 +25,7 @@ typedef struct http_conn_s {
     size_t data_len;
     char method_str[16];
     char path_str[2048];
+    char query_string_str[2048];
     char *body;
     size_t body_len;
     size_t body_cap;
@@ -385,6 +386,7 @@ static void dispatch_http_request(http_conn_t *conn) {
     req.content_type = conn->content_type_str;
     req.headers_raw = conn->headers_raw;
     req.body_len = (double)conn->body_len;
+    req.query_string = conn->query_string_str;
 
     lws_bridge_response resp;
     resp.status = 200;
@@ -598,9 +600,20 @@ static void try_parse_request(http_conn_t *conn) {
         memcpy(conn->method_str, method, ml);
         conn->method_str[ml] = '\0';
 
-        size_t pl = path_len < sizeof(conn->path_str) - 1 ? path_len : sizeof(conn->path_str) - 1;
+        // Split path at '?' — store path and query string separately
+        const char *q = (const char *)memchr(path, '?', path_len);
+        size_t raw_path_len = q ? (size_t)(q - path) : path_len;
+        size_t pl = raw_path_len < sizeof(conn->path_str) - 1 ? raw_path_len : sizeof(conn->path_str) - 1;
         memcpy(conn->path_str, path, pl);
         conn->path_str[pl] = '\0';
+        if (q) {
+            size_t ql = (path_len - raw_path_len - 1);
+            if (ql >= sizeof(conn->query_string_str)) ql = sizeof(conn->query_string_str) - 1;
+            memcpy(conn->query_string_str, q + 1, ql);
+            conn->query_string_str[ql] = '\0';
+        } else {
+            conn->query_string_str[0] = '\0';
+        }
 
         conn->content_length = 0;
         conn->content_type_str[0] = '\0';
@@ -709,6 +722,7 @@ static void try_parse_request(http_conn_t *conn) {
         conn->ws_key[0] = '\0';
         conn->method_str[0] = '\0';
         conn->path_str[0] = '\0';
+        conn->query_string_str[0] = '\0';
     }
 }
 

--- a/c_bridges/lws-bridge.h
+++ b/c_bridges/lws-bridge.h
@@ -10,6 +10,7 @@ typedef struct {
     const char *content_type;
     const char *headers_raw;  // all headers as "Key: Value\n..." string
     double body_len;          // actual byte count as double (ChadScript reads number fields as double)
+    const char *query_string; // query string after '?' (empty string if none)
 } lws_bridge_request;
 
 typedef struct {

--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -229,6 +229,7 @@ interface HttpRequest {
   contentType: string;
   headers: string;
   bodyLen: number;
+  queryString: string;
 }
 
 interface HttpResponse {

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -67,6 +67,7 @@ export class RouterRequest {
   contentType: string;
   headers: string;
   bodyLen: number;
+  queryString: string;
   private _params: Map<string, string>;
 
   constructor(req: HttpRequest, params: Map<string, string>) {
@@ -76,6 +77,7 @@ export class RouterRequest {
     this.contentType = req.contentType;
     this.headers = req.headers;
     this.bodyLen = req.bodyLen;
+    this.queryString = req.queryString;
     this._params = params;
   }
 

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -350,8 +350,16 @@ export class FunctionGenerator {
             let biTypes: string[] = [];
             const ptype = paramTypes[i];
             if (ptype === "HttpRequest") {
-              biKeys = ["method", "path", "body", "contentType", "headers", "bodyLen"];
-              biTypes = ["i8*", "i8*", "i8*", "i8*", "i8*", "double"];
+              biKeys = [
+                "method",
+                "path",
+                "body",
+                "contentType",
+                "headers",
+                "bodyLen",
+                "queryString",
+              ];
+              biTypes = ["i8*", "i8*", "i8*", "i8*", "i8*", "double", "i8*"];
             } else if (ptype === "HttpResponse") {
               biKeys = ["status", "body", "headers"];
               biTypes = ["double", "i8*", "i8*"];

--- a/src/codegen/stdlib/http-server.ts
+++ b/src/codegen/stdlib/http-server.ts
@@ -17,7 +17,7 @@ export class HttpServerGenerator {
     let ir = "; libwebsockets HTTP server declarations (via lws-bridge)\n\n";
 
     ir += "; lws bridge types (match lws-bridge.h structs)\n";
-    ir += "%struct.lws_bridge_request = type { i8*, i8*, i8*, i8*, i8*, double }\n";
+    ir += "%struct.lws_bridge_request = type { i8*, i8*, i8*, i8*, i8*, double, i8* }\n";
     ir += "%struct.lws_bridge_response = type { i32, i8*, i64, i8* }\n\n";
 
     ir += "; lws bridge functions\n";

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -1542,9 +1542,17 @@ export class ClassGenerator {
     let builtinIfaceTypes: string[] = [];
     let builtinIfaceTsTypes: string[] = [];
     if (tsType === "HttpRequest") {
-      builtinIfaceKeys = ["method", "path", "body", "contentType", "headers", "bodyLen"];
-      builtinIfaceTypes = ["i8*", "i8*", "i8*", "i8*", "i8*", "double"];
-      builtinIfaceTsTypes = ["string", "string", "string", "string", "string", "number"];
+      builtinIfaceKeys = [
+        "method",
+        "path",
+        "body",
+        "contentType",
+        "headers",
+        "bodyLen",
+        "queryString",
+      ];
+      builtinIfaceTypes = ["i8*", "i8*", "i8*", "i8*", "i8*", "double", "i8*"];
+      builtinIfaceTsTypes = ["string", "string", "string", "string", "string", "number", "string"];
     } else if (tsType === "HttpResponse") {
       builtinIfaceKeys = ["status", "body", "headers"];
       builtinIfaceTypes = ["double", "i8*", "i8*"];

--- a/tests/fixtures/network/http-query-string-test.ts
+++ b/tests/fixtures/network/http-query-string-test.ts
@@ -1,0 +1,31 @@
+// @test-skip
+// HTTP query string fixture used by http-query-string.test.ts
+import { httpServe } from "chadscript/http";
+
+interface Request {
+  method: string;
+  path: string;
+  body: string;
+  contentType: string;
+  headers: string;
+  bodyLen: number;
+  queryString: string;
+}
+
+interface Response {
+  status: number;
+  body: string;
+  headers: string;
+}
+
+function handleRequest(req: Request): Response {
+  if (req.path == "/echo-query") {
+    return { status: 200, body: req.queryString, headers: "" };
+  }
+  if (req.path == "/check-path") {
+    return { status: 200, body: req.path, headers: "" };
+  }
+  return { status: 404, body: "Not Found", headers: "" };
+}
+
+httpServe(9985, handleRequest);

--- a/tests/http-query-string.test.ts
+++ b/tests/http-query-string.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { exec, spawn, ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import * as fsSync from "node:fs";
+
+const execAsync = promisify(exec);
+
+const SERVER_SOURCE = "tests/fixtures/network/http-query-string-test.ts";
+const SERVER_BINARY = ".build/tests/fixtures/network/http-query-string-test";
+const PORT = 9985;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("HTTP Query String Tests", { concurrency: 1 }, () => {
+  let serverProcess: ChildProcess | null = null;
+
+  before(async () => {
+    await execAsync(`node dist/chad-node.js build ${SERVER_SOURCE}`, { timeout: 60000 });
+    assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");
+  });
+
+  after(async () => {
+    if (serverProcess?.pid) {
+      try {
+        process.kill(-serverProcess.pid, "SIGTERM");
+      } catch {}
+    }
+  });
+
+  async function waitForServer(maxAttempts = 50): Promise<void> {
+    for (let i = 0; i < maxAttempts; i++) {
+      try {
+        const resp = await fetch(`http://127.0.0.1:${PORT}/check-path`);
+        await resp.text();
+        return;
+      } catch {
+        await sleep(100);
+      }
+    }
+    throw new Error(`Server not ready after ${maxAttempts * 100}ms`);
+  }
+
+  async function startServer(): Promise<ChildProcess> {
+    if (serverProcess?.pid && isProcessAlive(serverProcess.pid)) {
+      try {
+        process.kill(-serverProcess.pid, "SIGTERM");
+      } catch {}
+      await sleep(500);
+    }
+
+    serverProcess = spawn(SERVER_BINARY, [], {
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    assert.ok(serverProcess.pid, "Server should have a PID");
+    await waitForServer();
+    assert.ok(isProcessAlive(serverProcess.pid), "Server should be alive after start");
+
+    return serverProcess;
+  }
+
+  async function stopServer(): Promise<void> {
+    if (serverProcess?.pid) {
+      try {
+        process.kill(-serverProcess.pid, "SIGTERM");
+      } catch {}
+      await sleep(500);
+      serverProcess = null;
+    }
+  }
+
+  it("query string is exposed in req.queryString", async () => {
+    const srv = await startServer();
+    try {
+      const resp = await fetch(`http://127.0.0.1:${PORT}/echo-query?foo=bar&baz=qux`);
+      const body = await resp.text();
+      assert.ok(isProcessAlive(srv.pid!), "Server should be alive");
+      assert.strictEqual(body, "foo=bar&baz=qux");
+    } finally {
+      await stopServer();
+    }
+  });
+
+  it("path does not include query string", async () => {
+    const srv = await startServer();
+    try {
+      const resp = await fetch(`http://127.0.0.1:${PORT}/check-path?x=1`);
+      const body = await resp.text();
+      assert.ok(isProcessAlive(srv.pid!), "Server should be alive");
+      assert.strictEqual(body, "/check-path");
+    } finally {
+      await stopServer();
+    }
+  });
+
+  it("queryString is empty when no query string present", async () => {
+    const srv = await startServer();
+    try {
+      const resp = await fetch(`http://127.0.0.1:${PORT}/echo-query`);
+      const body = await resp.text();
+      assert.ok(isProcessAlive(srv.pid!), "Server should be alive");
+      assert.strictEqual(body, "");
+    } finally {
+      await stopServer();
+    }
+  });
+});


### PR DESCRIPTION
lws-bridge splits path at '?' into path_str and query_string_str; lws_bridge_request gets query_string field; llvm struct updated to 7 fields; HttpRequest builtin iface gains queryString at index 6; RouterRequest propagates it; chadscript.d.ts updated; test fixture + test file added