### PR TITLE
feat: add code coverage via c8

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,6 @@
+{
+  "include": ["dist/**"],
+  "exclude": ["dist/parser-native/**", "dist/chad-native*"],
+  "reporter": ["text", "html"],
+  "report-dir": "coverage"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ docs/.vitepress/dist/
 docs/.vitepress/cache/
 benchmarks/tools/httpbench
 .worktrees/
+
+# Coverage
+coverage/

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "test:parity": "npm run build && node --import tsx --test tests/ast-parity.test.ts",
     "verify": "bash scripts/verify.sh",
     "verify:quick": "bash scripts/verify.sh --quick",
+    "coverage": "CHADC_COMPILER='node dist/chad-node.js' c8 node --import tsx --test tests/compiler.test.ts tests/unit/symbol-table.test.ts tests/unit/type-system.test.ts",
+    "coverage:report": "c8 report",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky"
@@ -42,6 +44,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
     "date-fns": "^4.1.0",
+    "c8": "^11.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",


### PR DESCRIPTION
## Summary
- Adds `c8` as devDependency for V8-native code coverage
- `npm run coverage` — runs compiler tests with coverage, outputs text + HTML report
- `npm run coverage:report` — regenerates report from last run
- `.c8rc.json` configures includes/excludes (covers `dist/`, excludes `parser-native/`)
- Current baseline: **67% line coverage**

Key low-coverage areas to target:
| File | Coverage | Notes |
|------|----------|-------|
| map.ts | 39% | many untested Map paths |
| combine.ts | 34% | array concat/flat |
| search-predicate.ts | 42% | find/findIndex/some/every |
| object.ts | 55% | object literal codegen |
| treesitter.ts | 13% | tree-sitter integration |
| type-checker.ts | 22% | TS type checker |

## Test plan
- [x] `npm run coverage` produces text + HTML reports
- [x] format-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)