### PR TITLE
fix: use dynamic ports in all network tests

### DIFF
--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -371,6 +371,8 @@ httpServe(${port}, handleRequest, wsHandler);
 
       // Start the server as a background process
       const serverProc = spawn(exeFile, [], { stdio: ["pipe", "pipe", "pipe"] });
+      let stderrOutput = "";
+      serverProc.stderr?.on("data", (d: Buffer) => (stderrOutput += d.toString()));
       const cleanup = () => {
         try {
           serverProc.kill("SIGKILL");
@@ -378,10 +380,10 @@ httpServe(${port}, handleRequest, wsHandler);
       };
 
       try {
-        // Poll the TCP port until the server is ready (printf is full-buffered
-        // when stdout is a pipe, so we can't rely on stdout messages)
         await new Promise<void>((resolve, reject) => {
-          const deadline = setTimeout(() => reject(new Error("Server startup timeout")), 5000);
+          const deadline = setTimeout(() => {
+            reject(new Error(`Server startup timeout (stderr: ${stderrOutput})`));
+          }, 15000);
           serverProc.on("exit", (code) => {
             clearTimeout(deadline);
             reject(new Error(`Server exited early with code ${code}`));
@@ -393,7 +395,7 @@ httpServe(${port}, handleRequest, wsHandler);
               resolve();
             });
             sock.on("error", () => {
-              setTimeout(tryConnect, 50);
+              setTimeout(tryConnect, 100);
             });
           };
           tryConnect();
@@ -407,7 +409,7 @@ httpServe(${port}, handleRequest, wsHandler);
             res.on("end", () => resolve(body));
           });
           req.on("error", reject);
-          req.setTimeout(3000, () => {
+          req.setTimeout(10000, () => {
             req.destroy();
             reject(new Error("HTTP request timeout"));
           });
@@ -422,7 +424,7 @@ httpServe(${port}, handleRequest, wsHandler);
         // on message — this tests the full flow including broadcast-during-open.
         const wsKey = crypto.randomBytes(16).toString("base64");
         const wsReceived = await new Promise<string[]>((resolve, reject) => {
-          const timeout = setTimeout(() => reject(new Error("WebSocket test timeout")), 5000);
+          const timeout = setTimeout(() => reject(new Error("WebSocket test timeout")), 15000);
           const req = http.request({
             hostname: "127.0.0.1",
             port,

--- a/tests/fixtures/network/async-fetch-test.ts
+++ b/tests/fixtures/network/async-fetch-test.ts
@@ -1,6 +1,17 @@
 // @test-skip
+function getPort(): string {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return args[i + 1];
+    }
+  }
+  return "19878";
+}
+
 async function testAsyncFetch(): Promise<string> {
-  const response = await fetch("http://127.0.0.1:19878/test");
+  const port = getPort();
+  const response = await fetch("http://127.0.0.1:" + port + "/test");
   if (response.ok) {
     const body = response.text();
     if (body === "/test") {

--- a/tests/fixtures/network/fetch-integration-test.ts
+++ b/tests/fixtures/network/fetch-integration-test.ts
@@ -1,22 +1,26 @@
 // @test-skip
-// Integration test for fetch() builtin with Response API
-// This test expects an HTTP server running on localhost:9998
-// that responds with specific test data
-
-// fetch() returns a Promise<Response> that resolves to a Response object with:
-// - .text() method to get body
-// - .json() method to parse JSON
-// - .status property for HTTP status code
-// - .ok property for success check (200-299)
+// @test-args: -p 9998
 
 interface JsonTestResponse {
   status: string;
   message: string;
 }
 
+function getPort(): string {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return args[i + 1];
+    }
+  }
+  return "9998";
+}
+
 async function runTests(): Promise<string> {
-  // Test 1: Basic endpoint with .ok and .status checks
-  const response1 = await fetch("http://localhost:9998/test");
+  const port = getPort();
+  const base = "http://localhost:" + port;
+
+  const response1 = await fetch(base + "/test");
   if (!response1.ok) {
     throw new Error("Expected response1.ok to be true");
   }
@@ -29,8 +33,7 @@ async function runTests(): Promise<string> {
     throw new Error("Expected at least 3 lines in response");
   }
 
-  // Test 2: JSON endpoint with .json<T>() method
-  const response2 = await fetch("http://localhost:9998/json");
+  const response2 = await fetch(base + "/json");
   if (!response2.ok) {
     throw new Error("Expected response2.ok to be true");
   }
@@ -42,8 +45,7 @@ async function runTests(): Promise<string> {
     throw new Error("Expected json2.message to equal 'JSON response'");
   }
 
-  // Test 3: Plain text endpoint
-  const response3 = await fetch("http://localhost:9998/plain");
+  const response3 = await fetch(base + "/plain");
   if (!response3.ok) {
     throw new Error("Expected response3.ok to be true");
   }

--- a/tests/fixtures/network/http-headers-test.ts
+++ b/tests/fixtures/network/http-headers-test.ts
@@ -53,4 +53,15 @@ function handleRequest(req: Request): Response {
   return { status: 404, body: "Not Found", headers: "" };
 }
 
-httpServe(9986, handleRequest);
+function getPortNum(): number {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return parseInt(args[i + 1]);
+    }
+  }
+  return 9986;
+}
+
+const port = getPortNum();
+httpServe(port, handleRequest);

--- a/tests/fixtures/network/http-query-string-test.ts
+++ b/tests/fixtures/network/http-query-string-test.ts
@@ -28,4 +28,15 @@ function handleRequest(req: Request): Response {
   return { status: 404, body: "Not Found", headers: "" };
 }
 
-httpServe(9985, handleRequest);
+function getPortNum(): number {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return parseInt(args[i + 1]);
+    }
+  }
+  return 9985;
+}
+
+const port = getPortNum();
+httpServe(port, handleRequest);

--- a/tests/fixtures/network/http-route-isolation-test.ts
+++ b/tests/fixtures/network/http-route-isolation-test.ts
@@ -1,5 +1,4 @@
 // @test-skip
-// HTTP route isolation fixture used by http-routes.test.ts (needs external test orchestration)
 import { httpServe } from "chadscript/http";
 
 interface Request {
@@ -16,6 +15,16 @@ interface Response {
   status: number;
   body: string;
   headers: string;
+}
+
+function getPortNum(): number {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return parseInt(args[i + 1]);
+    }
+  }
+  return 9987;
 }
 
 function homeHandler(req: Request): Response {
@@ -88,4 +97,5 @@ function handleRequest(req: Request): Response {
   return notFoundHandler(req);
 }
 
-httpServe(9987, handleRequest);
+const port = getPortNum();
+httpServe(port, handleRequest);

--- a/tests/fixtures/network/http-server-test.ts
+++ b/tests/fixtures/network/http-server-test.ts
@@ -1,5 +1,4 @@
 // @test-skip
-// HTTP server fixture used by network.test.ts (needs external test orchestration)
 import { httpServe } from "chadscript/http";
 
 interface Request {
@@ -16,6 +15,16 @@ interface Response {
   headers: string;
 }
 
+function getPortNum(): number {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return parseInt(args[i + 1]);
+    }
+  }
+  return 9997;
+}
+
 function handleRequest(req: Request): Response {
   if (req.path == "/") {
     return { status: 200, body: "Hello from ChadScript!", headers: "" };
@@ -26,4 +35,5 @@ function handleRequest(req: Request): Response {
   return { status: 404, body: "Not Found", headers: "" };
 }
 
-httpServe(9997, handleRequest);
+const port = getPortNum();
+httpServe(port, handleRequest);

--- a/tests/fixtures/network/json-parse-and-response-json-test.ts
+++ b/tests/fixtures/network/json-parse-and-response-json-test.ts
@@ -1,11 +1,18 @@
 // @test-skip
-// Regression test: using JSON.parse<T>() and response.json<T>() with the same
-// interface in the same file previously caused a duplicate parse_json_T
-// function definition in the generated LLVM IR.
 
 interface Item {
   id: number;
   name: string;
+}
+
+function getPort(): string {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return args[i + 1];
+    }
+  }
+  return "19882";
 }
 
 async function runTests(): Promise<void> {
@@ -19,7 +26,8 @@ async function runTests(): Promise<void> {
     process.exit(1);
   }
 
-  const response = await fetch("http://127.0.0.1:19882/item");
+  const port = getPort();
+  const response = await fetch("http://127.0.0.1:" + port + "/item");
   const fromJson = response.json<Item>();
   if (fromJson.id !== 2) {
     console.log("FAIL: response.json id");

--- a/tests/fixtures/network/multipart-test.ts
+++ b/tests/fixtures/network/multipart-test.ts
@@ -53,4 +53,15 @@ function handleRequest(req: Request): Response {
   return { status: 404, body: "Not Found", headers: "" };
 }
 
-httpServe(9987, handleRequest);
+function getPortNum(): number {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return parseInt(args[i + 1]);
+    }
+  }
+  return 9987;
+}
+
+const port = getPortNum();
+httpServe(port, handleRequest);

--- a/tests/fixtures/network/promise-all-concurrent.ts
+++ b/tests/fixtures/network/promise-all-concurrent.ts
@@ -1,10 +1,22 @@
 // @test-skip
+function getPort(): string {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return args[i + 1];
+    }
+  }
+  return "19880";
+}
+
 async function testPromiseAll(): Promise<string> {
+  const port = getPort();
+  const base = "http://127.0.0.1:" + port;
   const start = process.uptime();
 
-  const p1 = fetch("http://127.0.0.1:19880/slow/1");
-  const p2 = fetch("http://127.0.0.1:19880/slow/2");
-  const p3 = fetch("http://127.0.0.1:19880/slow/3");
+  const p1 = fetch(base + "/slow/1");
+  const p2 = fetch(base + "/slow/2");
+  const p3 = fetch(base + "/slow/3");
 
   const results = await Promise.all([p1, p2, p3]);
 

--- a/tests/fixtures/network/promise-all-fetch-test.ts
+++ b/tests/fixtures/network/promise-all-fetch-test.ts
@@ -1,10 +1,19 @@
 // @test-skip
+function getPort(): string {
+  const args = process.argv;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-p") {
+      return args[i + 1];
+    }
+  }
+  return "19881";
+}
+
 async function testPromiseAllFetch(): Promise<void> {
-  const results = await Promise.all([
-    fetch("http://127.0.0.1:19881/a"),
-    fetch("http://127.0.0.1:19881/b"),
-    fetch("http://127.0.0.1:19881/c"),
-  ]);
+  const port = getPort();
+  const base = "http://127.0.0.1:" + port;
+
+  const results = await Promise.all([fetch(base + "/a"), fetch(base + "/b"), fetch(base + "/c")]);
 
   const bodyA = results[0].text();
   const bodyB = results[1].text();

--- a/tests/http-headers.test.ts
+++ b/tests/http-headers.test.ts
@@ -4,12 +4,13 @@ import { exec, spawn, ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
 import * as fsSync from "node:fs";
 import * as http from "node:http";
+import * as net from "node:net";
 
 const execAsync = promisify(exec);
 
 const SERVER_SOURCE = "tests/fixtures/network/http-headers-test.ts";
 const SERVER_BINARY = ".build/tests/fixtures/network/http-headers-test";
-const PORT = 9986;
+let PORT = 0;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -28,6 +29,14 @@ describe("HTTP Headers Tests", { concurrency: 1 }, () => {
   let serverProcess: ChildProcess | null = null;
 
   before(async () => {
+    PORT = await new Promise<number>((resolve, reject) => {
+      const srv = net.createServer();
+      srv.listen(0, "127.0.0.1", () => {
+        const p = (srv.address() as net.AddressInfo).port;
+        srv.close(() => resolve(p));
+      });
+      srv.on("error", reject);
+    });
     await execAsync(`node dist/chad-node.js build ${SERVER_SOURCE}`, { timeout: 60000 });
     assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");
   });
@@ -40,7 +49,7 @@ describe("HTTP Headers Tests", { concurrency: 1 }, () => {
     }
   });
 
-  async function waitForServer(maxAttempts = 50): Promise<void> {
+  async function waitForServer(maxAttempts = 100): Promise<void> {
     for (let i = 0; i < maxAttempts; i++) {
       try {
         const resp = await fetch(`http://127.0.0.1:${PORT}/custom-ct`);
@@ -61,7 +70,7 @@ describe("HTTP Headers Tests", { concurrency: 1 }, () => {
       await sleep(500);
     }
 
-    serverProcess = spawn(SERVER_BINARY, [], {
+    serverProcess = spawn(SERVER_BINARY, ["-p", String(PORT)], {
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/tests/http-query-string.test.ts
+++ b/tests/http-query-string.test.ts
@@ -3,12 +3,13 @@ import assert from "node:assert";
 import { exec, spawn, ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
 import * as fsSync from "node:fs";
+import * as net from "node:net";
 
 const execAsync = promisify(exec);
 
 const SERVER_SOURCE = "tests/fixtures/network/http-query-string-test.ts";
 const SERVER_BINARY = ".build/tests/fixtures/network/http-query-string-test";
-const PORT = 9985;
+let PORT = 0;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -27,6 +28,14 @@ describe("HTTP Query String Tests", { concurrency: 1 }, () => {
   let serverProcess: ChildProcess | null = null;
 
   before(async () => {
+    PORT = await new Promise<number>((resolve, reject) => {
+      const srv = net.createServer();
+      srv.listen(0, "127.0.0.1", () => {
+        const p = (srv.address() as net.AddressInfo).port;
+        srv.close(() => resolve(p));
+      });
+      srv.on("error", reject);
+    });
     await execAsync(`node dist/chad-node.js build ${SERVER_SOURCE}`, { timeout: 60000 });
     assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");
   });
@@ -39,7 +48,7 @@ describe("HTTP Query String Tests", { concurrency: 1 }, () => {
     }
   });
 
-  async function waitForServer(maxAttempts = 50): Promise<void> {
+  async function waitForServer(maxAttempts = 100): Promise<void> {
     for (let i = 0; i < maxAttempts; i++) {
       try {
         const resp = await fetch(`http://127.0.0.1:${PORT}/check-path`);
@@ -60,7 +69,7 @@ describe("HTTP Query String Tests", { concurrency: 1 }, () => {
       await sleep(500);
     }
 
-    serverProcess = spawn(SERVER_BINARY, [], {
+    serverProcess = spawn(SERVER_BINARY, ["-p", String(PORT)], {
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/tests/http-routes.test.ts
+++ b/tests/http-routes.test.ts
@@ -5,12 +5,13 @@ import { promisify } from "node:util";
 import * as fsSync from "node:fs";
 import * as zlib from "node:zlib";
 import * as http from "node:http";
+import * as net from "node:net";
 
 const execAsync = promisify(exec);
 
 const SERVER_SOURCE = "tests/fixtures/network/http-route-isolation-test.ts";
 const SERVER_BINARY = ".build/tests/fixtures/network/http-route-isolation-test";
-const PORT = 9987;
+let PORT = 0;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -29,6 +30,14 @@ describe("HTTP Route Isolation Tests", { concurrency: 1 }, () => {
   let serverProcess: ChildProcess | null = null;
 
   before(async () => {
+    PORT = await new Promise<number>((resolve, reject) => {
+      const srv = net.createServer();
+      srv.listen(0, "127.0.0.1", () => {
+        const p = (srv.address() as net.AddressInfo).port;
+        srv.close(() => resolve(p));
+      });
+      srv.on("error", reject);
+    });
     await execAsync(`node dist/chad-node.js build ${SERVER_SOURCE}`, { timeout: 60000 });
     assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");
   });
@@ -41,7 +50,7 @@ describe("HTTP Route Isolation Tests", { concurrency: 1 }, () => {
     }
   });
 
-  async function waitForServer(maxAttempts = 50): Promise<void> {
+  async function waitForServer(maxAttempts = 100): Promise<void> {
     for (let i = 0; i < maxAttempts; i++) {
       try {
         const resp = await fetch(`http://127.0.0.1:${PORT}/`);
@@ -62,7 +71,7 @@ describe("HTTP Route Isolation Tests", { concurrency: 1 }, () => {
       await sleep(500);
     }
 
-    serverProcess = spawn(SERVER_BINARY, [], {
+    serverProcess = spawn(SERVER_BINARY, ["-p", String(PORT)], {
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/tests/multipart.test.ts
+++ b/tests/multipart.test.ts
@@ -4,12 +4,13 @@ import { exec, spawn, ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
 import * as fsSync from "node:fs";
 import * as http from "node:http";
+import * as net from "node:net";
 
 const execAsync = promisify(exec);
 
 const SERVER_SOURCE = "tests/fixtures/network/multipart-test.ts";
 const SERVER_BINARY = ".build/tests/fixtures/network/multipart-test";
-const PORT = 9987;
+let PORT = 0;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -28,6 +29,14 @@ describe("Multipart Parser Tests", { concurrency: 1 }, () => {
   let serverProcess: ChildProcess | null = null;
 
   before(async () => {
+    PORT = await new Promise<number>((resolve, reject) => {
+      const srv = net.createServer();
+      srv.listen(0, "127.0.0.1", () => {
+        const p = (srv.address() as net.AddressInfo).port;
+        srv.close(() => resolve(p));
+      });
+      srv.on("error", reject);
+    });
     await execAsync(`node dist/chad-node.js build ${SERVER_SOURCE}`, {
       timeout: 60000,
     });
@@ -42,7 +51,7 @@ describe("Multipart Parser Tests", { concurrency: 1 }, () => {
     }
   });
 
-  async function waitForServer(maxAttempts = 50): Promise<void> {
+  async function waitForServer(maxAttempts = 100): Promise<void> {
     for (let i = 0; i < maxAttempts; i++) {
       try {
         const resp = await fetch(`http://127.0.0.1:${PORT}/upload`, {
@@ -66,7 +75,7 @@ describe("Multipart Parser Tests", { concurrency: 1 }, () => {
       await sleep(500);
     }
 
-    serverProcess = spawn(SERVER_BINARY, [], {
+    serverProcess = spawn(SERVER_BINARY, ["-p", String(PORT)], {
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -3,16 +3,23 @@ import assert from "node:assert";
 import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import * as http from "node:http";
+import * as net from "node:net";
 
 const execAsync = promisify(exec);
 
-describe("Network Tests", () => {
-  // TCP socket and client tests are static fixtures auto-discovered by compiler.test.ts:
-  //   tests/fixtures/network/tcp-test-socket.ts
-  //   tests/fixtures/network/tcp-client.ts
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
 
+describe("Network Tests", () => {
   it("should perform HTTP requests using fetch() builtin", async () => {
-    // Start a Node.js HTTP server for testing
     const server = http.createServer((req, res) => {
       if (req.url === "/test") {
         res.writeHead(200, { "Content-Type": "text/plain" });
@@ -30,20 +37,19 @@ describe("Network Tests", () => {
     });
 
     await new Promise<void>((resolve) => {
-      server.listen(9998, "127.0.0.1", resolve);
+      server.listen(0, "127.0.0.1", resolve);
     });
 
+    const port = (server.address() as { port: number }).port;
+
     try {
-      // Compile the fetch test fixture
       const testFile = "tests/fixtures/network/fetch-integration-test.ts";
       await execAsync(`node dist/chad-node.js build ${testFile}`);
 
-      // Run the compiled program
-      const { stdout, stderr } = await execAsync(
-        ".build/tests/fixtures/network/fetch-integration-test",
+      const { stdout } = await execAsync(
+        `.build/tests/fixtures/network/fetch-integration-test -p ${port}`,
       );
 
-      // Verify the test passed
       assert.ok(stdout.includes("TEST_PASSED"), "fetch() integration test should pass");
       assert.ok(!stdout.includes("TEST_FAILED"), "fetch() test should not fail");
     } finally {
@@ -69,13 +75,17 @@ describe("Network Tests", () => {
     });
 
     await new Promise<void>((resolve) => {
-      server.listen(19881, "127.0.0.1", resolve);
+      server.listen(0, "127.0.0.1", resolve);
     });
+
+    const port = (server.address() as { port: number }).port;
 
     try {
       const testFile = "tests/fixtures/network/promise-all-fetch-test.ts";
       await execAsync(`node dist/chad-node.js build ${testFile}`);
-      const { stdout } = await execAsync(".build/tests/fixtures/network/promise-all-fetch-test");
+      const { stdout } = await execAsync(
+        `.build/tests/fixtures/network/promise-all-fetch-test -p ${port}`,
+      );
       assert.ok(stdout.includes("TEST_PASSED"), "Promise.all + fetch test should pass");
     } finally {
       server.close();
@@ -89,13 +99,17 @@ describe("Network Tests", () => {
     });
 
     await new Promise<void>((resolve) => {
-      server.listen(19878, "127.0.0.1", resolve);
+      server.listen(0, "127.0.0.1", resolve);
     });
+
+    const port = (server.address() as { port: number }).port;
 
     try {
       const testFile = "tests/fixtures/network/async-fetch-test.ts";
       await execAsync(`node dist/chad-node.js build ${testFile}`);
-      const { stdout } = await execAsync(".build/tests/fixtures/network/async-fetch-test");
+      const { stdout } = await execAsync(
+        `.build/tests/fixtures/network/async-fetch-test -p ${port}`,
+      );
       assert.ok(stdout.includes("TEST_PASSED"), "async fetch test should pass");
     } finally {
       server.close();
@@ -112,13 +126,17 @@ describe("Network Tests", () => {
     });
 
     await new Promise<void>((resolve) => {
-      server.listen(19880, "127.0.0.1", resolve);
+      server.listen(0, "127.0.0.1", resolve);
     });
+
+    const port = (server.address() as { port: number }).port;
 
     try {
       const testFile = "tests/fixtures/network/promise-all-concurrent.ts";
       await execAsync(`node dist/chad-node.js build ${testFile}`);
-      const { stdout } = await execAsync(".build/tests/fixtures/network/promise-all-concurrent");
+      const { stdout } = await execAsync(
+        `.build/tests/fixtures/network/promise-all-concurrent -p ${port}`,
+      );
       assert.ok(stdout.includes("TEST_PASSED"), "Promise.all concurrent test should pass");
     } finally {
       server.close();
@@ -137,14 +155,16 @@ describe("Network Tests", () => {
     });
 
     await new Promise<void>((resolve) => {
-      server.listen(19882, "127.0.0.1", resolve);
+      server.listen(0, "127.0.0.1", resolve);
     });
+
+    const port = (server.address() as { port: number }).port;
 
     try {
       const testFile = "tests/fixtures/network/json-parse-and-response-json-test.ts";
       await execAsync(`node dist/chad-node.js build ${testFile}`);
       const { stdout } = await execAsync(
-        ".build/tests/fixtures/network/json-parse-and-response-json-test",
+        `.build/tests/fixtures/network/json-parse-and-response-json-test -p ${port}`,
       );
       assert.ok(
         stdout.includes("TEST_PASSED"),
@@ -163,19 +183,21 @@ describe("Network Tests", () => {
   });
 
   it("should run HTTP server using httpServe()", async () => {
+    const port = await getRandomPort();
     const testFile = "tests/fixtures/network/http-server-test.ts";
     await execAsync(`node dist/chad-node.js build ${testFile}`);
 
-    const serverProcess = spawn(".build/tests/fixtures/network/http-server-test", [], {
-      detached: true,
-      stdio: "ignore",
-    });
+    const serverProcess = spawn(
+      ".build/tests/fixtures/network/http-server-test",
+      ["-p", String(port)],
+      { detached: true, stdio: "ignore" },
+    );
 
-    async function waitForServer9997(maxMs = 5000): Promise<void> {
+    async function waitForServer(maxMs = 10000): Promise<void> {
       const start = Date.now();
       while (Date.now() - start < maxMs) {
         try {
-          await fetch("http://127.0.0.1:9997/");
+          await fetch(`http://127.0.0.1:${port}/`);
           return;
         } catch {
           await new Promise((resolve) => setTimeout(resolve, 100));
@@ -184,13 +206,13 @@ describe("Network Tests", () => {
       throw new Error("Server not ready after " + maxMs + "ms");
     }
 
-    await waitForServer9997();
+    await waitForServer();
 
     try {
       const responses = await Promise.all([
-        fetch("http://127.0.0.1:9997/").then((r) => r.text()),
-        fetch("http://127.0.0.1:9997/json").then((r) => r.text()),
-        fetch("http://127.0.0.1:9997/notfound").then((r) => r.text()),
+        fetch(`http://127.0.0.1:${port}/`).then((r) => r.text()),
+        fetch(`http://127.0.0.1:${port}/json`).then((r) => r.text()),
+        fetch(`http://127.0.0.1:${port}/notfound`).then((r) => r.text()),
       ]);
 
       assert.strictEqual(


### PR DESCRIPTION
## Summary
- fixes ws e2e test timeout under load (5s→15s, was failing at concurrency 32)
- all network test fixtures now accept `-p PORT` cli arg instead of hardcoded ports
- all test harnesses use os-assigned ports (port 0) — safe for concurrent agents
- server wait timeouts increased from 5s to 10s across all http server test suites

## Test plan
- [x] all 461 tests pass with 0 failures, 0 skipped
- [x] network tests pass in isolation
- [x] network tests pass when all 4 http server suites run concurrently
- [x] ws e2e test passes under full test suite load