### PR TITLE
fix: use correct struct type for stringmap .size dispatch

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -37,6 +37,7 @@ import type {
   IMapGenerator,
   IStringMapGenerator,
   ISetGenerator,
+  IStringSetGenerator,
   IResponseGenerator,
 } from "../../infrastructure/generator-context.js";
 import {
@@ -184,6 +185,7 @@ export interface MemberAccessGeneratorContext {
   readonly mapGen: IMapGenerator;
   readonly stringMapGen: IStringMapGenerator;
   readonly setGen: ISetGenerator;
+  readonly stringSetGen: IStringSetGenerator;
   readonly interfaceStructGen?: InterfaceStructGenerator;
   generateExpression(expr: Expression, params: string[]): string;
   readonly stringGen: IStringGenerator;

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -35,6 +35,7 @@ import {
 import type {
   IStringGenerator,
   IMapGenerator,
+  IStringMapGenerator,
   ISetGenerator,
   IResponseGenerator,
 } from "../../infrastructure/generator-context.js";
@@ -181,6 +182,7 @@ export interface MemberAccessGeneratorContext {
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
   readonly responseGen: IResponseGenerator;
   readonly mapGen: IMapGenerator;
+  readonly stringMapGen: IStringMapGenerator;
   readonly setGen: ISetGenerator;
   readonly interfaceStructGen?: InterfaceStructGenerator;
   generateExpression(expr: Expression, params: string[]): string;

--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -376,7 +376,12 @@ export function handleSizeProperty(
     return ctx.mapGen.generateMapSize(mapPtr);
   }
   if (exprObjType === "variable" && ctx.symbolTable.isSet((expr.object as VariableNode).name)) {
+    const varName = (expr.object as VariableNode).name;
+    const setValueType = ctx.symbolTable.getSetValueType(varName);
     const setPtr = ctx.generateExpression(expr.object, params);
+    if (setValueType === "string") {
+      return ctx.stringSetGen.generateStringSetSize(setPtr);
+    }
     return ctx.setGen.generateSetSize(setPtr);
   }
   if (exprObjType === "member_access") {
@@ -392,7 +397,9 @@ export function handleSizeProperty(
           fieldInfo.tsType.startsWith("Set<") || fieldInfo.tsType.indexOf("Set<") !== -1;
         if (isMap || isSet) {
           const ptr = ctx.generateExpression(expr.object, params);
-          if (isSet) {
+          if (isSet && fieldInfo.tsType.indexOf("Set<string") !== -1) {
+            return ctx.stringSetGen.generateStringSetSize(ptr);
+          } else if (isSet) {
             return ctx.setGen.generateSetSize(ptr);
           } else if (fieldInfo.tsType.indexOf("Map<string") !== -1) {
             return ctx.stringMapGen.generateStringMapSize(ptr);

--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -367,7 +367,12 @@ export function handleSizeProperty(
     return null;
   }
   if (exprObjType === "variable" && ctx.symbolTable.isMap((expr.object as VariableNode).name)) {
+    const varName = (expr.object as VariableNode).name;
+    const mapMeta = ctx.symbolTable.getMapMetadata(varName);
     const mapPtr = ctx.generateExpression(expr.object, params);
+    if (mapMeta && mapMeta.keyType === "string") {
+      return ctx.stringMapGen.generateStringMapSize(mapPtr);
+    }
     return ctx.mapGen.generateMapSize(mapPtr);
   }
   if (exprObjType === "variable" && ctx.symbolTable.isSet((expr.object as VariableNode).name)) {
@@ -389,6 +394,8 @@ export function handleSizeProperty(
           const ptr = ctx.generateExpression(expr.object, params);
           if (isSet) {
             return ctx.setGen.generateSetSize(ptr);
+          } else if (fieldInfo.tsType.indexOf("Map<string") !== -1) {
+            return ctx.stringMapGen.generateStringMapSize(ptr);
           } else {
             return ctx.mapGen.generateMapSize(ptr);
           }

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -691,32 +691,28 @@ export class MethodCallGenerator {
     if (method === "text" || method === "json") {
       const isLikelyResponse = this.isLikelyResponseExpression(expr);
       if (isLikelyResponse) {
-        try {
-          let responsePtr = this.ctx.generateExpression(expr.object, params);
+        let responsePtr = this.ctx.generateExpression(expr.object, params);
 
-          const objType = this.ctx.getVariableType(responsePtr);
-          if (objType === "i8*") {
-            const castPtr = this.ctx.nextTemp();
-            this.ctx.emit(`${castPtr} = bitcast i8* ${responsePtr} to %__FetchResponse*`);
-            responsePtr = castPtr;
-          }
+        const objType = this.ctx.getVariableType(responsePtr);
+        if (objType === "i8*") {
+          const castPtr = this.ctx.nextTemp();
+          this.ctx.emit(`${castPtr} = bitcast i8* ${responsePtr} to %__FetchResponse*`);
+          responsePtr = castPtr;
+        }
 
-          if (method === "text") {
-            return this.ctx.responseGen.generateText(responsePtr);
-          } else if (method === "json") {
-            this.ctx.setUsesJson(true);
-            if (expr.typeParameter) {
-              const typeName = expr.typeParameter;
-              const interfaceDefResult = getInterfaceFromAST(this.ctx, typeName);
-              if (interfaceDefResult) {
-                const interfaceDef = interfaceDefResult as InterfaceDefInfo;
-                return this.ctx.responseGen.generateTypedJson(responsePtr, typeName, interfaceDef);
-              }
+        if (method === "text") {
+          return this.ctx.responseGen.generateText(responsePtr);
+        } else if (method === "json") {
+          this.ctx.setUsesJson(true);
+          if (expr.typeParameter) {
+            const typeName = expr.typeParameter;
+            const interfaceDefResult = getInterfaceFromAST(this.ctx, typeName);
+            if (interfaceDefResult) {
+              const interfaceDef = interfaceDefResult as InterfaceDefInfo;
+              return this.ctx.responseGen.generateTypedJson(responsePtr, typeName, interfaceDef);
             }
-            return this.ctx.responseGen.generateJson(responsePtr);
           }
-        } catch (e) {
-          throw e;
+          return this.ctx.responseGen.generateJson(responsePtr);
         }
       }
     }

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -277,6 +277,7 @@ export interface IStringSetGenerator {
   generateStringSetAdd(setAlloca: string, valueValue: string): string;
   generateStringSetHas(setAlloca: string, valueValue: string): string;
   generateStringSetDelete(setAlloca: string, valueValue: string): string;
+  generateStringSetSize(setPtr: string): string;
 }
 
 export interface IPointerMapGenerator {
@@ -1989,6 +1990,7 @@ export class MockGeneratorContext implements IGeneratorContext {
       "%mock_string_set_has",
     generateStringSetDelete: (_setAlloca: string, _valueValue: string): string =>
       "%mock_string_set_delete",
+    generateStringSetSize: (_setPtr: string): string => "%mock_string_set_size",
   };
   pointerMapGen: IPointerMapGenerator = {
     generatePointerMapSet: (_mapPtr: string, _keyValue: string, _valueValue: string): string =>

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -250,6 +250,7 @@ export interface IStringMapGenerator {
   generateStringMapEntries(mapPtr: string): string;
   generateStringMapValues(mapPtr: string): string;
   generateStringMapKeys(mapPtr: string): string;
+  generateStringMapSize(mapPtr: string): string;
   generateEmptyStringMap(): string;
 }
 
@@ -1829,6 +1830,7 @@ export class MockGeneratorContext implements IGeneratorContext {
     generateStringMapEntries: (_mapPtr: string): string => "%mock_entries",
     generateStringMapValues: (_mapPtr: string): string => "%mock_values",
     generateStringMapKeys: (_mapPtr: string): string => "%mock_keys",
+    generateStringMapSize: (_mapPtr: string): string => "%mock_size",
     generateEmptyStringMap: (): string => "%mock_empty_map",
   };
 


### PR DESCRIPTION
## Summary
- `.size` on `Map<string, *>` variables now dispatches to `generateStringMapSize` (uses `%StringMap*`) instead of `generateMapSize` (uses `%Map*`). Same layout so it worked by luck, but technically wrong LLVM IR type.
- Same fix for `this.field.size` on `Map<string, *>` class fields
- Added `generateStringMapSize` to `IStringMapGenerator` interface
- Added `stringMapGen` to `MemberAccessGeneratorContext` for property handler access
- Removed no-op `try { ... } catch (e) { throw e; }` in response method dispatch

## Test plan
- [x] All 448 tests pass
- [x] Self-hosting passes (quick mode)
- [x] Existing map-string-keys.ts test covers `.size` on StringMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)