### PR TITLE
fix: use getAllInterfaceFields for http handler return type

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2614,7 +2614,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       if (handlerReturnType) {
         const retIface = this.getInterfaceFromAST(handlerReturnType);
         if (retIface) {
-          const fields = (retIface as { fields: { name: string }[] }).fields;
+          const fields = this.getAllInterfaceFields(retIface as InterfaceDeclaration);
           for (let fj = 0; fj < fields.length; fj++) {
             if (fields[fj].name === "headers") {
               hasHeaders = true;


### PR DESCRIPTION
## Summary
- Fixes direct `.fields` access on interface in HTTP server handler return type detection
- `llvm-generator.ts:2617` was using `retIface.fields` which only returns OWN fields, missing inherited fields from `extends`
- Now uses `getAllInterfaceFields(retIface)` to correctly detect `headers` and `bodyLen` fields on interfaces that inherit from a parent
- Without this fix, if an HTTP handler returns an interface that inherits `headers`/`bodyLen` from a parent interface, the server wouldn't generate the correct response handling code

## Test plan
- [x] All 434 tests pass
- [x] Self-hosting verification passes (verify:quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)