### PR TITLE
fix: detect for...of on strings and emit compile error

### DIFF
--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -435,6 +435,14 @@ export class ControlFlowGenerator {
       return this.generateMapEntriesForOf(stmt, params);
     }
 
+    const isStringIterable = this.ctx.isStringExpression(forOfStmt.iterable);
+    if (isStringIterable) {
+      return this.ctx.emitError(
+        "for...of on strings is not yet supported — use a for loop with str[i] or str.charCodeAt(i) instead",
+        stmt.loc,
+      );
+    }
+
     const iterableValue = this.ctx.generateExpression(forOfStmt.iterable, params);
 
     const isStringArray = this.ctx.isStringArrayExpression(forOfStmt.iterable);


### PR DESCRIPTION
## Summary

- `for (const ch of someString)` previously generated invalid LLVM IR that treated string characters as `double` array elements, causing SIGILL (illegal instruction) crashes at runtime
- Now emits a clear compile-time error: `for...of on strings is not yet supported — use a for loop with str[i] or str.charCodeAt(i) instead`

## What this means for users

If you try `for (const ch of myString)`, you'll now get a helpful error pointing to the exact line with a suggested workaround, instead of a mysterious crash when running the compiled binary.

## Test plan

- [x] All 451 compiler tests pass
- [x] Self-hosting Stage 0 + Stage 1 pass
- [x] Verified error message shows for `for...of` on string variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)