### PR TITLE
fix: replace catch-all else branches with explicit method checks in map/set dispatch

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -751,8 +751,10 @@ export class MethodCallGenerator {
             `Map.${method}() only supported for Map<string, *> types`,
             expr.loc,
           );
-        } else {
+        } else if (method === "clear") {
           return this.ctx.mapGen.generateMapClear(expr, params);
+        } else {
+          return this.ctx.emitError(`Map.${method}() is not supported`, expr.loc);
         }
       }
 
@@ -780,8 +782,13 @@ export class MethodCallGenerator {
               return this.ctx.stringMapGen.generateStringMapEntries(mapPtr);
             } else if (method === "values") {
               return this.ctx.stringMapGen.generateStringMapValues(mapPtr);
-            } else {
+            } else if (method === "keys") {
               return this.ctx.stringMapGen.generateStringMapKeys(mapPtr);
+            } else {
+              return this.ctx.emitError(
+                `Map.${method}() not supported for Map<string, *> parameter types`,
+                expr.loc,
+              );
             }
           } else {
             if (method === "set") {
@@ -824,8 +831,13 @@ export class MethodCallGenerator {
             return this.ctx.stringMapGen.generateStringMapEntries(mapPtr);
           } else if (method === "values") {
             return this.ctx.stringMapGen.generateStringMapValues(mapPtr);
-          } else {
+          } else if (method === "clear") {
             return this.ctx.stringMapGen.generateStringMapClear(mapPtr);
+          } else {
+            return this.ctx.emitError(
+              `Map.${method}() not supported for Map<string, *> types`,
+              expr.loc,
+            );
           }
         } else {
           const mapPtr = this.ctx.generateExpression(expr.object, params);
@@ -863,9 +875,11 @@ export class MethodCallGenerator {
             } else if (method === "has") {
               const valueValue = this.ctx.generateExpression(expr.args[0], params);
               return this.ctx.stringSetGen.generateStringSetHas(setAlloca, valueValue);
-            } else {
+            } else if (method === "delete") {
               const valueValue = this.ctx.generateExpression(expr.args[0], params);
               return this.ctx.stringSetGen.generateStringSetDelete(setAlloca, valueValue);
+            } else {
+              return this.ctx.emitError(`Set.${method}() is not supported`, expr.loc);
             }
           }
         }
@@ -874,8 +888,10 @@ export class MethodCallGenerator {
           return this.ctx.setGen.generateSetAdd(expr, params);
         } else if (method === "has") {
           return this.ctx.setGen.generateSetHas(expr, params);
-        } else {
+        } else if (method === "delete") {
           return this.ctx.setGen.generateSetDelete(expr, params);
+        } else {
+          return this.ctx.emitError(`Set.${method}() is not supported`, expr.loc);
         }
       }
 
@@ -889,9 +905,11 @@ export class MethodCallGenerator {
           } else if (method === "has") {
             const valueValue = this.ctx.generateExpression(expr.args[0], params);
             return this.ctx.stringSetGen.generateStringSetHas(setPtr, valueValue);
-          } else {
+          } else if (method === "delete") {
             const valueValue = this.ctx.generateExpression(expr.args[0], params);
             return this.ctx.stringSetGen.generateStringSetDelete(setPtr, valueValue);
+          } else {
+            return this.ctx.emitError(`Set.${method}() is not supported`, expr.loc);
           }
         }
       }


### PR DESCRIPTION
## Summary
- Map dispatch used `else { clear() }` catch-all — any unrecognized method silently compiled as `clear()`. Now explicit `method === "clear"` check with `emitError` fallback.
- String Map dispatch used `else { keys() }` catch-all — same issue. Now explicit `method === "keys"` check.
- String Map (field path) used `else { clear() }` catch-all — same issue. Now explicit check.
- Set dispatch `else` branches made explicit with `method === "delete"` checks and `emitError` fallback for defense-in-depth (outer guard already filters to add/has/delete).
- 6 catch-all branches → 6 explicit checks + 6 new error paths

## Test plan
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 0 + Stage 1)
- [x] No new test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)