### PR TITLE
fix: object destructuring from function calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,8 +224,9 @@ Existing bridges: `regex-bridge.c`, `yyjson-bridge.c`, `os-bridge.c`, `child-pro
 When building field lists for an interface (keys/types arrays for ObjectMetadata), always use
 `getAllInterfaceFields(interfaceDef)` instead of `interfaceDef.fields`. The latter only returns the
 interface's OWN fields, missing inherited fields from `extends`. This causes wrong GEP indices for
-any interface with inheritance. `allocateDeclaredInterface` does this correctly; several other methods
-(`allocateMemberAccessInterface`, `allocateFunctionInterfaceReturn`, etc.) currently do not.
+any interface with inheritance. All current allocation methods (`allocateDeclaredInterface`,
+`allocateMemberAccessInterface`, `allocateFunctionInterfaceReturn`, etc.) use `getAllInterfaceFields`
+correctly — maintain this when adding new ones.
 
 ## Loop Style
 

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -2409,10 +2409,7 @@ export class MemberAccessGenerator {
     return value;
   }
 
-  private handleCallResultPropertyAccess(
-    expr: MemberAccessNode,
-    params: string[],
-  ): string | null {
+  private handleCallResultPropertyAccess(expr: MemberAccessNode, params: string[]): string | null {
     const callExpr = expr.object as CallNode;
     const ast = this.ctx.getAst();
     if (!ast || !ast.functions) return null;

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -14,6 +14,8 @@ import {
   IndexAccessNode,
   TypeAssertionNode,
   FunctionParameter,
+  CallNode,
+  FunctionNode,
   SourceLocation,
 } from "../../../ast/types.js";
 import type { SymbolTable } from "../../infrastructure/symbol-table.js";
@@ -333,6 +335,11 @@ export class MemberAccessGenerator {
 
     if (exprObjType === "method_call") {
       result = this.handleMethodCallResultPropertyAccess(expr, params);
+      if (result !== null) return result;
+    }
+
+    if (exprObjType === "call") {
+      result = this.handleCallResultPropertyAccess(expr, params);
       if (result !== null) return result;
     }
 
@@ -2402,6 +2409,63 @@ export class MemberAccessGenerator {
     return value;
   }
 
+  private handleCallResultPropertyAccess(
+    expr: MemberAccessNode,
+    params: string[],
+  ): string | null {
+    const callExpr = expr.object as CallNode;
+    const ast = this.ctx.getAst();
+    if (!ast || !ast.functions) return null;
+
+    let func: FunctionNode | null = null;
+    for (const f of ast.functions) {
+      if ((f as FunctionNode).name === callExpr.name) {
+        func = f as FunctionNode;
+        break;
+      }
+    }
+    if (!func || !func.returnType) return null;
+
+    let returnType = stripNullable(func.returnType);
+    if (returnType.startsWith("{")) return null;
+
+    const interfaceDef = this.getInterfaceDecl(returnType);
+    if (!interfaceDef) return null;
+    const allFields = this.ctx.getAllInterfaceFields(interfaceDef as InterfaceDeclaration);
+
+    let propIndex = -1;
+    for (let i = 0; i < allFields.length; i++) {
+      const f = allFields[i] as { name: string; type: string };
+      if (stripOptional(f.name) === expr.property) {
+        propIndex = i;
+        break;
+      }
+    }
+    if (propIndex === -1) return null;
+
+    const propField = allFields[propIndex] as { name: string; type: string };
+    const propType = tsTypeToLlvm(propField.type);
+    const structTypes: string[] = [];
+    for (let i = 0; i < allFields.length; i++) {
+      const field = allFields[i] as { name: string; type: string };
+      structTypes.push(tsTypeToLlvm(field.type));
+    }
+    const structType = `{ ${structTypes.join(", ")} }`;
+
+    const objPtr = this.ctx.generateExpression(expr.object, params);
+
+    const typedPtr = this.ctx.emitBitcast(objPtr, "i8*", `${structType}*`);
+    const fieldPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${fieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${typedPtr}, i32 0, i32 ${propIndex}`,
+    );
+
+    const value = this.ctx.emitLoad(propType, fieldPtr);
+    this.ctx.setVariableType(value, propType);
+
+    return value;
+  }
+
   private handleLengthProperty(expr: MemberAccessNode, params: string[]): string {
     return handleLengthProperty(this.ctx, expr, params);
   }
@@ -2481,7 +2545,8 @@ export class MemberAccessGenerator {
       if (
         exprObjType === "member_access" ||
         exprObjType === "method_call" ||
-        exprObjType === "index_access"
+        exprObjType === "index_access" ||
+        exprObjType === "call"
       ) {
         const innerPtr = this.ctx.generateExpression(expr.object, params);
         const innerType = this.ctx.getVariableType(innerPtr);

--- a/src/codegen/infrastructure/interface-allocator.ts
+++ b/src/codegen/infrastructure/interface-allocator.ts
@@ -149,7 +149,8 @@ export class InterfaceAllocator {
       !stmt.value ||
       (stmt.value.type !== "variable" &&
         stmt.value.type !== "object" &&
-        stmt.value.type !== "method_call")
+        stmt.value.type !== "method_call" &&
+        stmt.value.type !== "call")
     )
       return null;
     const interfaceDefResult2 = this.getInterface(stmt.declaredType);

--- a/src/parser-ts/handlers/statements.ts
+++ b/src/parser-ts/handlers/statements.ts
@@ -15,6 +15,7 @@ import {
   TryStatement,
   IndexAccessNode,
   MemberAccessNode,
+  VariableNode,
 } from "../../ast/types.js";
 import { transformExpression } from "./expressions.js";
 import { getLoc } from "../transformer.js";
@@ -107,6 +108,8 @@ function transformVariableStatement(
   return first;
 }
 
+let destructureCounter = 0;
+
 function desugarObjectDestructuring(
   decl: ts.VariableDeclaration,
   pattern: ts.ObjectBindingPattern,
@@ -121,6 +124,27 @@ function desugarObjectDestructuring(
     source = transformExpression(decl.initializer, checker);
   }
 
+  let objectRef: Expression = source!;
+  if (source && source.type !== "variable") {
+    const tempName = `__destructure_${destructureCounter++}`;
+    let declaredType: string | undefined;
+    if (decl.initializer && checker) {
+      const initType = checker.getTypeAtLocation(decl.initializer);
+      const typeStr = checker.typeToString(initType);
+      if (typeStr && typeStr !== "any" && typeStr !== "unknown") {
+        declaredType = typeStr;
+      }
+    }
+    statements.push({
+      type: "variable_declaration",
+      kind: "const",
+      name: tempName,
+      value: source,
+      declaredType,
+    } as VariableDeclaration);
+    objectRef = { type: "variable", name: tempName } as VariableNode;
+  }
+
   for (const element of pattern.elements) {
     if (!ts.isBindingElement(element)) continue;
     if (!ts.isIdentifier(element.name)) continue;
@@ -133,7 +157,7 @@ function desugarObjectDestructuring(
 
     const memberAccess: MemberAccessNode = {
       type: "member_access",
-      object: source!,
+      object: objectRef,
       property: propertyName,
     };
 
@@ -157,6 +181,27 @@ function desugarArrayDestructuring(
     source = transformExpression(decl.initializer, checker);
   }
 
+  let arrayRef: Expression = source!;
+  if (source && source.type !== "variable") {
+    const tempName = `__destructure_${destructureCounter++}`;
+    let declaredType: string | undefined;
+    if (decl.initializer && checker) {
+      const initType = checker.getTypeAtLocation(decl.initializer);
+      const typeStr = checker.typeToString(initType);
+      if (typeStr && typeStr !== "any" && typeStr !== "unknown") {
+        declaredType = typeStr;
+      }
+    }
+    statements.push({
+      type: "variable_declaration",
+      kind: "const",
+      name: tempName,
+      value: source,
+      declaredType,
+    } as VariableDeclaration);
+    arrayRef = { type: "variable", name: tempName } as VariableNode;
+  }
+
   for (let i = 0; i < pattern.elements.length; i++) {
     const element = pattern.elements[i];
     if (ts.isOmittedExpression(element)) continue;
@@ -167,7 +212,7 @@ function desugarArrayDestructuring(
 
     const indexAccess: IndexAccessNode = {
       type: "index_access",
-      object: source!,
+      object: arrayRef,
       index: { type: "number", value: i },
     };
 

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -445,6 +445,8 @@ function getCompoundOperator(op: ts.SyntaxKind): string | null {
   }
 }
 
+let destructureSeqTransformer = 0;
+
 export function transformVariableDeclaration(
   decl: ts.VariableDeclaration,
   flags: ts.NodeFlags,
@@ -459,6 +461,27 @@ export function transformVariableDeclaration(
       source = transformExpression(decl.initializer, checker);
     }
 
+    let objectRef: Expression | null = source;
+    if (source && source.type !== "variable") {
+      const tempName = `__destructure_obj_${destructureSeqTransformer++}`;
+      let declaredType: string | undefined;
+      if (decl.initializer && checker) {
+        const initType = checker.getTypeAtLocation(decl.initializer);
+        const typeStr = checker.typeToString(initType);
+        if (typeStr && typeStr !== "any" && typeStr !== "unknown") {
+          declaredType = typeStr;
+        }
+      }
+      statements.push({
+        type: "variable_declaration",
+        kind: "const",
+        name: tempName,
+        value: source,
+        declaredType,
+      } as VariableDeclaration);
+      objectRef = { type: "variable", name: tempName } as Expression;
+    }
+
     for (const element of decl.name.elements) {
       if (!ts.isBindingElement(element)) continue;
       if (!ts.isIdentifier(element.name)) continue;
@@ -471,7 +494,7 @@ export function transformVariableDeclaration(
 
       const memberAccess: MemberAccessNode = {
         type: "member_access",
-        object: source!,
+        object: objectRef!,
         property: propertyName,
       };
 
@@ -490,6 +513,27 @@ export function transformVariableDeclaration(
       source = transformExpression(decl.initializer, checker);
     }
 
+    let arrayRef: Expression | null = source;
+    if (source && source.type !== "variable") {
+      const tempName = `__destructure_arr_${destructureSeqTransformer++}`;
+      let declaredType: string | undefined;
+      if (decl.initializer && checker) {
+        const initType = checker.getTypeAtLocation(decl.initializer);
+        const typeStr = checker.typeToString(initType);
+        if (typeStr && typeStr !== "any" && typeStr !== "unknown") {
+          declaredType = typeStr;
+        }
+      }
+      statements.push({
+        type: "variable_declaration",
+        kind: "const",
+        name: tempName,
+        value: source,
+        declaredType,
+      } as VariableDeclaration);
+      arrayRef = { type: "variable", name: tempName } as Expression;
+    }
+
     for (let i = 0; i < decl.name.elements.length; i++) {
       const element = decl.name.elements[i];
       if (ts.isOmittedExpression(element)) continue;
@@ -500,7 +544,7 @@ export function transformVariableDeclaration(
 
       const indexAccess: IndexAccessNode = {
         type: "index_access",
-        object: source!,
+        object: arrayRef!,
         index: { type: "number", value: i },
       };
 

--- a/tests/fixtures/destructuring/destructure-call-result.ts
+++ b/tests/fixtures/destructuring/destructure-call-result.ts
@@ -1,0 +1,16 @@
+interface Point {
+  x: number;
+  y: number;
+}
+
+function getPoint(): Point {
+  return { x: 10, y: 20 };
+}
+
+const { x, y } = getPoint();
+
+if (x === 10 && y === 20) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: x=" + x + " y=" + y);
+}


### PR DESCRIPTION
## Summary
- `const { x, y } = getPoint()` was returning zeros instead of actual values
- Root cause: parser desugared destructuring into repeated `member_access` on the `call` expression (calling the function N times), and codegen's `member.ts` had no handler for `call` as an object expression type — falling through to `return "0.0"`
- Fix: TS parser (`transformer.ts` + `statements.ts`) now introduces a temp variable when destructuring from non-variable expressions
- Fix: codegen `member.ts` adds `handleCallResultPropertyAccess` that resolves the function's return type interface and generates correct GEP
- Fix: `interface-allocator.ts` now allows `call` value type in `getDeclaredInterfaceType`

## Test plan
- [x] New test fixture `destructuring/destructure-call-result.ts` 
- [x] All 435 tests pass with native compiler
- [x] Self-hosting verification passes (verify:quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)