### PR TITLE
feat: compile error for uninitialized class fields

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -131,6 +131,7 @@ import type { TargetInfo } from "../target-types.js";
 import { checkClosureMutations } from "../semantic/closure-mutation-checker.js";
 import { checkUnionTypes } from "../semantic/union-type-checker.js";
 import { checkTypeAssertions } from "../semantic/type-assertion-checker.js";
+import { checkUninitializedFields } from "../semantic/uninitialized-field-checker.js";
 import { analyzeEscapes } from "../semantic/escape-analysis.js";
 
 export interface SemaSymbolData {
@@ -2538,6 +2539,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     checkClosureMutations(this.ast);
     checkUnionTypes(this.ast);
     checkTypeAssertions(this.ast);
+    checkUninitializedFields(this.ast);
     this.stackEligibleVars = analyzeEscapes(this.ast);
 
     const irParts: string[] = [];

--- a/src/semantic/uninitialized-field-checker.ts
+++ b/src/semantic/uninitialized-field-checker.ts
@@ -1,0 +1,177 @@
+import type {
+  AST,
+  ClassNode,
+  ClassMethod,
+  ClassField,
+  Statement,
+  AssignmentStatement,
+  IfStatement,
+  WhileStatement,
+  DoWhileStatement,
+  ForStatement,
+  ForOfStatement,
+  TryStatement,
+  SwitchStatement,
+  MemberAccessAssignmentNode,
+} from "../ast/types.js";
+
+export function checkUninitializedFields(ast: AST): void {
+  const checker = new UninitializedFieldChecker();
+  checker.check(ast);
+}
+
+class UninitializedFieldChecker {
+  check(ast: AST): void {
+    for (let i = 0; i < ast.classes.length; i++) {
+      this.checkClass(ast.classes[i]);
+    }
+  }
+
+  private checkClass(cls: ClassNode): void {
+    if (cls.fields.length === 0) return;
+
+    const uninitializedFields: ClassField[] = [];
+    for (let i = 0; i < cls.fields.length; i++) {
+      const field = cls.fields[i];
+      if (field.isStatic) continue;
+      if (field.initializer) continue;
+      if (field.tsType) continue;
+      if (field.fieldType !== "string" && field.fieldType !== "double") continue;
+      uninitializedFields.push(field);
+    }
+    if (uninitializedFields.length === 0) return;
+
+    const assignedNames: string[] = [];
+
+    const constructor = this.findConstructor(cls);
+
+    const paramPropNames: string[] = [];
+    if (constructor) {
+      this.walkStatements(constructor.body.statements, assignedNames);
+      if (constructor.parameterProperties) {
+        for (let i = 0; i < constructor.parameterProperties.length; i++) {
+          paramPropNames.push(constructor.parameterProperties[i]);
+        }
+      }
+    }
+
+    for (let i = 0; i < cls.methods.length; i++) {
+      if (!cls.methods[i].isConstructor) {
+        this.walkStatements(cls.methods[i].body.statements, assignedNames);
+      }
+    }
+
+    const stillUninitialized: ClassField[] = [];
+    for (let i = 0; i < uninitializedFields.length; i++) {
+      const field = uninitializedFields[i];
+      if (this.arrayContains(assignedNames, field.name)) continue;
+      if (this.arrayContains(paramPropNames, field.name)) continue;
+      stillUninitialized.push(field);
+    }
+
+    if (stillUninitialized.length > 0) {
+      this.emitErrors(cls, stillUninitialized);
+    }
+  }
+
+  private arrayContains(arr: string[], name: string): boolean {
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i] === name) return true;
+    }
+    return false;
+  }
+
+  private findConstructor(cls: ClassNode): ClassMethod | null {
+    for (let i = 0; i < cls.methods.length; i++) {
+      if (cls.methods[i].isConstructor) return cls.methods[i];
+    }
+    return null;
+  }
+
+  private walkStatements(stmts: Statement[], assigned: string[]): void {
+    for (let i = 0; i < stmts.length; i++) {
+      this.walkStatement(stmts[i], assigned);
+    }
+  }
+
+  private walkStatement(stmt: Statement, assigned: string[]): void {
+    if (!stmt) return;
+    const s = stmt as { type: string };
+
+    if (s.type === "assignment") {
+      const assign = stmt as AssignmentStatement;
+      if (assign.name && assign.name.startsWith("__member_access__")) {
+        const maNode = assign.value as MemberAccessAssignmentNode;
+        if (
+          maNode &&
+          maNode.type === "member_access_assignment" &&
+          maNode.object &&
+          (maNode.object as { type: string }).type === "this"
+        ) {
+          assigned.push(maNode.property);
+        }
+      }
+    } else if (s.type === "if") {
+      const ifStmt = stmt as IfStatement;
+      this.walkStatements(ifStmt.thenBlock.statements, assigned);
+      if (ifStmt.elseBlock) {
+        this.walkStatements(ifStmt.elseBlock.statements, assigned);
+      }
+    } else if (s.type === "while") {
+      const w = stmt as WhileStatement;
+      this.walkStatements(w.body.statements, assigned);
+    } else if (s.type === "do_while") {
+      const dw = stmt as DoWhileStatement;
+      this.walkStatements(dw.body.statements, assigned);
+    } else if (s.type === "for") {
+      const f = stmt as ForStatement;
+      this.walkStatements(f.body.statements, assigned);
+    } else if (s.type === "for_of") {
+      const fo = stmt as ForOfStatement;
+      this.walkStatements(fo.body.statements, assigned);
+    } else if (s.type === "try") {
+      const t = stmt as TryStatement;
+      this.walkStatements(t.tryBlock.statements, assigned);
+      if (t.catchBody) this.walkStatements(t.catchBody.statements, assigned);
+      if (t.finallyBlock) this.walkStatements(t.finallyBlock.statements, assigned);
+    } else if (s.type === "switch") {
+      const sw = stmt as SwitchStatement;
+      for (let i = 0; i < sw.cases.length; i++) {
+        this.walkStatements(sw.cases[i].consequent, assigned);
+      }
+    }
+  }
+
+  private emitErrors(cls: ClassNode, fields: ClassField[]): void {
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i];
+      const loc = cls.loc;
+      if (loc) {
+        const file = loc.file || "<unknown>";
+        const line = loc.line || 0;
+        const col = loc.column || 0;
+        console.log(
+          file +
+            ":" +
+            String(line) +
+            ":" +
+            String(col) +
+            ": error: class '" +
+            cls.name +
+            "' has uninitialized field '" +
+            field.name +
+            "' — assign a value in the field declaration or constructor",
+        );
+      } else {
+        console.log(
+          "error: class '" +
+            cls.name +
+            "' has uninitialized field '" +
+            field.name +
+            "' — assign a value in the field declaration or constructor",
+        );
+      }
+    }
+    process.exit(1);
+  }
+}

--- a/tests/fixtures/classes/initialized-field-constructor.ts
+++ b/tests/fixtures/classes/initialized-field-constructor.ts
@@ -1,0 +1,16 @@
+// @test-description: class with field initialized in constructor compiles fine
+
+class Person {
+  name: string;
+  age: number;
+
+  constructor(n: string, a: number) {
+    this.name = n;
+    this.age = a;
+  }
+}
+
+const p = new Person("Alice", 30);
+if (p.name === "Alice" && p.age === 30) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/classes/uninitialized-field.ts
+++ b/tests/fixtures/classes/uninitialized-field.ts
@@ -1,0 +1,9 @@
+// @test-compile-error: uninitialized field 'name'
+// @test-description: compile error for uninitialized class field
+
+class Broken {
+  name: string;
+}
+
+const b = new Broken();
+console.log(b.name);


### PR DESCRIPTION
## Summary
- Classes with string or number fields that are never assigned now produce a compile error instead of silently compiling to code that segfaults at runtime
- Example: `class Foo { name: string; }` → `new Foo().name.length` would segfault because `name` is null. Now you get: `error: class 'Foo' has uninitialized field 'name' — assign a value in the field declaration or constructor`

## How it works
New semantic pass (`src/semantic/uninitialized-field-checker.ts`) runs before codegen:
1. For each class, finds fields without initializers (skips static, interface-typed, and array/collection fields which get safe defaults)
2. Checks if the field is assigned via constructor parameter properties, `this.x = y` in the constructor, or `this.x = y` in any method
3. If a string/number field is never assigned anywhere, emits a compile error

## Test plan
- [x] All 453 tests pass (node + native)
- [x] Self-hosting Stage 0 + Stage 1 pass
- [x] New test: `uninitialized-field.ts` — verifies compile error fires
- [x] New test: `initialized-field-constructor.ts` — verifies constructor assignment is recognized