### PR TITLE
fix: add missing return before emitError in 7 codegen locations

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -2981,7 +2981,7 @@ export class MemberAccessGenerator {
         this.ctx.setVariableType(value, "i8*");
         return value;
       }
-      this.ctx.emitError(
+      return this.ctx.emitError(
         `cannot access property '${prop}' on '${varName}' — no type information available`,
         expr.loc,
       );
@@ -2994,7 +2994,7 @@ export class MemberAccessGenerator {
       this.ctx.setVariableType(objPtr, "i8*");
       return objPtr;
     }
-    this.ctx.emitError(
+    return this.ctx.emitError(
       `cannot access property '${prop}' on '${varName}' — variable has no type information or alloca`,
       expr.loc,
     );

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -1114,7 +1114,7 @@ export class MethodCallGenerator {
       ? `Method '${method}' on '${objectDescription}' is not supported.`
       : `Method '${method}' is not supported.`;
 
-    this.ctx.emitError(errorMsg, methodCallExpr ? methodCallExpr.loc : undefined, suggestion);
+    return this.ctx.emitError(errorMsg, methodCallExpr ? methodCallExpr.loc : undefined, suggestion);
   }
 
   private isLikelyResponseExpression(expr: MethodCallNode): boolean {

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -1114,7 +1114,11 @@ export class MethodCallGenerator {
       ? `Method '${method}' on '${objectDescription}' is not supported.`
       : `Method '${method}' is not supported.`;
 
-    return this.ctx.emitError(errorMsg, methodCallExpr ? methodCallExpr.loc : undefined, suggestion);
+    return this.ctx.emitError(
+      errorMsg,
+      methodCallExpr ? methodCallExpr.loc : undefined,
+      suggestion,
+    );
   }
 
   private isLikelyResponseExpression(expr: MethodCallNode): boolean {

--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -131,7 +131,7 @@ export class ExpressionGenerator {
     const remaining = this.dispatchRemainingExpressions(dctx, expr, params);
     if (remaining !== null) return remaining;
 
-    this.ctx.emitError(
+    return this.ctx.emitError(
       "unsupported expression type: " + expr.type,
       (expr as { loc?: { line: number; column: number } }).loc,
     );

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -300,7 +300,7 @@ export class AssignmentGenerator {
       this.ctx.emit(`${fieldPtr} = getelementptr inbounds double, double* ${instancePtr}, i32 0`);
       this.ctx.emit(`store double ${this.ctx.ensureDouble(value)}, double* ${fieldPtr}`);
     } else {
-      this.ctx.emitError(
+      return this.ctx.emitError(
         "Field '" +
           property +
           "' not found in class " +

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -142,14 +142,14 @@ export class FunctionGenerator {
     if (funcIsAsync) {
       const asyncRetType = func.returnType || "";
       if (asyncRetType === "any") {
-        this.ctx.emitError(
+        return this.ctx.emitError(
           "Async function '" +
             funcName +
             "' has return type 'any' — async functions must have an explicit Promise<T> return type (e.g., Promise<void>, Promise<string>)",
         );
       }
       if (asyncRetType !== "" && !asyncRetType.startsWith("Promise<")) {
-        this.ctx.emitError(
+        return this.ctx.emitError(
           "Async function '" +
             funcName +
             "' has return type '" +


### PR DESCRIPTION
## Summary
- Add `return` before 7 `emitError()` calls across 5 files that were missing it
- Without `return`, the native compiler (which doesn't respect TypeScript's `never` type) continues executing dead code after `emitError()`, leading to null dereferences, array bounds violations, and corrupt IR
- Files fixed: `member.ts` (2), `orchestrator.ts` (1), `method-calls.ts` (1), `assignment-generator.ts` (1), `function-generator.ts` (2)

## Test plan
- [x] All 437 tests pass
- [x] `verify:quick` passes (tsc + Stage 0 + Stage 1 + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)