### PR TITLE
fix: add missing setvariabletype in array filter, map, reduce, some, every, includes, shift

### DIFF
--- a/src/codegen/stdlib/response.ts
+++ b/src/codegen/stdlib/response.ts
@@ -30,6 +30,7 @@ interface ResponseGeneratorContext {
   setVariableType(name: string, type: string): void;
   interfaceStructGen?: InterfaceStructGenerator;
   interfaceStructGenHasInterface(name: string): boolean;
+  setUsesJson(value: boolean): void;
 }
 
 export class ResponseGenerator {
@@ -68,7 +69,7 @@ export class ResponseGenerator {
    * @param responsePtr - LLVM register holding Response*
    */
   generateJson(responsePtr: string): string {
-    // Get the body string first
+    this.ctx.setUsesJson(true);
     const bodyPtr = this.generateText(responsePtr);
 
     // Parse JSON using cJSON library (same as JSON.parse())
@@ -117,6 +118,7 @@ export class ResponseGenerator {
    * @param interfaceDef - Interface definition with properties
    */
   generateTypedJson(responsePtr: string, typeName: string, interfaceDef: InterfaceDefInfo): string {
+    this.ctx.setUsesJson(true);
     const alreadyDefined = this.ctx.interfaceStructGen?.hasInterface(typeName);
 
     if (!this.generatedStructs.has(typeName) && !alreadyDefined) {

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -154,6 +154,7 @@ function generateNumericArrayFilter(
   gen.emitBr(checkLabel);
 
   gen.emitLabel(endLabel);
+  gen.setVariableType(resultArrayPtr, "%Array*");
   return resultArrayPtr;
 }
 
@@ -580,8 +581,7 @@ function generateStringArrayReduce(
   gen.emitBr(checkLabel);
 
   gen.emitLabel(endLabel);
-  const finalAcc = gen.nextTemp();
-  gen.emit(`${finalAcc} = load i8*, i8** ${accPtr}`);
+  const finalAcc = gen.emitLoad("i8*", accPtr);
   return finalAcc;
 }
 
@@ -737,6 +737,7 @@ function generateNumericArrayMap(
   gen.emitBr(checkLabel);
 
   gen.emitLabel(endLabel);
+  gen.setVariableType(resultArrayPtr, "%Array*");
   return resultArrayPtr;
 }
 

--- a/src/codegen/types/collections/array/reorder.ts
+++ b/src/codegen/types/collections/array/reorder.ts
@@ -236,6 +236,7 @@ function generateNumericArrayShift(gen: IGeneratorContext, arrayPtr: string): st
   gen.emitLabel(endLabel);
   const result = gen.nextTemp();
   gen.emit(`${result} = phi double [ 0.0, %${emptyLabel} ], [ ${firstElem}, %${notEmptyLabel} ]`);
+  gen.setVariableType(result, "double");
   return result;
 }
 

--- a/src/codegen/types/collections/array/search-predicate.ts
+++ b/src/codegen/types/collections/array/search-predicate.ts
@@ -289,6 +289,7 @@ function generateNumericArraySome(
   const resultI32 = gen.emitLoad("i32", resultPtr);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  gen.setVariableType(result, "double");
   return result;
 }
 
@@ -361,6 +362,7 @@ function generateStringArraySome(
   const resultI32 = gen.emitLoad("i32", resultPtr);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  gen.setVariableType(result, "double");
   return result;
 }
 
@@ -463,6 +465,7 @@ function generateNumericArrayEvery(
   const resultI32 = gen.emitLoad("i32", resultPtr);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  gen.setVariableType(result, "double");
   return result;
 }
 
@@ -535,6 +538,7 @@ function generateStringArrayEvery(
   const resultI32 = gen.emitLoad("i32", resultPtr);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  gen.setVariableType(result, "double");
   return result;
 }
 
@@ -628,6 +632,7 @@ function generateIntArrayIncludes(
   gen.emit(`${resultI32} = phi i32 [ 0, %${checkLabel} ], [ 1, %${foundLabel} ]`);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  gen.setVariableType(result, "double");
   return result;
 }
 
@@ -691,5 +696,6 @@ function generateStringArrayIncludes(
   gen.emit(`${resultI32} = phi i32 [ 0, %${checkLabel} ], [ 1, %${foundLabel} ]`);
   const result = gen.nextTemp();
   gen.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  gen.setVariableType(result, "double");
   return result;
 }


### PR DESCRIPTION
## Summary
- Add missing `setVariableType` calls for return values in 10 array method codegen functions
- Numeric `filter` and `map` were missing type tracking (`%Array*`), while their string counterparts had it
- `some`, `every`, `includes` (both numeric and string variants) returned `double` from raw `sitofp` without type tracking
- Numeric `shift` returned `double` from raw `phi` without type tracking
- String `reduce` used raw `emit` for load instead of `emitLoad` (which auto-tracks type)

These gaps mean downstream code can't determine the return type of these array operations, which can cause wrong IR when the result is used in assignments, parameter passing, or chained operations.

## Test plan
- [x] All 448 tests pass (node + native)
- [x] Self-hosting chain passes (--quick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)