### PR TITLE
fix: replace inline type assertions with named InterfaceField type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
           cache: npm
       - run: npm install --ignore-scripts
       - run: npx prettier --check .
+      - name: Ban inline InterfaceField assertions
+        run: |
+          if grep -rn 'as { name: string; type: string }' src/codegen/; then
+            echo "::error::Found inline 'as { name: string; type: string }' assertions. Use 'as InterfaceField' from src/ast/types.ts instead."
+            exit 1
+          fi
 
   build-linux-glibc:
     runs-on: ubuntu-22.04

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -815,7 +815,7 @@ export class MemberAccessGenerator {
           const tsTypes: string[] = [];
           const nestedProps = nestedInterface.properties as InterfaceProperty[];
           for (let pi = 0; pi < nestedProps.length; pi++) {
-            const p = nestedProps[pi] as { name: string; type: string };
+            const p = nestedProps[pi] as InterfaceField;
             keys.push(stripOptional(p.name));
             types.push(tsTypeToLlvm(p.type));
             tsTypes.push(p.type);
@@ -1168,7 +1168,7 @@ export class MemberAccessGenerator {
       const types: string[] = [];
       const allFields = this.ctx.getAllInterfaceFields(interfaceDef);
       for (let i = 0; i < allFields.length; i++) {
-        const f = allFields[i] as { name: string; type: string };
+        const f = allFields[i] as InterfaceField;
         keys.push(stripOptional(f.name));
         tsTypes.push(f.type);
         types.push(tsTypeToLlvm(f.type));
@@ -1705,7 +1705,7 @@ export class MemberAccessGenerator {
     let propIndex: number = -1;
     let propTsType: string | undefined;
     for (let i = 0; i < allFields1628.length; i++) {
-      const f = allFields1628[i] as { name: string; type: string };
+      const f = allFields1628[i] as InterfaceField;
       const fName = stripOptional(f.name);
       if (fName === expr.property) {
         propIndex = i;
@@ -2078,7 +2078,7 @@ export class MemberAccessGenerator {
               const types: string[] = [];
               const tsTypes: string[] = [];
               for (let j = 0; j < fields.length; j++) {
-                const f = fields[j] as { name: string; type: string };
+                const f = fields[j] as InterfaceField;
                 keys.push(stripOptional(f.name));
                 tsTypes.push(f.type);
                 if (f.type === "string") {
@@ -2109,7 +2109,7 @@ export class MemberAccessGenerator {
                 const types: string[] = [];
                 const tsTypes: string[] = [];
                 for (let j = 0; j < fields.length; j++) {
-                  const f = fields[j] as { name: string; type: string };
+                  const f = fields[j] as InterfaceField;
                   keys.push(stripOptional(f.name));
                   tsTypes.push(f.type);
                   if (f.type === "string") {
@@ -2408,7 +2408,7 @@ export class MemberAccessGenerator {
 
     let propIndex: number = -1;
     for (let i = 0; i < allFields2328.length; i++) {
-      const f = allFields2328[i] as { name: string; type: string };
+      const f = allFields2328[i] as InterfaceField;
       if (f.name === expr.property) {
         propIndex = i;
         break;
@@ -2417,7 +2417,7 @@ export class MemberAccessGenerator {
     if (propIndex === -1) {
       const fieldNames: string[] = [];
       for (let i = 0; i < allFields2328.length; i++) {
-        const field = allFields2328[i] as { name: string; type: string };
+        const field = allFields2328[i] as InterfaceField;
         fieldNames.push(field.name);
       }
       throw new Error(
@@ -2425,11 +2425,11 @@ export class MemberAccessGenerator {
       );
     }
 
-    const propField = allFields2328[propIndex] as { name: string; type: string };
+    const propField = allFields2328[propIndex] as InterfaceField;
     const propType = tsTypeToLlvm(propField.type);
     const structTypes: string[] = [];
     for (let i = 0; i < allFields2328.length; i++) {
-      const field = allFields2328[i] as { name: string; type: string };
+      const field = allFields2328[i] as InterfaceField;
       structTypes.push(tsTypeToLlvm(field.type));
     }
     const structType = `{ ${structTypes.join(", ")} }`;
@@ -2477,7 +2477,7 @@ export class MemberAccessGenerator {
 
     let propIndex: number = -1;
     for (let i = 0; i < allFields.length; i++) {
-      const f = allFields[i] as { name: string; type: string };
+      const f = allFields[i] as InterfaceField;
       if (stripOptional(f.name) === expr.property) {
         propIndex = i;
         break;
@@ -2485,11 +2485,11 @@ export class MemberAccessGenerator {
     }
     if (propIndex === -1) return null;
 
-    const propField = allFields[propIndex] as { name: string; type: string };
+    const propField = allFields[propIndex] as InterfaceField;
     const propType = tsTypeToLlvm(propField.type);
     const structTypes: string[] = [];
     for (let i = 0; i < allFields.length; i++) {
-      const field = allFields[i] as { name: string; type: string };
+      const field = allFields[i] as InterfaceField;
       structTypes.push(tsTypeToLlvm(field.type));
     }
     const structType = `{ ${structTypes.join(", ")} }`;
@@ -3056,7 +3056,7 @@ export class MemberAccessGenerator {
 
     let fieldIndex: number = -1;
     for (let i = 0; i < fields.length; i++) {
-      const f = fields[i] as { name: string; type: string };
+      const f = fields[i] as InterfaceField;
       if (f.name === property) {
         fieldIndex = i;
         break;
@@ -3064,12 +3064,12 @@ export class MemberAccessGenerator {
     }
     if (fieldIndex === -1) return null;
 
-    const field = fields[fieldIndex] as { name: string; type: string };
+    const field = fields[fieldIndex] as InterfaceField;
     const fieldLlvmType = tsTypeToLlvm(field.type);
 
     const types: string[] = [];
     for (let i = 0; i < fields.length; i++) {
-      const f = fields[i] as { name: string; type: string };
+      const f = fields[i] as InterfaceField;
       types.push(tsTypeToLlvm(f.type));
     }
     const structType = `{ ${types.join(", ")} }`;

--- a/src/codegen/expressions/method-calls/class-dispatch.ts
+++ b/src/codegen/expressions/method-calls/class-dispatch.ts
@@ -58,7 +58,7 @@ export function getInterfaceFromAST(
       const allFields = ctx.getAllInterfaceFields(ifaceItem);
       const properties: { name: string; type: string }[] = [];
       for (let j = 0; j < allFields.length; j++) {
-        const field = allFields[j] as { name: string; type: string };
+        const field = allFields[j] as InterfaceField;
         properties.push({ name: field.name, type: field.type });
       }
       return { properties };
@@ -391,13 +391,13 @@ export function resolveNestedMemberAccessType(
       let fieldResult: InterfaceField | null = null;
       const allIfaceFields = ctx.getAllInterfaceFields(interfaceDecl);
       for (let i = 0; i < allIfaceFields.length; i++) {
-        const f = allIfaceFields[i] as { name: string; type: string };
+        const f = allIfaceFields[i] as InterfaceField;
         if (f.name === memberAccess.property) {
           fieldResult = f;
           break;
         }
       }
-      const field = fieldResult as { name: string; type: string };
+      const field = fieldResult as InterfaceField;
       if (fieldResult) {
         let fieldType = field.type;
         if (fieldType.endsWith(" | null") || fieldType.endsWith(" | undefined")) {
@@ -645,7 +645,7 @@ export function handleClassMethods(
             const interfaceDecl = interfaceDeclResult as InterfaceDeclaration;
             const allDispatchFields = ctx.getAllInterfaceFields(interfaceDecl);
             for (let i = 0; i < allDispatchFields.length; i++) {
-              const f = allDispatchFields[i] as { name: string; type: string };
+              const f = allDispatchFields[i] as InterfaceField;
               if (f.name === memberAccess.property) {
                 let fieldType = f.type;
                 if (fieldType.endsWith(" | null") || fieldType.endsWith(" | undefined")) {

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -402,7 +402,7 @@ export class FunctionGenerator {
             const keys: string[] = [];
             const types: string[] = [];
             for (let j = 0; j < interfaceDefFields.length; j++) {
-              const field = interfaceDefFields[j] as { name: string; type: string };
+              const field = interfaceDefFields[j] as InterfaceField;
               if (!field || !field.name) continue;
               const fieldName = stripOptional(field.name);
               keys.push(fieldName);
@@ -849,7 +849,7 @@ export class FunctionGenerator {
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstFields.length; fi++) {
-      const field = firstFields[fi] as { name: string; type: string };
+      const field = firstFields[fi] as InterfaceField;
       if (!field || !field.name) continue;
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
@@ -857,7 +857,7 @@ export class FunctionGenerator {
         const ifaceFields = this.ctx.getAllInterfaceFields(ifaceTyped);
         let found = false;
         for (let fj = 0; fj < ifaceFields.length; fj++) {
-          const f = ifaceFields[fj] as { name: string; type: string };
+          const f = ifaceFields[fj] as InterfaceField;
           if (!f || !f.name) continue;
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             found = true;

--- a/src/codegen/infrastructure/interface-allocator.ts
+++ b/src/codegen/infrastructure/interface-allocator.ts
@@ -172,7 +172,7 @@ export class InterfaceAllocator {
       const inlineFields = this.parseInlineObjectType(interfaceName);
       if (inlineFields) {
         for (let i = 0; i < inlineFields.length; i++) {
-          const field = inlineFields[i] as { name: string; type: string };
+          const field = inlineFields[i] as InterfaceField;
           keys.push(stripOptional(field.name));
           types.push(this.convertTsType(field.type));
           tsTypes.push(field.type);
@@ -183,7 +183,7 @@ export class InterfaceAllocator {
       const interfaceDef = interfaceDefResult as InterfaceDeclaration;
       const allFields = this.getAllInterfaceFields(interfaceDef);
       for (let i = 0; i < allFields.length; i++) {
-        const field = allFields[i] as { name: string; type: string };
+        const field = allFields[i] as InterfaceField;
         keys.push(stripOptional(field.name));
         types.push(this.convertTsType(field.type));
         tsTypes.push(field.type);
@@ -280,7 +280,7 @@ export class InterfaceAllocator {
     const tsTypes: string[] = [];
     const allFields = this.getAllInterfaceFields(interfaceDef);
     for (let i = 0; i < allFields.length; i++) {
-      const field = allFields[i] as { name: string; type: string };
+      const field = allFields[i] as InterfaceField;
       keys.push(stripOptional(field.name));
       types.push(this.convertTsType(field.type));
       tsTypes.push(field.type);

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -863,7 +863,7 @@ export class TypeInference {
     if (!iface) return null;
     const allFields = this.getAllFieldsForInterface(iface);
     for (let i = 0; i < allFields.length; i++) {
-      const f = allFields[i] as { name: string; type: string };
+      const f = allFields[i] as InterfaceField;
       let fieldName = f.name;
       if (fieldName.endsWith("?")) {
         fieldName = fieldName.slice(0, fieldName.length - 1);
@@ -1072,7 +1072,7 @@ export class TypeInference {
     if (iface) {
       const field = this.getInterfaceProperty(typeName, fieldName);
       if (field) {
-        const fieldTyped = field as { name: string; type: string };
+        const fieldTyped = field as InterfaceField;
         return fieldTyped.type;
       }
     }
@@ -1090,7 +1090,7 @@ export class TypeInference {
     if (inner.length === 0) return null;
     const fields = this.parseInlineObjectFields(inner);
     for (let i = 0; i < fields.length; i++) {
-      const field = fields[i] as { name: string; type: string };
+      const field = fields[i] as InterfaceField;
       const cleanName = field.name.replace(/\?$/, "");
       if (cleanName === fieldName) {
         return field.type;

--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -448,7 +448,7 @@ export class TypeResolver {
     const tsTypes: string[] = [];
     const allFields = this.getAllInterfaceFields(iface);
     for (let i = 0; i < allFields.length; i++) {
-      const f = allFields[i] as { name: string; type: string };
+      const f = allFields[i] as InterfaceField;
       keys.push(stripOptional(f.name));
       types.push(canonicalTypeToLlvm(f.type, "default", this.isEnumType(f.type), false, ""));
       tsTypes.push(f.type);
@@ -464,7 +464,7 @@ export class TypeResolver {
     if (!iface) return null;
     const allFields = this.getAllInterfaceFields(iface);
     for (let i = 0; i < allFields.length; i++) {
-      const f = allFields[i] as { name: string; type: string };
+      const f = allFields[i] as InterfaceField;
       if (!f || !f.name) {
         continue;
       }
@@ -483,7 +483,7 @@ export class TypeResolver {
     const properties: { name: string; type: string }[] = [];
     const allFields = this.getAllInterfaceFields(iface);
     for (let i = 0; i < allFields.length; i++) {
-      const f = allFields[i] as { name: string; type: string };
+      const f = allFields[i] as InterfaceField;
       properties.push({ name: f.name, type: f.type });
     }
     return { properties };
@@ -628,14 +628,14 @@ export class TypeResolver {
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstFields.length; fi++) {
-      const field = firstFields[fi] as { name: string; type: string };
+      const field = firstFields[fi] as InterfaceField;
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
         const iface = interfaces[ii] as InterfaceDeclaration;
         const ifaceFields = this.getAllInterfaceFields(iface);
         let hasMatch = false;
         for (let jj = 0; jj < ifaceFields.length; jj++) {
-          const f = ifaceFields[jj] as { name: string; type: string };
+          const f = ifaceFields[jj] as InterfaceField;
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             hasMatch = true;
             break;
@@ -874,7 +874,7 @@ export class TypeResolver {
     field: string,
   ): string | null {
     for (let i = 0; i < fields.length; i++) {
-      const f = fields[i] as { name: string; type: string };
+      const f = fields[i] as InterfaceField;
       if (f.name === field) {
         if (f.type === `'${value}'` || f.type === `"${value}"`) {
           return ifaceName;
@@ -950,14 +950,14 @@ export class TypeResolver {
         let field: { name: string; type: string } | null = null;
         const allIfaceFields = this.getAllInterfaceFields(iface);
         for (let i = 0; i < allIfaceFields.length; i++) {
-          const f = allIfaceFields[i] as { name: string; type: string };
+          const f = allIfaceFields[i] as InterfaceField;
           if (f.name === memberExpr.property) {
             field = f;
             break;
           }
         }
         if (field) {
-          const fieldTyped = field as { name: string; type: string };
+          const fieldTyped = field as InterfaceField;
           const mapParsed = parseMapTypeString(fieldTyped.type);
           if (mapParsed) {
             return {
@@ -1016,14 +1016,14 @@ export class TypeResolver {
       let field: { name: string; type: string } | null = null;
       const allNestedFields = this.getAllInterfaceFields(iface);
       for (let i = 0; i < allNestedFields.length; i++) {
-        const f = allNestedFields[i] as { name: string; type: string };
+        const f = allNestedFields[i] as InterfaceField;
         if (f.name === memberExpr.property) {
           field = f;
           break;
         }
       }
       if (field) {
-        const fieldTyped = field as { name: string; type: string };
+        const fieldTyped = field as InterfaceField;
         let fieldType = fieldTyped.type;
         if (fieldType.endsWith(" | null") || fieldType.endsWith(" | undefined")) {
           fieldType = fieldType.replace(/ \| null$/, "").replace(/ \| undefined$/, "");
@@ -1113,14 +1113,14 @@ export class TypeResolver {
         let field: { name: string; type: string } | null = null;
         const allKeyFields = this.getAllInterfaceFields(iface);
         for (let i = 0; i < allKeyFields.length; i++) {
-          const f = allKeyFields[i] as { name: string; type: string };
+          const f = allKeyFields[i] as InterfaceField;
           if (f.name === memberExpr.property) {
             field = f;
             break;
           }
         }
         if (field) {
-          const fieldTyped = field as { name: string; type: string };
+          const fieldTyped = field as InterfaceField;
           const mapParsed = parseMapTypeString(fieldTyped.type);
           if (mapParsed) {
             return mapParsed.keyType;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -625,7 +625,7 @@ export class VariableAllocator {
               for (let fi = 0; fi < inlineFields.length; fi++) {
                 const fieldRaw = inlineFields[fi];
                 if (!fieldRaw) continue;
-                const field = fieldRaw as { name: string; type: string };
+                const field = fieldRaw as InterfaceField;
                 if (!field.name || !field.type) continue;
                 keys.push(stripOptional(field.name));
                 types.push(this.convertTsType(field.type));
@@ -655,7 +655,7 @@ export class VariableAllocator {
               for (let fi = 0; fi < allFields.length; fi++) {
                 const fieldRaw = allFields[fi];
                 if (!fieldRaw) continue;
-                const field = fieldRaw as { name: string; type: string };
+                const field = fieldRaw as InterfaceField;
                 if (!field.name || !field.type) continue;
                 keys.push(stripOptional(field.name));
                 types.push(this.convertTsType(field.type));
@@ -1004,7 +1004,7 @@ export class VariableAllocator {
       const inlineFields = this.parseInlineObjectType(interfaceName);
       if (inlineFields) {
         for (let i = 0; i < inlineFields.length; i++) {
-          const field = inlineFields[i] as { name: string; type: string };
+          const field = inlineFields[i] as InterfaceField;
           keys.push(stripOptional(field.name));
           types.push(this.convertTsType(field.type));
           tsTypes.push(field.type);
@@ -1019,7 +1019,7 @@ export class VariableAllocator {
       }
       const allFields = this.getAllInterfaceFields(interfaceDefResult as InterfaceDeclaration);
       for (let i = 0; i < allFields.length; i++) {
-        const field = allFields[i] as { name: string; type: string };
+        const field = allFields[i] as InterfaceField;
         keys.push(stripOptional(field.name));
         types.push(this.convertTsType(field.type));
         tsTypes.push(field.type);
@@ -1053,7 +1053,7 @@ export class VariableAllocator {
       const inlineFields = this.parseInlineObjectType(interfaceName);
       if (inlineFields) {
         for (let i = 0; i < inlineFields.length; i++) {
-          const field = inlineFields[i] as { name: string; type: string };
+          const field = inlineFields[i] as InterfaceField;
           keys.push(stripOptional(field.name));
           types.push(this.convertTsType(field.type));
           tsTypes.push(field.type);
@@ -1120,7 +1120,7 @@ export class VariableAllocator {
       }
       const allFields = this.getAllInterfaceFields(interfaceDefResult as InterfaceDeclaration);
       for (let i = 0; i < allFields.length; i++) {
-        const field = allFields[i] as { name: string; type: string };
+        const field = allFields[i] as InterfaceField;
         keys.push(stripOptional(field.name));
         types.push(this.convertTsType(field.type));
         tsTypes.push(field.type);
@@ -1154,7 +1154,7 @@ export class VariableAllocator {
       const inlineFields = this.parseInlineObjectType(elementType);
       if (inlineFields) {
         for (let i = 0; i < inlineFields.length; i++) {
-          const field = inlineFields[i] as { name: string; type: string };
+          const field = inlineFields[i] as InterfaceField;
           elementKeys.push(stripOptional(field.name));
           elementTypes.push(this.convertTsType(field.type));
           elementTsTypes.push(field.type);
@@ -1166,7 +1166,7 @@ export class VariableAllocator {
         const interfaceDef = interfaceDefResult as InterfaceDeclaration;
         const allFields = this.getAllInterfaceFields(interfaceDef);
         for (let i = 0; i < allFields.length; i++) {
-          const field = allFields[i] as { name: string; type: string };
+          const field = allFields[i] as InterfaceField;
           elementKeys.push(stripOptional(field.name));
           elementTypes.push(this.convertTsType(field.type));
           elementTsTypes.push(field.type);
@@ -1283,7 +1283,7 @@ export class VariableAllocator {
     const tsTypes: string[] = [];
     const allFields = this.getAllInterfaceFields(interfaceDef);
     for (let i = 0; i < allFields.length; i++) {
-      const field = allFields[i] as { name: string; type: string };
+      const field = allFields[i] as InterfaceField;
       keys.push(stripOptional(field.name));
       types.push(this.convertTsType(field.type));
       tsTypes.push(field.type);
@@ -1386,7 +1386,7 @@ export class VariableAllocator {
     if (!objIface.fields) return null;
     const allObjFields = this.getAllInterfaceFields(objIface);
     for (let i = 0; i < allObjFields.length; i++) {
-      const field = allObjFields[i] as { name: string; type: string };
+      const field = allObjFields[i] as InterfaceField;
       if (!field || !field.name) continue;
       const fieldName = stripOptional(field.name);
       if (fieldName === memberExpr.property) {
@@ -1677,7 +1677,7 @@ export class VariableAllocator {
       const types: string[] = [];
       const allFields = this.getAllInterfaceFields(interfaceDef);
       for (let i = 0; i < allFields.length; i++) {
-        const field = allFields[i] as { name: string; type: string };
+        const field = allFields[i] as InterfaceField;
         keys.push(stripOptional(field.name));
         tsTypes.push(field.type);
         types.push(this.convertTsTypeJson(field.type));
@@ -1713,7 +1713,7 @@ export class VariableAllocator {
       tsTypes = [];
       const allFields = this.getAllInterfaceFields(interfaceDef);
       for (let i = 0; i < allFields.length; i++) {
-        const field = allFields[i] as { name: string; type: string };
+        const field = allFields[i] as InterfaceField;
         keys.push(stripOptional(field.name));
         types.push(this.convertTsType(field.type));
         tsTypes.push(field.type);
@@ -2249,7 +2249,7 @@ export class VariableAllocator {
           const types: string[] = [];
           const tsTypes: string[] = [];
           for (let fi = 0; fi < inlineFields.length; fi++) {
-            const field = inlineFields[fi] as { name: string; type: string };
+            const field = inlineFields[fi] as InterfaceField;
             keys.push(stripOptional(field.name));
             types.push(this.convertTsType(field.type));
             tsTypes.push(field.type);
@@ -2275,7 +2275,7 @@ export class VariableAllocator {
         const tsTypes: string[] = [];
         const allFields = this.getAllInterfaceFields(interfaceDef);
         for (let fi = 0; fi < allFields.length; fi++) {
-          const field = allFields[fi] as { name: string; type: string };
+          const field = allFields[fi] as InterfaceField;
           keys.push(stripOptional(field.name));
           types.push(this.convertTsType(field.type));
           tsTypes.push(field.type);
@@ -2637,7 +2637,7 @@ export class VariableAllocator {
     const iface = ifaceResult as InterfaceDeclaration;
     const allFields = this.getAllInterfaceFields(iface);
     for (let i = 0; i < allFields.length; i++) {
-      const f = allFields[i] as { name: string; type: string };
+      const f = allFields[i] as InterfaceField;
       if (f.name === fieldName) {
         return f.type;
       }
@@ -2660,7 +2660,7 @@ export class VariableAllocator {
         const types: string[] = [];
         const tsTypes: string[] = [];
         for (let i = 0; i < inlineFields.length; i++) {
-          const field = inlineFields[i] as { name: string; type: string };
+          const field = inlineFields[i] as InterfaceField;
           keys.push(stripOptional(field.name));
           types.push(this.convertTsType(field.type));
           tsTypes.push(field.type);
@@ -2677,7 +2677,7 @@ export class VariableAllocator {
       const tsTypes: string[] = [];
       const allFields = this.getAllInterfaceFields(interfaceDef);
       for (let i = 0; i < allFields.length; i++) {
-        const field = allFields[i] as { name: string; type: string };
+        const field = allFields[i] as InterfaceField;
         keys.push(stripOptional(field.name));
         types.push(this.convertTsType(field.type));
         tsTypes.push(field.type);
@@ -2727,14 +2727,14 @@ export class VariableAllocator {
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstFields.length; fi++) {
-      const field = firstFields[fi] as { name: string; type: string };
+      const field = firstFields[fi] as InterfaceField;
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
         const ifaceTyped = interfaces[ii] as InterfaceDeclaration;
         const ifaceFields = this.getAllInterfaceFields(ifaceTyped);
         let found = false;
         for (let fj = 0; fj < ifaceFields.length; fj++) {
-          const f = ifaceFields[fj] as { name: string; type: string };
+          const f = ifaceFields[fj] as InterfaceField;
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             found = true;
             break;

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2221,7 +2221,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               const types: string[] = [];
               const allFields = this.getAllInterfaceFields(interfaceDef);
               for (let i = 0; i < allFields.length; i++) {
-                const field = allFields[i] as { name: string; type: string };
+                const field = allFields[i] as InterfaceField;
                 keys.push(stripOptional(field.name));
                 tsTypes.push(field.type);
                 types.push(this.tsTypeToLlvmJsonWithEnums(field.type));

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -608,7 +608,7 @@ export class ControlFlowGenerator {
         for (let i = 0; i < fields.length; i++) {
           const fRaw = fields[i];
           if (!fRaw) continue;
-          const f = fRaw as { name: string; type: string };
+          const f = fRaw as InterfaceField;
           if (!f.name || !f.type) continue;
           elementKeys.push(f.name);
           elementTsTypes.push(f.type);
@@ -640,7 +640,7 @@ export class ControlFlowGenerator {
       for (let i = 0; i < allFields.length; i++) {
         const fRaw = allFields[i];
         if (!fRaw) continue;
-        const f = fRaw as { name: string; type: string };
+        const f = fRaw as InterfaceField;
         if (!f.name || !f.type) continue;
         elementKeys.push(f.name);
         elementTsTypes.push(f.type);
@@ -684,7 +684,7 @@ export class ControlFlowGenerator {
     for (let i = 0; i < allFields.length; i++) {
       const fRaw = allFields[i];
       if (!fRaw) continue;
-      const f = fRaw as { name: string; type: string };
+      const f = fRaw as InterfaceField;
       if (!f.name) continue;
       if (f.name === fieldName) {
         return f.type;
@@ -737,7 +737,7 @@ export class ControlFlowGenerator {
                 for (let i = 0; i < fields.length; i++) {
                   const fRaw = fields[i];
                   if (!fRaw) continue;
-                  const f = fRaw as { name: string; type: string };
+                  const f = fRaw as InterfaceField;
                   if (!f.name || !f.type) continue;
                   elementKeys.push(f.name);
                   elementTsTypes.push(f.type);
@@ -771,7 +771,7 @@ export class ControlFlowGenerator {
               const elementTypes: string[] = [];
               const elementTsTypes: string[] = [];
               for (let i = 0; i < fields.length; i++) {
-                const f = fields[i] as { name: string; type: string };
+                const f = fields[i] as InterfaceField;
                 elementKeys.push(f.name);
                 elementTsTypes.push(f.type);
                 if (f.type === "string") {
@@ -802,7 +802,7 @@ export class ControlFlowGenerator {
               for (let i = 0; i < allFields.length; i++) {
                 const fRaw = allFields[i];
                 if (!fRaw) continue;
-                const f = fRaw as { name: string; type: string };
+                const f = fRaw as InterfaceField;
                 if (!f.name || !f.type) continue;
                 elementKeys.push(f.name);
                 elementTsTypes.push(f.type);
@@ -887,7 +887,7 @@ export class ControlFlowGenerator {
         for (let i = 0; i < allFields.length; i++) {
           const fRaw = allFields[i];
           if (!fRaw) continue;
-          const f = fRaw as { name: string; type: string };
+          const f = fRaw as InterfaceField;
           if (!f.name) continue;
           const fieldName = f.name.replace("?", "");
           if (fieldName === ma.property) {
@@ -921,15 +921,15 @@ export class ControlFlowGenerator {
     for (let i = 0; i < chainedAllFields.length; i++) {
       const fRaw = chainedAllFields[i];
       if (!fRaw) continue;
-      const f = fRaw as { name: string; type: string };
+      const f = fRaw as InterfaceField;
       if (!f.name) continue;
       const fieldName = f.name.replace("?", "");
       if (fieldName === propName) {
-        fieldDefResult = f as { name: string; type: string };
+        fieldDefResult = f as InterfaceField;
         break;
       }
     }
-    const fieldDef = fieldDefResult as { name: string; type: string };
+    const fieldDef = fieldDefResult as InterfaceField;
     if (!fieldDefResult || !fieldDef.type.endsWith("[]")) {
       return null;
     }
@@ -945,7 +945,7 @@ export class ControlFlowGenerator {
         for (let i = 0; i < fields.length; i++) {
           const fRaw = fields[i];
           if (!fRaw) continue;
-          const f = fRaw as { name: string; type: string };
+          const f = fRaw as InterfaceField;
           if (!f.name || !f.type) continue;
           elementKeys.push(f.name);
           elementTsTypes.push(f.type);
@@ -988,7 +988,7 @@ export class ControlFlowGenerator {
       const elementTypes: string[] = [];
       const elementTsTypes: string[] = [];
       for (let i = 0; i < elementAllFields.length; i++) {
-        const f = elementAllFields[i] as { name: string; type: string };
+        const f = elementAllFields[i] as InterfaceField;
         elementKeys.push(f.name);
         elementTsTypes.push(f.type);
         if (f.type === "string") {
@@ -1034,7 +1034,7 @@ export class ControlFlowGenerator {
         for (let i = 0; i < fields.length; i++) {
           const fRaw = fields[i];
           if (!fRaw) continue;
-          const f = fRaw as { name: string; type: string };
+          const f = fRaw as InterfaceField;
           if (!f.name || !f.type) continue;
           elementKeys.push(f.name);
           elementTsTypes.push(f.type);
@@ -1070,7 +1070,7 @@ export class ControlFlowGenerator {
       const elementTypes: string[] = [];
       const elementTsTypes: string[] = [];
       for (let i = 0; i < elementAllFields.length; i++) {
-        const f = elementAllFields[i] as { name: string; type: string };
+        const f = elementAllFields[i] as InterfaceField;
         elementKeys.push(f.name);
         elementTsTypes.push(f.type);
         if (f.type === "string") {
@@ -1143,13 +1143,13 @@ export class ControlFlowGenerator {
     const firstInterface = memberInterfaces[0];
     const firstInterfaceAllFields = this.ctx.getAllInterfaceFields(firstInterface);
     for (let i = 0; i < firstInterfaceAllFields.length; i++) {
-      const f = firstInterfaceAllFields[i] as { name: string; type: string };
+      const f = firstInterfaceAllFields[i] as InterfaceField;
       firstFields.set(f.name, f.type);
     }
 
     const commonFields: CommonField[] = [];
     for (let _ffi = 0; _ffi < firstInterfaceAllFields.length; _ffi++) {
-      const firstField = firstInterfaceAllFields[_ffi] as { name: string; type: string };
+      const firstField = firstInterfaceAllFields[_ffi] as InterfaceField;
       const fieldName = firstField.name;
       const fieldType = firstField.type;
       let isCommon = true;
@@ -1159,13 +1159,13 @@ export class ControlFlowGenerator {
         const otherAllFields = this.ctx.getAllInterfaceFields(otherIface);
         let otherFieldResult: InterfaceField | null = null;
         for (let j = 0; j < otherAllFields.length; j++) {
-          const f = otherAllFields[j] as { name: string; type: string };
+          const f = otherAllFields[j] as InterfaceField;
           if (f.name === fieldName) {
             otherFieldResult = f;
             break;
           }
         }
-        const otherField = otherFieldResult as { name: string; type: string };
+        const otherField = otherFieldResult as InterfaceField;
         if (!otherFieldResult) {
           isCommon = false;
           break;
@@ -1634,14 +1634,14 @@ export class ControlFlowGenerator {
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstAllFields.length; fi++) {
-      const field = firstAllFields[fi] as { name: string; type: string };
+      const field = firstAllFields[fi] as InterfaceField;
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
         const ifaceTyped = interfaces[ii] as InterfaceDeclaration;
         const ifaceAllFields = this.ctx.getAllInterfaceFields(ifaceTyped);
         let found = false;
         for (let fj = 0; fj < ifaceAllFields.length; fj++) {
-          const f = ifaceAllFields[fj] as { name: string; type: string };
+          const f = ifaceAllFields[fj] as InterfaceField;
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             found = true;
             break;
@@ -1803,7 +1803,7 @@ export class ControlFlowGenerator {
     const types: string[] = [];
     const tsTypes: string[] = [];
     for (let i = 0; i < ifaceAllFields.length; i++) {
-      const f = ifaceAllFields[i] as { name: string; type: string };
+      const f = ifaceAllFields[i] as InterfaceField;
       keys.push(stripOptional(f.name));
       types.push(this.fieldTypeToLlvm(f.type));
       tsTypes.push(f.type);
@@ -1846,7 +1846,7 @@ export class ControlFlowGenerator {
     discriminantValue: string,
   ): string | null {
     for (let i = 0; i < fields.length; i++) {
-      const f = fields[i] as { name: string; type: string };
+      const f = fields[i] as InterfaceField;
       if (f.name === "type") {
         const fieldType = f.type;
         if (fieldType === `'${discriminantValue}'` || fieldType === `"${discriminantValue}"`) {

--- a/src/codegen/stdlib/response.ts
+++ b/src/codegen/stdlib/response.ts
@@ -8,6 +8,8 @@
  * - response.ok - Boolean indicating success (status 200-299)
  */
 
+import type { InterfaceField } from "../../ast/types.js";
+
 interface InterfaceStructGenerator {
   hasInterface(name: string): boolean;
 }
@@ -146,7 +148,7 @@ export class ResponseGenerator {
   private generateJsonStruct(typeName: string, interfaceDef: InterfaceDefInfo): void {
     const fieldTypes: string[] = [];
     for (let i = 0; i < interfaceDef.properties.length; i++) {
-      const prop = interfaceDef.properties[i] as { name: string; type: string };
+      const prop = interfaceDef.properties[i] as InterfaceField;
       if (prop.type === "string") {
         fieldTypes.push("i8*");
       } else if (prop.type === "number") {
@@ -199,7 +201,7 @@ export class ResponseGenerator {
 
     parserIR += `json_error:` + "\n";
     for (let fieldIndex = 0; fieldIndex < interfaceDef.properties.length; fieldIndex++) {
-      const prop = interfaceDef.properties[fieldIndex] as { name: string; type: string };
+      const prop = interfaceDef.properties[fieldIndex] as InterfaceField;
       const propType = prop.type;
       const fieldPtr = `%err_field_ptr_${fieldIndex}`;
       parserIR +=
@@ -219,7 +221,7 @@ export class ResponseGenerator {
 
     parserIR += `json_ok:` + "\n";
     for (let fieldIndex = 0; fieldIndex < interfaceDef.properties.length; fieldIndex++) {
-      const prop = interfaceDef.properties[fieldIndex] as { name: string; type: string };
+      const prop = interfaceDef.properties[fieldIndex] as InterfaceField;
       const propName = prop.name;
       const propType = prop.type;
       const fieldNameConst = this.ctx.nextString();

--- a/src/codegen/types/interface-struct-generator.ts
+++ b/src/codegen/types/interface-struct-generator.ts
@@ -1,4 +1,4 @@
-import { InterfaceDeclaration } from "../../ast/types.js";
+import { InterfaceDeclaration, InterfaceField } from "../../ast/types.js";
 import { canonicalTypeToLlvm } from "../infrastructure/type-system.js";
 
 const BUILTIN_TYPES = [
@@ -119,7 +119,7 @@ export class InterfaceStructGenerator {
       const pFieldsLen = pFields.length;
       if (pFieldsLen === 0) continue;
       for (let j = 0; j < pFieldsLen; j++) {
-        const f = pFields[j] as { name: string; type: string };
+        const f = pFields[j] as InterfaceField;
         let fieldName = f.name;
         if (fieldName.endsWith("?")) {
           fieldName = fieldName.slice(0, fieldName.length - 1);
@@ -143,7 +143,7 @@ export class InterfaceStructGenerator {
     }
     const fields = this.getInterfaceFields(idx);
     for (let i = 0; i < fields.length; i++) {
-      const f = fields[i] as { name: string; type: string };
+      const f = fields[i] as InterfaceField;
       let fieldName = f.name;
       if (fieldName.endsWith("?")) {
         fieldName = fieldName.slice(0, fieldName.length - 1);

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -5,6 +5,7 @@ import {
   ClassField,
   VariableNode,
   InterfaceDeclaration,
+  InterfaceField,
   CommonField,
   TypeAliasDeclaration,
 } from "../../../ast/types.js";
@@ -1437,7 +1438,7 @@ export class ClassGenerator {
       const tsTypes: string[] = [];
       const allFields = this.ctx.getAllInterfaceFields(interfaceDef);
       for (let fi = 0; fi < allFields.length; fi++) {
-        const f = allFields[fi] as { name: string; type: string };
+        const f = allFields[fi] as InterfaceField;
         keys.push(stripOptional(f.name));
         types.push(this.fieldTypeToLlvm(f.type));
         tsTypes.push(f.type);
@@ -1515,7 +1516,7 @@ export class ClassGenerator {
         const types: string[] = [];
         const tsTypes: string[] = [];
         for (let fi = 0; fi < inlineFields.length; fi++) {
-          const f = inlineFields[fi] as { name: string; type: string };
+          const f = inlineFields[fi] as InterfaceField;
           keys.push(stripOptional(f.name));
           types.push(this.fieldTypeToLlvm(f.type));
           tsTypes.push(f.type);
@@ -1666,14 +1667,14 @@ export class ClassGenerator {
     const commonFields: CommonField[] = [];
 
     for (let fi = 0; fi < firstFields.length; fi++) {
-      const field = firstFields[fi] as { name: string; type: string };
+      const field = firstFields[fi] as InterfaceField;
       let isCommon = true;
       for (let ii = 0; ii < interfaces.length; ii++) {
         const ifaceTyped = interfaces[ii] as InterfaceDeclaration;
         const ifaceFields = this.ctx.getAllInterfaceFields(ifaceTyped);
         let found = false;
         for (let fj = 0; fj < ifaceFields.length; fj++) {
-          const f = ifaceFields[fj] as { name: string; type: string };
+          const f = ifaceFields[fj] as InterfaceField;
           if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
             found = true;
             break;

--- a/src/codegen/types/objects/object.ts
+++ b/src/codegen/types/objects/object.ts
@@ -1,4 +1,4 @@
-import { Expression, ObjectNode, ObjectProperty } from "../../../ast/types.js";
+import { Expression, InterfaceField, ObjectNode, ObjectProperty } from "../../../ast/types.js";
 import { IGeneratorContext } from "../../infrastructure/generator-context.js";
 import type { InterfaceStructGenerator } from "../interface-struct-generator.js";
 import { tsTypeToLlvm } from "../../infrastructure/type-system.js";
@@ -109,7 +109,7 @@ export class ObjectGenerator {
     const orderedFields: { key: string; llvmType: string; value: string }[] = [];
 
     for (let fieldIdx = 0; fieldIdx < fields.length; fieldIdx++) {
-      const field = fields[fieldIdx] as { name: string; type: string };
+      const field = fields[fieldIdx] as InterfaceField;
       const llvmType = this.tsTypeToLlvm(field.type);
       const valueExpr = propMap.get(field.name);
       let finalValue: string;


### PR DESCRIPTION
## Summary
- Replaced all 93 instances of `as { name: string; type: string }` with `as InterfaceField` across 13 codegen files
- Added `InterfaceField` import to 4 files that didn't have it (interface-struct-generator.ts, object.ts, class.ts, response.ts)
- Root cause fix for 294 corrupted type strings per native compiler build — inline anonymous type assertions cause the native compiler to fall back to `csyyjson_obj_get` instead of direct GEP, reading garbage memory

## Test plan
- [x] `npm run build` — clean TypeScript compilation
- [x] `npm test` — 437 tests pass
- [x] `npm run verify:quick` — Stage 0 + Stage 1 self-hosting passes