### PR TITLE
fix: type assertion property access warning to error + loc propagation

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -2681,11 +2681,10 @@ export class MemberAccessGenerator {
         return innerPtr;
       }
       if (exprObjBase.type === "type_assertion") {
-        this.ctx.emitWarning(
-          `unresolved property '${prop}' on type_assertion expression — defaulting to 0.0`,
+        return this.ctx.emitError(
+          `unresolved property '${prop}' on type_assertion expression`,
           expr.loc,
         );
-        return "0.0";
       }
       return this.ctx.emitError(
         `unresolved property '${prop}' on expression of type '${exprObjBase.type}'`,
@@ -3028,6 +3027,7 @@ export class MemberAccessGenerator {
         type: "member_access",
         object: assertion.expression,
         property: property,
+        loc: expr.loc,
       };
       return this.generate(syntheticExpr, params);
     } else {
@@ -3053,6 +3053,7 @@ export class MemberAccessGenerator {
             type: "member_access",
             object: assertion.expression,
             property: property,
+            loc: expr.loc,
           };
           return this.generate(syntheticExpr, params);
         }

--- a/src/semantic/escape-analysis.ts
+++ b/src/semantic/escape-analysis.ts
@@ -44,8 +44,8 @@ import type {
 } from "../ast/types.js";
 
 export function varDeclKey(decl: VariableDeclaration): string {
-  const line = (decl as VariableDeclaration).loc?.line ?? (decl as VariableDeclaration).line ?? -1;
-  const col = (decl as VariableDeclaration).loc?.column ?? -1;
+  const line = decl.loc ? decl.loc.line : (decl.line ? decl.line : -1);
+  const col = decl.loc ? decl.loc.column : -1;
   return decl.name + ":" + line + ":" + col;
 }
 

--- a/src/semantic/escape-analysis.ts
+++ b/src/semantic/escape-analysis.ts
@@ -44,7 +44,7 @@ import type {
 } from "../ast/types.js";
 
 export function varDeclKey(decl: VariableDeclaration): string {
-  const line = decl.loc ? decl.loc.line : (decl.line ? decl.line : -1);
+  const line = decl.loc ? decl.loc.line : decl.line ? decl.line : -1;
   const col = decl.loc ? decl.loc.column : -1;
   return decl.name + ":" + line + ":" + col;
 }


### PR DESCRIPTION
## Summary
- Property access on type assertion expressions that can't be resolved now produces a compile error instead of silently returning 0.0 (wrong value at runtime)
- Synthetic member access expressions created during type assertion resolution now carry source location info for accurate error messages
- Fixed redundant `as VariableDeclaration` casts in escape-analysis.ts that were silently returning 0.0 for `.loc` access

## Changes
- `member.ts`: Added `loc: expr.loc` to both synthetic expression creation sites in `handleTypeAssertionPropertyAccess`
- `member.ts`: Converted `emitWarning` + `return "0.0"` to `emitError` for unresolved type_assertion properties
- `escape-analysis.ts`: Removed redundant type assertions that triggered the type_assertion property handler

## Test plan
- [x] All tests pass
- [x] Self-hosting Stage 0 + Stage 1 pass