### PR TITLE
suppress macos linker warnings from boehm gc

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -486,11 +486,12 @@ export function compile(
   // Homebrew's clang can't find lld by short name on macOS CI runners.
   // Try ld.lld first (ELF-specific), fall back to lld (multicall binary, auto-detects format).
   const crossLinker = crossCompiling ? ` -fuse-ld=${findLLD()}` : "";
+  const suppressLdWarnings = targetIsMac ? " -Wl,-w" : "";
   // User-provided linker flags (--link-obj, --link-lib, --link-path)
   const userObjs = extraLinkObjs.length > 0 ? " " + extraLinkObjs.join(" ") : "";
   const userPaths = extraLinkPaths.map((p) => ` -L${p}`).join("");
   const userLibs = extraLinkLibs.map((l) => ` -l${l}`).join("");
-  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${cpSpawnObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
+  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${cpSpawnObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${suppressLdWarnings}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
   logger.info(` ${linkCmd}`);
   const linkStdio = logger.getLevel() >= LogLevel.Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -557,6 +557,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
   // Use full path because Homebrew clang can't find lld by short name.
   // Try ld.lld first (ELF-specific), fall back to lld (multicall binary, auto-detects format).
   const crossLinker = crossCompiling ? " -fuse-ld=" + findLLD() : "";
+  const suppressLdWarnings = isMac ? " -Wl,-w" : "";
 
   // User-provided linker flags (--link-obj, --link-lib, --link-path)
   let userLinkObjs = "";
@@ -608,6 +609,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
     staticFlag +
     crossTargetFlag +
     crossLinker +
+    suppressLdWarnings +
     " " +
     linkLibs +
     userLinkFlags;


### PR DESCRIPTION
## Summary
- Adds `-Wl,-w` on macOS to suppress deprecated `REFERENCED_DYNAMICALLY` linker warnings from Boehm GC's Mach exception handler symbols
- Applied to both `compiler.ts` (JS compiler) and `native-compiler-lib.ts` (native compiler)

## Test plan
- [x] All 448 tests pass
- [x] Self-hosting verification passes (verify:quick)