### PR TITLE
fix: annotate let x = -1 with : number to prevent native compiler mistype

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -698,7 +698,7 @@ export class MemberAccessGenerator {
     const interfaceDef = interfaceDefResult as InterfaceInfo;
     if (!interfaceDef.properties) return null;
 
-    let propIndex = -1;
+    let propIndex: number = -1;
     for (let i = 0; i < interfaceDef.properties.length; i++) {
       const p = interfaceDef.properties[i] as InterfaceProperty;
       if (p.name === expr.property) {
@@ -1268,7 +1268,7 @@ export class MemberAccessGenerator {
 
     const innerInterfaceDefResult = this.getInterfaceFromAST(innerInterfaceName);
 
-    let propIndex = -1;
+    let propIndex: number = -1;
     let propType = "";
     let fieldPtr = "";
 
@@ -1575,7 +1575,7 @@ export class MemberAccessGenerator {
         return null;
       }
 
-      let propIndex = -1;
+      let propIndex: number = -1;
       for (let i = 0; i < ifInfoProps.length; i++) {
         const p = ifInfoProps[i] as InterfaceProperty;
         if (p.name === expr.property) {
@@ -1627,7 +1627,7 @@ export class MemberAccessGenerator {
     const interfaceDef = interfaceDefResult as InterfaceDeclaration;
     if (!interfaceDef.fields) return null;
     const allFields1628 = this.ctx.getAllInterfaceFields(interfaceDef);
-    let propIndex = -1;
+    let propIndex: number = -1;
     let propTsType: string | undefined;
     for (let i = 0; i < allFields1628.length; i++) {
       const f = allFields1628[i] as { name: string; type: string };
@@ -2331,7 +2331,7 @@ export class MemberAccessGenerator {
 
     const objPtr = this.ctx.generateExpression(expr.object, params);
 
-    let propIndex = -1;
+    let propIndex: number = -1;
     for (let i = 0; i < allFields2328.length; i++) {
       const f = allFields2328[i] as { name: string; type: string };
       if (f.name === expr.property) {
@@ -2521,7 +2521,7 @@ export class MemberAccessGenerator {
             if (innerIfaceProps.length === 0) {
               return innerPtr;
             }
-            let propIndex = -1;
+            let propIndex: number = -1;
             for (let i = 0; i < innerIfaceProps.length; i++) {
               const p = innerIfaceProps[i] as InterfaceProperty;
               if (p.name === expr.property) {
@@ -2597,7 +2597,7 @@ export class MemberAccessGenerator {
           } else if (interfaceProps.length === 0) {
             // empty properties - skip
           } else {
-            let propIndex = -1;
+            let propIndex: number = -1;
             let propType = "";
             for (let i = 0; i < interfaceProps.length; i++) {
               const prop = interfaceProps[i] as InterfaceProperty;
@@ -2664,7 +2664,7 @@ export class MemberAccessGenerator {
         if (paramInterfaceType.startsWith("{")) {
           const inlineFields = this.parseInlineObjectTypeForAssertion(paramInterfaceType);
           if (inlineFields) {
-            let propIndex = -1;
+            let propIndex: number = -1;
             let propType = "";
             for (let pi = 0; pi < inlineFields.length; pi++) {
               const field = inlineFields[pi] as InterfaceField;
@@ -2725,7 +2725,7 @@ export class MemberAccessGenerator {
             }
             return "0.0";
           }
-          let propIndex = -1;
+          let propIndex: number = -1;
           for (let pi = 0; pi < ifaceProps.length; pi++) {
             const p = ifaceProps[pi] as InterfaceProperty;
             if (p.name === expr.property) {
@@ -2922,7 +2922,7 @@ export class MemberAccessGenerator {
       }
     }
 
-    let fieldIndex = -1;
+    let fieldIndex: number = -1;
     for (let i = 0; i < fields.length; i++) {
       const f = fields[i] as { name: string; type: string };
       if (f.name === property) {
@@ -2997,7 +2997,7 @@ export class MemberAccessGenerator {
       throw new Error(`Interface ${interfaceType} not found in interface struct generator`);
     }
 
-    let propIndex = -1;
+    let propIndex: number = -1;
     let propLlvmType = "";
     let propTsType = "";
     const fields = interfaceInfo.fields as InterfaceFieldInfo[];
@@ -3096,7 +3096,7 @@ export class MemberAccessGenerator {
       throw new Error(`Interface ${interfaceType} not found in interface struct generator`);
     }
 
-    let propIndex = -1;
+    let propIndex: number = -1;
     let propLlvmType = "";
     let propTsType = "";
     const fields = interfaceInfo.fields as InterfaceFieldInfo[];

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -227,7 +227,7 @@ export class AssignmentGenerator {
   ): void {
     const fieldInfoResult = this.ctx.classGenGetFieldInfo(className, property);
 
-    let fieldIndex = -1;
+    let fieldIndex: number = -1;
     let fieldType = "";
     let fieldTsType: string | null = null;
     if (fieldInfoResult) {

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -304,7 +304,7 @@ export function parseMapTypeString(s: string): { keyType: string; valueType: str
   if (!trimmed.endsWith(">")) return null;
   const inner = trimmed.substring(4, trimmed.length - 1);
   let depth = 0;
-  let commaIdx = -1;
+  let commaIdx: number = -1;
   for (let i = 0; i < inner.length; i++) {
     const ch = inner[i];
     if (ch === "<") {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -324,7 +324,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
 
   private dbgInit(sourceFilePath: string): void {
-    let lastSlash = -1;
+    let lastSlash: number = -1;
     for (let i = 0; i < sourceFilePath.length; i++) {
       if (sourceFilePath.charAt(i) === "/") {
         lastSlash = i;
@@ -1666,7 +1666,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       )
         continue;
 
-      let semaIdx = -1;
+      let semaIdx: number = -1;
       for (let si = 0; si < this.semaSymbolCount; si++) {
         if (this.semaSymbolNames[si] === name) {
           semaIdx = si;

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -2136,7 +2136,7 @@ export class ControlFlowGenerator {
     this.loopBreakLabels.push(endLabel);
 
     const caseLabels: string[] = [];
-    let defaultLabelIndex = -1;
+    let defaultLabelIndex: number = -1;
 
     for (let i = 0; i < switchStmt.cases.length; i++) {
       const caseItem = switchStmt.cases[i];

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -164,7 +164,7 @@ export class JsonGenerator {
     this.ctx.emit(`${iInc} = add i32 ${i}, 1`);
     this.ctx.emitBr(loopCond);
 
-    let phiIdx = -1;
+    let phiIdx: number = -1;
     for (let phiSearchIdx = 0; phiSearchIdx < this.ctx.getOutputLength(); phiSearchIdx++) {
       if (this.ctx.getOutputLine(phiSearchIdx).includes(phiPlaceholder)) {
         phiIdx = phiSearchIdx;

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -271,7 +271,7 @@ export class ClassGenerator {
     }
 
     if (fields) {
-      let index = -1;
+      let index: number = -1;
       for (let i = 0; i < fields.length; i++) {
         const f = fields[i] as { name: string; fieldType: string; tsType: string };
         if (f.name === fieldName) {
@@ -546,7 +546,7 @@ export class ClassGenerator {
       const paramPropsLen = paramProps.length;
       for (let i = 0; i < paramPropsLen; i++) {
         const propName = paramProps[i];
-        let paramIndex = -1;
+        let paramIndex: number = -1;
         for (let pi = 0; pi < constructor.params.length; pi++) {
           if (constructor.params[pi] === propName) {
             paramIndex = pi;


### PR DESCRIPTION
## Summary
- 20 instances of `let x = -1` across 7 codegen files annotated with `: number`
- Stage 0 native compiler mistyped untyped `-1` initializers as `i8*` (pointer), causing IR validation failures when used as array indices
- Files fixed: `member.ts`, `assignment-generator.ts`, `type-system.ts`, `llvm-generator.ts`, `control-flow.ts`, `json.ts`, `class.ts`

## Test plan
- [x] All 428 unit tests pass