### PR TITLE
fix: use getAllInterfaceFields for function interface parameter metadata

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -14,6 +14,8 @@ import {
   SwitchStatement,
   SourceLocation,
   Statement,
+  InterfaceDeclaration,
+  InterfaceField,
 } from "../../ast/types.js";
 import {
   SymbolKind,
@@ -105,6 +107,7 @@ export interface FunctionGeneratorContext {
   getTargetOS(): string;
   setRawInterfaceType(name: string, type: string): void;
   getUsesMathRandom(): boolean;
+  getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[];
 }
 
 export class FunctionGenerator {
@@ -328,20 +331,14 @@ export class FunctionGenerator {
           }
 
           let interfaceDefName: string = "";
-          let interfaceDefFields: { name: string; type: string }[] = [];
+          let interfaceDefFields: InterfaceField[] = [];
           const interfaces = ast ? ast.interfaces || [] : [];
           for (let ji = 0; ji < interfaces.length; ji++) {
-            const iface = interfaces[ji] as {
-              name: string;
-              extends: string[];
-              fields: { name: string; type: string }[];
-            };
+            const iface = interfaces[ji] as InterfaceDeclaration;
             if (!iface || !iface.name) continue;
             if (iface.name === paramTypes[i]) {
               interfaceDefName = iface.name;
-              if (iface.fields) {
-                interfaceDefFields = iface.fields;
-              }
+              interfaceDefFields = this.ctx.getAllInterfaceFields(iface);
               break;
             }
           }

--- a/tests/fixtures/interfaces/interface-extends-param.ts
+++ b/tests/fixtures/interfaces/interface-extends-param.ts
@@ -1,0 +1,25 @@
+interface Base {
+  id: number;
+  name: string;
+}
+
+interface Extended extends Base {
+  value: string;
+}
+
+function printBase(obj: Base): string {
+  return obj.name;
+}
+
+function printExtended(obj: Extended): string {
+  return obj.name + ":" + obj.value;
+}
+
+const e: Extended = { id: 1, name: "test", value: "hello" };
+
+const n = printBase(e);
+const r = printExtended(e);
+
+if (n === "test" && r === "test:hello") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `FunctionGenerator` built `ObjectMetadata` for interface-typed function parameters using `iface.fields` directly — only own fields, missing inherited ones from `extends`
- Added `getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[]` to `FunctionGeneratorContext` interface (already implemented by `LLVMGenerator.getAllInterfaceFields`)
- Changed inline anonymous type cast to `InterfaceDeclaration` and call `ctx.getAllInterfaceFields(iface)` for the field list
- Added test fixture `interfaces/interface-extends-param.ts` verifying inherited field access inside functions

## Test plan
- [ ] All 430 unit tests pass (includes new `interface-extends-param` test)
- [ ] Full 3-stage self-hosting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)