### PR TITLE
fix: replace 18 more stack traces with compile errors across codegen

### DIFF
--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -103,11 +103,9 @@ export function handleConcat(
         }
       }
     }
-    throw new Error(
-      `concat() was dispatched to string handler but received an array type '${ptrType}'.\n` +
-        `  This indicates isArrayExpression/isStringArrayExpression/isObjectArrayExpression failed to detect the array.\n` +
-        `  ${details}\n` +
-        `  Check type tracking for this expression.`,
+    return ctx.emitError(
+      `concat() was dispatched to string handler but received an array type '${ptrType}'. Check type tracking for this expression.`,
+      expr.loc,
     );
   }
 
@@ -435,11 +433,9 @@ export function handleStringIncludes(
       ptrType === "%ObjectArray*" ||
       ptrType.endsWith("Array*"))
   ) {
-    throw new Error(
-      `includes() was dispatched to string handler but received an array type '${ptrType}'.\n` +
-        `  This indicates isArrayExpression/isStringArrayExpression failed to detect the array.\n` +
-        `  Expression type: ${expr.object.type}\n` +
-        `  Check type tracking for this expression.`,
+    return ctx.emitError(
+      `includes() was dispatched to string handler but received an array type '${ptrType}'. Check type tracking for this expression.`,
+      expr.loc,
     );
   }
 
@@ -452,12 +448,9 @@ export function handleStringIncludes(
       const mc = expr.object as MethodCallNode;
       details += `, method: ${mc.method}`;
     }
-    throw new Error(
-      `includes() called on expression with unknown type.\n` +
-        `  Result register: ${strPtr}, type: ${ptrType || "undefined"}\n` +
-        `  ${details}\n` +
-        `  If this is an array, isArrayExpression/isStringArrayExpression is not detecting it.\n` +
-        `  Fix type tracking to ensure proper dispatch.`,
+    return ctx.emitError(
+      `includes() called on expression with unknown type (${details}). If this is an array, the type tracker is not detecting it.`,
+      expr.loc,
     );
   }
 
@@ -484,11 +477,9 @@ export function handleSlice(
       ptrType === "%ObjectArray*" ||
       ptrType.endsWith("Array*"))
   ) {
-    throw new Error(
-      `slice() was dispatched to string handler but received an array type '${ptrType}'.\n` +
-        `  This indicates isArrayExpression/isStringArrayExpression/isObjectArrayExpression failed to detect the array.\n` +
-        `  Expression type: ${expr.object.type}\n` +
-        `  Check type tracking for this expression.`,
+    return ctx.emitError(
+      `slice() was dispatched to string handler but received an array type '${ptrType}'. Check type tracking for this expression.`,
+      expr.loc,
     );
   }
 
@@ -501,12 +492,9 @@ export function handleSlice(
       const mc = expr.object as MethodCallNode;
       details += `, method: ${mc.method}`;
     }
-    throw new Error(
-      `slice() called on expression with unknown type.\n` +
-        `  Result register: ${strPtr}, type: ${ptrType || "undefined"}\n` +
-        `  ${details}\n` +
-        `  If this is an array, isArrayExpression/isStringArrayExpression/isObjectArrayExpression is not detecting it.\n` +
-        `  Fix type tracking to ensure proper dispatch.`,
+    return ctx.emitError(
+      `slice() called on expression with unknown type (${details}). If this is an array, the type tracker is not detecting it.`,
+      expr.loc,
     );
   }
 

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1429,7 +1429,9 @@ export class VariableAllocator {
       const methodExpr = stmt.value as MethodCallNode;
       className = this.getMapGetClassName(methodExpr) || "Unknown";
     } else {
-      throw new Error(`Cannot allocate class instance for expression type: ${valueBase.type}`);
+      return this.ctx.emitError(
+        `Cannot allocate class instance for expression type: ${valueBase.type}`,
+      );
     }
 
     const fields = this.ctx.classGenGetClassFields(className);
@@ -2376,7 +2378,9 @@ export class VariableAllocator {
         const captureItem = captures[i] as CaptureInfo;
         const allocaReg = this.ctx.symbolTable.getAlloca(captureItem.name);
         if (!allocaReg) {
-          throw new Error(`Closure capture error: variable '${captureItem.name}' not found`);
+          return this.ctx.emitError(
+            `Closure capture error: variable '${captureItem.name}' not found`,
+          );
         }
 
         const valueReg = this.ctx.nextTemp();

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -3102,7 +3102,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
     const allocaReg = this.getVariableAlloca(stmtName);
     if (!allocaReg) {
-      throw new Error(`Unknown variable: ${stmtName}`);
+      this.emitError(`Unknown variable: ${stmtName}`);
     }
     const varType = this.getVariableType(stmtName) || "double";
     const valueType = this.getVariableType(value);
@@ -3179,7 +3179,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
     const allocaReg = this.getVariableAlloca(stmtName);
     if (!allocaReg) {
-      throw new Error(`Unknown variable: ${stmtName}`);
+      this.emitError(`Unknown variable: ${stmtName}`);
     }
     const varType = this.getVariableType(stmtName) || "double";
     const valueType = this.getVariableType(value);
@@ -3448,7 +3448,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         this.currentDeclaredInterfaceType = undefined;
 
         if (!lastValue || lastValue === "") {
-          throw new Error(
+          this.emitError(
             `Return statement generated empty value for function ${this.currentFunction}`,
           );
         }

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -36,7 +36,7 @@ export class MapGenerator {
   generateMapLiteral(expr: Expression, params: string[]): string {
     const mapExpr = expr as MapNode;
     if (mapExpr.type !== "map") {
-      throw new Error("Expected map literal");
+      return this.ctx.emitError("Expected map literal");
     }
 
     const entries = mapExpr.entries || [];

--- a/src/codegen/types/collections/set.ts
+++ b/src/codegen/types/collections/set.ts
@@ -31,7 +31,7 @@ export class SetGenerator {
   generateSetLiteral(expr: Expression, params: string[]): string {
     const setExpr = expr as SetNode;
     if (setExpr.type !== "set") {
-      throw new Error("Expected set literal");
+      return this.ctx.emitError("Expected set literal");
     }
 
     // Allocate Set struct on heap so it's safe to store in class fields

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -65,7 +65,7 @@ export class ClassGenerator {
   }
 
   private fieldToLlvmType(f: ClassField): string {
-    if (!f) throw new Error("fieldToLlvmType called with null/undefined field");
+    if (!f) return this.ctx.emitError("fieldToLlvmType called with null/undefined field");
     const ft = f.fieldType;
     let ts = f.tsType;
     if (ts && ts.indexOf(" | ") !== -1) {
@@ -104,7 +104,9 @@ export class ClassGenerator {
         return "i8*";
       }
       if (ft === "double") return "double";
-      throw new Error(`fieldToLlvmType: field '${f.name}' has no fieldType and no tsType`);
+      return this.ctx.emitError(
+        `fieldToLlvmType: field '${f.name}' has no fieldType and no tsType`,
+      );
     }
     if (ft === "string") {
       return "i8*";
@@ -140,7 +142,7 @@ export class ClassGenerator {
         return "i8*";
       }
     }
-    throw new Error(
+    return this.ctx.emitError(
       `fieldToLlvmType: unrecognized field type '${ft}' with no tsType for field '${f.name}'`,
     );
   }
@@ -1064,7 +1066,7 @@ export class ClassGenerator {
   ): string {
     const methodInfoResult = this.getMethodInfo(className, methodName);
     if (!methodInfoResult) {
-      throw new Error(`Method ${methodName} not found in class ${className}`);
+      return this.ctx.emitError(`Method ${methodName} not found in class ${className}`);
     }
     const methodInfo = methodInfoResult as { method: ClassMethod; ownerClass: string };
     const method = methodInfo.method as ClassMethod;
@@ -1204,7 +1206,7 @@ export class ClassGenerator {
   ): string {
     const methodInfoResult = this.getMethodInfo(className, methodName);
     if (!methodInfoResult) {
-      throw new Error(`Static method ${methodName} not found in class ${className}`);
+      return this.ctx.emitError(`Static method ${methodName} not found in class ${className}`);
     }
     const methodInfo = methodInfoResult as { method: ClassMethod; ownerClass: string };
     const method = methodInfo.method as ClassMethod;

--- a/src/codegen/types/objects/object.ts
+++ b/src/codegen/types/objects/object.ts
@@ -31,7 +31,7 @@ export class ObjectGenerator {
 
   generateObjectLiteral(expr: Expression, params: string[]): string {
     if (expr.type !== "object") {
-      throw new Error("Expected object literal");
+      return this.ctx.emitError("Expected object literal");
     }
     const objExpr = expr as ObjectNode;
 


### PR DESCRIPTION
## Summary
- When users hit type dispatch errors, class method/field not found, closure capture failures, or unknown variables, they now get clear compile errors with context instead of Node.js stack traces
- 18 `throw new Error` calls converted to `emitError()` across 7 files: `string-methods.ts`, `class.ts`, `map.ts`, `set.ts`, `object.ts`, `variable-allocator.ts`, `llvm-generator.ts`

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)