### PR TITLE
fix: consolidate duplicate FieldInfo interfaces

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -83,11 +83,7 @@ interface ExprBase {
   type: string;
 }
 
-interface FieldInfo {
-  index: number;
-  type: string;
-  tsType?: string;
-}
+import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
 
 interface MapGeneratorLike {
   generateMapSize(mapPtr: string): string;
@@ -182,7 +178,7 @@ export interface MemberAccessGeneratorContext {
   classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   classGenGetFieldType(className: string, fieldName: string): string | null;
   classGenGetFieldTsType(className: string, fieldName: string): string | null;
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
@@ -919,7 +915,7 @@ export class MemberAccessGenerator {
     const fields = this.ctx.classGenGetClassFields(className);
 
     if (fieldInfoResult) {
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       const fieldPtr = this.ctx.nextTemp();
       if (fields.length > 0) {
         this.ctx.emit(
@@ -1374,11 +1370,7 @@ export class MemberAccessGenerator {
       if (implementingClass) {
         const classFieldInfo = this.ctx.classGenGetFieldInfo(implementingClass, expr.property);
         if (classFieldInfo) {
-          const classFieldInfoTyped = classFieldInfo as {
-            index: number;
-            type: string;
-            tsType?: string;
-          };
+          const classFieldInfoTyped = classFieldInfo as FieldInfo;
           const castPtr = this.ctx.nextTemp();
           this.ctx.emit(
             `${castPtr} = bitcast %${innerInterfaceName}* ${innerPtr} to %${implementingClass}_struct*`,
@@ -1409,11 +1401,7 @@ export class MemberAccessGenerator {
         if (structuralClass) {
           const classFieldInfo = this.ctx.classGenGetFieldInfo(structuralClass, expr.property);
           if (classFieldInfo) {
-            const classFieldInfoTyped = classFieldInfo as {
-              index: number;
-              type: string;
-              tsType?: string;
-            };
+            const classFieldInfoTyped = classFieldInfo as FieldInfo;
             const castPtr = this.ctx.nextTemp();
             this.ctx.emit(
               `${castPtr} = bitcast %${innerInterfaceName}* ${innerPtr} to %${structuralClass}_struct*`,
@@ -1584,7 +1572,7 @@ export class MemberAccessGenerator {
     const fieldName = innerExpr.property;
     const fieldInfoResult = this.ctx.classGenGetFieldInfo(className, fieldName);
     if (!fieldInfoResult) return null;
-    const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+    const fieldInfo = fieldInfoResult as FieldInfo;
     if (!fieldInfo.tsType) return null;
 
     // Strip nullable suffixes so "Foo | undefined" produces valid LLVM type "%Foo"
@@ -1623,11 +1611,7 @@ export class MemberAccessGenerator {
       if (implementingClass) {
         const classFieldInfo = this.ctx.classGenGetFieldInfo(implementingClass, expr.property);
         if (classFieldInfo) {
-          const classFieldInfoTyped = classFieldInfo as {
-            index: number;
-            type: string;
-            tsType?: string;
-          };
+          const classFieldInfoTyped = classFieldInfo as FieldInfo;
           const innerPtr = this.ctx.generateExpression(expr.object, params);
           const resolvedClass = this.ctx.getActualClassType(innerPtr) || implementingClass;
           const castPtr = this.ctx.nextTemp();
@@ -1681,11 +1665,7 @@ export class MemberAccessGenerator {
     if (implementingClass2) {
       const classFieldInfo = this.ctx.classGenGetFieldInfo(implementingClass2, expr.property);
       if (classFieldInfo) {
-        const classFieldInfoTyped = classFieldInfo as {
-          index: number;
-          type: string;
-          tsType?: string;
-        };
+        const classFieldInfoTyped = classFieldInfo as FieldInfo;
         const innerPtr = this.ctx.generateExpression(expr.object, params);
         const resolvedClass2 = this.ctx.getActualClassType(innerPtr) || implementingClass2;
         const castPtr = this.ctx.nextTemp();
@@ -2031,7 +2011,7 @@ export class MemberAccessGenerator {
         const className = this.ctx.getCurrentClassName();
         if (className) {
           const fieldInfoResult = this.ctx.classGenGetFieldInfo(className, memberAccess.property);
-          const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+          const fieldInfo = fieldInfoResult as FieldInfo;
           if (fieldInfoResult && fieldInfo.tsType) {
             return fieldInfo.tsType;
           }
@@ -2392,7 +2372,7 @@ export class MemberAccessGenerator {
     if (!classNameForLookup) return null;
 
     const fieldInfoResult = this.ctx.classGenGetFieldInfo(classNameForLookup, memberExpr.property);
-    const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+    const fieldInfo = fieldInfoResult as FieldInfo;
     if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
     const mapParsed = parseMapTypeString(fieldInfo.tsType);
@@ -2872,11 +2852,7 @@ export class MemberAccessGenerator {
                   expr.property,
                 );
                 if (classFieldInfo) {
-                  const classFieldInfoTyped = classFieldInfo as {
-                    index: number;
-                    type: string;
-                    tsType?: string;
-                  };
+                  const classFieldInfoTyped = classFieldInfo as FieldInfo;
                   const objPtrRaw = this.ctx.nextTemp();
                   this.ctx.emit(`${objPtrRaw} = load i8*, i8** ${paramPtr}`);
                   const objPtr = this.ctx.nextTemp();

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -175,10 +175,7 @@ export interface MemberAccessGeneratorContext {
   emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
   emitWarning(message: string, loc?: SourceLocation, suggestion?: string): void;
   getObjectMetadata(obj: ObjectNode): ObjectMetadata;
-  classGenGetFieldInfo(
-    className: string | null,
-    fieldName: string | null,
-  ): FieldInfo | null;
+  classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   classGenGetFieldType(className: string, fieldName: string): string | null;
   classGenGetFieldTsType(className: string, fieldName: string): string | null;
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];

--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -1,5 +1,6 @@
 import { Expression, MemberAccessNode, VariableNode } from "../../../ast/types.js";
 import type { MemberAccessGeneratorContext } from "./member.js";
+import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
 
 export function handleUrlProperty(
   ctx: MemberAccessGeneratorContext,
@@ -163,7 +164,7 @@ export function handleMemberAccessLength(
     const classMeta = ctx.symbolTable.getClassInfo((innerAccess.object as VariableNode).name);
     if (classMeta) {
       const fieldInfoResult = ctx.classGenGetFieldInfo(classMeta.className, innerAccess.property);
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       if (fieldInfoResult && fieldInfo.type === "string[]") {
         const stringArrayPtr = ctx.generateExpression(expr.object, params);
         return getStringArrayLength(ctx, stringArrayPtr);
@@ -238,7 +239,7 @@ export function handleMemberAccessLength(
     const className = ctx.getCurrentClassName();
     if (className) {
       const fieldInfoResult = ctx.classGenGetFieldInfo(className, innerAccess.property);
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       if (fieldInfoResult && fieldInfo.type === "string[]") {
         const stringArrayPtr = ctx.generateExpression(expr.object, params);
         return getStringArrayLength(ctx, stringArrayPtr);

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -55,6 +55,7 @@ import type {
   IEmbedGenerator,
 } from "../infrastructure/generator-context.js";
 import { parseMapTypeString, parseSetTypeString } from "../infrastructure/type-system.js";
+import type { FieldInfo } from "../infrastructure/type-resolver/types.js";
 import { isProcessStdoutOrStderr, handleProcessWrite } from "./method-calls/process.js";
 import {
   generateObjectKeys,
@@ -159,7 +160,7 @@ export interface MethodCallGeneratorContext {
   classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   classGenGenerateMethodCall(
     instancePtr: string,
     className: string,
@@ -486,7 +487,7 @@ export class MethodCallGenerator {
         classNameForLookup,
         memberExpr.property,
       );
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
       const mapParsed = parseMapTypeString(fieldInfo.tsType);
@@ -512,7 +513,7 @@ export class MethodCallGenerator {
     const classNameForSet = this.ctx.getCurrentClassName();
     if (!classNameForSet) return null;
     const fieldInfoResult = this.ctx.classGenGetFieldInfo(classNameForSet, memberExpr.property);
-    const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+    const fieldInfo = fieldInfoResult as FieldInfo;
     if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
     const setParsed = parseSetTypeString(fieldInfo.tsType);

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -157,10 +157,7 @@ export interface MethodCallGeneratorContext {
   setUsesHttpServer(value: boolean): void;
   setUsesMultipart(value: boolean): void;
   setUsesTestRunner(value: boolean): void;
-  classGenGetFieldInfo(
-    className: string | null,
-    fieldName: string | null,
-  ): FieldInfo | null;
+  classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   classGenGenerateMethodCall(
     instancePtr: string,
     className: string,

--- a/src/codegen/expressions/method-calls/class-dispatch.ts
+++ b/src/codegen/expressions/method-calls/class-dispatch.ts
@@ -11,6 +11,7 @@ import {
   IndexAccessNode,
 } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
+import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
 
 interface ExprBase {
   type: string;
@@ -348,7 +349,7 @@ export function resolveNestedMemberAccessType(
     }
     if (classExists) {
       const fieldInfoResult = ctx.classGenGetFieldInfo(parentType, memberAccess.property);
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       if (fieldInfoResult && fieldInfo.tsType) {
         let cleanFieldType = fieldInfo.tsType;
         if (cleanFieldType.indexOf(" | ") !== -1) {
@@ -524,7 +525,7 @@ export function handleClassMethods(
     const classNameForField = ctx.getCurrentClassName();
     if (memberAccessObjBase.type === "this" && classNameForField) {
       const fieldInfoResult = ctx.classGenGetFieldInfo(classNameForField, memberAccess.property);
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       if (fieldInfoResult && fieldInfo.tsType) {
         let fieldClassName = fieldInfo.tsType;
         if (fieldClassName.indexOf(" | ") !== -1) {
@@ -572,7 +573,7 @@ export function handleClassMethods(
         ctx.symbolTable.getConcreteClass(varName) || ctx.getActualClassType(varName);
       if (concreteClass) {
         const fieldInfoResult = ctx.classGenGetFieldInfo(concreteClass, memberAccess.property);
-        const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+        const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType) {
           let fieldClassName = fieldInfo.tsType;
           if (fieldClassName.indexOf(" | ") !== -1) {
@@ -597,7 +598,7 @@ export function handleClassMethods(
         const classMeta = ctx.symbolTable.getClassInfo(varName)!;
         const outerClassName = classMeta.className;
         const fieldInfoResult = ctx.classGenGetFieldInfo(outerClassName, memberAccess.property);
-        const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+        const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType) {
           let fieldClassName = fieldInfo.tsType;
           if (fieldClassName.indexOf(" | ") !== -1) {
@@ -686,7 +687,7 @@ export function handleClassMethods(
         const curClassName = ctx.getCurrentClassName();
         if (curClassName) {
           const fieldInfoResult = ctx.classGenGetFieldInfo(curClassName, memberAccess.property);
-          const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+          const fieldInfo = fieldInfoResult as FieldInfo;
           if (fieldInfoResult && fieldInfo.tsType) {
             let tsType = fieldInfo.tsType;
             if (tsType.indexOf(" | ") !== -1) {

--- a/src/codegen/expressions/operators/unary.ts
+++ b/src/codegen/expressions/operators/unary.ts
@@ -1,6 +1,7 @@
 import { Expression, MemberAccessNode, VariableNode, SourceLocation } from "../../../ast/types.js";
 import type { SymbolTable } from "../../infrastructure/symbol-table.js";
 import type { IStringGenerator } from "../../infrastructure/generator-context.js";
+import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
 
 interface ExprBase {
   type: string;
@@ -18,7 +19,7 @@ interface UnaryExpressionContext {
   classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   generateExpression(expr: Expression, params: string[]): string;
   ensureDouble(value: string): string;
   readonly stringGen: IStringGenerator;
@@ -220,7 +221,7 @@ export class UnaryExpressionGenerator {
     if (!fieldInfoResult) {
       return this.ctx.emitError("Cannot find field '" + fieldName + "' in class " + className);
     }
-    const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+    const fieldInfo = fieldInfoResult as FieldInfo;
 
     const fieldPtr = this.ctx.nextTemp();
     this.ctx.emit(

--- a/src/codegen/expressions/operators/unary.ts
+++ b/src/codegen/expressions/operators/unary.ts
@@ -16,10 +16,7 @@ interface UnaryExpressionContext {
   getThisPointer(): string | null;
   getCurrentClassName(): string | null;
   hasClassGen(): boolean;
-  classGenGetFieldInfo(
-    className: string | null,
-    fieldName: string | null,
-  ): FieldInfo | null;
+  classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   generateExpression(expr: Expression, params: string[]): string;
   ensureDouble(value: string): string;
   readonly stringGen: IStringGenerator;

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -31,10 +31,7 @@ export interface AssignmentGeneratorContext {
   generateExpression(expr: Expression, params: string[]): string;
   getVariableAlloca(name: string): string | null;
   getVariableType(name: string): string | null;
-  classGenGetFieldInfo(
-    className: string | null,
-    fieldName: string | null,
-  ): FieldInfo | null;
+  classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
   getAst(): AST | undefined;
   expectedArrayElementType: "string" | "number" | "boolean" | "pointer" | null;

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -13,11 +13,7 @@ import {
 import type { SymbolTable, ClassInfo, ObjectArrayMetadata } from "./symbol-table.js";
 import type { InterfaceStructGenerator } from "../types/interface-struct-generator.js";
 
-interface FieldInfo {
-  index: number;
-  type: string;
-  tsType?: string;
-}
+import type { FieldInfo } from "./type-resolver/types.js";
 
 interface ObjectInfo {
   ptr: string;
@@ -38,7 +34,7 @@ export interface AssignmentGeneratorContext {
   classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
   getAst(): AST | undefined;
   expectedArrayElementType: "string" | "number" | "boolean" | "pointer" | null;
@@ -231,7 +227,7 @@ export class AssignmentGenerator {
     let fieldType = "";
     let fieldTsType: string | null = null;
     if (fieldInfoResult) {
-      const fi = fieldInfoResult as { index: number; type: string; tsType?: string };
+      const fi = fieldInfoResult as FieldInfo;
       fieldIndex = fi.index;
       fieldType = fi.type;
       if (fi.tsType !== null && fi.tsType !== undefined) {
@@ -388,7 +384,7 @@ export class AssignmentGenerator {
     value: string,
     memberAccessValue: MemberAccessAssignmentNode,
   ): void {
-    const fi = fieldInfo as { index: number; type: string; tsType?: string };
+    const fi = fieldInfo as FieldInfo;
     const fiType = fi.type;
 
     if (fiType === null || fiType === undefined) {
@@ -577,7 +573,7 @@ export class AssignmentGenerator {
     if (arrayExprObj.type === "this" && currentClass) {
       const fieldInfo = this.ctx.classGenGetFieldInfo(currentClass, arrayExpr.property);
       if (fieldInfo) {
-        const fi = fieldInfo as { index: number; type: string; tsType: string };
+        const fi = fieldInfo as FieldInfo;
         if (fi.type === "string[]") {
           arrayType = "%StringArray";
         } else if (fi.type.endsWith("[]")) {

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -44,7 +44,7 @@ import type {
   InterfaceStructInfo,
   InterfaceFieldInfo,
 } from "../types/interface-struct-generator.js";
-import type { TypeGuardInfo } from "./type-resolver/types.js";
+import type { TypeGuardInfo, FieldInfo } from "./type-resolver/types.js";
 import type { JsonObjectMeta } from "../expressions/access/member.js";
 import type { DiagnosticEngine } from "../../diagnostics/engine.js";
 import { TypeContext } from "./type-context.js";
@@ -57,7 +57,7 @@ export interface IClassGenContext {
   getFieldInfo(
     className: string,
     fieldName: string,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   getClassFields(className: string): { name: string; fieldType: string }[];
   getFieldType(className: string, fieldName: string): string | null;
   getFieldTsType(className: string, fieldName: string): string | null;
@@ -846,7 +846,7 @@ export interface IGeneratorContext {
   classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   classGenGetFieldType(className: string, fieldName: string): string | null;
   classGenGetFieldTsType(className: string, fieldName: string): string | null;
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
@@ -1768,7 +1768,7 @@ export class MockGeneratorContext implements IGeneratorContext {
     getFieldInfo: (
       _className: string,
       _fieldName: string,
-    ): { index: number; type: string; tsType?: string } | null => null,
+    ): FieldInfo | null => null,
     getClassFields: (_className: string): { name: string; fieldType: string }[] => [],
     getFieldType: (_className: string, _fieldName: string): string | null => null,
     getFieldTsType: (_className: string, _fieldName: string): string | null => null,
@@ -1785,7 +1785,7 @@ export class MockGeneratorContext implements IGeneratorContext {
   classGenGetFieldInfo(
     _className: string | null,
     _fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null {
+  ): FieldInfo | null {
     return null;
   }
   classGenGetFieldType(_className: string, _fieldName: string): string | null {

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -54,10 +54,7 @@ interface ExprBase {
 }
 
 export interface IClassGenContext {
-  getFieldInfo(
-    className: string,
-    fieldName: string,
-  ): FieldInfo | null;
+  getFieldInfo(className: string, fieldName: string): FieldInfo | null;
   getClassFields(className: string): { name: string; fieldType: string }[];
   getFieldType(className: string, fieldName: string): string | null;
   getFieldTsType(className: string, fieldName: string): string | null;
@@ -843,10 +840,7 @@ export interface IGeneratorContext {
    * Access to class generator for field type lookups
    */
   readonly classGen: IClassGenContext;
-  classGenGetFieldInfo(
-    className: string | null,
-    fieldName: string | null,
-  ): FieldInfo | null;
+  classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   classGenGetFieldType(className: string, fieldName: string): string | null;
   classGenGetFieldTsType(className: string, fieldName: string): string | null;
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
@@ -1765,10 +1759,7 @@ export class MockGeneratorContext implements IGeneratorContext {
   }
 
   classGen = {
-    getFieldInfo: (
-      _className: string,
-      _fieldName: string,
-    ): FieldInfo | null => null,
+    getFieldInfo: (_className: string, _fieldName: string): FieldInfo | null => null,
     getClassFields: (_className: string): { name: string; fieldType: string }[] => [],
     getFieldType: (_className: string, _fieldName: string): string | null => null,
     getFieldTsType: (_className: string, _fieldName: string): string | null => null,
@@ -1782,10 +1773,7 @@ export class MockGeneratorContext implements IGeneratorContext {
       _params: string[],
     ): string => "%mock_method_result",
   };
-  classGenGetFieldInfo(
-    _className: string | null,
-    _fieldName: string | null,
-  ): FieldInfo | null {
+  classGenGetFieldInfo(_className: string | null, _fieldName: string | null): FieldInfo | null {
     return null;
   }
   classGenGetFieldType(_className: string, _fieldName: string): string | null {

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -24,6 +24,7 @@ import { SymbolTable, SymbolKind } from "./symbol-table.js";
 import type { TypeChecker } from "../../typescript/type-checker.js";
 import type { ClassGenerator } from "../types/objects/class.js";
 import type { TypeResolver } from "./type-resolver/index.js";
+import type { FieldInfo } from "./type-resolver/types.js";
 import { stripNullable, parseMapTypeString } from "./type-system.js";
 import type { ResolvedType } from "./type-system.js";
 import type { TypeContext } from "./type-context.js";
@@ -57,7 +58,7 @@ export interface TypeInferenceContext {
   classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   classGenGetFieldType(className: string, fieldName: string): string | null;
   classGenGetFieldTsType(className: string, fieldName: string): string | null;
   typeResolver?: TypeResolver;
@@ -618,7 +619,7 @@ export class TypeInference {
             this.ctx.getCurrentClassName(),
             memberAccess.property,
           );
-          const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+          const fieldInfo = fieldInfoResult as FieldInfo;
           if (fieldInfoResult && fieldInfo.tsType) {
             const mapParsed = parseMapTypeString(fieldInfo.tsType);
             if (mapParsed) {

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -55,10 +55,7 @@ export interface TypeInferenceContext {
   typeChecker: TypeChecker | null;
   classGen: ClassGenerator | null;
   hasClassGen(): boolean;
-  classGenGetFieldInfo(
-    className: string | null,
-    fieldName: string | null,
-  ): FieldInfo | null;
+  classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   classGenGetFieldType(className: string, fieldName: string): string | null;
   classGenGetFieldTsType(className: string, fieldName: string): string | null;
   typeResolver?: TypeResolver;

--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -68,7 +68,7 @@ export interface TypeResolverContext {
   classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   hasClassGen(): boolean;
 }
 
@@ -516,7 +516,7 @@ export class TypeResolver {
             this.ctx.getCurrentClassName()!,
             member.property,
           );
-          const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+          const fieldInfo = fieldInfoResult as FieldInfo;
           if (fieldInfoResult && fieldInfo.tsType) {
             return fieldInfo.tsType;
           }
@@ -669,7 +669,7 @@ export class TypeResolver {
 
   getClassFieldMapType(className: string, fieldName: string): MapTypeInfo | null {
     const fieldInfoResult = this.getClassFieldInfo(className, fieldName);
-    const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+    const fieldInfo = fieldInfoResult as FieldInfo;
     if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
     const mapParsed = parseMapTypeString(fieldInfo.tsType);
@@ -694,7 +694,7 @@ export class TypeResolver {
 
   getClassFieldSetType(className: string, fieldName: string): SetTypeInfo | null {
     const fieldInfoResult = this.getClassFieldInfo(className, fieldName);
-    const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+    const fieldInfo = fieldInfoResult as FieldInfo;
     if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
     const setParsed = parseSetTypeString(fieldInfo.tsType);
@@ -931,7 +931,7 @@ export class TypeResolver {
       if (!currentCls) return null;
 
       const fieldInfoResult = this.getClassFieldInfo(currentCls, fieldName);
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
       const mapParsed = parseMapTypeString(fieldInfo.tsType);
@@ -1076,7 +1076,7 @@ export class TypeResolver {
     if (!currentClsSet) return null;
 
     const fieldInfoResult = this.getClassFieldInfo(currentClsSet, fieldName);
-    const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+    const fieldInfo = fieldInfoResult as FieldInfo;
     if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
     const setParsed = parseSetTypeString(fieldInfo.tsType);
@@ -1095,7 +1095,7 @@ export class TypeResolver {
       const currentClsKey = this.ctx.getCurrentClassName();
       if (!currentClsKey) return null;
       const fieldInfoResult = this.getClassFieldInfo(currentClsKey, memberExpr.property);
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
       const mapParsed = parseMapTypeString(fieldInfo.tsType);
@@ -1164,7 +1164,7 @@ export class TypeResolver {
     const currentClsSetVal = this.ctx.getCurrentClassName();
     if (!currentClsSetVal) return null;
     const fieldInfoResult = this.getClassFieldInfo(currentClsSetVal, memberExpr.property);
-    const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+    const fieldInfo = fieldInfoResult as FieldInfo;
     if (!fieldInfoResult || !fieldInfo.tsType) return null;
 
     const setParsed = parseSetTypeString(fieldInfo.tsType);

--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -65,10 +65,7 @@ export interface TypeResolverContext {
   currentClassName?: string | null;
   getCurrentClassName(): string | null;
   currentFunction?: string | null;
-  classGenGetFieldInfo(
-    className: string | null,
-    fieldName: string | null,
-  ): FieldInfo | null;
+  classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   hasClassGen(): boolean;
 }
 

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -281,9 +281,6 @@ export function canonicalTypeToLlvm(
     return "i8*";
   }
 
-  // native compiler string corruption produces garbage type strings (294+ per build)
-  // root cause: inline `as { name: string; type: string }` assertions on InterfaceField
-  // TODO: fix root cause by replacing inline assertions with named InterfaceField type
   return "i8*";
 }
 

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -203,10 +203,7 @@ export interface VariableAllocatorContext {
   emitWarning(message: string, loc?: SourceLocation, suggestion?: string): void;
   getAst(): AST | undefined;
   hasClassGen(): boolean;
-  classGenGetFieldInfo(
-    className: string | null,
-    fieldName: string | null,
-  ): FieldInfo | null;
+  classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
   readonly symbolTable: SymbolTable;
   setExpectedArrayElementType(type: "string" | "number" | "boolean" | "pointer" | null): void;
@@ -2556,9 +2553,7 @@ export class VariableAllocator {
     if (!objectType) return null;
 
     const classFieldInfo = this.ctx.classGenGetFieldInfo(objectType, memberAccess.property);
-    const classFieldTsType = classFieldInfo
-      ? (classFieldInfo as FieldInfo).tsType
-      : null;
+    const classFieldTsType = classFieldInfo ? (classFieldInfo as FieldInfo).tsType : null;
     const fieldType =
       this.getInterfaceFieldTypeByName(objectType, memberAccess.property) || classFieldTsType;
     if (!fieldType) return null;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -55,6 +55,7 @@ import {
 } from "./symbol-table.js";
 import type { TypeChecker } from "../../typescript/type-checker.js";
 import { TypeResolver, UnionCommonFields } from "./type-resolver/index.js";
+import type { FieldInfo } from "./type-resolver/types.js";
 import {
   stripOptional,
   stripNullable,
@@ -205,7 +206,7 @@ export interface VariableAllocatorContext {
   classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null;
+  ): FieldInfo | null;
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
   readonly symbolTable: SymbolTable;
   setExpectedArrayElementType(type: "string" | "number" | "boolean" | "pointer" | null): void;
@@ -1238,7 +1239,7 @@ export class VariableAllocator {
         memberExpr.property,
       );
       if (!fieldInfoResult) return null;
-      const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+      const fieldInfo = fieldInfoResult as FieldInfo;
       if (!fieldInfo.tsType) return null;
 
       const mapParsed = parseMapTypeString(fieldInfo.tsType);
@@ -1477,7 +1478,7 @@ export class VariableAllocator {
           this.ctx.getCurrentClassName()!,
           memberExpr.property,
         );
-        const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+        const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType) {
           const mapParsed = parseMapTypeString(fieldInfo.tsType);
           if (mapParsed && mapParsed.valueType) {
@@ -2556,7 +2557,7 @@ export class VariableAllocator {
 
     const classFieldInfo = this.ctx.classGenGetFieldInfo(objectType, memberAccess.property);
     const classFieldTsType = classFieldInfo
-      ? (classFieldInfo as { index: number; type: string; tsType: string }).tsType
+      ? (classFieldInfo as FieldInfo).tsType
       : null;
     const fieldType =
       this.getInterfaceFieldTypeByName(objectType, memberAccess.property) || classFieldTsType;
@@ -2595,7 +2596,7 @@ export class VariableAllocator {
       if (!memberObjBase || !memberObjBase.type) return null;
       if (memberObjBase.type === "this") {
         const fieldInfoResult = this.getThisFieldInfo(member.property);
-        const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+        const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType) {
           return fieldInfo.tsType;
         }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -88,6 +88,7 @@ import type { ResolvedType } from "./infrastructure/type-system.js";
 import { DiagnosticEngine } from "../diagnostics/engine.js";
 import { TypeContext } from "./infrastructure/type-context.js";
 import { IGeneratorContext, IArrowFunctionGenerator } from "./infrastructure/generator-context.js";
+import type { FieldInfo } from "./infrastructure/type-resolver/types.js";
 import { ArrayGenerator } from "./types/collections/array.js";
 import { StringGenerator } from "./types/collections/string.js";
 import { ObjectGenerator } from "./types/objects/object.js";
@@ -1306,7 +1307,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public classGenGetFieldInfo(
     className: string | null,
     fieldName: string | null,
-  ): { index: number; type: string; tsType?: string } | null {
+  ): FieldInfo | null {
     if (!className || !fieldName) return null;
     return this.classGen.getFieldInfo(className, fieldName);
   }

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -34,6 +34,7 @@ import {
   createObjectMetadataWithInterface,
 } from "../infrastructure/symbol-table.js";
 import type { UnionCommonFields } from "../infrastructure/type-resolver/index.js";
+import type { FieldInfo } from "../infrastructure/type-resolver/types.js";
 import { stripOptional } from "../infrastructure/type-system.js";
 
 interface ExprBase {
@@ -1875,7 +1876,7 @@ export class ControlFlowGenerator {
       const className = this.ctx.getCurrentClassName();
       if (memberObjBase.type === "this" && className) {
         const fieldInfoResult = this.ctx.classGenGetFieldInfo(className, memberExpr.property);
-        const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+        const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType && fieldInfo.tsType.startsWith("Set<string>")) {
           return true;
         }
@@ -1899,7 +1900,7 @@ export class ControlFlowGenerator {
       const className = this.ctx.getCurrentClassName();
       if (memberObjBase.type === "this" && className) {
         const fieldInfoResult = this.ctx.classGenGetFieldInfo(className, memberExpr.property);
-        const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+        const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType && fieldInfo.tsType.startsWith("Map<")) {
           return true;
         }
@@ -1922,7 +1923,7 @@ export class ControlFlowGenerator {
       const className = this.ctx.getCurrentClassName();
       if (memberObjBase.type === "this" && className) {
         const fieldInfoResult = this.ctx.classGenGetFieldInfo(className, memberExpr.property);
-        const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+        const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType && fieldInfo.tsType.startsWith("Map<")) {
           return true;
         }
@@ -2025,7 +2026,7 @@ export class ControlFlowGenerator {
           classNameForLookup,
           memberExpr.property,
         );
-        const fieldInfo = fieldInfoResult as { index: number; type: string; tsType: string };
+        const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType && fieldInfo.tsType.startsWith("Map<")) {
           const mapPtr = this.ctx.generateExpression(stmt.iterable, params);
           iterableValue = this.ctx.stringMapGen.generateStringMapEntries(mapPtr);

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -17,6 +17,7 @@ import {
   createClassMetadata,
 } from "../../infrastructure/symbol-table.js";
 import { stripOptional, canonicalTypeToLlvm } from "../../infrastructure/type-system.js";
+import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
 
 // ============================================
 // CLASS GENERATOR - Class and instance operations
@@ -300,7 +301,7 @@ export class ClassGenerator {
   getFieldType(className: string, fieldName: string): string | null {
     const info = this.getFieldInfo(className, fieldName);
     if (info) {
-      const infoTyped = info as { index: number; type: string; tsType: string };
+      const infoTyped = info as FieldInfo;
       return infoTyped.type;
     }
     return null;
@@ -310,7 +311,7 @@ export class ClassGenerator {
   getFieldTsType(className: string, fieldName: string): string | null {
     const info = this.getFieldInfo(className, fieldName);
     if (info) {
-      const infoTyped = info as { index: number; type: string; tsType: string };
+      const infoTyped = info as FieldInfo;
       return infoTyped.tsType || null;
     }
     return null;
@@ -560,7 +561,7 @@ export class ClassGenerator {
         if (paramIndex !== -1) {
           const fieldInfo = this.getFieldInfo(className, propName);
           if (fieldInfo) {
-            const fieldInfoTyped = fieldInfo as { index: number; type: string; tsType?: string };
+            const fieldInfoTyped = fieldInfo as FieldInfo;
             const fieldIndex = fieldInfoTyped.index;
             const paramAlloca = this.ctx.getVariableAlloca(propName);
             if (paramAlloca) {


### PR DESCRIPTION
## Summary
- Consolidates 3 duplicate `FieldInfo` interface definitions into 1 canonical export from `type-resolver/types.ts`
- Replaces 48 inline `{ index: number; type: string; tsType?: string }` type annotations across 14 files with `FieldInfo`
- Removes stale corruption comment in `type-system.ts` (root cause fixed in #162)

## Test plan
- [x] All 437 tests pass
- [x] verify:quick passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)