### PR TITLE
fix: add null checks for getInterface() before getAllInterfaceFields()

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1012,8 +1012,12 @@ export class VariableAllocator {
       }
     } else {
       const interfaceDefResult = this.getInterface(interfaceName);
-      const interfaceDef = interfaceDefResult as InterfaceDeclaration;
-      const allFields = this.getAllInterfaceFields(interfaceDef);
+      if (!interfaceDefResult) {
+        return this.ctx.emitError(
+          `interface '${interfaceName}' not found when allocating function return variable '${stmt.name}'`,
+        );
+      }
+      const allFields = this.getAllInterfaceFields(interfaceDefResult as InterfaceDeclaration);
       for (let i = 0; i < allFields.length; i++) {
         const field = allFields[i] as { name: string; type: string };
         keys.push(stripOptional(field.name));
@@ -1109,8 +1113,12 @@ export class VariableAllocator {
       tsTypes.push("number");
     } else {
       const interfaceDefResult = this.getInterface(interfaceName);
-      const interfaceDef = interfaceDefResult as InterfaceDeclaration;
-      const allFields = this.getAllInterfaceFields(interfaceDef);
+      if (!interfaceDefResult) {
+        return this.ctx.emitError(
+          `interface '${interfaceName}' not found when allocating method return variable '${stmt.name}'`,
+        );
+      }
+      const allFields = this.getAllInterfaceFields(interfaceDefResult as InterfaceDeclaration);
       for (let i = 0; i < allFields.length; i++) {
         const field = allFields[i] as { name: string; type: string };
         keys.push(stripOptional(field.name));
@@ -1263,6 +1271,11 @@ export class VariableAllocator {
       return;
     }
     const interfaceDefResult = this.getInterface(interfaceName);
+    if (!interfaceDefResult) {
+      return this.ctx.emitError(
+        `interface '${interfaceName}' not found when allocating Map.get() return variable '${stmt.name}'`,
+      );
+    }
     const interfaceDef = interfaceDefResult as InterfaceDeclaration;
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
     const keys: string[] = [];


### PR DESCRIPTION
## Summary
- Add null checks after `getInterface()` in 3 methods in `variable-allocator.ts` before passing result to `getAllInterfaceFields()`
- Previously, if `getInterface()` returned null, the null was cast to `InterfaceDeclaration` and passed to `getAllInterfaceFields()`, causing a crash in the native compiler
- Fixed methods: `allocateFunctionInterfaceReturn`, `allocateMethodInterfaceReturn`, `allocateMapGetInterface`
- Now emits a clear compile-time error identifying the missing interface

## Test plan
- [x] All 437 tests pass
- [x] Self-hosting verification passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)