### PR TITLE
refactor: extract if-chains from dispatchNamedObject to prevent if-drop bug

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -55,37 +55,7 @@ import type {
   IEmbedGenerator,
 } from "../infrastructure/generator-context.js";
 import { parseMapTypeString, parseSetTypeString } from "../infrastructure/type-system.js";
-import {
-  isProcessStdoutOrStderr,
-  handleProcessWrite,
-  generateProcessExitInline,
-  generateProcessCwdInline,
-  handleProcessChdir,
-  handleProcessKill,
-  handleProcessUptime,
-  handleProcessSyscallI32,
-} from "./method-calls/process.js";
-import {
-  generateConsoleCallInline,
-  generateConsoleTime,
-  generateConsoleTimeEnd,
-} from "./method-calls/console.js";
-import {
-  handleAssertStrictEqual,
-  handleAssertNotStrictEqual,
-  handleAssertOk,
-  handleAssertDeepEqual,
-  handleAssertFail,
-} from "./method-calls/assert.js";
-import {
-  handleOsHostname,
-  handleOsHomedir,
-  handleOsTmpdir,
-  handleOsCpus,
-  handleOsTotalmem,
-  handleOsFreemem,
-  handleOsUptime,
-} from "./method-calls/os.js";
+import { isProcessStdoutOrStderr, handleProcessWrite } from "./method-calls/process.js";
 import {
   generateObjectKeys,
   generateObjectValues,
@@ -101,6 +71,12 @@ import {
   handleUint8ArrayFromRawBytes,
   handleTtyIsatty,
   handleCryptoMethod,
+  handleProcessMethod,
+  handleAssertMethod,
+  handleOsMethod,
+  handleConsoleMethod,
+  handleChadScriptMethod,
+  handleSqliteMethod,
 } from "./method-calls/named-object-dispatch.js";
 import {
   handleSubstr,
@@ -365,15 +341,7 @@ export class MethodCallGenerator {
         return handlePromiseStaticMethods(this.ctx, expr, params);
 
       case "ChadScript":
-        if (method === "embedFile") return this.ctx.embedGen.generateEmbedFile(expr, params);
-        if (method === "embedDir") return this.ctx.embedGen.generateEmbedDir(expr, params);
-        if (method === "getEmbeddedFile")
-          return this.ctx.embedGen.generateGetEmbeddedFile(expr, params);
-        if (method === "getEmbeddedFileAsUint8Array")
-          return this.ctx.embedGen.generateGetEmbeddedFileAsUint8Array(expr, params);
-        if (method === "serveEmbedded")
-          return this.ctx.embedGen.generateServeEmbedded(expr, params);
-        return this.ctx.emitError(`ChadScript.${method}() is not a supported method`, expr.loc);
+        return handleChadScriptMethod(this.ctx, method, expr, params);
 
       case "Uint8Array":
         if (method === "fromRawBytes") return handleUint8ArrayFromRawBytes(this.ctx, expr, params);
@@ -430,56 +398,20 @@ export class MethodCallGenerator {
         return null;
 
       case "console":
-        if (method === "log" || method === "error" || method === "warn" || method === "debug")
-          return generateConsoleCallInline(this.ctx, expr, params);
-        if (method === "time") return generateConsoleTime(this.ctx, expr, params);
-        if (method === "timeEnd") return generateConsoleTimeEnd(this.ctx, expr, params);
-        return null;
+        return handleConsoleMethod(this.ctx, method, expr, params);
 
       case "assert":
-        this.ctx.setUsesTestRunner(true);
-        if (method === "strictEqual") return handleAssertStrictEqual(this.ctx, expr, params);
-        if (method === "notStrictEqual") return handleAssertNotStrictEqual(this.ctx, expr, params);
-        if (method === "ok") return handleAssertOk(this.ctx, expr, params);
-        if (method === "deepEqual") return handleAssertDeepEqual(this.ctx, expr, params);
-        if (method === "fail") return handleAssertFail(this.ctx, expr, params);
-        return null;
+        return handleAssertMethod(this.ctx, method, expr, params);
 
       case "process":
-        if (method === "exit") return generateProcessExitInline(this.ctx, expr, params);
-        if (method === "cwd") return generateProcessCwdInline(this.ctx);
-        if (method === "chdir") return handleProcessChdir(this.ctx, expr, params);
-        if (method === "abort") {
-          this.ctx.emit(`call void @abort()`);
-          return "0";
-        }
-        if (method === "kill") return handleProcessKill(this.ctx, expr, params);
-        if (method === "uptime") return handleProcessUptime(this.ctx);
-        if (method === "getuid") return handleProcessSyscallI32(this.ctx, "@getuid");
-        if (method === "getgid") return handleProcessSyscallI32(this.ctx, "@getgid");
-        if (method === "geteuid") return handleProcessSyscallI32(this.ctx, "@geteuid");
-        if (method === "getegid") return handleProcessSyscallI32(this.ctx, "@getegid");
-        return null;
+        return handleProcessMethod(this.ctx, method, expr, params);
 
       case "tty":
         if (method === "isatty") return handleTtyIsatty(this.ctx, expr, params);
         return null;
 
       case "os":
-        if (method === "hostname") return handleOsHostname(this.ctx);
-        if (method === "homedir") return handleOsHomedir(this.ctx);
-        if (method === "tmpdir") return handleOsTmpdir(this.ctx);
-        if (method === "cpus") return handleOsCpus(this.ctx);
-        if (method === "totalmem") return handleOsTotalmem(this.ctx);
-        if (method === "freemem") {
-          this.ctx.setUsesOs(true);
-          return handleOsFreemem(this.ctx);
-        }
-        if (method === "uptime") {
-          this.ctx.setUsesOs(true);
-          return handleOsUptime(this.ctx);
-        }
-        return null;
+        return handleOsMethod(this.ctx, method, expr, params);
 
       case "fs":
         return handleFsMethod(this.ctx, method, expr, params);
@@ -503,27 +435,11 @@ export class MethodCallGenerator {
         return handleCryptoMethod(this.ctx, method, expr, params);
 
       case "sqlite":
-        return this.dispatchSqliteMethod(method, expr, params);
+        return handleSqliteMethod(this.ctx, method, expr, params);
 
       default:
         return null;
     }
-  }
-
-  private dispatchSqliteMethod(
-    method: string,
-    expr: MethodCallNode,
-    params: string[],
-  ): string | null {
-    this.ctx.setUsesSqlite(true);
-    if (method === "open") return this.ctx.sqliteGen.generateOpen(expr, params);
-    if (method === "exec") return this.ctx.sqliteGen.generateExec(expr, params);
-    if (method === "get") return this.ctx.sqliteGen.generateGet(expr, params);
-    if (method === "getRow") return this.ctx.sqliteGen.generateGetRow(expr, params);
-    if (method === "all") return this.ctx.sqliteGen.generateAll(expr, params);
-    if (method === "query") return this.ctx.sqliteGen.generateQuery(expr, params);
-    if (method === "close") return this.ctx.sqliteGen.generateClose(expr, params);
-    return null;
   }
 
   private getParameterMapKeyType(varName: string): string | null {

--- a/src/codegen/expressions/method-calls/named-object-dispatch.ts
+++ b/src/codegen/expressions/method-calls/named-object-dispatch.ts
@@ -1,5 +1,34 @@
 import { MethodCallNode } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
+import {
+  generateProcessExitInline,
+  generateProcessCwdInline,
+  handleProcessChdir,
+  handleProcessKill,
+  handleProcessUptime,
+  handleProcessSyscallI32,
+} from "./process.js";
+import {
+  generateConsoleCallInline,
+  generateConsoleTime,
+  generateConsoleTimeEnd,
+} from "./console.js";
+import {
+  handleAssertStrictEqual,
+  handleAssertNotStrictEqual,
+  handleAssertOk,
+  handleAssertDeepEqual,
+  handleAssertFail,
+} from "./assert.js";
+import {
+  handleOsHostname,
+  handleOsHomedir,
+  handleOsTmpdir,
+  handleOsCpus,
+  handleOsTotalmem,
+  handleOsFreemem,
+  handleOsUptime,
+} from "./os.js";
 
 export function handleFsMethod(
   ctx: MethodCallGeneratorContext,
@@ -168,4 +197,108 @@ export function handleTtyIsatty(
   const doubleResult = ctx.nextTemp();
   ctx.emit(`${doubleResult} = uitofp i1 ${boolResult} to double`);
   return doubleResult;
+}
+
+export function handleProcessMethod(
+  ctx: MethodCallGeneratorContext,
+  method: string,
+  expr: MethodCallNode,
+  params: string[],
+): string | null {
+  if (method === "exit") return generateProcessExitInline(ctx, expr, params);
+  if (method === "cwd") return generateProcessCwdInline(ctx);
+  if (method === "chdir") return handleProcessChdir(ctx, expr, params);
+  if (method === "abort") {
+    ctx.emit(`call void @abort()`);
+    return "0";
+  }
+  if (method === "kill") return handleProcessKill(ctx, expr, params);
+  if (method === "uptime") return handleProcessUptime(ctx);
+  if (method === "getuid") return handleProcessSyscallI32(ctx, "@getuid");
+  if (method === "getgid") return handleProcessSyscallI32(ctx, "@getgid");
+  if (method === "geteuid") return handleProcessSyscallI32(ctx, "@geteuid");
+  if (method === "getegid") return handleProcessSyscallI32(ctx, "@getegid");
+  return null;
+}
+
+export function handleAssertMethod(
+  ctx: MethodCallGeneratorContext,
+  method: string,
+  expr: MethodCallNode,
+  params: string[],
+): string | null {
+  ctx.setUsesTestRunner(true);
+  if (method === "strictEqual") return handleAssertStrictEqual(ctx, expr, params);
+  if (method === "notStrictEqual") return handleAssertNotStrictEqual(ctx, expr, params);
+  if (method === "ok") return handleAssertOk(ctx, expr, params);
+  if (method === "deepEqual") return handleAssertDeepEqual(ctx, expr, params);
+  if (method === "fail") return handleAssertFail(ctx, expr, params);
+  return null;
+}
+
+export function handleOsMethod(
+  ctx: MethodCallGeneratorContext,
+  method: string,
+  expr: MethodCallNode,
+  params: string[],
+): string | null {
+  if (method === "hostname") return handleOsHostname(ctx);
+  if (method === "homedir") return handleOsHomedir(ctx);
+  if (method === "tmpdir") return handleOsTmpdir(ctx);
+  if (method === "cpus") return handleOsCpus(ctx);
+  if (method === "totalmem") return handleOsTotalmem(ctx);
+  if (method === "freemem") {
+    ctx.setUsesOs(true);
+    return handleOsFreemem(ctx);
+  }
+  if (method === "uptime") {
+    ctx.setUsesOs(true);
+    return handleOsUptime(ctx);
+  }
+  return null;
+}
+
+export function handleConsoleMethod(
+  ctx: MethodCallGeneratorContext,
+  method: string,
+  expr: MethodCallNode,
+  params: string[],
+): string | null {
+  if (method === "log" || method === "error" || method === "warn" || method === "debug")
+    return generateConsoleCallInline(ctx, expr, params);
+  if (method === "time") return generateConsoleTime(ctx, expr, params);
+  if (method === "timeEnd") return generateConsoleTimeEnd(ctx, expr, params);
+  return null;
+}
+
+export function handleChadScriptMethod(
+  ctx: MethodCallGeneratorContext,
+  method: string,
+  expr: MethodCallNode,
+  params: string[],
+): string | null {
+  if (method === "embedFile") return ctx.embedGen.generateEmbedFile(expr, params);
+  if (method === "embedDir") return ctx.embedGen.generateEmbedDir(expr, params);
+  if (method === "getEmbeddedFile") return ctx.embedGen.generateGetEmbeddedFile(expr, params);
+  if (method === "getEmbeddedFileAsUint8Array")
+    return ctx.embedGen.generateGetEmbeddedFileAsUint8Array(expr, params);
+  if (method === "serveEmbedded") return ctx.embedGen.generateServeEmbedded(expr, params);
+  return ctx.emitError(`ChadScript.${method}() is not a supported method`, expr.loc);
+}
+
+export function handleSqliteMethod(
+  ctx: MethodCallGeneratorContext,
+  method: string,
+  expr: MethodCallNode,
+  params: string[],
+): string | null {
+  ctx.setUsesSqlite(true);
+  if (method === "open") return ctx.sqliteGen.generateOpen(expr, params);
+  if (method === "exec") return ctx.sqliteGen.generateExec(expr, params);
+  if (method === "get") return ctx.sqliteGen.generateGet(expr, params);
+  if (method === "getRow") return ctx.sqliteGen.generateGetRow(expr, params);
+  if (method === "all") return ctx.sqliteGen.generateAll(expr, params);
+  if (method === "query") return ctx.sqliteGen.generateQuery(expr, params);
+  if (method === "close") return ctx.sqliteGen.generateClose(expr, params);
+  return null;
 }


### PR DESCRIPTION
## Summary
- Extracts process, assert, os, console, ChadScript, and sqlite dispatch chains from `dispatchNamedObject()` into standalone functions in `named-object-dispatch.ts`
- Follows the existing pattern used by `handleFsMethod`, `handleCryptoMethod`, `handlePathMethod`, etc.
- Removes the `dispatchSqliteMethod` private class method in favor of a standalone function for consistency
- Reduces the number of consecutive if-return blocks within `dispatchNamedObject()` from 10+ to 0, mitigating the native compiler's if-drop bug that drops 5th+ consecutive if-return blocks

## Test plan
- [x] All 432 tests pass
- [x] Self-hosting verification passes (verify:quick)
- [x] Prettier formatting check passes
- [x] No new functionality — pure refactor moving existing code to standalone functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)