### PR TITLE
fix: replace for-of on getAllInterfaceFields with index loops

### DIFF
--- a/src/codegen/expressions/access/chained-access.ts
+++ b/src/codegen/expressions/access/chained-access.ts
@@ -30,7 +30,9 @@ export function handleNestedInterfaceField(
     const keys: string[] = [];
     const tsTypes: string[] = [];
     const types: string[] = [];
-    for (const f of ctx.getAllInterfaceFields(nestedInterfaceDef)) {
+    const allFields = ctx.getAllInterfaceFields(nestedInterfaceDef);
+    for (let fi = 0; fi < allFields.length; fi++) {
+      const f = allFields[fi] as { name: string; type: string };
       keys.push(stripOptional(f.name));
       tsTypes.push(f.type);
       types.push(tsTypeToLlvm(f.type));

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -699,14 +699,15 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     for (const iface of this.ast.interfaces) {
       if (!iface) continue;
       if (iface.name === cleanName) {
-        for (const field of this.getAllInterfaceFields(iface)) {
+        const allFields = this.getAllInterfaceFields(iface);
+        for (let fi = 0; fi < allFields.length; fi++) {
+          const field = allFields[fi] as InterfaceField;
           if (!field) continue;
           let fieldName = field.name;
           if (fieldName.endsWith("?")) {
             fieldName = fieldName.slice(0, fieldName.length - 1);
           }
           keys.push(fieldName);
-          // field.type is a TS type (e.g. "string", "number") — convert to LLVM for types[]
           types.push(tsTypeToLlvm(field.type));
           tsTypes.push(field.type);
         }
@@ -805,7 +806,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     for (const iface of this.ast.interfaces) {
       if (!iface) continue;
       if (iface.name === interfaceName) {
-        for (const f of this.getAllInterfaceFields(iface)) {
+        const allFields = this.getAllInterfaceFields(iface);
+        for (let fi = 0; fi < allFields.length; fi++) {
+          const f = allFields[fi] as InterfaceField;
           if (!f) continue;
           let fName = f.name;
           if (fName.endsWith("?")) {


### PR DESCRIPTION
## Summary
- Replace 3 `for...of` loops on `getAllInterfaceFields()` results with index-based loops
- `for...of` on `getAllInterfaceFields()` is a known Stage 1 failure pattern (see MEMORY.md)
- Safe pattern: store result first, use `for (let i = 0; i < allFields.length; i++)`

Files fixed:
- `llvm-generator.ts`: 2 instances (getInterfaceMetadata, getInterfaceFieldType)
- `chained-access.ts`: 1 instance (nested interface field extraction)

## Test plan
- [x] All 437 tests pass
- [x] Self-hosting verification passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)