### PR TITLE
fix: resolve inline type assertions to matching interfaces

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -158,6 +158,7 @@ export interface MemberAccessGeneratorContext {
     name: string,
   ): { keys: string[]; types: string[]; tsTypes: string[] } | null;
   getInterfaceDeclByName(name: string): InterfaceDeclaration | null;
+  findInterfaceForFields(fieldNames: string[]): string | null;
   getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[];
   isTypeAlias(name: string): boolean;
   getTypeAliasCommonProperties(
@@ -3014,6 +3015,23 @@ export class MemberAccessGenerator {
     let fields: InterfaceField[] = [];
 
     if (assertedType.startsWith("{")) {
+      const inlineFields = parseInlineObjectTypeForAssertion(assertedType);
+      if (inlineFields && inlineFields.length >= 2) {
+        const fieldNames: string[] = [];
+        for (let fi = 0; fi < inlineFields.length; fi++) {
+          fieldNames.push(inlineFields[fi].name);
+        }
+        const matchedIface = this.ctx.findInterfaceForFields(fieldNames);
+        if (matchedIface) {
+          const objPtr = this.ctx.generateExpression(assertion.expression, params);
+          const ifaceResult = this.accessObjectPropertyWithNamedInterface(
+            objPtr,
+            property,
+            matchedIface,
+          );
+          if (ifaceResult !== null) return ifaceResult;
+        }
+      }
       const syntheticExpr: MemberAccessNode = {
         type: "member_access",
         object: assertion.expression,

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -628,6 +628,7 @@ export interface IGeneratorContext {
     name: string,
   ): { keys: string[]; types: string[]; tsTypes: string[] } | null;
   getInterfaceDeclByName(name: string): InterfaceDeclaration | null;
+  findInterfaceForFields(fieldNames: string[]): string | null;
   getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[];
   isTypeAlias(name: string): boolean;
   getTypeAliasCommonProperties(
@@ -1113,6 +1114,9 @@ export class MockGeneratorContext implements IGeneratorContext {
     return null;
   }
   getInterfaceDeclByName(_name: string): InterfaceDeclaration | null {
+    return null;
+  }
+  findInterfaceForFields(_fieldNames: string[]): string | null {
     return null;
   }
   getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[] {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -729,6 +729,32 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     return null;
   }
 
+  public findInterfaceForFields(fieldNames: string[]): string | null {
+    if (!this.ast || !this.ast.interfaces) return null;
+    for (let i = 0; i < this.ast.interfaces.length; i++) {
+      const iface = this.ast.interfaces[i];
+      if (!iface) continue;
+      const allFields = this.getAllInterfaceFields(iface);
+      let allFound = true;
+      for (let j = 0; j < fieldNames.length; j++) {
+        let found = false;
+        for (let k = 0; k < allFields.length; k++) {
+          const fn = allFields[k].name;
+          if (fn === fieldNames[j] || fn === fieldNames[j] + "?") {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          allFound = false;
+          break;
+        }
+      }
+      if (allFound && this.interfaceStructGen?.hasInterface(iface.name)) return iface.name;
+    }
+    return null;
+  }
+
   public getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[] {
     return this.varAllocator.getAllInterfaceFields(iface);
   }


### PR DESCRIPTION
## Summary
- When codegen encounters `as { name: string; type: string }`, it now parses the inline fields and finds the matching declared interface
- Uses `accessObjectPropertyWithNamedInterface` with correct GEP indices instead of falling back to untyped member access
- Added `findInterfaceForFields(fieldNames)` to generator context and LLVMGenerator
- Falls back to existing synthetic member access if no matching interface found

This is the root cause fix for the 294 corrupted type strings per native compiler build. Previously, inline multi-field type assertions caused the native compiler to use JSON-style field lookup (`csyyjson_obj_get`) instead of direct struct access (GEP), reading garbage memory.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 437 tests pass
- [x] `npm run verify:quick` — Stage 0 + Stage 1 self-hosting passes