### PR TITLE
fix: emit compile error for for...of on numeric maps instead of segfaulting

### DIFF
--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -2149,6 +2149,13 @@ export class ControlFlowGenerator {
     if (iterableBase.type === "variable") {
       const varName = (stmt.iterable as VariableNode).name;
       if (this.ctx.symbolTable.isMap(varName)) {
+        const mapMeta = this.ctx.symbolTable.getMapMetadata(varName);
+        if (!mapMeta || mapMeta.keyType !== "string") {
+          return this.ctx.emitError(
+            "for...of on Map<number, *> is not supported — use Map<string, *> instead",
+            stmt.loc,
+          );
+        }
         const mapPtr = this.ctx.generateExpression(stmt.iterable, params);
         iterableValue = this.ctx.stringMapGen.generateStringMapEntries(mapPtr);
       } else {
@@ -2165,6 +2172,12 @@ export class ControlFlowGenerator {
         );
         const fieldInfo = fieldInfoResult as FieldInfo;
         if (fieldInfoResult && fieldInfo.tsType && fieldInfo.tsType.startsWith("Map<")) {
+          if (fieldInfo.tsType.startsWith("Map<number")) {
+            return this.ctx.emitError(
+              "for...of on Map<number, *> is not supported — use Map<string, *> instead",
+              stmt.loc,
+            );
+          }
           const mapPtr = this.ctx.generateExpression(stmt.iterable, params);
           iterableValue = this.ctx.stringMapGen.generateStringMapEntries(mapPtr);
         } else {

--- a/tests/fixtures/data-structures/map-numeric-entries-error.ts
+++ b/tests/fixtures/data-structures/map-numeric-entries-error.ts
@@ -1,0 +1,11 @@
+// @test-compile-error: for...of on Map<number, *> is not supported
+// @test-description: compile error for iterating numeric map entries
+function testNumericMapEntries() {
+  const m = new Map<number, number>();
+  m.set(1, 10);
+  for (const [k, v] of m) {
+    console.log(k);
+  }
+}
+
+testNumericMapEntries();


### PR DESCRIPTION
## Problem

`for (const [k, v] of numericMap)` on a `Map<number, number>` silently generated wrong code — it called `stringMapGen.generateStringMapEntries` on a `%Map` struct (which has `double*` arrays, not `i8**`). The destructured values were treated as `i8*` string pointers, so any use of `k` or `v` (e.g. `console.log(k)`) caused a segfault.

## Fix

Added a guard in `generateMapEntriesForOf` that checks map metadata before generating entries iteration. If the map has no metadata (numeric maps don't store `mapMetadata`) or the key type isn't `"string"`, the compiler now emits a clear compile error:

```
file.ts:6:3: error: for...of on Map<number, *> is not supported — use Map<string, *> instead
```

This is consistent with `method-calls.ts` which already emits compile errors for `numericMap.entries()`, `numericMap.keys()`, and `numericMap.values()`.

## Test plan
- New test fixture: `map-numeric-entries-error.ts` (expects compile error)
- All 459 tests pass