### PR TITLE
fix: replace silent returns with emitError in assignment codegen

### DIFF
--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -70,10 +70,7 @@ export class AssignmentGenerator {
     const stmtValueTyped = stmtValue as { type: string };
     const valueType = stmtValueTyped.type;
     if (valueType === null || valueType === undefined) {
-      return this.ctx.emitError(
-        "malformed assignment — value expression has no type",
-        stmt.loc,
-      );
+      return this.ctx.emitError("malformed assignment — value expression has no type", stmt.loc);
     }
     if (valueType !== "member_access_assignment") {
       return this.ctx.emitError("Invalid member access assignment format");
@@ -84,10 +81,7 @@ export class AssignmentGenerator {
     const objectTyped = object as { type: string };
     const objType = objectTyped.type;
     if (objType === null || objType === undefined) {
-      return this.ctx.emitError(
-        "malformed assignment — target object has no type",
-        stmt.loc,
-      );
+      return this.ctx.emitError("malformed assignment — target object has no type", stmt.loc);
     }
     const property = memberAccessValue.property;
 

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -70,7 +70,10 @@ export class AssignmentGenerator {
     const stmtValueTyped = stmtValue as { type: string };
     const valueType = stmtValueTyped.type;
     if (valueType === null || valueType === undefined) {
-      return;
+      return this.ctx.emitError(
+        "malformed assignment — value expression has no type",
+        stmt.loc,
+      );
     }
     if (valueType !== "member_access_assignment") {
       return this.ctx.emitError("Invalid member access assignment format");
@@ -81,7 +84,10 @@ export class AssignmentGenerator {
     const objectTyped = object as { type: string };
     const objType = objectTyped.type;
     if (objType === null || objType === undefined) {
-      return;
+      return this.ctx.emitError(
+        "malformed assignment — target object has no type",
+        stmt.loc,
+      );
     }
     const property = memberAccessValue.property;
 
@@ -455,10 +461,18 @@ export class AssignmentGenerator {
     params: string[],
   ): void {
     const elementInfo = this.getObjectArrayElementInfoForAssignment(indexAccess.object);
-    if (!elementInfo) return;
+    if (!elementInfo) {
+      return this.ctx.emitError(
+        `cannot assign to '${property}' — unable to determine element type for index access`,
+      );
+    }
 
     const propIndex = elementInfo.keys.indexOf(property);
-    if (propIndex === -1) return;
+    if (propIndex === -1) {
+      return this.ctx.emitError(
+        `unknown property '${property}' on array element — available properties: ${elementInfo.keys.join(", ")}`,
+      );
+    }
 
     const arrayPtr = this.ctx.generateExpression(indexAccess.object, params);
     const indexDouble = this.ctx.generateExpression(indexAccess.index, params);


### PR DESCRIPTION
## Summary
- Replace silent `return;` with `emitError()` in `assignment-generator.ts` for 4 error paths:
  - Malformed assignment value expression with no type (line 72)
  - Malformed assignment target object with no type (line 83)
  - Index access property assignment with unknown element type (line 453)
  - Index access property assignment with unknown property name (line 456)
- Keeps `handleObjectPropertyAssignment` silent return (line 171) — `isObject()` and `getObjectInfo()` aren't fully in sync, so erroring there breaks `ast.defaultExportName` assignments

## Test plan
- [x] 443/444 tests pass (1 pre-existing promise-race SIGKILL)
- [x] Self-hosting chain passes (quick mode)