### PR TITLE
bump version to 0.1.1-alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dependencies
 node_modules/
 
+# Generated
+src/version.ts
+
 # Build outputs
 dist/
 build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,16 @@ Or manually:
 
 New features have complex side effects that may not be caught by unit tests alone. A change that passes all tests can still break self-hosting. The Stage 2 test is the true verification — it proves the compiler's output is correct enough to compile itself.
 
+## Versioning & Releases
+
+Version is defined in one place: `package.json`. `npm run build` auto-generates `src/version.ts` via the `prebuild` script (`scripts/gen-version.js`). Both `chad-node.ts` and `chad-native.ts` import `VERSION` from there.
+
+To bump a version:
+1. Edit `version` in `package.json`
+2. `npm run build` (regenerates `src/version.ts`)
+3. Merge to main
+4. `git tag v<version> && git push origin v<version>` — CI creates a GitHub Release with binaries
+
 ## Stale Native Compiler
 
 After a rebase or merge that brings in new codegen features, `.build/chad` becomes stale — it was compiled

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chadscript",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha",
   "description": "A JavaScript to native code compiler using LLVM",
   "type": "module",
   "main": "dist/chad-node.js",
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "compile": "tsx src/chad-node.ts build",
+    "prebuild": "node scripts/gen-version.js",
     "build": "tsc",
     "test": "npm run test:node && npm run test:native",
     "test:node": "node scripts/test.js --node",

--- a/scripts/gen-version.js
+++ b/scripts/gen-version.js
@@ -1,0 +1,3 @@
+import { readFileSync, writeFileSync } from "fs";
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+writeFileSync("src/version.ts", `export const VERSION = "${pkg.version}";\n`);

--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -55,7 +55,7 @@ declare function cs_watch_loop(
   output_binary: string,
 ): void;
 
-const VERSION = "0.1.0";
+import { VERSION } from "./version.js";
 
 const parser = new ArgumentParser("chad", "compile TypeScript to native binaries via LLVM");
 // Color enabled unless NO_COLOR is set (https://no-color.org/) or TERM=dumb

--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -24,6 +24,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { execSync, spawn as spawnProc, ChildProcess } from "child_process";
 import { installTargetSDK, listInstalledSDKs, getSDKBaseDir } from "./cross-compile.js";
+import { VERSION } from "./version.js";
 
 const parser = new ArgumentParser("chad", "compile TypeScript to native binaries via LLVM");
 parser.setColorEnabled(process.stdout.isTTY === true);
@@ -88,13 +89,7 @@ parser.addPositional("input", "Input .ts or .js file");
 parser.parse(process.argv.slice(2));
 
 if (parser.getFlag("version")) {
-  const packageJsonPath = path.join(import.meta.dirname || process.cwd(), "..", "package.json");
-  try {
-    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-    console.log(`chad ${pkg.version}`);
-  } catch {
-    console.log("chad 0.1.0");
-  }
+  console.log(`chad ${VERSION}`);
   process.exit(0);
 }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -11,6 +11,7 @@ import { AST, ImportDeclaration, ClassNode, FunctionNode } from "./ast/types.js"
 import { LogLevel, logger } from "./utils/logger.js";
 import { TargetInfo, resolveTarget, getHostTarget, isCrossCompiling } from "./target.js";
 import { loadTargetSDK, ensureTargetSDK, TargetSDK } from "./cross-compile.js";
+import { VERSION } from "./version.js";
 
 function findLLVMTool(name: string): string {
   const candidates = [
@@ -159,12 +160,7 @@ export function compile(
   const target = targetOverride || getHostTarget();
   const crossCompiling = isCrossCompiling(target);
 
-  // Get version from package.json
-  const packageJsonPath = path.join(process.cwd(), "package.json");
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-  const version = packageJson.version;
-
-  logger.info(`ChadScript compiler version ${version}`);
+  logger.info(`ChadScript compiler version ${VERSION}`);
   logger.info(`Target: ${target.archString}-${target.platformString}`);
   if (crossCompiling) {
     logger.info(`Cross-compiling for ${target.triple}`);


### PR DESCRIPTION
## Summary
- single source of truth for version: `package.json`
- `scripts/gen-version.js` generates `src/version.ts` at build time (via `prebuild` script)
- `chad-node.ts`, `chad-native.ts`, and `compiler.ts` all import from `src/version.ts`
- removed runtime package.json reads and hardcoded version strings

## Release process
1. bump version in `package.json`
2. run `npm run build` (auto-generates `src/version.ts`)
3. merge to main
4. tag: `git tag v0.1.1-alpha && git push origin v0.1.1-alpha`
5. CI creates github release with binaries