### PR TITLE
fix: index access on function call results

### DIFF
--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -97,14 +97,12 @@ export class IndexAccessGenerator {
       return this.generateJSONArrayIndex(expr, params);
     }
 
-    // Determine if we're indexing into a string array, numeric array, or object array
     const isStringArray = this.ctx.isStringArrayExpression(expr.object);
     const isObjectArray = !isStringArray && this.ctx.isObjectArrayExpression(expr.object);
     const isUint8Array =
       !isStringArray && !isObjectArray && this.ctx.isUint8ArrayExpression(expr.object);
     const isNumericArray =
       !isStringArray && !isObjectArray && !isUint8Array && this.ctx.isArrayExpression(expr.object);
-
     if (isStringArray) {
       return this.generateStringArrayIndex(expr, params);
     } else if (isObjectArray) {

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -833,6 +833,15 @@ export class TypeInference {
     return null;
   }
 
+  private getCallReturnType(expr: Expression): string | null {
+    const e = expr as ExprBase;
+    if (e.type !== "call") return null;
+    const callExpr = expr as CallNode;
+    const func = this.getFunction(callExpr.name);
+    if (!func || !func.returnType) return null;
+    return stripNullable(func.returnType);
+  }
+
   // Resolve import aliases by checking the AST's import specifiers directly
   private resolveClassAlias(name: string): string {
     const ast = this.ctx.getAst();
@@ -1182,6 +1191,11 @@ export class TypeInference {
       }
       return false;
     }
+    if (e.type === "call") {
+      const rt = this.getCallReturnType(expr);
+      if (rt === "number[]" || rt === "boolean[]") return true;
+      return false;
+    }
     if (e.type === "member_access") {
       const memberExpr = expr as MemberAccessNode;
       if (!memberExpr.object) {
@@ -1251,6 +1265,13 @@ export class TypeInference {
           return this.isObjectArrayExpression(binExpr.left);
         }
       }
+    }
+    if (e.type === "call") {
+      const rt = this.getCallReturnType(expr);
+      if (rt && rt.endsWith("[]") && rt !== "string[]" && rt !== "number[]" && rt !== "boolean[]") {
+        return true;
+      }
+      return false;
     }
     if (e.type === "variable") {
       const resolved = this.resolveExpressionType(expr);
@@ -2101,6 +2122,11 @@ export class TypeInference {
         return true;
       }
       return this.isStringArrayExpression(assertion.expression);
+    }
+    if (e.type === "call") {
+      const rt = this.getCallReturnType(expr);
+      if (rt === "string[]") return true;
+      return false;
     }
     if (e.type === "variable") {
       const resolved = this.resolveExpressionType(expr);

--- a/tests/fixtures/arrays/array-index-call-result.ts
+++ b/tests/fixtures/arrays/array-index-call-result.ts
@@ -1,0 +1,17 @@
+function getNumbers(): number[] {
+  return [10, 20, 30];
+}
+
+function getStrings(): string[] {
+  return ["hello", "world"];
+}
+
+const first = getNumbers()[0];
+const second = getNumbers()[1];
+const greeting = getStrings()[0];
+
+if (first === 10 && second === 20 && greeting === "hello") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: first=" + first + " second=" + second + " greeting=" + greeting);
+}


### PR DESCRIPTION
## Summary
- `getNumbers()[0]` and `getStrings()[0]` (index access on function call returning array) crashed with LLVM type mismatch
- Root cause: `isArrayExpression`, `isStringArrayExpression`, `isObjectArrayExpression` in type-inference.ts had no handler for `call` expression type, causing fallback to string char index codegen
- Added `getCallReturnType` helper and `call` handlers to all three type detection methods
- Added test fixture covering both numeric and string array index on call results

## Test plan
- [x] New test `arrays/array-index-call-result` passes
- [x] All 436 tests pass
- [x] verify:quick passes (tests + stage 0/1 self-hosting)