### PR TITLE
fix: declare destructured for-of variables in semantic analyzer + map iteration tests

### DIFF
--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -508,6 +508,16 @@ export class SemanticAnalyzer {
             llvmType: elemLlvm,
           });
         }
+        if (forOfStmt.destructuredNames) {
+          const names = forOfStmt.destructuredNames as string[];
+          for (let i = 0; i < names.length; i++) {
+            this.symbols.set(names[i], {
+              name: names[i],
+              type: "string",
+              llvmType: "i8*",
+            });
+          }
+        }
         if (forOfStmt.body) this.analyzeBlock(forOfStmt.body);
       } else if (stmtType === "try") {
         const tryStmt = stmt as TryStatement;

--- a/tests/fixtures/data-structures/map-entries-bare.ts
+++ b/tests/fixtures/data-structures/map-entries-bare.ts
@@ -1,0 +1,19 @@
+function testMapEntriesBare() {
+  const m = new Map<string, string>();
+  m.set("one", "1");
+  m.set("two", "2");
+
+  let count = 0;
+  for (const [k, v] of m) {
+    count = count + 1;
+  }
+
+  if (count !== 2) {
+    console.log("FAIL: expected 2 entries from bare map, got " + count);
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testMapEntriesBare();

--- a/tests/fixtures/data-structures/map-entries.ts
+++ b/tests/fixtures/data-structures/map-entries.ts
@@ -1,0 +1,35 @@
+function testMapEntries() {
+  const m = new Map<string, string>();
+  m.set("a", "1");
+  m.set("b", "2");
+  m.set("c", "3");
+
+  let count = 0;
+  let keys = "";
+  let values = "";
+
+  for (const [k, v] of m.entries()) {
+    keys = keys + k;
+    values = values + v;
+    count = count + 1;
+  }
+
+  if (count !== 3) {
+    console.log("FAIL: expected 3 entries, got " + count);
+    return;
+  }
+
+  if (keys.length !== 3) {
+    console.log("FAIL: expected 3 chars in keys");
+    return;
+  }
+
+  if (values.length !== 3) {
+    console.log("FAIL: expected 3 chars in values");
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testMapEntries();

--- a/tests/fixtures/data-structures/map-keys.ts
+++ b/tests/fixtures/data-structures/map-keys.ts
@@ -1,0 +1,20 @@
+function testMapKeys() {
+  const m = new Map<string, string>();
+  m.set("hello", "world");
+  m.set("foo", "bar");
+
+  const keys = m.keys();
+  let count = 0;
+  for (const k of keys) {
+    count = count + 1;
+  }
+
+  if (count !== 2) {
+    console.log("FAIL: expected 2 keys, got " + count);
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testMapKeys();

--- a/tests/fixtures/data-structures/map-string-number-entries.ts
+++ b/tests/fixtures/data-structures/map-string-number-entries.ts
@@ -1,0 +1,28 @@
+function testMapStringNumberEntries() {
+  const m = new Map<string, number>();
+  m.set("a", 10);
+  m.set("b", 20);
+  m.set("c", 30);
+
+  let count = 0;
+  let allKeys = "";
+
+  for (const [k, v] of m.entries()) {
+    allKeys = allKeys + k;
+    count = count + 1;
+  }
+
+  if (count !== 3) {
+    console.log("FAIL: expected 3 entries, got " + count);
+    return;
+  }
+
+  if (allKeys.length !== 3) {
+    console.log("FAIL: expected 3 chars in keys");
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testMapStringNumberEntries();

--- a/tests/fixtures/data-structures/map-values.ts
+++ b/tests/fixtures/data-structures/map-values.ts
@@ -1,0 +1,20 @@
+function testMapValues() {
+  const m = new Map<string, string>();
+  m.set("x", "alpha");
+  m.set("y", "beta");
+
+  const vals = m.values();
+  let count = 0;
+  for (const v of vals) {
+    count = count + 1;
+  }
+
+  if (count !== 2) {
+    console.log("FAIL: expected 2 values, got " + count);
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testMapValues();


### PR DESCRIPTION
## Summary
- **Bug fix**: `for (const [k, v] of map.entries())` previously failed with "Reference to undeclared variable" because the semantic analyzer only declared single-variable for-of loops (`variableName`), not destructured ones (`destructuredNames`). Now both paths are handled.
- **New tests**: 5 test fixtures covering Map iteration patterns that were previously untested:
  - `map-entries.ts` — `for...of map.entries()` with string keys/values
  - `map-entries-bare.ts` — `for...of map` (bare map iteration)
  - `map-keys.ts` — `map.keys()` iteration
  - `map-values.ts` — `map.values()` iteration
  - `map-string-number-entries.ts` — `Map<string, number>` entries iteration

## Test plan
- [x] All 458 tests pass
- [ ] `npm run verify:quick` (in progress)