### PR TITLE
remove router.compile dead code, fix http docs, add uint8array doc, f…

### DIFF
--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -301,7 +301,8 @@ declare namespace ChadScript {
   function embedFile(path: string): string;
   function embedDir(path: string): void;
   function getEmbeddedFile(key: string): string;
-  function serveEmbedded(req: HttpRequest): HttpResponse;
+  function getEmbeddedFileAsUint8Array(key: string): Uint8Array;
+  function serveEmbedded(path: string): HttpResponse;
 }
 
 interface MultipartPart {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -84,6 +84,7 @@ export default defineConfig({
               { text: 'Syscalls', link: '/stdlib/syscalls' },
               { text: 'Test Runner', link: '/stdlib/test-runner' },
               { text: 'tty', link: '/stdlib/tty' },
+              { text: 'Uint8Array', link: '/stdlib/uint8array' },
             ]
           },
         ]

--- a/docs/stdlib/http-server.md
+++ b/docs/stdlib/http-server.md
@@ -49,7 +49,6 @@ httpServe(3000, (req) => app.handle(req));
 | `app.all(pattern, handler)` | Match any HTTP method |
 | `app.notFound(handler)` | Custom 404 handler |
 | `app.handle(req)` | Dispatch an `HttpRequest` → `HttpResponse` |
-| `app.compile()` | Pre-compile the combined regex (called automatically on first `handle`) |
 
 Route patterns support `:param` segments and `*` wildcards:
 
@@ -87,6 +86,7 @@ app.get("/example", (c: Context) => {
 | `c.json(body)` | `application/json` | pass a JSON string |
 | `c.html(body)` | `text/html` | |
 | `c.redirect(url)` | — | 302, sets `Location` header |
+| `c.bytes(data, contentType)` | `contentType` | binary-safe; use for images, files, etc. |
 
 **Chainable setters** (return `Context`, call before a response method):
 
@@ -186,7 +186,8 @@ function wsHandler(event: WsEvent): string {
 |----------|------|-------------|
 | `method` | `string` | HTTP method (`"GET"`, `"POST"`, etc.) |
 | `path` | `string` | Request path (`"/"`, `"/api/users"`, etc.) |
-| `body` | `string` | Request body |
+| `body` | `string` | Request body (use `bodyLen` for binary-safe length) |
+| `bodyLen` | `number` | Exact byte length of `body` — use this instead of `body.length` for binary data |
 | `contentType` | `string` | Content-Type header value |
 | `headers` | `string` | All request headers as `"Key: Value\n..."` string |
 
@@ -196,9 +197,12 @@ function wsHandler(event: WsEvent): string {
 |----------|------|-------------|
 | `status` | `number` | HTTP status code |
 | `body` | `string` | Response body |
+| `bodyLen` | `number` | Byte length of body for binary responses — set to `0` for text responses (server uses `strlen`), set to the actual byte count for binary data |
 | `headers` | `string` | Extra response headers as `"\n"`-separated lines (e.g. `"Set-Cookie: session=abc\nX-Custom: value"`) |
 
 If `headers` contains a `Content-Type:` line, it overrides the auto-detected content type. Set `headers` to `""` when no extra headers are needed.
+
+For binary responses built by hand, set `bodyLen` to the actual byte count. Text responses can leave it as `0`.
 
 ## WsEvent Object
 
@@ -338,6 +342,43 @@ function handleRequest(req: HttpRequest): HttpResponse {
   return { status: 401, body: "Unauthorized", headers: "" };
 }
 ```
+
+## `serveFile(path, contentType)`
+
+Serve a file from disk as a binary-safe `HttpResponse`. Reads the file with `fs.readFileSync` and returns a 200 response with the correct `Content-Type` and `bodyLen` set.
+
+```typescript
+import { httpServe, serveFile } from "chadscript/http";
+
+function handleRequest(req: HttpRequest): HttpResponse {
+  if (req.path == "/logo.png") {
+    return serveFile("./assets/logo.png", "image/png");
+  }
+  return { status: 404, body: "Not Found", headers: "", bodyLen: 0 };
+}
+
+httpServe(3000, handleRequest);
+```
+
+For serving compile-time embedded files, see [`ChadScript.serveEmbedded`](/stdlib/embed#chadscriptserveembeddedpath).
+
+## `bytesResponse(data, status, headers)`
+
+Build an `HttpResponse` from a `Uint8Array`. Use this when you have binary data in memory and need to return it as an HTTP response.
+
+```typescript
+import { httpServe, bytesResponse } from "chadscript/http";
+
+function handleRequest(req: HttpRequest): HttpResponse {
+  if (req.path == "/data") {
+    const data: Uint8Array = buildBinaryPayload();
+    return bytesResponse(data, 200, "Content-Type: application/octet-stream");
+  }
+  return { status: 404, body: "Not Found", headers: "", bodyLen: 0 };
+}
+```
+
+`headers` follows the same `"\n"`-separated format as `HttpResponse.headers`. Pass `""` when no extra headers are needed.
 
 ## Native Implementation
 

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -25,7 +25,7 @@ import { ArgumentParser } from "chadscript/argparse";
 
 | Module | Contents |
 |--------|----------|
-| `chadscript/http` | `httpServe`, `wsBroadcast`, `wsSend`, `parseMultipart`, `getHeader`, `parseQueryString`, `parseCookies`, `Router`, `Context`, `RouterRequest` |
+| `chadscript/http` | `httpServe`, `wsBroadcast`, `wsSend`, `parseMultipart`, `bytesResponse`, `serveFile`, `getHeader`, `parseQueryString`, `parseCookies`, `Router`, `Context`, `RouterRequest` |
 | `chadscript/argparse` | `ArgumentParser` |
 
 The `chadscript/` prefix works like Node's `node:` prefix — unambiguous and collision-free.

--- a/docs/stdlib/uint8array.md
+++ b/docs/stdlib/uint8array.md
@@ -1,0 +1,83 @@
+# Uint8Array
+
+A fixed-length array of 8-bit unsigned integers. Used for binary data — file contents, HTTP request/response bodies, embedded assets, and any other byte-oriented data.
+
+```typescript
+const buf: Uint8Array = fs.readFileSync("image.png");
+console.log(buf.length); // byte count
+```
+
+## Creating
+
+### `new Uint8Array(length)`
+
+Allocate a zero-filled buffer of `length` bytes.
+
+```typescript
+const buf = new Uint8Array(1024);
+```
+
+### `Buffer.from(str, 'base64')`
+
+Decode a base64 string into a `Uint8Array`.
+
+```typescript
+const decoded: Uint8Array = Buffer.from("aGVsbG8=", "base64");
+```
+
+### `Uint8Array.fromRawBytes(ptr, len)`
+
+Wrap a raw byte pointer and length. Used internally by `bodyBytes()` and similar APIs — rarely needed in user code.
+
+## Properties
+
+### `.length`
+
+Number of bytes in the array.
+
+```typescript
+const buf: Uint8Array = fs.readFileSync("file.bin");
+console.log(buf.length);
+```
+
+## Where Uint8Array appears
+
+| API | Notes |
+|-----|-------|
+| `fs.readFileSync(path)` | Returns `Uint8Array` |
+| `fs.writeFileSync(path, data)` | Accepts `Uint8Array` |
+| `req.bodyBytes()` | Binary-safe request body as `Uint8Array` |
+| `c.bytes(data, contentType)` | Router response from `Uint8Array` |
+| `bytesResponse(data, status, headers)` | Raw HTTP response from `Uint8Array` |
+| `ChadScript.getEmbeddedFileAsUint8Array(key)` | Embedded file as `Uint8Array` |
+| `Buffer.from(str, 'base64')` | Base64 decode → `Uint8Array` |
+
+## Example: binary HTTP response
+
+```typescript
+import { httpServe, bytesResponse } from "chadscript/http";
+
+function handleRequest(req: HttpRequest): HttpResponse {
+  if (req.path == "/image") {
+    const data: Uint8Array = fs.readFileSync("./assets/photo.jpg");
+    return bytesResponse(data, 200, "Content-Type: image/jpeg");
+  }
+  return { status: 404, body: "Not Found", headers: "", bodyLen: 0 };
+}
+
+httpServe(3000, handleRequest);
+```
+
+## Example: binary upload
+
+```typescript
+function handleRequest(req: HttpRequest): HttpResponse {
+  if (req.method == "POST" && req.path == "/upload") {
+    const data: Uint8Array = req.bodyBytes();
+    console.log("received " + data.length.toString() + " bytes");
+    fs.writeFileSync("/tmp/upload.bin", data);
+    return { status: 200, body: "OK", headers: "", bodyLen: 0 };
+  }
+  return { status: 404, body: "Not Found", headers: "", bodyLen: 0 };
+}
+```

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -210,8 +210,6 @@ interface RouteEntry {
   method: string;
   pattern: string;
   paramNames: string;
-  groupOffset: number;
-  groupCount: number;
   handlerIndex: number;
 }
 
@@ -219,15 +217,11 @@ export class Router {
   private routes: RouteEntry[];
   private handlers: RouteHandler[];
   private notFoundHandler: RouteHandler | null;
-  private compiled: boolean;
-  private compiledRegex: RegExp;
 
   constructor() {
     this.routes = [];
     this.handlers = [];
     this.notFoundHandler = null;
-    this.compiled = false;
-    this.compiledRegex = new RegExp(".");
   }
 
   private addRoute(
@@ -236,14 +230,11 @@ export class Router {
     handler: (c: Context) => HttpResponse,
     env: string,
   ): void {
-    this.compiled = false;
     const paramNames = this.extractParamNames(pattern);
     const entry: RouteEntry = {
       method: method,
       pattern: pattern,
       paramNames: paramNames,
-      groupOffset: 0,
-      groupCount: 0,
       handlerIndex: this.handlers.length,
     };
     this.routes.push(entry);
@@ -320,39 +311,6 @@ export class Router {
       }
     }
     return result;
-  }
-
-  private countGroups(regexPart: string): number {
-    let count = 0;
-    for (let i = 0; i < regexPart.length; i++) {
-      if (regexPart[i] === "(") {
-        count = count + 1;
-      }
-    }
-    return count;
-  }
-
-  compile(): void {
-    if (this.compiled) return;
-    let combined = "";
-    let offset = 2;
-    for (let i = 0; i < this.routes.length; i++) {
-      const route = this.routes[i];
-      const regexPart = this.patternToRegex(route.pattern);
-      const wrapped = "(" + regexPart + ")";
-      const innerGroups = this.countGroups(regexPart);
-
-      route.groupOffset = offset;
-      route.groupCount = innerGroups;
-
-      if (combined.length > 0) {
-        combined = combined + "|";
-      }
-      combined = combined + wrapped;
-      offset = offset + 1 + innerGroups;
-    }
-    this.compiledRegex = new RegExp("^(" + combined + ")$");
-    this.compiled = true;
   }
 
   handle(rawReq: HttpRequest): HttpResponse {


### PR DESCRIPTION
## Summary

- **Remove `Router.compile()` dead code** — `handle()` never used `this.compiledRegex`; the method, its helper `countGroups()`, and the associated fields (`compiled`, `compiledRegex`, `groupOffset`, `groupCount`) were never read. Removed entirely.
- **Fix `ChadScript.serveEmbedded` d.ts signature** — was typed as `(req: HttpRequest)` but actually takes `(path: string)`. Also added missing `getEmbeddedFileAsUint8Array` to the namespace declaration.
- **Add `c.bytes()` to Context response table** in http-server.md — it existed in code and d.ts but wasn't documented.
- **Add `bodyLen` to `HttpRequest`/`HttpResponse` doc tables** — required for binary-safe request reading and response construction; was missing from both tables.
- **Document `serveFile()` and `bytesResponse()`** — exported from `chadscript/http` but absent from docs and the stdlib index module table.
- **Add `Uint8Array` stdlib page** — used across fs, HTTP, embed, and crypto APIs but had no reference page.

## Test plan

- [ ] `npm test` passes (all existing tests green)
- [ ] `Router` still works correctly — `handle()` logic unchanged, only dead fields/methods removed
- [ ] Docs build: `cd docs && npm run dev` renders Uint8Array page and updated http-server page correctly
