### PR TITLE
fix: use getAllInterfaceFields in type-inference getInterfaceProperty

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -749,6 +749,26 @@ export class TypeInference {
     return null;
   }
 
+  private getAllFieldsForInterface(iface: InterfaceDeclaration): InterfaceField[] {
+    const result: InterfaceField[] = [];
+    if (iface.extends && iface.extends.length > 0) {
+      for (let i = 0; i < iface.extends.length; i++) {
+        const parentName = iface.extends[i];
+        const parent = this.getInterface(parentName);
+        if (parent) {
+          const parentFields = this.getAllFieldsForInterface(parent);
+          for (let j = 0; j < parentFields.length; j++) {
+            result.push(parentFields[j]);
+          }
+        }
+      }
+    }
+    for (let i = 0; i < iface.fields.length; i++) {
+      result.push(iface.fields[i]);
+    }
+    return result;
+  }
+
   private getInterfaceProperty(interfaceName: string, propName: string): InterfaceField | null {
     if (!interfaceName || !propName) {
       return null;
@@ -759,8 +779,9 @@ export class TypeInference {
     }
     const iface = this.getInterface(interfaceName);
     if (!iface) return null;
-    for (let i = 0; i < iface.fields.length; i++) {
-      const f = iface.fields[i] as { name: string; type: string };
+    const allFields = this.getAllFieldsForInterface(iface);
+    for (let i = 0; i < allFields.length; i++) {
+      const f = allFields[i] as { name: string; type: string };
       let fieldName = f.name;
       if (fieldName.endsWith("?")) {
         fieldName = fieldName.slice(0, fieldName.length - 1);


### PR DESCRIPTION
## Summary
- `getInterfaceProperty()` in `type-inference.ts` used `iface.fields` directly in its fallback path, missing inherited fields from `extends` chains
- Added `getAllFieldsForInterface()` private method that recursively collects fields from parent interfaces
- The primary path via `typeResolverGetInterfaceProperty` already handled inheritance correctly; this fixes the fallback path when typeResolver is unavailable

## Test plan
- [x] All 433 tests pass
- [x] Self-hosting verification passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)