### PR TITLE
fix: replace remaining inline type assertions with named types

### DIFF
--- a/src/codegen/expressions/arrow-functions.ts
+++ b/src/codegen/expressions/arrow-functions.ts
@@ -130,9 +130,8 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
         funcName,
         scopeVarInterfaceTypes,
       );
-      const typedResult = analyzeResult as { captures: CapturedVariable[]; envStructName: string };
-      closureCaptures = typedResult.captures;
-      closureEnvStructName = typedResult.envStructName;
+      closureCaptures = analyzeResult.captures;
+      closureEnvStructName = analyzeResult.envStructName;
 
       if (closureCaptures.length > 0) {
         this.envStructDefs.push({
@@ -141,7 +140,7 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
         });
 
         expr.captures = closureCaptures;
-        closureInfo = typedResult;
+        closureInfo = analyzeResult;
       }
     }
 
@@ -190,7 +189,7 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
     let ir = "";
     for (let defIdx = 0; defIdx < this.envStructDefs.length; defIdx++) {
       const envDefRaw = this.envStructDefs[defIdx];
-      const envDef = envDefRaw as { name: string; fields: CapturedVariable[] };
+      const envDef = envDefRaw as EnvStructDef;
       const fieldTypesArr: string[] = [];
       for (let i = 0; i < envDef.fields.length; i++) {
         const envField = envDef.fields[i] as { name: string; llvmType: string };

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2674,7 +2674,7 @@ export class VariableAllocator {
 
     const typeAliasRaw = this.getTypeAlias(elementType);
     if (typeAliasRaw) {
-      const typeAlias = typeAliasRaw as { name: string; unionMembers: string[] };
+      const typeAlias = typeAliasRaw as TypeAliasDeclaration;
       if (typeAlias.unionMembers) {
         const commonFieldsResult = this.getUnionCommonFields(typeAlias.unionMembers);
         const commonFields = commonFieldsResult as UnionCommonFields;

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -6,6 +6,7 @@ import {
   VariableNode,
   InterfaceDeclaration,
   CommonField,
+  TypeAliasDeclaration,
 } from "../../../ast/types.js";
 import { IGeneratorContext } from "../../infrastructure/generator-context.js";
 import {
@@ -1469,14 +1470,14 @@ export class ClassGenerator {
     const ast2 = this.ctx.getAst();
     const typeAliases = ast2 ? ast2.typeAliases || [] : [];
     for (let i = 0; i < typeAliases.length; i++) {
-      const ta = typeAliases[i] as { name: string; unionMembers: string[] };
+      const ta = typeAliases[i] as TypeAliasDeclaration;
       if (ta.name === tsType) {
         typeAlias = ta;
         break;
       }
     }
     if (typeAlias) {
-      const typeAliasTyped = typeAlias as { name: string; unionMembers: string[] };
+      const typeAliasTyped = typeAlias as TypeAliasDeclaration;
       if (typeAliasTyped.unionMembers) {
         const commonFields = this.getUnionCommonFields(typeAliasTyped.unionMembers);
         this.ctx.defineVariableWithMetadata(


### PR DESCRIPTION
## Summary
- Replaces `as { name: string; unionMembers: string[] }` with `TypeAliasDeclaration` in variable-allocator.ts and class.ts
- Replaces `as { name: string; fields: CapturedVariable[] }` with `EnvStructDef` in arrow-functions.ts
- Removes redundant `as { captures: CapturedVariable[]; envStructName: string }` assertion in arrow-functions.ts — the `ClosureAnalyzer.analyze()` already returns `ClosureInfo`
- llvm-generator.ts assertions (EnumDeclaration/EnumMember/BlockStatement) deferred — changes there trigger the if-drop bug by shifting binary layout

## Test plan
- [x] All 433 tests pass
- [x] Self-hosting verification passes (Stage 0 + Stage 1)
- [x] Prettier formatting passes
- [x] Pure refactor — type assertion replacements only

🤖 Generated with [Claude Code](https://claude.com/claude-code)