### PR TITLE
fix: propagate ?. optional chaining to method call nodes in native parser

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -970,6 +970,16 @@ function transformCallExpression(node: TreeSitterNode): Expression {
       : { type: "variable" as const, name: "undefined" };
     const method = propNode ? (propNode as NodeBase).text : "";
 
+    let isOptional = false;
+    if (objNode) {
+      const objEnd = (objNode as NodeBase).endIndex;
+      const propStart = propNode ? (propNode as NodeBase).startIndex : fn.endIndex;
+      const operatorText = fn.source.substring(objEnd, propStart);
+      if (operatorText.indexOf("?.") !== -1) {
+        isOptional = true;
+      }
+    }
+
     return {
       type: "method_call",
       object: object,
@@ -977,6 +987,8 @@ function transformCallExpression(node: TreeSitterNode): Expression {
       args: args,
       typeParameter: typeParameter,
       pos: 0,
+      loc: undefined,
+      optional: isOptional || undefined,
     };
   } else if (fn.type === "identifier") {
     let callTypeArgs: string[] | undefined;
@@ -1002,6 +1014,8 @@ function transformCallExpression(node: TreeSitterNode): Expression {
       args,
       typeParameter: undefined,
       pos: 0,
+      loc: undefined,
+      optional: undefined,
     };
   }
 }
@@ -2107,6 +2121,8 @@ function transformForInStatement(node: TreeSitterNode): ForOfStatement {
       args: [iterable],
       typeParameter: undefined,
       pos: 0,
+      loc: undefined,
+      optional: undefined,
     };
   }
 

--- a/tests/fixtures/classes/optional-method-call.ts
+++ b/tests/fixtures/classes/optional-method-call.ts
@@ -1,0 +1,31 @@
+class Helper {
+  process(s: string): string {
+    return s + "_processed";
+  }
+}
+
+class Container {
+  helper: Helper | null = null;
+
+  setHelper(h: Helper): void {
+    this.helper = h;
+  }
+
+  doWork(s: string): string {
+    const result = this.helper?.process(s);
+    if (result) return result;
+    return "no_helper";
+  }
+}
+
+const c = new Container();
+if (c.doWork("test") !== "no_helper") {
+  console.log("FAIL: expected no_helper");
+  process.exit(1);
+}
+c.setHelper(new Helper());
+if (c.doWork("test") !== "test_processed") {
+  console.log("FAIL: expected test_processed");
+  process.exit(1);
+}
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- The native parser (`parser-native/transformer.ts`) never propagated `?.` from member expressions to `MethodCallNode.optional`, causing the native compiler to skip null-check branching for all `obj?.method()` calls
- This was the root cause of the "if-drop" bug — the dropped `optcall` null-check blocks caused IR divergence between JS and native compilers (956 out of 2036 functions differed), leading to self-hosting failures
- Added `loc` and `optional` fields to all MethodCallNode creation sites in the native parser for consistent struct layout

## Test plan
- [x] New test fixture `classes/optional-method-call.ts` verifies `?.` returns null when object is null
- [x] All 437 tests pass
- [x] `verify:quick` passes (Stage 0 + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)