### PR TITLE
fix: support Map<string, number> with value boxing/unboxing

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -717,7 +717,16 @@ export class MethodCallGenerator {
               return this.ctx.stringMapGen.generateStringMapSet(mapAlloca, keyValue, valueValue);
             } else if (method === "get") {
               const keyValue = this.ctx.generateExpression(expr.args[0], params);
-              return this.ctx.stringMapGen.generateStringMapGet(mapAlloca, keyValue);
+              const rawResult = this.ctx.stringMapGen.generateStringMapGet(mapAlloca, keyValue);
+              if (mapMeta.valueType === "number") {
+                const asI64 = this.ctx.nextTemp();
+                this.ctx.emit(`${asI64} = ptrtoint i8* ${rawResult} to i64`);
+                const asDouble = this.ctx.nextTemp();
+                this.ctx.emit(`${asDouble} = bitcast i64 ${asI64} to double`);
+                this.ctx.setVariableType(asDouble, "double");
+                return asDouble;
+              }
+              return rawResult;
             } else if (method === "has") {
               const keyValue = this.ctx.generateExpression(expr.args[0], params);
               return this.ctx.stringMapGen.generateStringMapHas(mapAlloca, keyValue);

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -84,7 +84,11 @@ import {
   mapReturnTypeToLLVM,
   mapParamTypeToLLVM,
 } from "./infrastructure/type-system.js";
-import { parseTypeString, type ResolvedType } from "./infrastructure/type-system.js";
+import {
+  parseTypeString,
+  parseMapTypeString,
+  type ResolvedType,
+} from "./infrastructure/type-system.js";
 import { DiagnosticEngine } from "../diagnostics/engine.js";
 import { TypeContext } from "./infrastructure/type-context.js";
 import { IGeneratorContext, IArrowFunctionGenerator } from "./infrastructure/generator-context.js";
@@ -2109,16 +2113,27 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
         } else if (isMap) {
           let isStringMap = false;
+          let mapValueType = "string";
           if (stmt.declaredType) {
             const dt = stmt.declaredType;
             if (dt.indexOf("Map<string") !== -1) {
               isStringMap = true;
+              const parsed = parseMapTypeString(dt);
+              if (parsed) mapValueType = parsed.valueType;
+            }
+          }
+          if (!isStringMap && stmt.value) {
+            const mapNode = stmt.value as MapNode;
+            if (mapNode.keyType === "string") {
+              isStringMap = true;
+              mapValueType = mapNode.valueType || "string";
             }
           }
           if (isStringMap) {
             llvmType = "%StringMap*";
             kind = SymbolKind.Map;
             defaultValue = "null";
+            const llvmValueType = mapValueType === "number" ? "double" : "i8*";
             ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
             this.globalVariables.set(name, { llvmType, kind, initialized: false });
             this.defineVariableWithMetadata(
@@ -2129,9 +2144,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               "global",
               createMapMetadataSymbol({
                 keyType: "string",
-                valueType: "string",
+                valueType: mapValueType,
                 llvmKeyType: "i8*",
-                llvmValueType: "i8*",
+                llvmValueType,
               }),
             );
             continue;

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -569,6 +569,29 @@ export class StringMapGenerator {
   }
 
   generateStringMapSet(mapPtr: string, keyValue: string, valueValue: string): string {
+    const valueType = this.ctx.getVariableType(valueValue);
+    let storedValue = valueValue;
+    if (valueType === "double") {
+      const asI64 = this.nextTemp();
+      this.emit(`${asI64} = bitcast double ${valueValue} to i64`);
+      storedValue = this.nextTemp();
+      this.emit(`${storedValue} = inttoptr i64 ${asI64} to i8*`);
+    } else if (valueType === "i64") {
+      const asDouble = this.nextTemp();
+      this.emit(`${asDouble} = sitofp i64 ${valueValue} to double`);
+      const asI64Bits = this.nextTemp();
+      this.emit(`${asI64Bits} = bitcast double ${asDouble} to i64`);
+      storedValue = this.nextTemp();
+      this.emit(`${storedValue} = inttoptr i64 ${asI64Bits} to i8*`);
+    } else if (valueType === "i1") {
+      const asDouble = this.nextTemp();
+      this.emit(`${asDouble} = uitofp i1 ${valueValue} to double`);
+      const asI64Bits = this.nextTemp();
+      this.emit(`${asI64Bits} = bitcast double ${asDouble} to i64`);
+      storedValue = this.nextTemp();
+      this.emit(`${storedValue} = inttoptr i64 ${asI64Bits} to i8*`);
+    }
+
     const keysFieldPtr = this.nextTemp();
     this.emit(
       `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
@@ -670,7 +693,7 @@ export class StringMapGenerator {
     this.ctx.emitLabel(foundLabel);
     const valElemPtrFound = this.nextTemp();
     this.emit(`${valElemPtrFound} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${slot}`);
-    this.ctx.emitStore("i8*", valueValue, valElemPtrFound);
+    this.ctx.emitStore("i8*", storedValue, valElemPtrFound);
     this.ctx.emitBr(endLabel);
 
     // Next probe slot
@@ -690,7 +713,7 @@ export class StringMapGenerator {
     this.ctx.emitStore("i8*", keyValue, keyInsertPtr);
     const valInsertPtr = this.nextTemp();
     this.emit(`${valInsertPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${insertSlot}`);
-    this.ctx.emitStore("i8*", valueValue, valInsertPtr);
+    this.ctx.emitStore("i8*", storedValue, valInsertPtr);
 
     const newSize = this.ctx.emitLoad("i32", sizeFieldPtr);
     const incSize = this.nextTemp();

--- a/tests/fixtures/data-structures/map-methods.ts
+++ b/tests/fixtures/data-structures/map-methods.ts
@@ -1,0 +1,42 @@
+function testMapMethods() {
+  const m = new Map<number, number>();
+  m.set(1, 10);
+  m.set(2, 20);
+  m.set(3, 30);
+
+  if (m.size !== 3) {
+    console.log("FAIL: size should be 3, got " + m.size);
+    return;
+  }
+
+  if (!m.has(2)) {
+    console.log("FAIL: has(2) should be true");
+    return;
+  }
+
+  if (m.has(99)) {
+    console.log("FAIL: has(99) should be false");
+    return;
+  }
+
+  m.delete(2);
+  if (m.has(2)) {
+    console.log("FAIL: has(2) should be false after delete");
+    return;
+  }
+
+  if (m.size !== 2) {
+    console.log("FAIL: size should be 2 after delete, got " + m.size);
+    return;
+  }
+
+  m.clear();
+  if (m.size !== 0) {
+    console.log("FAIL: size should be 0 after clear, got " + m.size);
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testMapMethods();

--- a/tests/fixtures/data-structures/map-string-keys.ts
+++ b/tests/fixtures/data-structures/map-string-keys.ts
@@ -1,0 +1,48 @@
+function testStringMap() {
+  const m = new Map<string, string>();
+  m.set("hello", "world");
+  m.set("foo", "bar");
+  m.set("baz", "qux");
+
+  if (m.size !== 3) {
+    console.log("FAIL: size should be 3, got " + m.size);
+    return;
+  }
+
+  const val = m.get("foo");
+  if (val !== "bar") {
+    console.log("FAIL: get('foo') should be 'bar', got " + val);
+    return;
+  }
+
+  if (!m.has("hello")) {
+    console.log("FAIL: has('hello') should be true");
+    return;
+  }
+
+  if (m.has("missing")) {
+    console.log("FAIL: has('missing') should be false");
+    return;
+  }
+
+  m.delete("foo");
+  if (m.has("foo")) {
+    console.log("FAIL: has('foo') should be false after delete");
+    return;
+  }
+
+  if (m.size !== 2) {
+    console.log("FAIL: size should be 2 after delete");
+    return;
+  }
+
+  m.clear();
+  if (m.size !== 0) {
+    console.log("FAIL: size should be 0 after clear");
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testStringMap();

--- a/tests/fixtures/data-structures/map-string-number.ts
+++ b/tests/fixtures/data-structures/map-string-number.ts
@@ -1,0 +1,32 @@
+function testStringNumberMap() {
+  const m = new Map<string, number>();
+  m.set("a", 1);
+  m.set("b", 2);
+  m.set("c", 3);
+
+  if (m.size !== 3) {
+    console.log("FAIL: size should be 3");
+    return;
+  }
+
+  const val = m.get("b");
+  if (val !== 2) {
+    console.log("FAIL: get('b') should be 2");
+    return;
+  }
+
+  if (!m.has("a")) {
+    console.log("FAIL: has('a') should be true");
+    return;
+  }
+
+  m.delete("c");
+  if (m.size !== 2) {
+    console.log("FAIL: size should be 2 after delete");
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testStringNumberMap();


### PR DESCRIPTION
## Summary
- `Map<string, number>` was completely broken — stored numeric values as raw i64/double into i8* slots, causing LLVM type errors or wrong values at runtime
- Added value boxing in `generateStringMapSet`: converts double/i64/i1 → double → bitcast to i64 → inttoptr to i8*
- Added value unboxing in method-calls.ts `get` path: ptrtoint i8* → i64 → bitcast to double when `mapMeta.valueType === "number"`
- Fixed global StringMap allocation to extract value type from MapNode (was hardcoded to "string")
- Added 3 new test fixtures: map-methods (has/delete/clear/size), map-string-keys (Map<string,string>), map-string-number (Map<string,number>)

## Test plan
- [x] 446/447 tests pass (1 pre-existing promise-race SIGKILL)
- [x] Self-hosting chain passes (quick mode)
- [x] New map-string-number fixture verifies set/get/has/delete/size all work correctly