### PR TITLE
fix: use getAllInterfaceFields in type-resolver for inherited interface fields

### DIFF
--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -335,6 +335,26 @@ export class TypeResolver {
     return resolved;
   }
 
+  private getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[] {
+    const result: InterfaceField[] = [];
+    if (iface.extends && iface.extends.length > 0) {
+      for (let i = 0; i < iface.extends.length; i++) {
+        const parentName = iface.extends[i];
+        const parent = this.getInterface(parentName);
+        if (parent) {
+          const parentFields = this.getAllInterfaceFields(parent);
+          for (let j = 0; j < parentFields.length; j++) {
+            result.push(parentFields[j]);
+          }
+        }
+      }
+    }
+    for (let i = 0; i < iface.fields.length; i++) {
+      result.push(iface.fields[i]);
+    }
+    return result;
+  }
+
   getInterface(name: string): InterfaceDeclaration | null {
     if (!name) {
       return null;
@@ -390,8 +410,9 @@ export class TypeResolver {
     const keys: string[] = [];
     const types: string[] = [];
     const tsTypes: string[] = [];
-    for (let i = 0; i < iface.fields.length; i++) {
-      const f = iface.fields[i] as { name: string; type: string };
+    const allFields = this.getAllInterfaceFields(iface);
+    for (let i = 0; i < allFields.length; i++) {
+      const f = allFields[i] as { name: string; type: string };
       keys.push(stripOptional(f.name));
       types.push(canonicalTypeToLlvm(f.type, "default", this.isEnumType(f.type), false, ""));
       tsTypes.push(f.type);
@@ -405,8 +426,9 @@ export class TypeResolver {
     }
     const iface = this.getInterface(interfaceName);
     if (!iface) return null;
-    for (let i = 0; i < iface.fields.length; i++) {
-      const f = iface.fields[i] as { name: string; type: string };
+    const allFields = this.getAllInterfaceFields(iface);
+    for (let i = 0; i < allFields.length; i++) {
+      const f = allFields[i] as { name: string; type: string };
       if (!f || !f.name) {
         continue;
       }
@@ -423,8 +445,9 @@ export class TypeResolver {
     const iface = this.getInterface(interfaceName);
     if (!iface) return null;
     const properties: { name: string; type: string }[] = [];
-    for (let i = 0; i < iface.fields.length; i++) {
-      const f = iface.fields[i] as { name: string; type: string };
+    const allFields = this.getAllInterfaceFields(iface);
+    for (let i = 0; i < allFields.length; i++) {
+      const f = allFields[i] as { name: string; type: string };
       properties.push({ name: f.name, type: f.type });
     }
     return { properties };
@@ -883,8 +906,9 @@ export class TypeResolver {
       if (ifaceDecl) {
         const iface = ifaceDecl as InterfaceDeclaration;
         let field: { name: string; type: string } | null = null;
-        for (let i = 0; i < iface.fields.length; i++) {
-          const f = iface.fields[i] as { name: string; type: string };
+        const allIfaceFields = this.getAllInterfaceFields(iface);
+        for (let i = 0; i < allIfaceFields.length; i++) {
+          const f = allIfaceFields[i] as { name: string; type: string };
           if (f.name === memberExpr.property) {
             field = f;
             break;
@@ -948,8 +972,9 @@ export class TypeResolver {
     if (ifaceDecl) {
       const iface = ifaceDecl as InterfaceDeclaration;
       let field: { name: string; type: string } | null = null;
-      for (let i = 0; i < iface.fields.length; i++) {
-        const f = iface.fields[i] as { name: string; type: string };
+      const allNestedFields = this.getAllInterfaceFields(iface);
+      for (let i = 0; i < allNestedFields.length; i++) {
+        const f = allNestedFields[i] as { name: string; type: string };
         if (f.name === memberExpr.property) {
           field = f;
           break;
@@ -1044,8 +1069,9 @@ export class TypeResolver {
       if (ifaceDecl) {
         const iface = ifaceDecl as InterfaceDeclaration;
         let field: { name: string; type: string } | null = null;
-        for (let i = 0; i < iface.fields.length; i++) {
-          const f = iface.fields[i] as { name: string; type: string };
+        const allKeyFields = this.getAllInterfaceFields(iface);
+        for (let i = 0; i < allKeyFields.length; i++) {
+          const f = allKeyFields[i] as { name: string; type: string };
           if (f.name === memberExpr.property) {
             field = f;
             break;

--- a/tests/fixtures/interfaces/interface-extends-type-resolve.ts
+++ b/tests/fixtures/interfaces/interface-extends-type-resolve.ts
@@ -1,0 +1,25 @@
+interface Animal {
+  name: string;
+  age: number;
+}
+
+interface Dog extends Animal {
+  breed: string;
+}
+
+function describeAnimal(a: Animal): string {
+  return a.name;
+}
+
+function describeDog(d: Dog): string {
+  return d.name + "-" + d.breed;
+}
+
+const d: Dog = { name: "Rex", age: 3, breed: "Labrador" };
+
+const n = describeAnimal(d);
+const s = describeDog(d);
+
+if (n === "Rex" && s === "Rex-Labrador" && d.age === 3) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `TypeResolver.getInterfaceMetadata`, `getInterfaceProperty`, `getInterfaceDefinition`, and three inline field lookups in nested member type resolution all used `iface.fields` directly — missing inherited fields from `extends`
- Added private `getAllInterfaceFields(iface)` to `TypeResolver` that recursively collects parent fields via `this.getInterface(parentName)`, matching the same recursive pattern as `interface-allocator.ts`
- All 6 field-iteration sites now use `getAllInterfaceFields`
- `getInterfaceProperty` is the most critical fix: it's the main entry point for type resolution of member accesses; missing inherited fields caused wrong types for `child.parentField` expressions

## Test plan
- [ ] All 430 unit tests pass (includes new `interface-extends-type-resolve` fixture)
- [ ] Full 3-stage self-hosting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)