### PR TITLE
fix: use getAllInterfaceFields in findInterfaceByDiscriminant for inherited discriminant fields

### DIFF
--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -819,7 +819,7 @@ export class TypeResolver {
       if (!ifaceName) continue;
       const iface = this.ctx.getAstInterfaceAt(i);
       if (!iface) continue;
-      const match = this.checkInterfaceForDiscriminant(ifaceName, iface.fields, value, field);
+      const match = this.checkInterfaceForDiscriminant(ifaceName, this.getAllInterfaceFields(iface), value, field);
       if (match) return match;
     }
     return null;

--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -819,7 +819,12 @@ export class TypeResolver {
       if (!ifaceName) continue;
       const iface = this.ctx.getAstInterfaceAt(i);
       if (!iface) continue;
-      const match = this.checkInterfaceForDiscriminant(ifaceName, this.getAllInterfaceFields(iface), value, field);
+      const match = this.checkInterfaceForDiscriminant(
+        ifaceName,
+        this.getAllInterfaceFields(iface),
+        value,
+        field,
+      );
       if (match) return match;
     }
     return null;

--- a/tests/fixtures/interfaces/interface-extends-discriminant.ts
+++ b/tests/fixtures/interfaces/interface-extends-discriminant.ts
@@ -1,5 +1,5 @@
 interface Typed {
-  type: 'cat';
+  type: "cat";
   name: string;
 }
 
@@ -7,10 +7,10 @@ interface Cat extends Typed {
   lives: number;
 }
 
-const c: Cat = { type: 'cat', name: "Whiskers", lives: 9 };
+const c: Cat = { type: "cat", name: "Whiskers", lives: 9 };
 
 let result = "unknown";
-if (c.type === 'cat') {
+if (c.type === "cat") {
   result = c.name + ":" + c.lives;
 }
 

--- a/tests/fixtures/interfaces/interface-extends-discriminant.ts
+++ b/tests/fixtures/interfaces/interface-extends-discriminant.ts
@@ -1,0 +1,19 @@
+interface Typed {
+  type: 'cat';
+  name: string;
+}
+
+interface Cat extends Typed {
+  lives: number;
+}
+
+const c: Cat = { type: 'cat', name: "Whiskers", lives: 9 };
+
+let result = "unknown";
+if (c.type === 'cat') {
+  result = c.name + ":" + c.lives;
+}
+
+if (result === "Whiskers:9") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `findInterfaceByDiscriminant` was passing `iface.fields` (own fields only) to `checkInterfaceForDiscriminant`
- This caused discriminant union narrowing to miss interfaces where the discriminant field is inherited from a parent interface (e.g., `interface Child extends Parent` where `Parent` has `type: 'literal'`)
- Fixed to use `this.getAllInterfaceFields(iface)` which includes all inherited fields
- Adds test fixture `interface-extends-discriminant.ts` verifying discriminant field access on interfaces with inheritance

## Test plan
- [x] 432 tests pass
- [x] Full 3-stage self-hosting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)