### PR TITLE
fix: propagate resolvedtype for global variables

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2473,6 +2473,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
         this.globalVariables.set(name, { llvmType, kind, initialized: false });
         this.defineVariable(name, `@${name}`, llvmType, kind, "global");
+        if (stmt.declaredType) {
+          this.symbolTable.setResolvedType(name, parseTypeString(stmt.declaredType));
+        } else if (stmt.value) {
+          const resolved = this.typeInference.resolveExpressionType(stmt.value);
+          if (resolved) {
+            this.symbolTable.setResolvedType(name, resolved);
+          }
+        }
       }
     }
     if (ir.length > 0) {


### PR DESCRIPTION
## Summary
- Adds `setResolvedType` in the catch-all `defineVariable` path of `generateGlobalVariableDeclarations`
- Global variables that reach the catch-all (strings, numbers, booleans, regex, etc.) now have cached type info
- Uses `declaredType` (via `parseTypeString`) when available, falls back to expression type inference

## Test plan
- [x] 444/444 node tests pass
- [x] 444/444 native tests pass
- [x] Self-hosting chain passes (--quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)