### PR TITLE
add pr workflow and description guidelines to claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ monitor CI, and merge when green. You have push access to feature branches and m
 
 **Never push to main directly.** Always go through PRs.
 
+PR descriptions should be **user-centric** — lead with how the change affects users (better error messages,
+fewer crashes, new capabilities), not just technical implementation details.
+
 ## Testing & Commit Workflow
 
 After completing each todo:


### PR DESCRIPTION
## Summary
Makes it easier for AI agents to work autonomously on ChadScript by documenting:
- The full PR workflow (create worktree → push → create PR → monitor CI → merge)
- That PR descriptions should focus on how changes affect users, not just technical details

No code changes — just documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)