### PR TITLE
fix: eliminate oob array access in function parameter counting

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -182,15 +182,8 @@ export class FunctionGenerator {
     } else {
       const hasParameters = func.parameters ? true : false;
       if (hasParameters) {
-        let paramCount = 0;
         const paramsArr = func.parameters;
-        if (paramsArr) {
-          let idx = 0;
-          while (paramsArr[idx]) {
-            paramCount = paramCount + 1;
-            idx = idx + 1;
-          }
-        }
+        const paramCount = paramsArr ? paramsArr.length : 0;
         if (paramCount > 0) {
           const entryTypes: string[] = [];
           const entryNames: string[] = [];


### PR DESCRIPTION
## Summary

- The compiler used `while (arr[idx])` to count function parameters, which accesses index 0 of an empty array when a function has no parameters. In JavaScript this silently returns `undefined`, but with runtime bounds checking enabled this becomes a crash.
- Replaced with direct `.length` check — simpler and correct for all cases.

## What this means for users

Previously, enabling full bounds checking (for string/object arrays) would cause the compiler itself to crash when compiling any code containing parameterless functions. This fix eliminates one of the compiler's own out-of-bounds array accesses, bringing us closer to enabling bounds checking across all array types.

## Test plan

- [x] All 451 compiler tests pass
- [x] Self-hosting Stage 0 + Stage 1 pass
- [x] Verified parameterless function compilation works with bounds checking enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)