### PR TITLE
fix: emit error instead of null for unsupported module method calls

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -1043,7 +1043,10 @@ export class MethodCallGenerator {
             imp.source.startsWith("../") ||
             imp.source.startsWith("/");
           if (!isRelative && imp.specifiers && imp.specifiers.indexOf(varName) !== -1) {
-            return "null";
+            return this.ctx.emitError(
+              `'${varName}.${method}()' — module '${imp.source}' is not supported by ChadScript`,
+              expr.loc,
+            );
           }
         }
       }


### PR DESCRIPTION
## Summary
- Replace `return "null"` with `return this.ctx.emitError(...)` in method-calls.ts when calling methods on unsupported external modules
- Previously, `someModule.method()` on a non-relative import silently returned a null pointer, compiling without error but crashing at runtime
- Now emits a clear compile-time error: `'module.method()' — module 'source' is not supported by ChadScript`

## Test plan
- [x] All 437 tests pass
- [x] Self-hosting verification passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)