### PR TITLE
fix: split infrastructure if-chains to prevent if-drop bug

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -798,15 +798,27 @@ export class FunctionGenerator {
     return this.ctx.isEnumType(typeName);
   }
 
-  private llvmTypeToSymbolKind(llvmType: string): number {
+  private llvmTypeToSymbolKindPrimitive(llvmType: string): number | null {
     if (llvmType === "double") return SymbolKind.Number;
     if (llvmType === "i8*") return SymbolKind.String;
     if (llvmType === "%Array*") return SymbolKind.Array;
     if (llvmType === "%ObjectArray*") return SymbolKind.ObjectArray;
+    return null;
+  }
+
+  private llvmTypeToSymbolKindCollection(llvmType: string): number | null {
     if (llvmType === "%StringArray*") return SymbolKind.StringArray;
     if (llvmType === "%Map*") return SymbolKind.Map;
     if (llvmType === "%StringMap*") return SymbolKind.Map;
     if (llvmType === "%Set*") return SymbolKind.Set;
+    return null;
+  }
+
+  private llvmTypeToSymbolKind(llvmType: string): number {
+    const prim = this.llvmTypeToSymbolKindPrimitive(llvmType);
+    if (prim !== null) return prim;
+    const coll = this.llvmTypeToSymbolKindCollection(llvmType);
+    if (coll !== null) return coll;
     if (llvmType === "%StringSet*") return SymbolKind.Set;
     return SymbolKind.Object;
   }

--- a/src/codegen/infrastructure/type-context.ts
+++ b/src/codegen/infrastructure/type-context.ts
@@ -108,15 +108,27 @@ export class TypeContext {
     return undefined;
   }
 
-  resolve(typeStr: string): ResolvedType {
+  private resolvePrimitive(typeStr: string): ResolvedType | null {
     if (!typeStr) return this.unknownType;
     if (typeStr === "string") return this.stringType;
     if (typeStr === "number") return this.numberType;
     if (typeStr === "boolean") return this.booleanType;
+    return null;
+  }
+
+  private resolveSpecial(typeStr: string): ResolvedType | null {
     if (typeStr === "void") return this.voidType;
     if (typeStr === "null" || typeStr === "undefined") return this.nullType;
     if (typeStr === "string[]") return this.getArrayType("string");
     if (typeStr === "number[]") return this.getArrayType("number");
+    return null;
+  }
+
+  resolve(typeStr: string): ResolvedType {
+    const prim = this.resolvePrimitive(typeStr);
+    if (prim) return prim;
+    const special = this.resolveSpecial(typeStr);
+    if (special) return special;
     if (typeStr === "boolean[]") return this.getArrayType("boolean");
     if (typeStr.endsWith("[]")) {
       const elem = typeStr.substring(0, typeStr.length - 2);

--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -208,20 +208,38 @@ function getBuiltinAstTypeByDiscriminant(discriminant: string): BuiltinAstType |
   return null;
 }
 
-function getBuiltinAstTypeByName(name: string): BuiltinAstType | null {
+function getBuiltinAstTypeGroup1(name: string): BuiltinAstType | null {
   if (name === "AssignmentStatement") return getBuiltinAstTypeByDiscriminant("assignment");
   if (name === "VariableDeclaration")
     return getBuiltinAstTypeByDiscriminant("variable_declaration");
   if (name === "ReturnStatement") return getBuiltinAstTypeByDiscriminant("return");
   if (name === "IfStatement") return getBuiltinAstTypeByDiscriminant("if");
+  return null;
+}
+
+function getBuiltinAstTypeGroup2(name: string): BuiltinAstType | null {
   if (name === "WhileStatement") return getBuiltinAstTypeByDiscriminant("while");
   if (name === "ForStatement") return getBuiltinAstTypeByDiscriminant("for");
   if (name === "ForOfStatement") return getBuiltinAstTypeByDiscriminant("for_of");
   if (name === "BlockStatement") return getBuiltinAstTypeByDiscriminant("block");
+  return null;
+}
+
+function getBuiltinAstTypeGroup3(name: string): BuiltinAstType | null {
   if (name === "ThrowStatement") return getBuiltinAstTypeByDiscriminant("throw");
   if (name === "TryStatement") return getBuiltinAstTypeByDiscriminant("try");
   if (name === "SwitchStatement") return getBuiltinAstTypeByDiscriminant("switch");
   if (name === "BreakStatement") return getBuiltinAstTypeByDiscriminant("break");
+  return null;
+}
+
+function getBuiltinAstTypeByName(name: string): BuiltinAstType | null {
+  const g1 = getBuiltinAstTypeGroup1(name);
+  if (g1) return g1;
+  const g2 = getBuiltinAstTypeGroup2(name);
+  if (g2) return g2;
+  const g3 = getBuiltinAstTypeGroup3(name);
+  if (g3) return g3;
   if (name === "ContinueStatement") return getBuiltinAstTypeByDiscriminant("continue");
   return null;
 }


### PR DESCRIPTION
## Summary
- Splits 3 infrastructure functions that exceeded the 4-branch if-return safety limit
- `getBuiltinAstTypeByName()` in type-resolver.ts: 15 → 3 sub-functions (4 each) + 4-branch coordinator
- `llvmTypeToSymbolKind()` in function-generator.ts: 9 → 2 sub-methods (4 each) + 3-branch coordinator
- `resolve()` in type-context.ts: 9 → 2 sub-methods (4 each) + 4-branch coordinator
- Prevents the native compiler's if-drop bug (5th+ consecutive if-return blocks silently dropped)

## Test plan
- [x] All 434 tests pass
- [x] Self-hosting verification passes (verify:quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)