### PR TITLE
fix: replace remaining catch-all else branches in map/set dispatch

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -730,8 +730,10 @@ export class MethodCallGenerator {
               return this.ctx.stringMapGen.generateStringMapValues(mapAlloca);
             } else if (method === "keys") {
               return this.ctx.stringMapGen.generateStringMapKeys(mapAlloca);
-            } else {
+            } else if (method === "clear") {
               return this.ctx.stringMapGen.generateStringMapClear(mapAlloca);
+            } else {
+              return this.ctx.emitError(`Map<string, *>.${method}() is not supported`, expr.loc);
             }
           }
           return this.ctx.emitError(
@@ -922,8 +924,10 @@ export class MethodCallGenerator {
             return this.ctx.setGen.generateSetAdd(expr, params);
           } else if (method === "has") {
             return this.ctx.setGen.generateSetHas(expr, params);
-          } else {
+          } else if (method === "delete") {
             return this.ctx.setGen.generateSetDelete(expr, params);
+          } else {
+            return this.ctx.emitError(`Set.${method}() is not supported`, expr.loc);
           }
         }
       }


### PR DESCRIPTION
## Summary
- String map local variable dispatch had catch-all `else` that assumed `clear` — any unrecognized method would silently clear the map instead of erroring
- Numeric set dispatch had catch-all `else` that assumed `delete` — any unrecognized method would silently delete from the set instead of erroring
- Both now have explicit `method === "clear"` / `method === "delete"` checks with `emitError` fallback

Same class of bug fixed in PRs #149/#150 but these two spots were missed.

## Test plan
- [x] All 437 tests pass
- [x] Self-hosting passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)