### PR TITLE
fix: error on silent no-op member assignment for unresolved classes

### DIFF
--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -158,6 +158,11 @@ export class AssignmentGenerator {
 
     if (className) {
       this.handleClassFieldAssignment(object, className, property, memberAccessValue, params);
+    } else {
+      const objTypeName = (object as { type: string }).type || "unknown";
+      this.ctx.emitError(
+        `cannot assign to '${property}' — unable to determine class for object of type '${objTypeName}'`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- `obj.field = value` where `obj`'s class couldn't be determined silently compiled to NO code — the assignment was completely dropped
- Now calls `emitError` to fail at compile time instead of producing a binary with uninitialized fields
- Affects cases like: non-class/non-object variable member assignment, method call result member assignment

## Test plan
- [x] 444/444 node tests pass
- [x] 444/444 native tests pass
- [x] Self-hosting chain passes (--quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)