### PR TITLE
refactor: extract string and array dispatch chains from generate()

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -79,37 +79,11 @@ import {
   handleSqliteMethod,
 } from "./method-calls/named-object-dispatch.js";
 import {
-  handleSubstr,
-  handleSubstring,
-  handleConcat,
-  handleRepeat,
-  handlePadStart,
-  handlePadEnd,
-  handleSplit,
-  handleStartsWith,
-  handleEndsWith,
-  handleTrim,
-  handleTrimStart,
-  handleTrimEnd,
-  handleIndexOf,
-  handleLastIndexOf,
-  handleStringArrayIndexOf,
-  handleStringArrayIncludes,
-  handleStringIncludes,
-  handleSlice,
-  handleReplace,
-  handleReplaceAll,
-  handleNumberToString,
-  handleNumberToFixed,
-  handleCharAt,
-  handleCharCodeAt,
-  handleToUpperCase,
-  handleToLowerCase,
-  handleMatch,
   handleNumberIsFinite,
   handleNumberIsNaN,
   handleNumberIsInteger,
 } from "./method-calls/string-methods.js";
+import { dispatchStringMethod, dispatchArrayMethod } from "./method-calls/string-dispatch.js";
 import { handlePromiseThen, handlePromiseFinally } from "./method-calls/promise-handlers.js";
 import {
   handleClassMethods,
@@ -718,111 +692,8 @@ export class MethodCallGenerator {
       }
     }
 
-    // Handle string methods
-    if (method === "substr") {
-      return handleSubstr(this.ctx, expr, params);
-    }
-    if (method === "substring") {
-      return handleSubstring(this.ctx, expr, params);
-    }
-    if (
-      method === "concat" &&
-      !this.ctx.isArrayExpression(expr.object) &&
-      !this.ctx.isStringArrayExpression(expr.object) &&
-      !this.ctx.isObjectArrayExpression(expr.object)
-    ) {
-      return handleConcat(this.ctx, expr, params);
-    }
-    if (method === "repeat") {
-      return handleRepeat(this.ctx, expr, params);
-    }
-    if (method === "padStart") {
-      return handlePadStart(this.ctx, expr, params);
-    }
-    if (method === "padEnd") {
-      return handlePadEnd(this.ctx, expr, params);
-    }
-    if (method === "split") {
-      return handleSplit(this.ctx, expr, params);
-    }
-    if (method === "startsWith") {
-      return handleStartsWith(this.ctx, expr, params);
-    }
-    if (method === "endsWith") {
-      return handleEndsWith(this.ctx, expr, params);
-    }
-    if (method === "trim") {
-      return handleTrim(this.ctx, expr, params);
-    }
-    if (method === "trimStart") {
-      return handleTrimStart(this.ctx, expr, params);
-    }
-    if (method === "trimEnd") {
-      return handleTrimEnd(this.ctx, expr, params);
-    }
-    if (method === "indexOf") {
-      if (this.ctx.isStringArrayExpression(expr.object)) {
-        return handleStringArrayIndexOf(this.ctx, expr, params);
-      }
-      if (this.ctx.isArrayExpression(expr.object)) {
-        return this.ctx.arrayGen.generateArrayIndexOf(expr, params);
-      }
-      return handleIndexOf(this.ctx, expr, params);
-    }
-    if (method === "lastIndexOf") {
-      return handleLastIndexOf(this.ctx, expr, params);
-    }
-    if (method === "includes") {
-      if (this.ctx.isStringArrayExpression(expr.object)) {
-        return handleStringArrayIncludes(this.ctx, expr, params);
-      }
-      if (!this.ctx.isArrayExpression(expr.object)) {
-        return handleStringIncludes(this.ctx, expr, params);
-      }
-    }
-    if (
-      method === "slice" &&
-      !this.ctx.isArrayExpression(expr.object) &&
-      !this.ctx.isStringArrayExpression(expr.object) &&
-      !this.ctx.isObjectArrayExpression(expr.object)
-    ) {
-      return handleSlice(this.ctx, expr, params);
-    }
-    if (method === "replace") {
-      return handleReplace(this.ctx, expr, params);
-    }
-    if (method === "replaceAll") {
-      return handleReplaceAll(this.ctx, expr, params);
-    }
-    if (method === "charAt") {
-      return handleCharAt(this.ctx, expr, params);
-    }
-    if (method === "charCodeAt") {
-      return handleCharCodeAt(this.ctx, expr, params);
-    }
-    if (method === "toUpperCase") {
-      return handleToUpperCase(this.ctx, expr, params);
-    }
-    if (method === "toLowerCase") {
-      return handleToLowerCase(this.ctx, expr, params);
-    }
-    if (method === "toString") {
-      if (
-        !this.ctx.isStringExpression(expr.object) &&
-        !this.ctx.isArrayExpression(expr.object) &&
-        !this.ctx.isStringArrayExpression(expr.object)
-      ) {
-        return handleNumberToString(this.ctx, expr, params);
-      }
-    }
-    if (method === "toFixed") {
-      return handleNumberToFixed(this.ctx, expr, params);
-    }
-    if (method === "match") {
-      if (this.ctx.isStringExpression(expr.object)) {
-        return handleMatch(this.ctx, expr, params);
-      }
-    }
+    const stringResult = dispatchStringMethod(this.ctx, method, expr, params);
+    if (stringResult !== null) return stringResult;
 
     // Handle Map methods
     if (
@@ -1098,65 +969,14 @@ export class MethodCallGenerator {
       }
     }
 
-    // Handle array methods (arrayGen uses context pattern - no sync needed! 🎯)
-    // Skip to class dispatch if object is a class instance (e.g. Stack.push / Stack.pop)
-    if (method === "push" && !this.isClassInstanceExpression(expr.object)) {
-      return this.ctx.arrayGen.generateArrayPush(expr, params);
-    } else if (method === "pop" && !this.isClassInstanceExpression(expr.object)) {
-      return this.ctx.arrayGen.generateArrayPop(expr, params);
-    } else if (method === "includes" && this.ctx.isArrayExpression(expr.object)) {
-      return this.ctx.arrayGen.generateArrayIncludes(expr, params);
-    } else if (method === "map") {
-      if (this.ctx.isStringArrayExpression(expr.object)) {
-        return this.ctx.arrayGen.generateStringArrayMap(expr, params);
-      }
-      return this.ctx.arrayGen.generateArrayMap(expr, params);
-    } else if (
-      method === "join" &&
-      (this.ctx.isStringArrayExpression(expr.object) ||
-        this.ctx.isArrayExpression(expr.object) ||
-        this.ctx.isObjectArrayExpression(expr.object))
-    ) {
-      return this.ctx.arrayGen.generateArrayJoin(expr, params);
-    } else if (method === "find") {
-      return this.ctx.arrayGen.generateArrayFind(expr, params);
-    } else if (method === "some") {
-      return this.ctx.arrayGen.generateArraySome(expr, params);
-    } else if (method === "every") {
-      return this.ctx.arrayGen.generateArrayEvery(expr, params);
-    } else if (method === "filter") {
-      return this.ctx.arrayGen.generateArrayFilter(expr, params);
-    } else if (method === "forEach") {
-      return this.ctx.arrayGen.generateArrayForEach(expr, params);
-    } else if (method === "reduce") {
-      return this.ctx.arrayGen.generateArrayReduce(expr, params);
-    } else if (
-      method === "slice" &&
-      (this.ctx.isArrayExpression(expr.object) ||
-        this.ctx.isStringArrayExpression(expr.object) ||
-        this.ctx.isObjectArrayExpression(expr.object))
-    ) {
-      return this.ctx.arrayGen.generateArraySlice(expr, params);
-    } else if (
-      method === "concat" &&
-      (this.ctx.isArrayExpression(expr.object) ||
-        this.ctx.isStringArrayExpression(expr.object) ||
-        this.ctx.isObjectArrayExpression(expr.object))
-    ) {
-      return this.ctx.arrayGen.generateArrayConcat(expr, params);
-    } else if (method === "reverse") {
-      return this.ctx.arrayGen.generateArrayReverse(expr, params);
-    } else if (method === "shift") {
-      return this.ctx.arrayGen.generateArrayShift(expr, params);
-    } else if (method === "unshift") {
-      return this.ctx.arrayGen.generateArrayUnshift(expr, params);
-    } else if (method === "findIndex") {
-      return this.ctx.arrayGen.generateArrayFindIndex(expr, params);
-    } else if (method === "sort") {
-      return this.ctx.arrayGen.generateArraySort(expr, params);
-    } else if (method === "splice") {
-      return this.ctx.arrayGen.generateArraySplice(expr, params);
-    }
+    const arrayResult = dispatchArrayMethod(
+      this.ctx,
+      method,
+      expr,
+      params,
+      this.isClassInstanceExpression(expr.object),
+    );
+    if (arrayResult !== null) return arrayResult;
 
     // Handle class instance methods
     const classResult = handleClassMethods(this.ctx, expr, params);

--- a/src/codegen/expressions/method-calls/string-dispatch.ts
+++ b/src/codegen/expressions/method-calls/string-dispatch.ts
@@ -1,0 +1,150 @@
+import { Expression, MethodCallNode } from "../../../ast/types.js";
+import type { MethodCallGeneratorContext } from "../method-calls.js";
+import {
+  handleSubstr,
+  handleSubstring,
+  handleConcat,
+  handleRepeat,
+  handlePadStart,
+  handlePadEnd,
+  handleSplit,
+  handleStartsWith,
+  handleEndsWith,
+  handleTrim,
+  handleTrimStart,
+  handleTrimEnd,
+  handleIndexOf,
+  handleLastIndexOf,
+  handleStringArrayIndexOf,
+  handleStringArrayIncludes,
+  handleStringIncludes,
+  handleSlice,
+  handleReplace,
+  handleReplaceAll,
+  handleNumberToString,
+  handleNumberToFixed,
+  handleCharAt,
+  handleCharCodeAt,
+  handleToUpperCase,
+  handleToLowerCase,
+  handleMatch,
+} from "./string-methods.js";
+
+export function dispatchStringMethod(
+  ctx: MethodCallGeneratorContext,
+  method: string,
+  expr: MethodCallNode,
+  params: string[],
+): string | null {
+  if (method === "substr") return handleSubstr(ctx, expr, params);
+  if (method === "substring") return handleSubstring(ctx, expr, params);
+  if (
+    method === "concat" &&
+    !ctx.isArrayExpression(expr.object) &&
+    !ctx.isStringArrayExpression(expr.object) &&
+    !ctx.isObjectArrayExpression(expr.object)
+  )
+    return handleConcat(ctx, expr, params);
+  if (method === "repeat") return handleRepeat(ctx, expr, params);
+  if (method === "padStart") return handlePadStart(ctx, expr, params);
+  if (method === "padEnd") return handlePadEnd(ctx, expr, params);
+  if (method === "split") return handleSplit(ctx, expr, params);
+  if (method === "startsWith") return handleStartsWith(ctx, expr, params);
+  if (method === "endsWith") return handleEndsWith(ctx, expr, params);
+  if (method === "trim") return handleTrim(ctx, expr, params);
+  if (method === "trimStart") return handleTrimStart(ctx, expr, params);
+  if (method === "trimEnd") return handleTrimEnd(ctx, expr, params);
+  if (method === "indexOf") {
+    if (ctx.isStringArrayExpression(expr.object))
+      return handleStringArrayIndexOf(ctx, expr, params);
+    if (ctx.isArrayExpression(expr.object)) return ctx.arrayGen.generateArrayIndexOf(expr, params);
+    return handleIndexOf(ctx, expr, params);
+  }
+  if (method === "lastIndexOf") return handleLastIndexOf(ctx, expr, params);
+  if (method === "includes") {
+    if (ctx.isStringArrayExpression(expr.object))
+      return handleStringArrayIncludes(ctx, expr, params);
+    if (!ctx.isArrayExpression(expr.object)) return handleStringIncludes(ctx, expr, params);
+    return null;
+  }
+  if (
+    method === "slice" &&
+    !ctx.isArrayExpression(expr.object) &&
+    !ctx.isStringArrayExpression(expr.object) &&
+    !ctx.isObjectArrayExpression(expr.object)
+  )
+    return handleSlice(ctx, expr, params);
+  if (method === "replace") return handleReplace(ctx, expr, params);
+  if (method === "replaceAll") return handleReplaceAll(ctx, expr, params);
+  if (method === "charAt") return handleCharAt(ctx, expr, params);
+  if (method === "charCodeAt") return handleCharCodeAt(ctx, expr, params);
+  if (method === "toUpperCase") return handleToUpperCase(ctx, expr, params);
+  if (method === "toLowerCase") return handleToLowerCase(ctx, expr, params);
+  if (method === "toString") {
+    if (
+      !ctx.isStringExpression(expr.object) &&
+      !ctx.isArrayExpression(expr.object) &&
+      !ctx.isStringArrayExpression(expr.object)
+    )
+      return handleNumberToString(ctx, expr, params);
+    return null;
+  }
+  if (method === "toFixed") return handleNumberToFixed(ctx, expr, params);
+  if (method === "match") {
+    if (ctx.isStringExpression(expr.object)) return handleMatch(ctx, expr, params);
+    return null;
+  }
+  return null;
+}
+
+export function dispatchArrayMethod(
+  ctx: MethodCallGeneratorContext,
+  method: string,
+  expr: MethodCallNode,
+  params: string[],
+  isClassInstance: boolean,
+): string | null {
+  if (method === "push" && !isClassInstance) return ctx.arrayGen.generateArrayPush(expr, params);
+  if (method === "pop" && !isClassInstance) return ctx.arrayGen.generateArrayPop(expr, params);
+  if (method === "includes" && ctx.isArrayExpression(expr.object))
+    return ctx.arrayGen.generateArrayIncludes(expr, params);
+  if (method === "map") {
+    if (ctx.isStringArrayExpression(expr.object))
+      return ctx.arrayGen.generateStringArrayMap(expr, params);
+    return ctx.arrayGen.generateArrayMap(expr, params);
+  }
+  if (
+    method === "join" &&
+    (ctx.isStringArrayExpression(expr.object) ||
+      ctx.isArrayExpression(expr.object) ||
+      ctx.isObjectArrayExpression(expr.object))
+  )
+    return ctx.arrayGen.generateArrayJoin(expr, params);
+  if (method === "find") return ctx.arrayGen.generateArrayFind(expr, params);
+  if (method === "some") return ctx.arrayGen.generateArraySome(expr, params);
+  if (method === "every") return ctx.arrayGen.generateArrayEvery(expr, params);
+  if (method === "filter") return ctx.arrayGen.generateArrayFilter(expr, params);
+  if (method === "forEach") return ctx.arrayGen.generateArrayForEach(expr, params);
+  if (method === "reduce") return ctx.arrayGen.generateArrayReduce(expr, params);
+  if (
+    method === "slice" &&
+    (ctx.isArrayExpression(expr.object) ||
+      ctx.isStringArrayExpression(expr.object) ||
+      ctx.isObjectArrayExpression(expr.object))
+  )
+    return ctx.arrayGen.generateArraySlice(expr, params);
+  if (
+    method === "concat" &&
+    (ctx.isArrayExpression(expr.object) ||
+      ctx.isStringArrayExpression(expr.object) ||
+      ctx.isObjectArrayExpression(expr.object))
+  )
+    return ctx.arrayGen.generateArrayConcat(expr, params);
+  if (method === "reverse") return ctx.arrayGen.generateArrayReverse(expr, params);
+  if (method === "shift") return ctx.arrayGen.generateArrayShift(expr, params);
+  if (method === "unshift") return ctx.arrayGen.generateArrayUnshift(expr, params);
+  if (method === "findIndex") return ctx.arrayGen.generateArrayFindIndex(expr, params);
+  if (method === "sort") return ctx.arrayGen.generateArraySort(expr, params);
+  if (method === "splice") return ctx.arrayGen.generateArraySplice(expr, params);
+  return null;
+}


### PR DESCRIPTION
## Summary
- Extracts the 23-block string method dispatch chain from `generate()` into `dispatchStringMethod()` in new file `string-dispatch.ts`
- Extracts the 16-block array method dispatch chain into `dispatchArrayMethod()` in the same file
- Reduces consecutive if-return blocks in `generate()` from 39+ to 2, mitigating the native compiler's if-drop bug
- Preserves fall-through semantics: methods like `concat`, `slice`, `includes` that handle both string and array cases return `null` to allow the array dispatcher to handle them

## Test plan
- [x] All 433 tests pass (test:node)
- [x] Self-hosting verification passes (verify:quick)
- [x] Prettier formatting passes
- [x] Pure refactor — no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)