### PR TITLE
fix: split type-inference and codegen if-chains for if-drop bug

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1239,16 +1239,22 @@ export class CallExpressionGenerator {
     return "0";
   }
 
+  private getFieldLlvmTypeForTsType(tsType: string): string | null {
+    if (tsType.startsWith("Map<string,")) return "%StringMap*";
+    if (tsType.startsWith("Map<")) return "%Map*";
+    if (tsType === "Set<string>") return "%StringSet*";
+    if (tsType.startsWith("Set<")) return "%Set*";
+    return null;
+  }
+
   private getFieldLlvmType(field: { name: string; fieldType: string; tsType?: string }): string {
     if (field.fieldType === "string") return "i8*";
     if (field.fieldType === "string[]") return "%StringArray*";
     if (field.fieldType.endsWith("[]")) return "%Array*";
     if (field.fieldType === "boolean") return "i1";
     if (field.tsType) {
-      if (field.tsType.startsWith("Map<string,")) return "%StringMap*";
-      if (field.tsType.startsWith("Map<")) return "%Map*";
-      if (field.tsType === "Set<string>") return "%StringSet*";
-      if (field.tsType.startsWith("Set<")) return "%Set*";
+      const collType = this.getFieldLlvmTypeForTsType(field.tsType);
+      if (collType) return collType;
       if (field.tsType === "number" || field.tsType === "boolean") return "double";
       const classFields = this.ctx.classGenGetClassFields(field.tsType);
       if (classFields.length > 0) {

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -68,17 +68,29 @@ export interface TypeInferenceContext {
 export class TypeInference {
   constructor(private ctx: TypeInferenceContext) {}
 
+  private resolveSimpleLiteralType(eType: string): ResolvedType | null {
+    if (eType === "number") return this.ctx.typeContext.numberType;
+    if (eType === "string") return this.ctx.typeContext.stringType;
+    if (eType === "template_literal") return this.ctx.typeContext.stringType;
+    if (eType === "boolean") return this.ctx.typeContext.booleanType;
+    return null;
+  }
+
+  private resolveSpecialLiteralType(eType: string): ResolvedType | null {
+    if (eType === "null") return this.ctx.typeContext.nullType;
+    if (eType === "regex") return this.ctx.typeContext.resolve("RegExp");
+    if (eType === "object") return this.ctx.typeContext.resolve("object");
+    return null;
+  }
+
   resolveExpressionType(expr: Expression): ResolvedType | null {
     if (!expr) return null;
     const e = expr as ExprBase;
     if (!e.type) return null;
-    if (e.type === "number") return this.ctx.typeContext.numberType;
-    if (e.type === "string") return this.ctx.typeContext.stringType;
-    if (e.type === "template_literal") return this.ctx.typeContext.stringType;
-    if (e.type === "boolean") return this.ctx.typeContext.booleanType;
-    if (e.type === "null") return this.ctx.typeContext.nullType;
-    if (e.type === "regex") return this.ctx.typeContext.resolve("RegExp");
-    if (e.type === "object") return this.ctx.typeContext.resolve("object");
+    const simple = this.resolveSimpleLiteralType(e.type);
+    if (simple) return simple;
+    const special = this.resolveSpecialLiteralType(e.type);
+    if (special) return special;
     if (e.type === "map") {
       const mapExpr = expr as MapNode;
       const keyType = mapExpr.keyType || "string";

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -1693,11 +1693,17 @@ export class ControlFlowGenerator {
     return type;
   }
 
-  private fieldTypeToLlvm(fieldType: string): string {
+  private fieldTypeToLlvmPrimitive(fieldType: string): string | null {
     if (fieldType === "string") return "i8*";
     if (fieldType === "number") return "double";
     if (fieldType === "boolean") return "double";
     if (fieldType.startsWith("'") || fieldType.startsWith('"')) return "i8*";
+    return null;
+  }
+
+  private fieldTypeToLlvm(fieldType: string): string {
+    const prim = this.fieldTypeToLlvmPrimitive(fieldType);
+    if (prim) return prim;
     if (this.isEnumType(fieldType)) return "double";
     return "i8*";
   }

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -1586,11 +1586,17 @@ export class ClassGenerator {
     this.ctx.defineVariable(paramName, allocaReg, llvmType, SymbolKind.Object, "local");
   }
 
-  private fieldTypeToLlvm(fieldType: string): string {
+  private fieldTypeToLlvmPrimitive(fieldType: string): string | null {
     if (fieldType === "string") return "i8*";
     if (fieldType === "number") return "double";
     if (fieldType === "boolean") return "double";
     if (fieldType.startsWith("'") || fieldType.startsWith('"')) return "i8*";
+    return null;
+  }
+
+  private fieldTypeToLlvm(fieldType: string): string {
+    const prim = this.fieldTypeToLlvmPrimitive(fieldType);
+    if (prim) return prim;
     if (fieldType === "string[]") return "%StringArray*";
     if (fieldType === "number[]" || fieldType === "boolean[]") return "%Array*";
     if (fieldType.endsWith("[]")) return "%ObjectArray*";


### PR DESCRIPTION
## Summary
- Splits 4 functions across 4 files that exceeded the 4-branch if-return safety limit
- `resolveExpressionType()` in type-inference.ts: 7 consecutive if-returns for literal types → 2 helpers (4+3)
- `fieldTypeToLlvm()` in class.ts: 7 consecutive if-returns → 1 helper (4) + 4-branch main
- `getFieldLlvmType()` inner tsType block in calls.ts: 5 nested if-returns → 1 helper (4) + 1 inline
- `fieldTypeToLlvm()` in control-flow.ts: 5 if-returns → 1 helper (4) + 1 inline
- Prevents the native compiler's if-drop bug (5th+ consecutive if-return blocks silently dropped)

## Test plan
- [x] All 434 tests pass
- [x] Self-hosting verification passes (verify:quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)