### PR TITLE
fix: replace 16 stack traces with compile errors for property/variable access failures

### DIFF
--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -18,6 +18,7 @@ interface ObjectMetaBasic {
 }
 import type { SymbolTable } from "../../infrastructure/symbol-table.js";
 import type { IStringGenerator } from "../../infrastructure/generator-context.js";
+import type { SourceLocation } from "../../../ast/types.js";
 
 export interface IndexAccessGeneratorContext {
   nextTemp(): string;
@@ -36,6 +37,7 @@ export interface IndexAccessGeneratorContext {
   readonly stringGen: IStringGenerator;
   ensureDouble(value: string): string;
   setUsesJson(value: boolean): void;
+  emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
 }
 
 /**
@@ -384,8 +386,9 @@ export class IndexAccessGenerator {
       index = this.ctx.nextTemp();
       this.ctx.emit(`${index} = trunc i64 ${indexDouble} to i32`);
     } else if (indexType !== "i32" && indexType !== "i64") {
-      throw new Error(
+      return this.ctx.emitError(
         `String character index must be a number, got type: ${indexType}. Dynamic object property access with string keys is not yet supported.`,
+        expr.loc,
       );
     }
 
@@ -654,7 +657,7 @@ export class IndexAccessGenerator {
       }
     }
 
-    throw new Error("Index access assignment only supported for arrays and objects");
+    return this.ctx.emitError("Index access assignment only supported for arrays and objects", expr.loc);
   }
 
   private generateStringArrayAssignment(
@@ -779,12 +782,12 @@ export class IndexAccessGenerator {
     const keyValue = this.ctx.generateExpression(expr.index, params);
     const keyType = this.ctx.getVariableType(keyValue);
     if (keyType !== "i8*" && !this.ctx.isStringExpression(expr.index)) {
-      throw new Error(`Dynamic object property access requires a string key, got: ${keyType}`);
+      return this.ctx.emitError(`Dynamic object property access requires a string key, got: ${keyType}`, expr.loc);
     }
 
     const objAlloca = this.ctx.getVariableAlloca(varName);
     if (!objAlloca) {
-      throw new Error(`Cannot find alloca for object '${varName}'`);
+      return this.ctx.emitError(`Cannot find alloca for object '${varName}'`, expr.loc);
     }
     const objPtr = this.ctx.nextTemp();
     this.ctx.emit(`${objPtr} = load i8*, i8** ${objAlloca}`);
@@ -879,12 +882,12 @@ export class IndexAccessGenerator {
     const keyValue = this.ctx.generateExpression(expr.index, params);
     const keyType = this.ctx.getVariableType(keyValue);
     if (keyType !== "i8*" && !this.ctx.isStringExpression(expr.index)) {
-      throw new Error(`Dynamic object property write requires a string key, got: ${keyType}`);
+      return this.ctx.emitError(`Dynamic object property write requires a string key, got: ${keyType}`, expr.loc);
     }
 
     const objAlloca = this.ctx.getVariableAlloca(varName);
     if (!objAlloca) {
-      throw new Error(`Cannot find alloca for object '${varName}'`);
+      return this.ctx.emitError(`Cannot find alloca for object '${varName}'`, expr.loc);
     }
     const objPtr = this.ctx.nextTemp();
     this.ctx.emit(`${objPtr} = load i8*, i8** ${objAlloca}`);

--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -657,7 +657,10 @@ export class IndexAccessGenerator {
       }
     }
 
-    return this.ctx.emitError("Index access assignment only supported for arrays and objects", expr.loc);
+    return this.ctx.emitError(
+      "Index access assignment only supported for arrays and objects",
+      expr.loc,
+    );
   }
 
   private generateStringArrayAssignment(
@@ -782,7 +785,10 @@ export class IndexAccessGenerator {
     const keyValue = this.ctx.generateExpression(expr.index, params);
     const keyType = this.ctx.getVariableType(keyValue);
     if (keyType !== "i8*" && !this.ctx.isStringExpression(expr.index)) {
-      return this.ctx.emitError(`Dynamic object property access requires a string key, got: ${keyType}`, expr.loc);
+      return this.ctx.emitError(
+        `Dynamic object property access requires a string key, got: ${keyType}`,
+        expr.loc,
+      );
     }
 
     const objAlloca = this.ctx.getVariableAlloca(varName);
@@ -882,7 +888,10 @@ export class IndexAccessGenerator {
     const keyValue = this.ctx.generateExpression(expr.index, params);
     const keyType = this.ctx.getVariableType(keyValue);
     if (keyType !== "i8*" && !this.ctx.isStringExpression(expr.index)) {
-      return this.ctx.emitError(`Dynamic object property write requires a string key, got: ${keyType}`, expr.loc);
+      return this.ctx.emitError(
+        `Dynamic object property write requires a string key, got: ${keyType}`,
+        expr.loc,
+      );
     }
 
     const objAlloca = this.ctx.getVariableAlloca(varName);

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -752,7 +752,7 @@ export class MemberAccessGenerator {
       }
     }
     if (propIndex === -1) {
-      throw new Error(`Property '${expr.property}' not found in interface ${structTypeName}`);
+      return this.ctx.emitError(`Property '${expr.property}' not found in interface ${structTypeName}`, expr.loc);
     }
 
     const propField = interfaceDef.properties[propIndex] as InterfaceProperty;
@@ -958,8 +958,9 @@ export class MemberAccessGenerator {
       this.ctx.emit(`${value} = load double, double* ${fieldPtr}`);
       return value;
     } else {
-      throw new Error(
+      return this.ctx.emitError(
         `Field '${expr.property}' not found in class ${className}. Did you forget to declare it with a type annotation?`,
+        expr.loc,
       );
     }
   }
@@ -2294,8 +2295,9 @@ export class MemberAccessGenerator {
     const propIndex = keys.indexOf(expr.property);
     if (propIndex === -1) {
       const objDesc = exprObjType === "variable" ? (expr.object as VariableNode).name : "literal";
-      throw new Error(
+      return this.ctx.emitError(
         `Unknown property: ${expr.property} on object ${objDesc}. Available properties: ${keys.join(", ")}`,
+        expr.loc,
       );
     }
 
@@ -2405,8 +2407,9 @@ export class MemberAccessGenerator {
         const field = allFields2328[i] as { name: string; type: string };
         fieldNames.push(field.name);
       }
-      throw new Error(
+      return this.ctx.emitError(
         `Unknown property: ${expr.property} on interface ${valueType}. Available properties: ${fieldNames.join(", ")}`,
+        expr.loc,
       );
     }
 
@@ -3130,7 +3133,7 @@ export class MemberAccessGenerator {
   ): string {
     const interfaceInfo = this.ctx.interfaceStructGen?.getInterfaceStruct(interfaceType);
     if (!interfaceInfo) {
-      throw new Error(`Interface ${interfaceType} not found in interface struct generator`);
+      return this.ctx.emitError(`Interface ${interfaceType} not found in interface struct generator`);
     }
 
     let propIndex: number = -1;
@@ -3161,7 +3164,7 @@ export class MemberAccessGenerator {
     const structType = `%${interfaceType}`;
     const varPtr = this.ctx.getVariableAlloca(varName);
     if (!varPtr) {
-      throw new Error(`Variable ${varName} not found in symbol table`);
+      return this.ctx.emitError(`Variable ${varName} not found in symbol table`);
     }
 
     const objPtrRaw = this.ctx.nextTemp();
@@ -3229,7 +3232,7 @@ export class MemberAccessGenerator {
 
     const interfaceInfo = this.ctx.interfaceStructGen?.getInterfaceStruct(interfaceType);
     if (!interfaceInfo) {
-      throw new Error(`Interface ${interfaceType} not found in interface struct generator`);
+      return this.ctx.emitError(`Interface ${interfaceType} not found in interface struct generator`);
     }
 
     let propIndex: number = -1;

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -752,7 +752,10 @@ export class MemberAccessGenerator {
       }
     }
     if (propIndex === -1) {
-      return this.ctx.emitError(`Property '${expr.property}' not found in interface ${structTypeName}`, expr.loc);
+      return this.ctx.emitError(
+        `Property '${expr.property}' not found in interface ${structTypeName}`,
+        expr.loc,
+      );
     }
 
     const propField = interfaceDef.properties[propIndex] as InterfaceProperty;
@@ -3133,7 +3136,9 @@ export class MemberAccessGenerator {
   ): string {
     const interfaceInfo = this.ctx.interfaceStructGen?.getInterfaceStruct(interfaceType);
     if (!interfaceInfo) {
-      return this.ctx.emitError(`Interface ${interfaceType} not found in interface struct generator`);
+      return this.ctx.emitError(
+        `Interface ${interfaceType} not found in interface struct generator`,
+      );
     }
 
     let propIndex: number = -1;
@@ -3232,7 +3237,9 @@ export class MemberAccessGenerator {
 
     const interfaceInfo = this.ctx.interfaceStructGen?.getInterfaceStruct(interfaceType);
     if (!interfaceInfo) {
-      return this.ctx.emitError(`Interface ${interfaceType} not found in interface struct generator`);
+      return this.ctx.emitError(
+        `Interface ${interfaceType} not found in interface struct generator`,
+      );
     }
 
     let propIndex: number = -1;

--- a/src/codegen/expressions/access/struct-access.ts
+++ b/src/codegen/expressions/access/struct-access.ts
@@ -26,7 +26,7 @@ export function accessObjectWithMetadata(
 
   const varPtr = ctx.getVariableAlloca(varName);
   if (!varPtr) {
-    throw new Error(`Variable ${varName} not found in symbol table`);
+    return ctx.emitError(`Variable ${varName} not found in symbol table`);
   }
 
   const objPtr = ctx.nextTemp();

--- a/src/codegen/expressions/operators/unary.ts
+++ b/src/codegen/expressions/operators/unary.ts
@@ -73,7 +73,7 @@ export class UnaryExpressionGenerator {
     const varName = operandVar.name;
     const allocaReg = this.ctx.getVariableAlloca(varName);
     if (!allocaReg) {
-      throw new Error(`Cannot find alloca for variable: ${varName}`);
+      return this.ctx.emitError(`Cannot find alloca for variable: ${varName}`);
     }
 
     const varLlvmType = this.ctx.getVariableType(varName) || "double";
@@ -117,7 +117,7 @@ export class UnaryExpressionGenerator {
     const varName = operandVarPre.name;
     const allocaReg = this.ctx.getVariableAlloca(varName);
     if (!allocaReg) {
-      throw new Error(`Cannot find alloca for variable: ${varName}`);
+      return this.ctx.emitError(`Cannot find alloca for variable: ${varName}`);
     }
 
     const varLlvmType = this.ctx.getVariableType(varName) || "double";


### PR DESCRIPTION
## Summary
- When users access a non-existent property on an object, class, or interface, they now get a clear compile error with file/line info instead of an ugly Node.js stack trace
- Same improvement for index access errors (wrong key type, unsupported assignment targets) and unary operator errors (increment/decrement on undeclared variables)
- 16 `throw new Error` calls converted to `emitError()` across 4 files: `member.ts`, `index.ts`, `struct-access.ts`, `unary.ts`

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)