### PR TITLE
fix: heap-allocate array structs in filter, map, split

### DIFF
--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -72,9 +72,9 @@ function generateNumericArrayFilter(
   const dataPtr = gen.nextTemp();
   gen.emit(`${dataPtr} = load double*, double** ${dataPtrField}`);
 
-  // Create result array (allocate with same capacity as input)
-  const resultArrayPtr = gen.nextTemp();
-  gen.emit(`${resultArrayPtr} = alloca %Array`);
+  // Create result array (heap-allocate so pointer survives if stored in class fields)
+  const resultArrayMem = gen.emitCall("i8*", "@GC_malloc", "i64 24");
+  const resultArrayPtr = gen.emitBitcast(resultArrayMem, "i8*", "%Array*");
 
   const doubleSize = 8;
   const lengthI64 = gen.nextTemp();
@@ -176,8 +176,8 @@ function generateStringArrayFilter(
   const dataPtr = gen.nextTemp();
   gen.emit(`${dataPtr} = load i8**, i8*** ${dataPtrField}`);
 
-  const resultArrayPtr = gen.nextTemp();
-  gen.emit(`${resultArrayPtr} = alloca %StringArray`);
+  const resultArrayMem = gen.emitCall("i8*", "@GC_malloc", "i64 24");
+  const resultArrayPtr = gen.emitBitcast(resultArrayMem, "i8*", "%StringArray*");
 
   const ptrSize = 8;
   const lengthI64 = gen.nextTemp();
@@ -673,9 +673,9 @@ function generateNumericArrayMap(
   const dataPtr = gen.nextTemp();
   gen.emit(`${dataPtr} = load double*, double** ${dataPtrField}`);
 
-  // Create result array with same length
-  const resultArrayPtr = gen.nextTemp();
-  gen.emit(`${resultArrayPtr} = alloca %Array`);
+  // Create result array with same length (heap-allocate for safety)
+  const resultArrayMem = gen.emitCall("i8*", "@GC_malloc", "i64 24");
+  const resultArrayPtr = gen.emitBitcast(resultArrayMem, "i8*", "%Array*");
 
   const doubleSize = 8;
   const lengthI64 = gen.nextTemp();
@@ -759,8 +759,8 @@ function generateStringArrayMapImpl(
   const dataPtr = gen.nextTemp();
   gen.emit(`${dataPtr} = load i8**, i8*** ${dataPtrField}`);
 
-  const resultArrayPtr = gen.nextTemp();
-  gen.emit(`${resultArrayPtr} = alloca %StringArray`);
+  const resultArrayMem = gen.emitCall("i8*", "@GC_malloc", "i64 24");
+  const resultArrayPtr = gen.emitBitcast(resultArrayMem, "i8*", "%StringArray*");
 
   const pointerSize = 8;
   const lengthI64 = gen.nextTemp();

--- a/src/codegen/types/collections/string/split.ts
+++ b/src/codegen/types/collections/string/split.ts
@@ -27,8 +27,8 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
 
   ctx.emitLabel(emptyDelimLabel);
 
-  const emptyArrPtr = ctx.nextTemp();
-  ctx.emit(`${emptyArrPtr} = alloca %StringArray`);
+  const emptyArrMem = ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+  const emptyArrPtr = ctx.emitBitcast(emptyArrMem, "i8*", "%StringArray*");
 
   const emptyDataSize = ctx.nextTemp();
   ctx.emit(`${emptyDataSize} = mul i32 ${strLenI32}, 8`);
@@ -158,8 +158,8 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   ctx.emitLabel(countEndLabel);
   const totalParts = ctx.emitLoad("i32", partCountPtr);
 
-  const arrayPtr = ctx.nextTemp();
-  ctx.emit(`${arrayPtr} = alloca %StringArray`);
+  const arrayMem = ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+  const arrayPtr = ctx.emitBitcast(arrayMem, "i8*", "%StringArray*");
 
   const dataSize = ctx.nextTemp();
   ctx.emit(`${dataSize} = mul i32 ${totalParts}, 8`);

--- a/tests/fixtures/arrays/filter-map-in-class.ts
+++ b/tests/fixtures/arrays/filter-map-in-class.ts
@@ -1,0 +1,29 @@
+class FilterStore {
+  filtered: number[];
+  mapped: string[];
+
+  constructor(items: number[]) {
+    this.filtered = items.filter((x: number): boolean => x > 2);
+    this.mapped = ["hello", "world", "test"].map(
+      (s: string): string => s + "!",
+    );
+  }
+
+  getFiltered(): number[] {
+    return this.filtered;
+  }
+
+  getMapped(): string[] {
+    return this.mapped;
+  }
+}
+
+const store = new FilterStore([1, 2, 3, 4, 5]);
+const f = store.getFiltered();
+const m = store.getMapped();
+
+if (f.length === 3 && f[0] === 3 && f[1] === 4 && f[2] === 5) {
+  if (m.length === 3 && m[0] === "hello!" && m[1] === "world!") {
+    console.log("TEST_PASSED");
+  }
+}

--- a/tests/fixtures/arrays/filter-map-in-class.ts
+++ b/tests/fixtures/arrays/filter-map-in-class.ts
@@ -4,9 +4,7 @@ class FilterStore {
 
   constructor(items: number[]) {
     this.filtered = items.filter((x: number): boolean => x > 2);
-    this.mapped = ["hello", "world", "test"].map(
-      (s: string): string => s + "!",
-    );
+    this.mapped = ["hello", "world", "test"].map((s: string): string => s + "!");
   }
 
   getFiltered(): number[] {

--- a/tests/fixtures/strings/split-in-class.ts
+++ b/tests/fixtures/strings/split-in-class.ts
@@ -1,0 +1,20 @@
+class Splitter {
+  parts: string[];
+
+  constructor(input: string, delim: string) {
+    this.parts = input.split(delim);
+  }
+
+  getFirst(): string {
+    return this.parts[0];
+  }
+
+  count(): number {
+    return this.parts.length;
+  }
+}
+
+const s = new Splitter("a,b,c", ",");
+if (s.count() === 3 && s.getFirst() === "a") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Replace `alloca %Array` / `alloca %StringArray` with `GC_malloc(24) + bitcast` in filter, map, and split codegen
- Same class of bug as the Set alloca fix (PR #146) — stack-allocated structs become dangling pointers when stored in class fields
- Affected: `generateNumericArrayFilter`, `generateStringArrayFilter`, `generateNumericArrayMap`, `generateStringArrayMapImpl`, `generateSplit` (both empty and normal paths)
- Added regression tests: `filter-map-in-class.ts` and `split-in-class.ts` that store results in class fields

## Test plan
- [x] All 450 tests pass (2 new)
- [x] Self-hosting (quick) passes
- [x] CI