### PR TITLE
fix: use ctx.getAllInterfaceFields in class-dispatch for inherited interface fields

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -29,6 +29,7 @@ import {
   FunctionNode,
   MemberAccessNode,
   InterfaceDeclaration,
+  InterfaceField,
   SourceLocation,
 } from "../../ast/types.js";
 import type { SymbolTable } from "../infrastructure/symbol-table.js";
@@ -250,6 +251,7 @@ export interface MethodCallGeneratorContext {
     getThisFieldMapKeyType(expr: Expression): string | null;
     getThisFieldSetValueType(expr: Expression): string | null;
   };
+  getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[];
   ensureDouble(value: string): string;
   ensureI64(value: string): string;
   getWantsBinaryReturn(): boolean;

--- a/src/codegen/expressions/method-calls/class-dispatch.ts
+++ b/src/codegen/expressions/method-calls/class-dispatch.ts
@@ -31,6 +31,20 @@ type ClassNode = {
   typeParameters?: string[];
 };
 
+export function getInterfaceDecl(
+  ctx: MethodCallGeneratorContext,
+  name: string,
+): InterfaceDeclaration | null {
+  const len = ctx.getAstInterfacesLength();
+  for (let i = 0; i < len; i++) {
+    const ifaceName = ctx.getAstInterfaceNameAt(i);
+    if (ifaceName === name) {
+      return ctx.getAstInterfaceAt(i);
+    }
+  }
+  return null;
+}
+
 export function getInterfaceFromAST(
   ctx: MethodCallGeneratorContext,
   name: string,
@@ -41,26 +55,13 @@ export function getInterfaceFromAST(
     if (ifaceName === name) {
       const ifaceItem = ctx.getAstInterfaceAt(i);
       if (!ifaceItem) continue;
+      const allFields = ctx.getAllInterfaceFields(ifaceItem);
       const properties: { name: string; type: string }[] = [];
-      for (let j = 0; j < ifaceItem.fields.length; j++) {
-        const field = ifaceItem.fields[j] as { name: string; type: string };
+      for (let j = 0; j < allFields.length; j++) {
+        const field = allFields[j] as { name: string; type: string };
         properties.push({ name: field.name, type: field.type });
       }
       return { properties };
-    }
-  }
-  return null;
-}
-
-export function getInterfaceDecl(
-  ctx: MethodCallGeneratorContext,
-  name: string,
-): InterfaceDeclaration | null {
-  const len = ctx.getAstInterfacesLength();
-  for (let i = 0; i < len; i++) {
-    const ifaceName = ctx.getAstInterfaceNameAt(i);
-    if (ifaceName === name) {
-      return ctx.getAstInterfaceAt(i);
     }
   }
   return null;
@@ -388,8 +389,9 @@ export function resolveNestedMemberAccessType(
     const interfaceDecl = interfaceDeclResult as InterfaceDeclaration;
     if (interfaceDeclResult) {
       let fieldResult: InterfaceField | null = null;
-      for (let i = 0; i < interfaceDecl.fields.length; i++) {
-        const f = interfaceDecl.fields[i] as { name: string; type: string };
+      const allIfaceFields = ctx.getAllInterfaceFields(interfaceDecl);
+      for (let i = 0; i < allIfaceFields.length; i++) {
+        const f = allIfaceFields[i] as { name: string; type: string };
         if (f.name === memberAccess.property) {
           fieldResult = f;
           break;
@@ -641,8 +643,9 @@ export function handleClassMethods(
           const interfaceDeclResult = getInterfaceDecl(ctx, interfaceType);
           if (interfaceDeclResult) {
             const interfaceDecl = interfaceDeclResult as InterfaceDeclaration;
-            for (let i = 0; i < interfaceDecl.fields.length; i++) {
-              const f = interfaceDecl.fields[i] as { name: string; type: string };
+            const allDispatchFields = ctx.getAllInterfaceFields(interfaceDecl);
+            for (let i = 0; i < allDispatchFields.length; i++) {
+              const f = allDispatchFields[i] as { name: string; type: string };
               if (f.name === memberAccess.property) {
                 let fieldType = f.type;
                 if (fieldType.endsWith(" | null") || fieldType.endsWith(" | undefined")) {


### PR DESCRIPTION
## Summary
- `getInterfaceFromAST`, and two field-search loops in `class-dispatch.ts` iterated `interfaceDecl.fields` directly, missing inherited fields from `extends`
- Added `getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[]` to `MethodCallGeneratorContext` interface (delegates to existing `LLVMGenerator.getAllInterfaceFields` which already works correctly)
- All three sites now call `ctx.getAllInterfaceFields()` to include parent interface fields

## Test plan
- [x] All 428 unit tests pass
- [x] Full 3-stage self-hosting passes (Stage 1 and Stage 2 both smoke-test clean)
- [x] No regressions: object-keys, interface dispatch, and method routing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)