### PR TITLE
fix: compile-time errors for silent map/set method dispatch fallthroughs

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -736,6 +736,10 @@ export class MethodCallGenerator {
               return this.ctx.stringMapGen.generateStringMapClear(mapAlloca);
             }
           }
+          return this.ctx.emitError(
+            `Map<string, *>.${method}() failed: no alloca found for '${varName}'`,
+            expr.loc,
+          );
         }
 
         if (method === "set") {
@@ -868,6 +872,10 @@ export class MethodCallGenerator {
               return this.ctx.stringSetGen.generateStringSetDelete(setAlloca, valueValue);
             }
           }
+          return this.ctx.emitError(
+            `Set<string>.${method}() failed: no alloca found for '${varName}'`,
+            expr.loc,
+          );
         }
 
         if (method === "add") {
@@ -892,6 +900,14 @@ export class MethodCallGenerator {
           } else {
             const valueValue = this.ctx.generateExpression(expr.args[0], params);
             return this.ctx.stringSetGen.generateStringSetDelete(setPtr, valueValue);
+          }
+        } else {
+          if (method === "add") {
+            return this.ctx.setGen.generateSetAdd(expr, params);
+          } else if (method === "has") {
+            return this.ctx.setGen.generateSetHas(expr, params);
+          } else {
+            return this.ctx.setGen.generateSetDelete(expr, params);
           }
         }
       }


### PR DESCRIPTION
## Summary
- Non-string Set fields (`this.fieldName.add/has/delete()`) silently fell through with no IR emitted and no error when `thisFieldSetValueType !== "string"` — now dispatches to numeric set handlers
- String Map/Set local variables with missing alloca silently fell through to wrong-type handlers — now emits compile-time error
- All three paths previously produced broken binaries with no diagnostic

## Test plan
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 0 + Stage 1)
- [x] No new test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)