### PR TITLE
fix: add missing setvariabletype in array reduce and numeric find

### DIFF
--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -511,6 +511,7 @@ function generateNumericArrayReduce(
 
   gen.emitLabel(endLabel);
   const finalAcc = gen.emitLoad("double", accPtr);
+  gen.setVariableType(finalAcc, "double");
   return finalAcc;
 }
 
@@ -585,6 +586,7 @@ function generateStringArrayReduce(
 
   gen.emitLabel(endLabel);
   const finalAcc = gen.emitLoad("i8*", accPtr);
+  gen.setVariableType(finalAcc, "i8*");
   return finalAcc;
 }
 

--- a/src/codegen/types/collections/array/search-predicate.ts
+++ b/src/codegen/types/collections/array/search-predicate.ts
@@ -115,6 +115,7 @@ function generateNumericArrayFind(
 
   gen.emitLabel(endLabel);
   const result = gen.emitLoad("double", resultPtr);
+  gen.setVariableType(result, "double");
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Array `reduce()` (both numeric and string variants) and numeric `find()` were missing `setVariableType` calls on their return values
- This caused downstream type tracking to lose track of what type the result is, which can lead to wrong codegen when the result is used in further operations

## Changes
- `iteration.ts`: Added `setVariableType` for `generateNumericArrayReduce` (double) and `generateStringArrayReduce` (i8*)
- `search-predicate.ts`: Added `setVariableType` for `generateNumericArrayFind` (double)

## Test plan
- [x] All 451 compiler tests pass
- [x] Self-hosting Stage 0 + Stage 1 pass