### PR TITLE
fix: throw on unrecognized types in canonicalTypeToLlvm

### DIFF
--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -281,7 +281,15 @@ export function canonicalTypeToLlvm(
     return "i8*";
   }
 
-  return "i8*";
+  for (let ci = 0; ci < tsType.length; ci++) {
+    if (tsType.charCodeAt(ci) < 32 || tsType.charCodeAt(ci) > 126) {
+      return "i8*";
+    }
+  }
+
+  throw new Error(
+    `canonicalTypeToLlvm: unrecognized type '${tsType}' (mode=${mode}, fieldName=${fieldName})`,
+  );
 }
 
 export function tsTypeToLlvmJson(tsType: string): string {


### PR DESCRIPTION
## Summary
- Replaces silent `return "i8*"` catch-all with `throw` for printable unrecognized types
- Keeps `i8*` fallback only for corrupted/non-printable strings from the native compiler
- Verified: zero hits on the catch-all from the JS compiler across all 437 tests + Stage 0

## Context
The catch-all was originally added to mask 294 corrupted type strings per build (fixed in #162). Now that the root cause is fixed, unrecognized printable types should be compile errors, not silent `i8*`.

## Test plan
- [x] All 437 tests pass
- [x] verify:quick passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)