### PR TITLE
fix: robust for...of support for nested arrays, class fields, and function returns

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -1347,14 +1347,17 @@ export class TypeInference {
     }
     if (e.type === "variable") {
       const resolved = this.resolveExpressionType(expr);
-      if (
-        resolved &&
-        resolved.arrayDepth > 0 &&
-        resolved.base !== "string" &&
-        resolved.base !== "number" &&
-        resolved.base !== "boolean"
-      ) {
-        return true;
+      if (resolved && resolved.arrayDepth > 0) {
+        if (resolved.arrayDepth > 1) {
+          return true;
+        }
+        if (
+          resolved.base !== "string" &&
+          resolved.base !== "number" &&
+          resolved.base !== "boolean"
+        ) {
+          return true;
+        }
       }
       return false;
     }
@@ -2209,7 +2212,7 @@ export class TypeInference {
     }
     if (e.type === "variable") {
       const resolved = this.resolveExpressionType(expr);
-      if (resolved && resolved.arrayDepth > 0 && resolved.base === "string") {
+      if (resolved && resolved.arrayDepth === 1 && resolved.base === "string") {
         return true;
       }
       return false;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -65,7 +65,7 @@ import {
   parseSetTypeString,
   parseArrayTypeString,
 } from "./type-system.js";
-import type { ResolvedType } from "./type-system.js";
+import { parseTypeString, type ResolvedType } from "./type-system.js";
 import { InterfaceAllocator } from "./interface-allocator.js";
 
 interface ExprBase {
@@ -981,8 +981,11 @@ export class VariableAllocator {
 
     this.ctx.setCurrentVarDeclKey(null);
 
-    if (resolved && !stmt.declaredType && !isNull) {
+    if (resolved && !isNull) {
       this.ctx.symbolTable.setResolvedType(stmt.name, resolved);
+    }
+    if (stmt.declaredType && !isNull) {
+      this.ctx.symbolTable.setResolvedType(stmt.name, parseTypeString(stmt.declaredType));
     }
 
     this.ctx.setExpectedArrayElementType(null);

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -84,7 +84,7 @@ import {
   mapReturnTypeToLLVM,
   mapParamTypeToLLVM,
 } from "./infrastructure/type-system.js";
-import type { ResolvedType } from "./infrastructure/type-system.js";
+import { parseTypeString, type ResolvedType } from "./infrastructure/type-system.js";
 import { DiagnosticEngine } from "../diagnostics/engine.js";
 import { TypeContext } from "./infrastructure/type-context.js";
 import { IGeneratorContext, IArrowFunctionGenerator } from "./infrastructure/generator-context.js";
@@ -2076,6 +2076,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             this.symbolTable.setRawInterfaceType(name, elementType);
           } else {
             this.defineVariable(name, `@${name}`, llvmType, kind, "global");
+          }
+          if (stmt.declaredType) {
+            this.symbolTable.setResolvedType(name, parseTypeString(stmt.declaredType));
           }
           continue;
         } else if (isArray) {

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -35,7 +35,7 @@ import {
 } from "../infrastructure/symbol-table.js";
 import type { UnionCommonFields } from "../infrastructure/type-resolver/index.js";
 import type { FieldInfo } from "../infrastructure/type-resolver/types.js";
-import { stripOptional } from "../infrastructure/type-system.js";
+import { stripOptional, createResolvedType } from "../infrastructure/type-system.js";
 
 interface ExprBase {
   type: string;
@@ -456,6 +456,18 @@ export class ControlFlowGenerator {
       arrayType = "%ObjectArray";
       elementType = "i8*";
       elementKind = SymbolKind.Object;
+      const iterableBase = forOfStmt.iterable as ExprBase;
+      if (iterableBase.type === "variable") {
+        const varName = (forOfStmt.iterable as VariableNode).name;
+        const sym = this.ctx.symbolTable.lookup(varName);
+        if (sym && sym.resolvedType && sym.resolvedType.arrayDepth > 1) {
+          if (sym.resolvedType.base === "string") {
+            elementKind = SymbolKind.StringArray;
+          } else if (sym.resolvedType.base === "number") {
+            elementKind = SymbolKind.Array;
+          }
+        }
+      }
     } else {
       arrayType = "%Array";
       elementType = "double";
@@ -473,10 +485,35 @@ export class ControlFlowGenerator {
     this.emit(`${indexAlloca} = alloca i32`);
     this.ctx.emitStore("i32", "0", indexAlloca);
 
-    const elemAlloca = this.ctx.nextAllocaReg(forOfStmt.variableName);
-    this.emit(`${elemAlloca} = alloca ${elementType}`);
+    let actualElementType = elementType;
+    if (elementKind === SymbolKind.StringArray) {
+      actualElementType = "%StringArray*";
+    } else if (elementKind === SymbolKind.Array && isObjectArray) {
+      actualElementType = "%Array*";
+    }
 
-    this.ctx.defineVariable(forOfStmt.variableName, elemAlloca, elementType, elementKind, "local");
+    const elemAlloca = this.ctx.nextAllocaReg(forOfStmt.variableName);
+    this.emit(`${elemAlloca} = alloca ${actualElementType}`);
+
+    this.ctx.defineVariable(
+      forOfStmt.variableName,
+      elemAlloca,
+      actualElementType,
+      elementKind,
+      "local",
+    );
+
+    if (elementKind === SymbolKind.StringArray) {
+      this.ctx.symbolTable.setResolvedType(
+        forOfStmt.variableName,
+        createResolvedType("string", {}, 1),
+      );
+    } else if (elementKind === SymbolKind.Array && isObjectArray) {
+      this.ctx.symbolTable.setResolvedType(
+        forOfStmt.variableName,
+        createResolvedType("number", {}, 1),
+      );
+    }
 
     const condLabel = this.nextLabel("forof_cond");
     const bodyLabel = this.nextLabel("forof_body");
@@ -528,8 +565,13 @@ export class ControlFlowGenerator {
     }
     const elemValue = this.ctx.emitLoad(elementType, elemPtr);
 
+    let storeValue = elemValue;
+    if (actualElementType !== elementType) {
+      storeValue = this.ctx.emitBitcast(elemValue, elementType, actualElementType);
+    }
+
     // Store in loop variable
-    this.ctx.emitStore(elementType, elemValue, elemAlloca);
+    this.ctx.emitStore(actualElementType, storeValue, elemAlloca);
 
     // Execute the loop body
     this.loopContinueLabels.push(updateLabel);
@@ -715,6 +757,46 @@ export class ControlFlowGenerator {
     if (iterable.type === "member_access") {
       const memberAccess = iterable as MemberAccessNode;
       const memberAccessObjBase = memberAccess.object as ExprBase;
+      if (memberAccessObjBase.type === "this") {
+        const className = this.ctx.getCurrentClassName();
+        if (className) {
+          const fieldTsType = this.ctx.classGenGetFieldTsType(className, memberAccess.property);
+          if (fieldTsType && fieldTsType.endsWith("[]")) {
+            const elementTypeName = fieldTsType.slice(0, -2).trim();
+            const elemIface = this.ctx.getInterfaceFromAST(elementTypeName);
+            if (elemIface) {
+              const elemIfaceTyped = elemIface as InterfaceDeclaration;
+              const allFields = this.ctx.getAllInterfaceFields(elemIfaceTyped);
+              const elementKeys: string[] = [];
+              const elementTypes: string[] = [];
+              const elementTsTypes: string[] = [];
+              for (let i = 0; i < allFields.length; i++) {
+                const fRaw = allFields[i];
+                if (!fRaw) continue;
+                const f = fRaw as InterfaceField;
+                if (!f.name || !f.type) continue;
+                elementKeys.push(f.name);
+                elementTsTypes.push(f.type);
+                if (f.type === "string") {
+                  elementTypes.push("i8*");
+                } else if (f.type === "number") {
+                  elementTypes.push("double");
+                } else if (f.type === "boolean") {
+                  elementTypes.push("i32");
+                } else {
+                  elementTypes.push("i8*");
+                }
+              }
+              return {
+                elementInterfaceName: elemIfaceTyped.name,
+                elementKeys,
+                elementTypes,
+                elementTsTypes,
+              };
+            }
+          }
+        }
+      }
       if (memberAccessObjBase.type === "variable") {
         const varName = (memberAccess.object as VariableNode).name;
         const propName = memberAccess.property;
@@ -838,6 +920,53 @@ export class ControlFlowGenerator {
       const methodCallInfo = this.getMethodCallArrayInfo(iterable as MethodCallNode);
       if (methodCallInfo) {
         return methodCallInfo;
+      }
+    }
+
+    if (iterable.type === "call") {
+      const callNode = iterable as { type: string; name: string };
+      const ast = this.ctx.getAst();
+      if (ast && ast.functions) {
+        for (let fi = 0; fi < ast.functions.length; fi++) {
+          const func = ast.functions[fi];
+          if (!func || func.name !== callNode.name) continue;
+          const retType = func.returnType;
+          if (retType && retType.endsWith("[]")) {
+            const elementTypeName = retType.slice(0, -2).trim();
+            const elemIface = this.ctx.getInterfaceFromAST(elementTypeName);
+            if (elemIface) {
+              const elemIfaceTyped = elemIface as InterfaceDeclaration;
+              const allFields = this.ctx.getAllInterfaceFields(elemIfaceTyped);
+              const elementKeys: string[] = [];
+              const elementTypes: string[] = [];
+              const elementTsTypes: string[] = [];
+              for (let ffi = 0; ffi < allFields.length; ffi++) {
+                const fRaw = allFields[ffi];
+                if (!fRaw) continue;
+                const f = fRaw as InterfaceField;
+                if (!f.name || !f.type) continue;
+                elementKeys.push(f.name);
+                elementTsTypes.push(f.type);
+                if (f.type === "string") {
+                  elementTypes.push("i8*");
+                } else if (f.type === "number") {
+                  elementTypes.push("double");
+                } else if (f.type === "boolean") {
+                  elementTypes.push("i32");
+                } else {
+                  elementTypes.push("i8*");
+                }
+              }
+              return {
+                elementInterfaceName: elemIfaceTyped.name,
+                elementKeys,
+                elementTypes,
+                elementTsTypes,
+              };
+            }
+          }
+          break;
+        }
       }
     }
 

--- a/tests/fixtures/control-flow/for-of-class-field.ts
+++ b/tests/fixtures/control-flow/for-of-class-field.ts
@@ -1,0 +1,51 @@
+interface Item {
+  name: string;
+  value: number;
+}
+
+class Container {
+  items: Item[] = [];
+
+  addItem(name: string, value: number): void {
+    this.items.push({ name: name, value: value });
+  }
+
+  sumValues(): number {
+    let sum = 0;
+    for (const item of this.items) {
+      sum = sum + item.value;
+    }
+    return sum;
+  }
+
+  getNames(): string {
+    let result = "";
+    for (const item of this.items) {
+      result = result + item.name + ",";
+    }
+    return result;
+  }
+}
+
+const c = new Container();
+c.addItem("a", 10);
+c.addItem("b", 20);
+c.addItem("c", 30);
+
+let passed = true;
+
+const sum = c.sumValues();
+if (sum !== 60) {
+  console.log("FAIL: sum expected 60 got " + sum);
+  passed = false;
+}
+
+const names = c.getNames();
+if (names !== "a,b,c,") {
+  console.log("FAIL: names expected 'a,b,c,' got '" + names + "'");
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/control-flow/for-of-continue.ts
+++ b/tests/fixtures/control-flow/for-of-continue.ts
@@ -1,0 +1,31 @@
+let passed = true;
+
+const nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+let evenSum = 0;
+for (const n of nums) {
+  if (n % 2 !== 0) {
+    continue;
+  }
+  evenSum = evenSum + n;
+}
+if (evenSum !== 30) {
+  console.log("FAIL: evenSum expected 30 got " + evenSum);
+  passed = false;
+}
+
+const words: string[] = ["hello", "", "world", "", "test"];
+let nonEmpty = "";
+for (const w of words) {
+  if (w === "") {
+    continue;
+  }
+  nonEmpty = nonEmpty + w + " ";
+}
+if (nonEmpty !== "hello world test ") {
+  console.log("FAIL: nonEmpty expected 'hello world test ' got '" + nonEmpty + "'");
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/control-flow/for-of-empty-array.ts
+++ b/tests/fixtures/control-flow/for-of-empty-array.ts
@@ -1,0 +1,38 @@
+let passed = true;
+
+const empty: number[] = [];
+let count = 0;
+for (const n of empty) {
+  count = count + 1;
+}
+if (count !== 0) {
+  console.log("FAIL: count expected 0 got " + count);
+  passed = false;
+}
+
+const emptyStrings: string[] = [];
+let strCount = 0;
+for (const s of emptyStrings) {
+  strCount = strCount + 1;
+}
+if (strCount !== 0) {
+  console.log("FAIL: strCount expected 0 got " + strCount);
+  passed = false;
+}
+
+interface Item {
+  name: string;
+}
+const emptyItems: Item[] = [];
+let itemCount = 0;
+for (const item of emptyItems) {
+  itemCount = itemCount + 1;
+}
+if (itemCount !== 0) {
+  console.log("FAIL: itemCount expected 0 got " + itemCount);
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/control-flow/for-of-method-call-body.ts
+++ b/tests/fixtures/control-flow/for-of-method-call-body.ts
@@ -1,0 +1,35 @@
+interface Animal {
+  name: string;
+  sound: string;
+}
+
+class Zoo {
+  animals: Animal[] = [];
+
+  add(name: string, sound: string): void {
+    this.animals.push({ name: name, sound: sound });
+  }
+
+  describe(a: Animal): string {
+    return a.name + " says " + a.sound;
+  }
+
+  describeAll(): string {
+    let result = "";
+    for (const animal of this.animals) {
+      result = result + this.describe(animal) + "; ";
+    }
+    return result;
+  }
+}
+
+const zoo = new Zoo();
+zoo.add("cat", "meow");
+zoo.add("dog", "woof");
+
+const desc = zoo.describeAll();
+if (desc === "cat says meow; dog says woof; ") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: got '" + desc + "'");
+}

--- a/tests/fixtures/control-flow/for-of-method-return.ts
+++ b/tests/fixtures/control-flow/for-of-method-return.ts
@@ -1,0 +1,53 @@
+interface Point {
+  x: number;
+  y: number;
+}
+
+function getPoints(): Point[] {
+  return [
+    { x: 1, y: 2 },
+    { x: 3, y: 4 },
+    { x: 5, y: 6 },
+  ];
+}
+
+function getNumbers(): number[] {
+  return [10, 20, 30];
+}
+
+function getStrings(): string[] {
+  return ["hello", "world"];
+}
+
+let passed = true;
+
+let sumX = 0;
+for (const p of getPoints()) {
+  sumX = sumX + p.x;
+}
+if (sumX !== 9) {
+  console.log("FAIL: sumX expected 9 got " + sumX);
+  passed = false;
+}
+
+let sumN = 0;
+for (const n of getNumbers()) {
+  sumN = sumN + n;
+}
+if (sumN !== 60) {
+  console.log("FAIL: sumN expected 60 got " + sumN);
+  passed = false;
+}
+
+let concat = "";
+for (const s of getStrings()) {
+  concat = concat + s;
+}
+if (concat !== "helloworld") {
+  console.log("FAIL: concat expected 'helloworld' got '" + concat + "'");
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/control-flow/for-of-nested.ts
+++ b/tests/fixtures/control-flow/for-of-nested.ts
@@ -1,6 +1,10 @@
 let passed = true;
 
-const matrix: number[][] = [[1, 2], [3, 4], [5, 6]];
+const matrix: number[][] = [
+  [1, 2],
+  [3, 4],
+  [5, 6],
+];
 let total = 0;
 for (const row of matrix) {
   for (const val of row) {
@@ -12,7 +16,10 @@ if (total !== 21) {
   passed = false;
 }
 
-const words: string[][] = [["hello", "world"], ["foo", "bar"]];
+const words: string[][] = [
+  ["hello", "world"],
+  ["foo", "bar"],
+];
 let allWords = "";
 for (const group of words) {
   for (const word of group) {

--- a/tests/fixtures/control-flow/for-of-nested.ts
+++ b/tests/fixtures/control-flow/for-of-nested.ts
@@ -1,0 +1,29 @@
+let passed = true;
+
+const matrix: number[][] = [[1, 2], [3, 4], [5, 6]];
+let total = 0;
+for (const row of matrix) {
+  for (const val of row) {
+    total = total + val;
+  }
+}
+if (total !== 21) {
+  console.log("FAIL: total expected 21 got " + total);
+  passed = false;
+}
+
+const words: string[][] = [["hello", "world"], ["foo", "bar"]];
+let allWords = "";
+for (const group of words) {
+  for (const word of group) {
+    allWords = allWords + word + " ";
+  }
+}
+if (allWords !== "hello world foo bar ") {
+  console.log("FAIL: allWords expected 'hello world foo bar ' got '" + allWords + "'");
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/control-flow/for-of-with-index.ts
+++ b/tests/fixtures/control-flow/for-of-with-index.ts
@@ -1,0 +1,17 @@
+let passed = true;
+
+const items: string[] = ["a", "b", "c", "d"];
+let idx = 0;
+let result = "";
+for (const item of items) {
+  result = result + idx + ":" + item + " ";
+  idx = idx + 1;
+}
+if (result !== "0:a 1:b 2:c 3:d ") {
+  console.log("FAIL: expected '0:a 1:b 2:c 3:d ' got '" + result + "'");
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Fix nested `for...of` on `string[][]` and `number[][]` — inner loop variables now get proper type tracking (`resolvedType`, `SymbolKind`, LLVM type) so the inner for...of correctly identifies them as StringArray/Array
- Fix `for...of` on `this.field` arrays (class field iteration) — `getObjectArrayInfo` now handles `this.` member access
- Fix `for...of` on function call returns — `getObjectArrayInfo` now resolves return types from AST function declarations
- Fix `isStringArrayExpression` to only match depth 1 (was matching any depth, causing `string[][]` to be misidentified)
- Fix `isObjectArrayExpression` to return true for depth > 1 (nested arrays are object arrays)
- Set `resolvedType` from `declaredType` in both global and local variable allocation paths
- 7 new test fixtures covering: nested arrays, class fields, function returns, continue, empty arrays, index tracking, method calls in body

## Test plan
- [x] All 444 tests pass
- [x] Self-hosting passes (Stage 0 + Stage 1)
- [x] `for-of-nested.ts` — nested `number[][]` and `string[][]`
- [x] `for-of-class-field.ts` — iterating `this.items`
- [x] `for-of-method-return.ts` — iterating function return value
- [x] `for-of-continue.ts`, `for-of-empty-array.ts`, `for-of-with-index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)