### PR TITLE
fix: add missing setVariableType in map/set has/delete/size

### DIFF
--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -317,7 +317,7 @@ export class MapGenerator {
 
     this.ctx.emitLabel(endLabel);
     const result = this.ctx.emitLoad("double", resultReg);
-
+    this.ctx.setVariableType(result, "double");
     return result;
   }
 
@@ -385,15 +385,17 @@ export class MapGenerator {
 
     this.ctx.emitLabel(endLabel);
     const result = this.ctx.emitLoad("double", resultReg);
-
+    this.ctx.setVariableType(result, "double");
     return result;
   }
 
   generateMapSize(mapPtr: string): string {
-    // Get size field
     const sizeFieldPtr = this.nextTemp();
     this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
-    const size = this.ctx.emitLoad("i32", sizeFieldPtr);
+    const sizeI32 = this.ctx.emitLoad("i32", sizeFieldPtr);
+    const size = this.nextTemp();
+    this.emit(`${size} = sitofp i32 ${sizeI32} to double`);
+    this.ctx.setVariableType(size, "double");
     return size;
   }
 
@@ -832,7 +834,7 @@ export class StringMapGenerator {
 
     this.ctx.emitLabel(endLabel);
     const result = this.ctx.emitLoad("double", resultReg);
-
+    this.ctx.setVariableType(result, "double");
     return result;
   }
 
@@ -841,7 +843,10 @@ export class StringMapGenerator {
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
     );
-    const size = this.ctx.emitLoad("i32", sizeFieldPtr);
+    const sizeI32 = this.ctx.emitLoad("i32", sizeFieldPtr);
+    const size = this.nextTemp();
+    this.emit(`${size} = sitofp i32 ${sizeI32} to double`);
+    this.ctx.setVariableType(size, "double");
     return size;
   }
 
@@ -1031,7 +1036,7 @@ export class StringMapGenerator {
 
     this.ctx.emitLabel(endLabel);
     const result = this.ctx.emitLoad("double", resultReg);
-
+    this.ctx.setVariableType(result, "double");
     return result;
   }
 

--- a/src/codegen/types/collections/set.ts
+++ b/src/codegen/types/collections/set.ts
@@ -685,7 +685,10 @@ export class StringSetGenerator {
     this.emit(
       `${sizeFieldPtr} = getelementptr inbounds %StringSet, %StringSet* ${setPtr}, i32 0, i32 1`,
     );
-    const size = this.ctx.emitLoad("i32", sizeFieldPtr);
+    const sizeI32 = this.ctx.emitLoad("i32", sizeFieldPtr);
+    const size = this.nextTemp();
+    this.emit(`${size} = sitofp i32 ${sizeI32} to double`);
+    this.ctx.setVariableType(size, "double");
     return size;
   }
 }

--- a/src/codegen/types/collections/set.ts
+++ b/src/codegen/types/collections/set.ts
@@ -266,7 +266,7 @@ export class SetGenerator {
 
     this.ctx.emitLabel(endLabel);
     const result = this.ctx.emitLoad("double", resultReg);
-
+    this.ctx.setVariableType(result, "double");
     return result;
   }
 
@@ -369,6 +369,7 @@ export class SetGenerator {
 
     this.ctx.emitLabel(endLabel);
     const result = this.ctx.emitLoad("double", resultReg);
+    this.ctx.setVariableType(result, "double");
     return result;
   }
 }


### PR DESCRIPTION
## Summary
- 6 methods (`has`, `delete` on Set, Map, StringMap) returned double results without calling `setVariableType`, leaving downstream type queries blind
- 2 `size` methods (Map, StringMap) returned raw `i32` instead of converting to `double` via `sitofp` — inconsistent with `SetGenerator.generateSetSize` which already did the conversion correctly
- All 8 methods now properly call `setVariableType(result, "double")`

## Test plan
- [x] 444/444 node tests pass
- [x] 444/444 native tests pass
- [x] Self-hosting chain passes (--quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)