### PR TITLE
fix: replace silent 0.0 defaults with emitError for unresolved properties

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -2667,11 +2667,17 @@ export class MemberAccessGenerator {
         }
         return innerPtr;
       }
-      this.ctx.emitWarning(
-        `unresolved property '${prop}' on expression of type '${exprObjBase.type}' — defaulting to 0.0`,
+      if (exprObjBase.type === "type_assertion") {
+        this.ctx.emitWarning(
+          `unresolved property '${prop}' on type_assertion expression — defaulting to 0.0`,
+          expr.loc,
+        );
+        return "0.0";
+      }
+      return this.ctx.emitError(
+        `unresolved property '${prop}' on expression of type '${exprObjBase.type}'`,
         expr.loc,
       );
-      return "0.0";
     }
 
     const varName = (expr.object as VariableNode).name;

--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -276,10 +276,7 @@ export function handleLengthProperty(
   const exprObjBase = expr.object as ExprBase;
   const exprObjType = exprObjBase.type;
   if (exprObjType === null || exprObjType === undefined) {
-    return ctx.emitError(
-      `cannot access .length on expression with unknown type`,
-      expr.loc,
-    );
+    return ctx.emitError(`cannot access .length on expression with unknown type`, expr.loc);
   }
   if (
     exprObjType === "variable" &&

--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -276,7 +276,10 @@ export function handleLengthProperty(
   const exprObjBase = expr.object as ExprBase;
   const exprObjType = exprObjBase.type;
   if (exprObjType === null || exprObjType === undefined) {
-    return "0.0";
+    return ctx.emitError(
+      `cannot access .length on expression with unknown type`,
+      expr.loc,
+    );
   }
   if (
     exprObjType === "variable" &&


### PR DESCRIPTION
## Summary
- `handleLengthProperty` returned `"0.0"` when `expr.object.type` was null/undefined — now calls `emitError` to fail at compile time instead of silently producing wrong runtime behavior
- Non-variable member access fallback returned `"0.0"` with a warning for unresolved properties — now calls `emitError` (except `type_assertion` which is a known codegen gap, kept as warning)

## Context
These `return "0.0"` patterns mask bugs — code that accesses `.length` on an untyped expression or an unresolved property silently evaluates to 0 at runtime instead of failing at compile time.

## Test plan
- [x] 444/444 node tests pass
- [x] 444/444 native tests pass
- [x] Self-hosting chain passes (--quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)