### PR TITLE
docs: fix incorrect process.exit() requirement in claude skill

### DIFF
--- a/lib/skill.md
+++ b/lib/skill.md
@@ -78,7 +78,7 @@ Combine with `ChadScript.embedDir("./public")` and `ChadScript.serveEmbedded(req
 - **No `node_modules` imports** — only built-in modules and local files
 - **No `any` type** — all values must have a concrete type
 - **Closures capture by value** — mutating a variable after it's captured in a closure won't update the closure's copy
-- **`process.exit()` is required** at the end of synchronous programs (no implicit exit)
+- Programs exit implicitly — `process.exit()` is only needed to exit early with a specific code
 - **Generics use type erasure** — `T` becomes `i8*` (opaque pointer), numeric type params not supported
 - **Union types** limited to members with the same LLVM representation
 


### PR DESCRIPTION
## Summary
- The skill doc incorrectly stated that `process.exit()` is required at the end of synchronous programs
- The compiler generates `ret i32 0` at the end of `main()`, so programs exit implicitly
- Updated to say `process.exit()` is only needed to exit early with a specific code

🤖 Generated with [Claude Code](https://claude.com/claude-code)