### PR TITLE
fix: use getAllInterfaceFields in getUnionCommonFields for inherited interface fields

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -812,18 +812,14 @@ export class FunctionGenerator {
   }
 
   private getUnionCommonFields(memberNames: string[]): { keys: string[]; types: string[] } {
-    const interfaces: { name: string; fields: { name: string; type: string }[] }[] = [];
+    const interfaces: InterfaceDeclaration[] = [];
     const ast = this.ctx.getAst();
     const astInterfaces = ast ? ast.interfaces || [] : [];
     for (let i = 0; i < memberNames.length; i++) {
       const memberName = memberNames[i];
       if (!memberName) continue;
       for (let j = 0; j < astInterfaces.length; j++) {
-        const iface = astInterfaces[j] as {
-          name: string;
-          extends: string[];
-          fields: { name: string; type: string }[];
-        };
+        const iface = astInterfaces[j] as InterfaceDeclaration;
         if (!iface || !iface.name) continue;
         if (iface.name === memberName) {
           interfaces.push(iface);
@@ -836,12 +832,8 @@ export class FunctionGenerator {
       return { keys: [], types: [] };
     }
 
-    const firstInterface = interfaces[0] as {
-      name: string;
-      extends: string[];
-      fields: { name: string; type: string }[];
-    };
-    const firstFields = firstInterface.fields || [];
+    const firstInterface = interfaces[0] as InterfaceDeclaration;
+    const firstFields = this.ctx.getAllInterfaceFields(firstInterface);
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstFields.length; fi++) {
@@ -849,18 +841,11 @@ export class FunctionGenerator {
       if (!field || !field.name) continue;
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
-        const ifaceTyped = interfaces[ii] as {
-          name: string;
-          extends: string[];
-          fields: { name: string; type: string }[];
-        };
-        if (!ifaceTyped.fields) {
-          isCommon = false;
-          break;
-        }
+        const ifaceTyped = interfaces[ii] as InterfaceDeclaration;
+        const ifaceFields = this.ctx.getAllInterfaceFields(ifaceTyped);
         let found = false;
-        for (let fj = 0; fj < ifaceTyped.fields.length; fj++) {
-          const f = ifaceTyped.fields[fj] as { name: string; type: string };
+        for (let fj = 0; fj < ifaceFields.length; fj++) {
+          const f = ifaceFields[fj] as { name: string; type: string };
           if (!f || !f.name) continue;
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             found = true;

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -749,25 +749,6 @@ export class TypeInference {
     return null;
   }
 
-  private getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[] {
-    const result: InterfaceField[] = [];
-    if (iface.extends && iface.extends.length > 0) {
-      for (let i = 0; i < iface.extends.length; i++) {
-        const parent = this.getInterface(iface.extends[i]);
-        if (parent) {
-          const parentFields = this.getAllInterfaceFields(parent);
-          for (let j = 0; j < parentFields.length; j++) {
-            result.push(parentFields[j]);
-          }
-        }
-      }
-    }
-    for (let i = 0; i < iface.fields.length; i++) {
-      result.push(iface.fields[i]);
-    }
-    return result;
-  }
-
   private getInterfaceProperty(interfaceName: string, propName: string): InterfaceField | null {
     if (!interfaceName || !propName) {
       return null;
@@ -778,9 +759,8 @@ export class TypeInference {
     }
     const iface = this.getInterface(interfaceName);
     if (!iface) return null;
-    const allFields = this.getAllInterfaceFields(iface);
-    for (let i = 0; i < allFields.length; i++) {
-      const f = allFields[i] as { name: string; type: string };
+    for (let i = 0; i < iface.fields.length; i++) {
+      const f = iface.fields[i] as { name: string; type: string };
       let fieldName = f.name;
       if (fieldName.endsWith("?")) {
         fieldName = fieldName.slice(0, fieldName.length - 1);

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -749,6 +749,25 @@ export class TypeInference {
     return null;
   }
 
+  private getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[] {
+    const result: InterfaceField[] = [];
+    if (iface.extends && iface.extends.length > 0) {
+      for (let i = 0; i < iface.extends.length; i++) {
+        const parent = this.getInterface(iface.extends[i]);
+        if (parent) {
+          const parentFields = this.getAllInterfaceFields(parent);
+          for (let j = 0; j < parentFields.length; j++) {
+            result.push(parentFields[j]);
+          }
+        }
+      }
+    }
+    for (let i = 0; i < iface.fields.length; i++) {
+      result.push(iface.fields[i]);
+    }
+    return result;
+  }
+
   private getInterfaceProperty(interfaceName: string, propName: string): InterfaceField | null {
     if (!interfaceName || !propName) {
       return null;
@@ -759,8 +778,9 @@ export class TypeInference {
     }
     const iface = this.getInterface(interfaceName);
     if (!iface) return null;
-    for (let i = 0; i < iface.fields.length; i++) {
-      const f = iface.fields[i] as { name: string; type: string };
+    const allFields = this.getAllInterfaceFields(iface);
+    for (let i = 0; i < allFields.length; i++) {
+      const f = allFields[i] as { name: string; type: string };
       let fieldName = f.name;
       if (fieldName.endsWith("?")) {
         fieldName = fieldName.slice(0, fieldName.length - 1);

--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -335,6 +335,25 @@ export class TypeResolver {
     return resolved;
   }
 
+  private getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[] {
+    const result: InterfaceField[] = [];
+    if (iface.extends && iface.extends.length > 0) {
+      for (let i = 0; i < iface.extends.length; i++) {
+        const parent = this.getInterface(iface.extends[i]);
+        if (parent) {
+          const parentFields = this.getAllInterfaceFields(parent);
+          for (let j = 0; j < parentFields.length; j++) {
+            result.push(parentFields[j]);
+          }
+        }
+      }
+    }
+    for (let i = 0; i < iface.fields.length; i++) {
+      result.push(iface.fields[i]);
+    }
+    return result;
+  }
+
   getInterface(name: string): InterfaceDeclaration | null {
     if (!name) {
       return null;
@@ -565,7 +584,7 @@ export class TypeResolver {
     }
 
     const firstInterface = interfaces[0] as InterfaceDeclaration;
-    const firstFields = firstInterface.fields;
+    const firstFields = this.getAllInterfaceFields(firstInterface);
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstFields.length; fi++) {
@@ -573,9 +592,10 @@ export class TypeResolver {
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
         const iface = interfaces[ii] as InterfaceDeclaration;
+        const ifaceFields = this.getAllInterfaceFields(iface);
         let hasMatch = false;
-        for (let jj = 0; jj < iface.fields.length; jj++) {
-          const f = iface.fields[jj] as { name: string; type: string };
+        for (let jj = 0; jj < ifaceFields.length; jj++) {
+          const f = ifaceFields[jj] as { name: string; type: string };
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             hasMatch = true;
             break;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2710,17 +2710,18 @@ export class VariableAllocator {
     }
 
     const firstInterface = interfaces[0] as InterfaceDeclaration;
-    const firstFields = firstInterface.fields;
+    const firstFields = this.getAllInterfaceFields(firstInterface);
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstFields.length; fi++) {
       const field = firstFields[fi] as { name: string; type: string };
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
-        const ifaceTyped = interfaces[ii] as { fields: { name: string; type: string }[] };
+        const ifaceTyped = interfaces[ii] as InterfaceDeclaration;
+        const ifaceFields = this.getAllInterfaceFields(ifaceTyped);
         let found = false;
-        for (let fj = 0; fj < ifaceTyped.fields.length; fj++) {
-          const f = ifaceTyped.fields[fj] as { name: string; type: string };
+        for (let fj = 0; fj < ifaceFields.length; fj++) {
+          const f = ifaceFields[fj] as { name: string; type: string };
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             found = true;
             break;

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -1642,23 +1642,13 @@ export class ClassGenerator {
   }
 
   private getUnionCommonFields(memberNames: string[]): { keys: string[]; types: string[] } {
-    const interfaces: {
-      name: string;
-      extends: string[];
-      fields: { name: string; type: string }[];
-      methods: { name: string }[];
-    }[] = [];
+    const interfaces: InterfaceDeclaration[] = [];
     const ast = this.ctx.getAst();
     const astInterfaces = ast ? ast.interfaces || [] : [];
     for (let i = 0; i < memberNames.length; i++) {
       const memberName = memberNames[i];
       for (let j = 0; j < astInterfaces.length; j++) {
-        const iface = astInterfaces[j] as {
-          name: string;
-          extends: string[];
-          fields: { name: string; type: string }[];
-          methods: { name: string }[];
-        };
+        const iface = astInterfaces[j] as InterfaceDeclaration;
         if (!iface) continue;
         if (!iface.name) continue;
         if (iface.name === memberName) {
@@ -1672,28 +1662,19 @@ export class ClassGenerator {
       return { keys: [], types: [] };
     }
 
-    const firstInterface = interfaces[0] as {
-      name: string;
-      extends: string[];
-      fields: { name: string; type: string }[];
-      methods: { name: string }[];
-    };
-    const firstFields = firstInterface.fields;
+    const firstInterface = interfaces[0] as InterfaceDeclaration;
+    const firstFields = this.ctx.getAllInterfaceFields(firstInterface);
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstFields.length; fi++) {
       const field = firstFields[fi] as { name: string; type: string };
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
-        const ifaceTyped = interfaces[ii] as {
-          name: string;
-          extends: string[];
-          fields: { name: string; type: string }[];
-          methods: { name: string }[];
-        };
+        const ifaceTyped = interfaces[ii] as InterfaceDeclaration;
+        const ifaceFields = this.ctx.getAllInterfaceFields(ifaceTyped);
         let found = false;
-        for (let fj = 0; fj < ifaceTyped.fields.length; fj++) {
-          const f = ifaceTyped.fields[fj] as { name: string; type: string };
+        for (let fj = 0; fj < ifaceFields.length; fj++) {
+          const f = ifaceFields[fj] as { name: string; type: string };
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             found = true;
             break;

--- a/tests/fixtures/interfaces/interface-extends-union.ts
+++ b/tests/fixtures/interfaces/interface-extends-union.ts
@@ -1,0 +1,34 @@
+interface Base {
+  id: number;
+  name: string;
+}
+
+interface TypeA extends Base {
+  kind: string;
+}
+
+interface TypeB extends Base {
+  value: number;
+}
+
+type Combined = TypeA | TypeB;
+
+function getId(obj: Combined): number {
+  return obj.id;
+}
+
+function getName(obj: Combined): string {
+  return obj.name;
+}
+
+const a: TypeA = { id: 1, name: "alpha", kind: "foo" };
+const b: TypeB = { id: 2, name: "beta", value: 42 };
+
+const idA = getId(a);
+const idB = getId(b);
+const nameA = getName(a);
+const nameB = getName(b);
+
+if (idA === 1 && idB === 2 && nameA === "alpha" && nameB === "beta") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Fixes `getUnionCommonFields` in `type-resolver.ts`, `variable-allocator.ts`, `function-generator.ts`, and `class.ts` to use `getAllInterfaceFields` instead of direct `.fields` access
- Fixes `TypeInference.getInterfaceProperty` fallback to use `getAllInterfaceFields` via a new private method
- Also adds `getAllInterfaceFields` to `TypeResolver` directly (same pattern as PR #123 but needed here too since this branch is based on pre-#123 main)
- Replaces unsafe inline anonymous type assertions (`as { name, extends, fields, methods }`) with proper `InterfaceDeclaration` casts
- Adds test fixture `interface-extends-union.ts` exercising union types over interfaces with inheritance

## Test plan
- [x] 431 tests pass
- [x] Full 3-stage self-hosting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)