### PR TITLE
fix: convert last 2 codegen throws to clean error messages

### DIFF
--- a/src/codegen/infrastructure/closure-analyzer.ts
+++ b/src/codegen/infrastructure/closure-analyzer.ts
@@ -270,7 +270,8 @@ export class ClosureAnalyzer {
     if (idx !== -1) {
       return this.scopeVarTypes[idx];
     }
-    throw new Error(`getScopeVarType: variable '${name}' not found in closure scope`);
+    console.log("error: variable '" + name + "' not found in closure scope");
+    process.exit(1);
   }
 
   private walkBlock(block: BlockStatement): void {

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -219,9 +219,10 @@ export function canonicalTypeToLlvm(
 
   if (mode === "param") {
     if (tsType === "any" || tsType === "unknown") {
-      throw new Error(
-        `Parameter type '${tsType}' is not allowed — add explicit type annotations or fix the parser`,
+      console.error(
+        "error: parameter type '" + tsType + "' is not allowed — add explicit type annotations",
       );
+      process.exit(1);
     }
   }
 


### PR DESCRIPTION
## Summary
- The last 2 `throw new Error` in codegen now produce clean error messages instead of Node.js stack traces
- Users hitting unknown/any parameter types or closure scope errors now see a single-line error message

## Changes
- `type-system.ts`: `any`/`unknown` parameter type error → `console.error` + `process.exit(1)`
- `closure-analyzer.ts`: Variable not found in closure scope → `console.log` + `process.exit(1)`

## Test plan
- [x] All 453 tests pass (node + native)
- [x] Self-hosting Stage 0 + Stage 1 pass
- [x] `should reject unknown type in function parameters` test still passes