### PR TITLE
fix: annotate let x = -1 with : number type

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -2430,7 +2430,7 @@ export class MemberAccessGenerator {
     if (!interfaceDef) return null;
     const allFields = this.ctx.getAllInterfaceFields(interfaceDef as InterfaceDeclaration);
 
-    let propIndex = -1;
+    let propIndex: number = -1;
     for (let i = 0; i < allFields.length; i++) {
       const f = allFields[i] as { name: string; type: string };
       if (stripOptional(f.name) === expr.property) {

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -1392,7 +1392,7 @@ function transformAwaitExpression(node: TreeSitterNode): Expression {
 
 function transformRegexNode(node: TreeSitterNode): RegexNode {
   const text = (node as NodeBase).text;
-  let lastSlash = -1;
+  let lastSlash: number = -1;
   for (let i = text.length - 1; i >= 0; i--) {
     if (text.charAt(i) === "/") {
       lastSlash = i;
@@ -2645,7 +2645,7 @@ function transformClassDeclaration(node: TreeSitterNode): ClassNode | null {
             const params = method.params;
             for (let pi = 0; pi < method.parameterProperties.length; pi++) {
               const propName = method.parameterProperties[pi];
-              let propIdx = -1;
+              let propIdx: number = -1;
               for (let k = 0; k < params.length; k++) {
                 if (params[k] === propName) {
                   propIdx = k;

--- a/src/semantic/type-assertion-checker.ts
+++ b/src/semantic/type-assertion-checker.ts
@@ -278,7 +278,7 @@ class TypeAssertionChecker {
       const indices: number[] = [];
       let allFound = true;
       for (let j = 0; j < assertedNames.length; j++) {
-        let idx = -1;
+        let idx: number = -1;
         for (let k = 0; k < allFields.length; k++) {
           const f = allFields[k] as InterfaceField;
           if (this.stripOpt(f.name) === assertedNames[j]) {
@@ -388,7 +388,7 @@ class TypeAssertionChecker {
         const tf = tFields[ti] as InterfaceField;
         if (tf.name.endsWith("?")) continue;
         const reqName = this.stripOpt(tf.name);
-        let uIdx = -1;
+        let uIdx: number = -1;
         for (let k = 0; k < uFields.length; k++) {
           if (this.stripOpt((uFields[k] as InterfaceField).name) === reqName) {
             uIdx = k;


### PR DESCRIPTION
## Summary
- 5 variables initialized to `-1` were missing `: number` type annotations
- Native compiler can mistype these as integer instead of float, causing silent wrong behavior
- Files: `parser-native/transformer.ts` (2), `semantic/type-assertion-checker.ts` (2), `codegen/expressions/access/member.ts` (1)

## Test plan
- [x] All 436 tests pass
- [x] verify:quick passes (tests + stage 0/1 self-hosting)