### PR TITLE
feat: rust-style beautiful error messages

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -479,7 +479,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
   public emitError(message: string, loc?: SourceLocation, suggestion?: string): never {
     this.diagnostics.error(message, loc, suggestion);
-    const output = this.diagnostics.formatDiagnostic(this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1]);
+    const output = this.diagnostics.formatDiagnostic(
+      this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1],
+    );
     process.stderr.write(output);
     process.exit(1);
   }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -478,19 +478,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
 
   public emitError(message: string, loc?: SourceLocation, suggestion?: string): never {
-    // Print and exit immediately rather than throwing — in the native compiler,
-    // throw doesn't propagate across function boundaries.
-    if (loc) {
-      const file = loc.file || "<unknown>";
-      const line = loc.line || 0;
-      const col = loc.column || 0;
-      console.log(file + ":" + String(line) + ":" + String(col) + ": error: " + message);
-    } else {
-      console.log("error: " + message);
-    }
-    if (suggestion) {
-      console.log("  suggestion: " + suggestion);
-    }
+    this.diagnostics.error(message, loc, suggestion);
+    const output = this.diagnostics.formatDiagnostic(this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1]);
+    process.stderr.write(output);
     process.exit(1);
   }
 
@@ -2536,10 +2526,10 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
 
   generateParts(): string[] {
-    checkClosureMutations(this.ast);
-    checkUnionTypes(this.ast);
-    checkTypeAssertions(this.ast);
-    checkUninitializedFields(this.ast);
+    checkClosureMutations(this.ast, this.sourceCode);
+    checkUnionTypes(this.ast, this.sourceCode);
+    checkTypeAssertions(this.ast, this.sourceCode);
+    checkUninitializedFields(this.ast, this.sourceCode);
     this.stackEligibleVars = analyzeEscapes(this.ast);
 
     const irParts: string[] = [];

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -12,6 +12,7 @@ import { LogLevel, logger } from "./utils/logger.js";
 import { TargetInfo, resolveTarget, getHostTarget, isCrossCompiling } from "./target.js";
 import { loadTargetSDK, ensureTargetSDK, TargetSDK } from "./cross-compile.js";
 import { VERSION } from "./version.js";
+import { setGlobalDiagnosticColor } from "./diagnostics/engine.js";
 
 function findLLVMTool(name: string): string {
   const candidates = [
@@ -87,6 +88,7 @@ let diagnosticColorEnabled: boolean = process.stderr.isTTY === true;
 
 export function setDiagnosticColor(enabled: boolean): void {
   diagnosticColorEnabled = enabled;
+  setGlobalDiagnosticColor(enabled);
 }
 
 export function setTargetCpu(value: string): void {
@@ -270,8 +272,9 @@ export function compile(
 
   // Generate LLVM IR
   let entryFileCode = "";
+  const absInputFile = path.resolve(inputFile);
   for (let efci = 0; efci < fileContentKeys.length; efci++) {
-    if (fileContentKeys[efci] === inputFile) {
+    if (fileContentKeys[efci] === inputFile || fileContentKeys[efci] === absInputFile) {
       entryFileCode = fileContentValues[efci];
       break;
     }
@@ -286,6 +289,7 @@ export function compile(
   };
   const generator = new LLVMGenerator(mergedAST, typeChecker, generatorOptions);
   generator.diagnostics.setColor(diagnosticColorEnabled);
+  setGlobalDiagnosticColor(diagnosticColorEnabled);
   const llvmIR = generator.generate();
 
   // Write IR to file

--- a/src/diagnostics/engine.ts
+++ b/src/diagnostics/engine.ts
@@ -8,7 +8,7 @@ const BOLD = "\x1b[1m";
 const RED = "\x1b[31m";
 const YELLOW = "\x1b[33m";
 const CYAN = "\x1b[36m";
-const GREEN = "\x1b[32m";
+const BLUE = "\x1b[34m";
 const RESET = "\x1b[0m";
 
 export interface Diagnostic {
@@ -16,6 +16,7 @@ export interface Diagnostic {
   message: string;
   loc?: SourceLocation;
   suggestion?: string;
+  notes?: string[];
 }
 
 export class DiagnosticEngine {
@@ -37,46 +38,27 @@ export class DiagnosticEngine {
   }
 
   error(message: string, loc?: SourceLocation, suggestion?: string): void {
-    this.diagnostics.push({
-      severity: DIAG_ERROR,
-      message,
-      loc,
-      suggestion,
-    });
+    this.diagnostics.push({ severity: DIAG_ERROR, message, loc, suggestion });
   }
 
   warning(message: string, loc?: SourceLocation, suggestion?: string): void {
-    this.diagnostics.push({
-      severity: DIAG_WARNING,
-      message,
-      loc,
-      suggestion,
-    });
+    this.diagnostics.push({ severity: DIAG_WARNING, message, loc, suggestion });
   }
 
   note(message: string, loc?: SourceLocation, suggestion?: string): void {
-    this.diagnostics.push({
-      severity: DIAG_NOTE,
-      message,
-      loc,
-      suggestion,
-    });
+    this.diagnostics.push({ severity: DIAG_NOTE, message, loc, suggestion });
   }
 
   hasErrors(): boolean {
     for (let i = 0; i < this.diagnostics.length; i++) {
-      if (this.diagnostics[i].severity === DIAG_ERROR) {
-        return true;
-      }
+      if (this.diagnostics[i].severity === DIAG_ERROR) return true;
     }
     return false;
   }
 
   hasWarnings(): boolean {
     for (let i = 0; i < this.diagnostics.length; i++) {
-      if (this.diagnostics[i].severity === DIAG_WARNING) {
-        return true;
-      }
+      if (this.diagnostics[i].severity === DIAG_WARNING) return true;
     }
     return false;
   }
@@ -88,9 +70,7 @@ export class DiagnosticEngine {
   getErrors(): Diagnostic[] {
     const result: Diagnostic[] = [];
     for (let i = 0; i < this.diagnostics.length; i++) {
-      if (this.diagnostics[i].severity === DIAG_ERROR) {
-        result.push(this.diagnostics[i]);
-      }
+      if (this.diagnostics[i].severity === DIAG_ERROR) result.push(this.diagnostics[i]);
     }
     return result;
   }
@@ -98,9 +78,7 @@ export class DiagnosticEngine {
   getWarnings(): Diagnostic[] {
     const result: Diagnostic[] = [];
     for (let i = 0; i < this.diagnostics.length; i++) {
-      if (this.diagnostics[i].severity === DIAG_WARNING) {
-        result.push(this.diagnostics[i]);
-      }
+      if (this.diagnostics[i].severity === DIAG_WARNING) result.push(this.diagnostics[i]);
     }
     return result;
   }
@@ -128,61 +106,112 @@ export class DiagnosticEngine {
     return BOLD + text + RESET;
   }
 
-  private green(text: string): string {
+  private blue(text: string): string {
     if (!this.colorEnabled) return text;
-    return GREEN + text + RESET;
+    return BLUE + text + RESET;
+  }
+
+  private red(text: string): string {
+    if (!this.colorEnabled) return text;
+    return RED + text + RESET;
+  }
+
+  private redBold(text: string): string {
+    if (!this.colorEnabled) return text;
+    return BOLD + RED + text + RESET;
+  }
+
+  private yellowBold(text: string): string {
+    if (!this.colorEnabled) return text;
+    return BOLD + YELLOW + text + RESET;
+  }
+
+  private cyanBold(text: string): string {
+    if (!this.colorEnabled) return text;
+    return BOLD + CYAN + text + RESET;
+  }
+
+  private applyUnderlineColor(severity: number, text: string): string {
+    if (severity === DIAG_ERROR) return this.redBold(text);
+    if (severity === DIAG_WARNING) return this.yellowBold(text);
+    return this.cyanBold(text);
+  }
+
+  private guessTokenLength(line: string, col: number): number {
+    if (col >= line.length) return 1;
+    const ch = line[col];
+    if (/[a-zA-Z_$]/.test(ch)) {
+      let end = col + 1;
+      while (end < line.length && /[a-zA-Z0-9_$]/.test(line[end])) end++;
+      return end - col;
+    }
+    if (/[0-9]/.test(ch)) {
+      let end = col + 1;
+      while (end < line.length && /[0-9.]/.test(line[end])) end++;
+      return end - col;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      let end = col + 1;
+      while (end < line.length && line[end] !== ch) end++;
+      return end - col + 1;
+    }
+    return 1;
   }
 
   formatDiagnostic(diag: Diagnostic): string {
     let output = "";
     const label = this.coloredSeverity(diag.severity);
 
-    if (diag.loc && this.sourceCode) {
+    output += label + this.bold(": " + diag.message) + "\n";
+
+    if (diag.loc) {
       const lineNum = diag.loc.line;
       const col = diag.loc.column;
       const displayFile = diag.loc.file || this.filename;
-      const allLines = this.sourceCode.split("\n");
 
       const lineNumStr = String(lineNum);
-      const lineNumWidth = lineNumStr.length > 2 ? lineNumStr.length : 2;
+      const lineNumWidth = lineNumStr.length < 2 ? 2 : lineNumStr.length;
+      const pad = " ".repeat(lineNumWidth);
 
-      output +=
-        this.bold(displayFile + ":" + lineNum + ":" + (col + 1) + ":") +
-        " " +
-        label +
-        ": " +
-        this.bold(diag.message) +
-        "\n";
-      output += " ".repeat(lineNumWidth) + " |" + "\n";
+      output += pad + " " + this.blue("-->") + " " + displayFile + ":" + lineNum + ":" + col + "\n";
 
-      const lineContent = allLines[lineNum - 1] || "";
-      output += lineNumStr.padStart(lineNumWidth) + " | " + lineContent + "\n";
-      output += " ".repeat(lineNumWidth) + " | " + " ".repeat(col) + this.green("^") + "\n";
+      if (this.sourceCode) {
+        const allLines = this.sourceCode.split("\n");
+        const lineContent = allLines[lineNum - 1];
 
-      if (diag.suggestion) {
-        output += " ".repeat(lineNumWidth) + " |" + "\n";
-        output +=
-          " ".repeat(lineNumWidth) + " = " + this.bold("help:") + " " + diag.suggestion + "\n";
+        if (lineContent !== undefined) {
+          const tokenLen = this.guessTokenLength(lineContent, col - 1);
+          const underline = "^" + "~".repeat(tokenLen > 1 ? tokenLen - 1 : 0);
+
+          output += pad + " " + this.blue("|") + "\n";
+          output += this.blue(lineNumStr.padStart(lineNumWidth) + " |") + " " + lineContent + "\n";
+          output += pad + " " + this.blue("|") + " " + " ".repeat(col - 1) + this.applyUnderlineColor(diag.severity, underline) + "\n";
+        }
+      } else {
+        output += pad + " " + this.blue("|") + "\n";
       }
-    } else if (diag.loc) {
-      const displayFile = diag.loc.file || this.filename;
-      output +=
-        this.bold(displayFile + ":" + diag.loc.line + ":" + (diag.loc.column + 1) + ":") +
-        " " +
-        label +
-        ": " +
-        this.bold(diag.message) +
-        "\n";
+
       if (diag.suggestion) {
-        output += "  " + this.bold("help:") + " " + diag.suggestion + "\n";
+        output += pad + " " + this.blue("|") + "\n";
+        output += pad + " " + this.blue("=") + " " + this.bold("help:") + " " + diag.suggestion + "\n";
+      }
+      if (diag.notes) {
+        for (let i = 0; i < diag.notes.length; i++) {
+          output += pad + " " + this.blue("=") + " " + this.bold("note:") + " " + diag.notes[i] + "\n";
+        }
       }
     } else {
-      output += label + ": " + this.bold(diag.message) + "\n";
       if (diag.suggestion) {
-        output += "  " + this.bold("help:") + " " + diag.suggestion + "\n";
+        output += "  " + this.blue("=") + " " + this.bold("help:") + " " + diag.suggestion + "\n";
+      }
+      if (diag.notes) {
+        for (let i = 0; i < diag.notes.length; i++) {
+          output += "  " + this.blue("=") + " " + this.bold("note:") + " " + diag.notes[i] + "\n";
+        }
       }
     }
 
+    output += "\n";
     return output;
   }
 
@@ -193,4 +222,27 @@ export class DiagnosticEngine {
     }
     return output;
   }
+}
+
+let globalColorEnabled = false;
+
+export function setGlobalDiagnosticColor(enabled: boolean): void {
+  globalColorEnabled = enabled;
+}
+
+export function formatCompileError(
+  sourceCode: string,
+  message: string,
+  loc?: SourceLocation,
+  suggestion?: string,
+  notes?: string[],
+  color?: boolean,
+): string {
+  const engine = new DiagnosticEngine();
+  engine.setSourceCode(sourceCode);
+  engine.setColor(color !== undefined ? color : globalColorEnabled);
+  engine.error(message, loc, suggestion);
+  const diag = engine.getErrors()[0];
+  if (notes) diag.notes = notes;
+  return engine.formatDiagnostic(diag);
 }

--- a/src/diagnostics/engine.ts
+++ b/src/diagnostics/engine.ts
@@ -185,7 +185,14 @@ export class DiagnosticEngine {
 
           output += pad + " " + this.blue("|") + "\n";
           output += this.blue(lineNumStr.padStart(lineNumWidth) + " |") + " " + lineContent + "\n";
-          output += pad + " " + this.blue("|") + " " + " ".repeat(col - 1) + this.applyUnderlineColor(diag.severity, underline) + "\n";
+          output +=
+            pad +
+            " " +
+            this.blue("|") +
+            " " +
+            " ".repeat(col - 1) +
+            this.applyUnderlineColor(diag.severity, underline) +
+            "\n";
         }
       } else {
         output += pad + " " + this.blue("|") + "\n";
@@ -193,11 +200,13 @@ export class DiagnosticEngine {
 
       if (diag.suggestion) {
         output += pad + " " + this.blue("|") + "\n";
-        output += pad + " " + this.blue("=") + " " + this.bold("help:") + " " + diag.suggestion + "\n";
+        output +=
+          pad + " " + this.blue("=") + " " + this.bold("help:") + " " + diag.suggestion + "\n";
       }
       if (diag.notes) {
         for (let i = 0; i < diag.notes.length; i++) {
-          output += pad + " " + this.blue("=") + " " + this.bold("note:") + " " + diag.notes[i] + "\n";
+          output +=
+            pad + " " + this.blue("=") + " " + this.bold("note:") + " " + diag.notes[i] + "\n";
         }
       }
     } else {

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -7,6 +7,7 @@ import { LLVMGenerator, LLVMGeneratorOptions, SemaSymbolData } from "./codegen/l
 import { SemanticAnalyzer } from "./analysis/semantic-analyzer.js";
 import { AST, ImportDeclaration, FunctionNode, ClassNode, ClassMethod } from "./ast/types.js";
 import { TargetInfo } from "./target-types.js";
+import { setGlobalDiagnosticColor } from "./diagnostics/engine.js";
 
 const stdlibKeys: string[] = [];
 const stdlibValues: string[] = [];
@@ -95,6 +96,7 @@ export let extraLinkPaths: string[] = [];
 
 export function setDiagnosticColor(value: boolean): void {
   diagnosticColorEnabled = value;
+  setGlobalDiagnosticColor(value);
 }
 
 export function setSkipSemanticAnalysis(value: boolean): void {

--- a/src/semantic/closure-mutation-checker.ts
+++ b/src/semantic/closure-mutation-checker.ts
@@ -25,16 +25,19 @@ import type {
   MapEntry,
   SourceLocation,
 } from "../ast/types.js";
+import { formatCompileError } from "../diagnostics/engine.js";
 
-export function checkClosureMutations(ast: AST): void {
-  const checker = new ClosureMutationChecker();
+export function checkClosureMutations(ast: AST, sourceCode: string): void {
+  const checker = new ClosureMutationChecker(sourceCode);
   checker.checkAST(ast);
 }
 
 class ClosureMutationChecker {
   private analyzer: ClosureAnalyzer;
+  private sourceCode: string;
 
-  constructor() {
+  constructor(sourceCode: string) {
+    this.sourceCode = sourceCode;
     this.analyzer = new ClosureAnalyzer();
   }
 
@@ -349,24 +352,14 @@ class ClosureMutationChecker {
   }
 
   private reportError(varName: string, loc?: SourceLocation): void {
-    let msg = "";
-    if (loc !== null && loc !== undefined) {
-      const file = loc.file || "<input>";
-      msg +=
-        file +
-        ":" +
-        loc.line +
-        ":" +
-        (loc.column + 1) +
-        ": error: variable '" +
-        varName +
-        "' is captured by a closure but reassigned after capture\n";
-    } else {
-      msg +=
-        "error: variable '" + varName + "' is captured by a closure but reassigned after capture\n";
-    }
-    msg += "  note: ChadScript closures capture by value; the closure will not see this change\n";
-    console.error(msg);
+    const output = formatCompileError(
+      this.sourceCode,
+      "variable '" + varName + "' is captured by a closure but reassigned after capture",
+      loc,
+      undefined,
+      ["ChadScript closures capture by value; the closure will not see this change"],
+    );
+    process.stderr.write(output);
     process.exit(1);
   }
 }

--- a/src/semantic/type-assertion-checker.ts
+++ b/src/semantic/type-assertion-checker.ts
@@ -459,12 +459,23 @@ class TypeAssertionChecker {
         }
         notes.push("interface '" + mismatchIfaceName + "': { " + uNames.join("; ") + " }");
       }
-      notes.push("GEP indices in native code are determined by field position in the asserted type");
+      notes.push(
+        "GEP indices in native code are determined by field position in the asserted type",
+      );
       const output = formatCompileError(
         this.sourceCode,
-        "named type assertion '" + assertedType + "' has wrong field indices relative to '" + mismatchIfaceName + "': " + mismatchReason,
+        "named type assertion '" +
+          assertedType +
+          "' has wrong field indices relative to '" +
+          mismatchIfaceName +
+          "': " +
+          mismatchReason,
         ta.loc,
-        "'" + assertedType + "' fields must appear at the same positions as in '" + mismatchIfaceName + "'",
+        "'" +
+          assertedType +
+          "' fields must appear at the same positions as in '" +
+          mismatchIfaceName +
+          "'",
         notes,
       );
       process.stderr.write(output);

--- a/src/semantic/type-assertion-checker.ts
+++ b/src/semantic/type-assertion-checker.ts
@@ -31,17 +31,20 @@ import type {
   MapEntry,
   MethodCallNode,
 } from "../ast/types.js";
+import { formatCompileError } from "../diagnostics/engine.js";
 
-export function checkTypeAssertions(ast: AST): void {
-  const checker = new TypeAssertionChecker(ast);
+export function checkTypeAssertions(ast: AST, sourceCode: string): void {
+  const checker = new TypeAssertionChecker(ast, sourceCode);
   checker.check();
 }
 
 class TypeAssertionChecker {
   private ast: AST;
+  private sourceCode: string;
 
-  constructor(ast: AST) {
+  constructor(ast: AST, sourceCode: string) {
     this.ast = ast;
+    this.sourceCode = sourceCode;
   }
 
   check(): void {
@@ -441,26 +444,12 @@ class TypeAssertionChecker {
     }
 
     if (anyMismatch && !anyValid) {
-      let msg = "";
-      if (ta.loc) {
-        const file = ta.loc.file || "<input>";
-        msg += file + ":" + ta.loc.line + ":" + (ta.loc.column + 1) + ": error: ";
-      } else {
-        msg += "error: ";
-      }
-      msg +=
-        "named type assertion '" +
-        assertedType +
-        "' has wrong field indices relative to '" +
-        mismatchIfaceName +
-        "': " +
-        mismatchReason +
-        "\n";
       const tNames: string[] = [];
       for (let i = 0; i < tFields.length; i++) {
         tNames.push(this.stripOpt((tFields[i] as InterfaceField).name));
       }
-      msg += "  asserted type '" + assertedType + "': { " + tNames.join("; ") + " }\n";
+      const notes: string[] = [];
+      notes.push("asserted type '" + assertedType + "': { " + tNames.join("; ") + " }");
       const mismatchIface = this.getInterface(mismatchIfaceName);
       if (mismatchIface !== null) {
         const uF = this.getAllFields(mismatchIface);
@@ -468,17 +457,17 @@ class TypeAssertionChecker {
         for (let i = 0; i < uF.length; i++) {
           uNames.push((uF[i] as InterfaceField).name);
         }
-        msg += "  interface '" + mismatchIfaceName + "': { " + uNames.join("; ") + " }\n";
+        notes.push("interface '" + mismatchIfaceName + "': { " + uNames.join("; ") + " }");
       }
-      msg +=
-        "  note: GEP indices in native code are determined by field position in the asserted type\n";
-      msg +=
-        "  hint: '" +
-        assertedType +
-        "' fields must appear at the same positions as in '" +
-        mismatchIfaceName +
-        "'\n";
-      console.error(msg);
+      notes.push("GEP indices in native code are determined by field position in the asserted type");
+      const output = formatCompileError(
+        this.sourceCode,
+        "named type assertion '" + assertedType + "' has wrong field indices relative to '" + mismatchIfaceName + "': " + mismatchReason,
+        ta.loc,
+        "'" + assertedType + "' fields must appear at the same positions as in '" + mismatchIfaceName + "'",
+        notes,
+      );
+      process.stderr.write(output);
       process.exit(1);
     }
   }
@@ -519,29 +508,22 @@ class TypeAssertionChecker {
     assertedNames: string[],
     reason: string,
   ): void {
-    let msg = "";
-    if (ta.loc) {
-      const file = ta.loc.file || "<input>";
-      msg += file + ":" + ta.loc.line + ":" + (ta.loc.column + 1) + ": error: ";
-    } else {
-      msg += "error: ";
-    }
-    msg +=
-      "inline type assertion fields do not form a valid prefix of '" +
-      iface.name +
-      "': " +
-      reason +
-      "\n";
-    msg += "  assertion: { " + assertedNames.join("; ") + " }\n";
     const ifaceFieldNames: string[] = [];
     for (let i = 0; i < ifaceFields.length; i++) {
       ifaceFieldNames.push((ifaceFields[i] as InterfaceField).name);
     }
-    msg += "  interface: { " + ifaceFieldNames.join("; ") + " }\n";
-    msg += "  note: inline assertion field positions define GEP indices in native code\n";
-    msg +=
-      "  hint: use 'as " + iface.name + "' or list fields as a prefix in exact interface order\n";
-    console.error(msg);
+    const output = formatCompileError(
+      this.sourceCode,
+      "inline type assertion fields do not form a valid prefix of '" + iface.name + "': " + reason,
+      ta.loc,
+      "use 'as " + iface.name + "' or list fields as a prefix in exact interface order",
+      [
+        "assertion: { " + assertedNames.join("; ") + " }",
+        "interface: { " + ifaceFieldNames.join("; ") + " }",
+        "inline assertion field positions define GEP indices in native code",
+      ],
+    );
+    process.stderr.write(output);
     process.exit(1);
   }
 

--- a/src/semantic/uninitialized-field-checker.ts
+++ b/src/semantic/uninitialized-field-checker.ts
@@ -14,13 +14,20 @@ import type {
   SwitchStatement,
   MemberAccessAssignmentNode,
 } from "../ast/types.js";
+import { formatCompileError } from "../diagnostics/engine.js";
 
-export function checkUninitializedFields(ast: AST): void {
-  const checker = new UninitializedFieldChecker();
+export function checkUninitializedFields(ast: AST, sourceCode: string): void {
+  const checker = new UninitializedFieldChecker(sourceCode);
   checker.check(ast);
 }
 
 class UninitializedFieldChecker {
+  private sourceCode: string;
+
+  constructor(sourceCode: string) {
+    this.sourceCode = sourceCode;
+  }
+
   check(ast: AST): void {
     for (let i = 0; i < ast.classes.length; i++) {
       this.checkClass(ast.classes[i]);
@@ -142,36 +149,40 @@ class UninitializedFieldChecker {
     }
   }
 
-  private emitErrors(cls: ClassNode, fields: ClassField[]): void {
-    for (let i = 0; i < fields.length; i++) {
-      const field = fields[i];
-      const loc = cls.loc;
-      if (loc) {
-        const file = loc.file || "<unknown>";
-        const line = loc.line || 0;
-        const col = loc.column || 0;
-        console.log(
-          file +
-            ":" +
-            String(line) +
-            ":" +
-            String(col) +
-            ": error: class '" +
-            cls.name +
-            "' has uninitialized field '" +
-            field.name +
-            "' — assign a value in the field declaration or constructor",
-        );
-      } else {
-        console.log(
-          "error: class '" +
-            cls.name +
-            "' has uninitialized field '" +
-            field.name +
-            "' — assign a value in the field declaration or constructor",
-        );
+  private findFieldLoc(cls: ClassNode, fieldName: string): { line: number; column: number; file: string } | null {
+    if (!cls.loc || !this.sourceCode) return null;
+    const lines = this.sourceCode.split("\n");
+    const startLine = cls.loc.line - 1;
+    for (let i = startLine; i < lines.length; i++) {
+      const line = lines[i];
+      const idx = line.indexOf(fieldName);
+      if (idx !== -1) {
+        const before = line.substring(0, idx).trim();
+        const after = line.substring(idx + fieldName.length).trimStart();
+        if ((before === "" || before === "public" || before === "private" || before === "protected" || before === "readonly") && (after.startsWith(":") || after.startsWith(";"))) {
+          return { line: i + 1, column: idx + 1, file: cls.loc.file || "<unknown>" };
+        }
       }
     }
+    return null;
+  }
+
+  private emitErrors(cls: ClassNode, fields: ClassField[]): void {
+    let output = "";
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i];
+      const fieldLoc = this.findFieldLoc(cls, field.name);
+      const loc = fieldLoc
+        ? { file: fieldLoc.file, line: fieldLoc.line, column: fieldLoc.column, offset: 0 }
+        : cls.loc;
+      output += formatCompileError(
+        this.sourceCode,
+        "class '" + cls.name + "' has uninitialized field '" + field.name + "'",
+        loc,
+        "assign a value in the field declaration or constructor",
+      );
+    }
+    process.stderr.write(output);
     process.exit(1);
   }
 }

--- a/src/semantic/uninitialized-field-checker.ts
+++ b/src/semantic/uninitialized-field-checker.ts
@@ -149,7 +149,10 @@ class UninitializedFieldChecker {
     }
   }
 
-  private findFieldLoc(cls: ClassNode, fieldName: string): { line: number; column: number; file: string } | null {
+  private findFieldLoc(
+    cls: ClassNode,
+    fieldName: string,
+  ): { line: number; column: number; file: string } | null {
     if (!cls.loc || !this.sourceCode) return null;
     const lines = this.sourceCode.split("\n");
     const startLine = cls.loc.line - 1;
@@ -159,7 +162,14 @@ class UninitializedFieldChecker {
       if (idx !== -1) {
         const before = line.substring(0, idx).trim();
         const after = line.substring(idx + fieldName.length).trimStart();
-        if ((before === "" || before === "public" || before === "private" || before === "protected" || before === "readonly") && (after.startsWith(":") || after.startsWith(";"))) {
+        if (
+          (before === "" ||
+            before === "public" ||
+            before === "private" ||
+            before === "protected" ||
+            before === "readonly") &&
+          (after.startsWith(":") || after.startsWith(";"))
+        ) {
           return { line: i + 1, column: idx + 1, file: cls.loc.file || "<unknown>" };
         }
       }

--- a/src/semantic/union-type-checker.ts
+++ b/src/semantic/union-type-checker.ts
@@ -48,10 +48,18 @@ function reportUnionError(
 ): void {
   const output = formatCompileError(
     sourceCode,
-    "in function '" + funcName + "', parameter type '" + aliasName + "' is a union type alias with mixed representations",
+    "in function '" +
+      funcName +
+      "', parameter type '" +
+      aliasName +
+      "' is a union type alias with mixed representations",
     loc,
     "use a common base interface or separate the types",
-    ["'" + aliasName + "' is a type alias for a union whose members have different native types (e.g., i8* vs double)"],
+    [
+      "'" +
+        aliasName +
+        "' is a type alias for a union whose members have different native types (e.g., i8* vs double)",
+    ],
   );
   process.stderr.write(output);
   process.exit(1);

--- a/src/semantic/union-type-checker.ts
+++ b/src/semantic/union-type-checker.ts
@@ -1,5 +1,6 @@
 import type { AST, SourceLocation } from "../ast/types.js";
 import { tsTypeToLlvm } from "../codegen/infrastructure/type-system.js";
+import { formatCompileError } from "../diagnostics/engine.js";
 
 function buildUnsafeAliases(ast: AST): string[] {
   const unsafeAliases: string[] = [];
@@ -40,43 +41,23 @@ function isUnsafeAlias(unsafeAliases: string[], typeName: string): boolean {
 }
 
 function reportUnionError(
+  sourceCode: string,
   funcName: string,
   aliasName: string,
   loc: SourceLocation | undefined,
 ): void {
-  let msg = "";
-  if (loc !== null && loc !== undefined) {
-    const file = loc.file || "<input>";
-    msg +=
-      file +
-      ":" +
-      loc.line +
-      ":" +
-      (loc.column + 1) +
-      ": error: in function '" +
-      funcName +
-      "', parameter type '" +
-      aliasName +
-      "' is a union type alias with mixed representations\n";
-  } else {
-    msg +=
-      "error: in function '" +
-      funcName +
-      "', parameter type '" +
-      aliasName +
-      "' is a union type alias with mixed representations\n";
-  }
-  msg +=
-    "  note: '" +
-    aliasName +
-    "' is a type alias for a union whose members have different native types (e.g., i8* vs double)\n";
-  msg +=
-    "  note: this will be miscompiled and segfault at runtime. Use a common base interface or separate the types.\n";
-  console.error(msg);
+  const output = formatCompileError(
+    sourceCode,
+    "in function '" + funcName + "', parameter type '" + aliasName + "' is a union type alias with mixed representations",
+    loc,
+    "use a common base interface or separate the types",
+    ["'" + aliasName + "' is a type alias for a union whose members have different native types (e.g., i8* vs double)"],
+  );
+  process.stderr.write(output);
   process.exit(1);
 }
 
-export function checkUnionTypes(ast: AST): void {
+export function checkUnionTypes(ast: AST, sourceCode: string): void {
   const unsafeAliases = buildUnsafeAliases(ast);
 
   for (let i = 0; i < ast.functions.length; i++) {
@@ -87,7 +68,7 @@ export function checkUnionTypes(ast: AST): void {
     const locHolder = fn as { loc?: SourceLocation };
     for (let j = 0; j < paramTypes.length; j++) {
       if (isUnsafeAlias(unsafeAliases, paramTypes[j])) {
-        reportUnionError(fn.name, paramTypes[j], locHolder.loc);
+        reportUnionError(sourceCode, fn.name, paramTypes[j], locHolder.loc);
       }
     }
   }
@@ -102,7 +83,7 @@ export function checkUnionTypes(ast: AST): void {
       const locHolder = method as { loc?: SourceLocation };
       for (let j = 0; j < paramTypes.length; j++) {
         if (isUnsafeAlias(unsafeAliases, paramTypes[j])) {
-          reportUnionError(qualName, paramTypes[j], locHolder.loc);
+          reportUnionError(sourceCode, qualName, paramTypes[j], locHolder.loc);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Compile errors now display Rust-style formatting with source code context, line numbers, colored underlines pointing to the exact token, and help/note annotations
- Before: `error: class 'User' has uninitialized field 'name' — assign a value...`
- After:
```
error: class 'User' has uninitialized field 'name'
   --> file.ts:2:3
   |
 2 |   name: string;
   |   ^~~~
   |
   = help: assign a value in the field declaration or constructor
```
- All 4 semantic passes (closure mutation, union types, type assertions, uninitialized fields) now use the shared `formatCompileError()` formatter
- Fixed a bug where `entryFileCode` wasn't found for relative input paths (abs path comparison mismatch)
- Uninitialized field errors now point to the field declaration line, not the class line

## Test plan
- [x] All 458 tests pass
- [x] Self-hosting passes (Stage 0 + Stage 1)
- [x] Native compiler builds successfully
- [x] Compile error test fixtures still match expected substrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)