### PR TITLE
fix: remove unnecessary double casts in json, json-array, and variable-allocator

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2047,13 +2047,13 @@ export class VariableAllocator {
   ): { keys: string[]; types: string[]; tsTypes: string[] } | null {
     const e = expr as ExprBase;
     if (e.type !== "array") return null;
-    const arrayExpr = expr as unknown as ArrayNode;
+    const arrayExpr = expr as ArrayNode;
     const elements = arrayExpr.elements || [];
     if (elements.length === 0) return null;
     const firstElem = elements[0] as ExprBase;
     if (firstElem.type !== "object") return null;
 
-    const objNode = elements[0] as unknown as ObjectNode;
+    const objNode = elements[0] as ObjectNode;
     const keys: string[] = [];
     const types: string[] = [];
     const tsTypes: string[] = [];

--- a/src/codegen/stdlib/json-array.ts
+++ b/src/codegen/stdlib/json-array.ts
@@ -22,7 +22,7 @@ function buildObjectProperties(
         "@csyyjson_obj_add_obj",
         `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}`,
       );
-      buildObjectProperties(ctx, prop.value as unknown as ObjectNode, params, jsonDoc, childObj);
+      buildObjectProperties(ctx, prop.value as ObjectNode, params, jsonDoc, childObj);
     } else if (prop.value.type === "boolean") {
       const val = ctx.generateExpression(prop.value, params);
       const boolI32 = ctx.nextTemp();
@@ -93,7 +93,7 @@ export function stringifyObjectArrayLiteral(
         "@csyyjson_mut_arr_add_obj",
         `i8* ${jsonDoc}, i8* ${jsonArr}`,
       );
-      buildObjectProperties(ctx, elem as unknown as ObjectNode, params, jsonDoc, subObj);
+      buildObjectProperties(ctx, elem as ObjectNode, params, jsonDoc, subObj);
     }
   }
 

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -518,7 +518,7 @@ export class JsonGenerator {
     const spaces = this.getSpaces(expr);
     if (expr.args[0].type === "type_assertion") {
       return this.generateStringifyArgWithSpaces(
-        (expr.args[0] as unknown as TypeAssertionNode).expression,
+        (expr.args[0] as TypeAssertionNode).expression,
         params,
         spaces,
       );
@@ -540,11 +540,11 @@ export class JsonGenerator {
     }
 
     if (arg.type === "object") {
-      return this.stringifyObjectLiteral(arg as unknown as ObjectNode, params, spaces);
+      return this.stringifyObjectLiteral(arg as ObjectNode, params, spaces);
     }
 
     if (arg.type === "array") {
-      const arrayExpr = arg as unknown as ArrayNode;
+      const arrayExpr = arg as ArrayNode;
       const elements = arrayExpr.elements || [];
       if (elements.length > 0 && (elements[0] as ExprBase).type === "object") {
         return stringifyObjectArrayLiteral(this.ctx, arrayExpr, params, spaces);
@@ -761,7 +761,7 @@ export class JsonGenerator {
   ): string {
     if (!this.ctx.interfaceStructGenHasInterface(elementType)) {
       if (arg.type === "variable") {
-        const varName = (arg as unknown as VariableNode).name;
+        const varName = (arg as VariableNode).name;
         const meta = this.ctx.symbolTable.getObjectArrayMetadata(varName);
         if (meta && meta.elementKeys.length > 0) {
           return stringifyObjectArrayWithMeta(
@@ -975,7 +975,7 @@ export class JsonGenerator {
           "@csyyjson_obj_add_obj",
           `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}`,
         );
-        this.buildJsonProperties(prop.value as unknown as ObjectNode, params, jsonDoc, childObj);
+        this.buildJsonProperties(prop.value as ObjectNode, params, jsonDoc, childObj);
       } else if (prop.value.type === "boolean") {
         const val = this.ctx.generateExpression(prop.value, params);
         const boolI32 = this.ctx.nextTemp();


### PR DESCRIPTION
## Summary
- Replaced 9 `as unknown as` double casts with direct `as` casts in json.ts, json-array.ts, and variable-allocator.ts
- All casts are from `Expression` union type to its member types (`ObjectNode`, `ArrayNode`, `TypeAssertionNode`, `VariableNode`) — TypeScript allows direct narrowing casts on union members
- Double casts bypass TypeScript's type checker and give the native compiler less type information for GEP index resolution

## Test plan
- [x] `tsc --noEmit` passes (direct casts are type-safe)
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)