### PR TITLE
fix: split discriminant and resolvedTypeToLlvm if-chains

### DIFF
--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -77,7 +77,7 @@ interface BuiltinAstType {
   fields: { name: string; type: string }[];
 }
 
-function getBuiltinAstTypeByDiscriminant(discriminant: string): BuiltinAstType | null {
+function getDiscriminantAssignVarReturn(discriminant: string): BuiltinAstType | null {
   if (discriminant === "assignment") {
     return {
       name: "AssignmentStatement",
@@ -120,6 +120,10 @@ function getBuiltinAstTypeByDiscriminant(discriminant: string): BuiltinAstType |
       ],
     };
   }
+  return null;
+}
+
+function getDiscriminantLoopBlock(discriminant: string): BuiltinAstType | null {
   if (discriminant === "while") {
     return {
       name: "WhileStatement",
@@ -163,6 +167,10 @@ function getBuiltinAstTypeByDiscriminant(discriminant: string): BuiltinAstType |
       ],
     };
   }
+  return null;
+}
+
+function getDiscriminantErrorHandler(discriminant: string): BuiltinAstType | null {
   if (discriminant === "throw") {
     return {
       name: "ThrowStatement",
@@ -199,6 +207,16 @@ function getBuiltinAstTypeByDiscriminant(discriminant: string): BuiltinAstType |
       fields: [{ name: "type", type: "'break'" }],
     };
   }
+  return null;
+}
+
+function getBuiltinAstTypeByDiscriminant(discriminant: string): BuiltinAstType | null {
+  const avr = getDiscriminantAssignVarReturn(discriminant);
+  if (avr) return avr;
+  const lb = getDiscriminantLoopBlock(discriminant);
+  if (lb) return lb;
+  const eh = getDiscriminantErrorHandler(discriminant);
+  if (eh) return eh;
   if (discriminant === "continue") {
     return {
       name: "ContinueStatement",

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -125,6 +125,22 @@ export function tsTypeToLlvm(tsType: string): string {
   return canonicalTypeToLlvm(tsType, "default", false, false, "");
 }
 
+function resolvedPrimitiveToLlvm(rt: ResolvedType): string | null {
+  if (rt.base === "string") return "i8*";
+  if (rt.base === "Uint8Array" && rt.arrayDepth === 0) return "%Uint8Array*";
+  if (rt.base === "number" && rt.qualifiers.numericKind === "integer") return "i64";
+  if (rt.base === "number" || rt.base === "boolean") return "double";
+  return null;
+}
+
+function resolvedSpecialToLlvm(rt: ResolvedType): string | null {
+  if (rt.base === "void") return "void";
+  if (rt.base === "null" || rt.base === "undefined") return "i8*";
+  if (rt.base.startsWith("Map")) return "%StringMap*";
+  if (rt.base.startsWith("Set")) return "%StringSet*";
+  return null;
+}
+
 export function resolvedTypeToLlvm(rt: ResolvedType): string {
   if (rt.cachedLlvmType) return rt.cachedLlvmType;
   if (rt.arrayDepth > 0) {
@@ -132,14 +148,10 @@ export function resolvedTypeToLlvm(rt: ResolvedType): string {
     if (rt.base === "number" || rt.base === "boolean") return "%Array*";
     return "%ObjectArray*";
   }
-  if (rt.base === "string") return "i8*";
-  if (rt.base === "Uint8Array" && rt.arrayDepth === 0) return "%Uint8Array*";
-  if (rt.base === "number" && rt.qualifiers.numericKind === "integer") return "i64";
-  if (rt.base === "number" || rt.base === "boolean") return "double";
-  if (rt.base === "void") return "void";
-  if (rt.base === "null" || rt.base === "undefined") return "i8*";
-  if (rt.base.startsWith("Map")) return "%StringMap*";
-  if (rt.base.startsWith("Set")) return "%StringSet*";
+  const prim = resolvedPrimitiveToLlvm(rt);
+  if (prim) return prim;
+  const special = resolvedSpecialToLlvm(rt);
+  if (special) return special;
   return "i8*";
 }
 


### PR DESCRIPTION
## Summary
- Split `getBuiltinAstTypeByDiscriminant()` (13 consecutive if-return blocks) into 3 helper functions with 4 branches each plus a coordinator
- Split `resolvedTypeToLlvm()` (8 consecutive if-returns after array block) into 2 helper functions with 4 branches each

Mitigates the native compiler's if-drop bug (5th+ consecutive if-return blocks silently dropped in Stage 0).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] all 434 tests pass
- [x] `npm run verify:quick` passes (self-hosting Stage 0 + Stage 1)