### PR TITLE
fix: support class instances and typed arrays returned from function calls

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1423,11 +1423,13 @@ export class VariableAllocator {
     const valueBase = stmt.value as ExprBase;
     if (valueBase.type === "new") {
       const newExpr = stmt.value as NewNode;
-      // Resolve import alias (e.g., import MyGreeter from './greeter' → Greeter)
       className = this.ctx.resolveImportAlias(newExpr.className);
     } else if (valueBase.type === "method_call") {
       const methodExpr = stmt.value as MethodCallNode;
       className = this.getMapGetClassName(methodExpr) || "Unknown";
+    } else if (valueBase.type === "call") {
+      const callExpr = stmt.value as CallNode;
+      className = this.getCallReturnClassName(callExpr) || "Unknown";
     } else {
       return this.ctx.emitError(
         `Cannot allocate class instance for expression type: ${valueBase.type}`,
@@ -1485,6 +1487,34 @@ export class VariableAllocator {
           const mapParsed = parseMapTypeString(fieldInfo.tsType);
           if (mapParsed && mapParsed.valueType) {
             return mapParsed.valueType;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private getCallReturnClassName(callExpr: CallNode): string | null {
+    if (!callExpr.name) return null;
+    const ast = this.ctx.getAst();
+    if (!ast) return null;
+    for (let i = 0; i < ast.functions.length; i++) {
+      const fn = ast.functions[i];
+      if (fn && fn.name === callExpr.name && fn.returnType) {
+        const rt = stripNullable(fn.returnType);
+        if (this.isKnownClass(rt)) {
+          return this.ctx.resolveImportAlias(rt);
+        }
+      }
+    }
+    if (callExpr.name) {
+      const resolved = this.ctx.resolveImportAlias(callExpr.name);
+      for (let i = 0; i < ast.functions.length; i++) {
+        const fn = ast.functions[i];
+        if (fn && fn.name === resolved && fn.returnType) {
+          const rt = stripNullable(fn.returnType);
+          if (this.isKnownClass(rt)) {
+            return this.ctx.resolveImportAlias(rt);
           }
         }
       }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -1914,6 +1914,77 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
                   handled = true;
                   break;
                 }
+                if (this.isKnownClass(rt)) {
+                  const resolvedClassName = this.resolveImportAlias(rt);
+                  const fields = this.classGen
+                    ? this.classGen.getClassFields(resolvedClassName) || []
+                    : [];
+                  const llvmType = fields.length > 0 ? `%${resolvedClassName}_struct*` : "i32*";
+                  ir += `@${name} = global ${llvmType} null` + "\n";
+                  this.globalVariables.set(name, {
+                    llvmType,
+                    kind: SymbolKind.Class,
+                    initialized: false,
+                  });
+                  this.defineVariableWithMetadata(
+                    name,
+                    `@${name}`,
+                    llvmType,
+                    SymbolKind.Class,
+                    "global",
+                    createClassMetadata({ className: resolvedClassName }),
+                  );
+                  handled = true;
+                  break;
+                }
+                if (rt.endsWith("[]")) {
+                  const elementType = rt.substring(0, rt.length - 2);
+                  if (elementType === "string") {
+                    ir += `@${name} = global %StringArray* null` + "\n";
+                    this.globalVariables.set(name, {
+                      llvmType: "%StringArray*",
+                      kind: SymbolKind.StringArray,
+                      initialized: false,
+                    });
+                    this.defineVariable(
+                      name,
+                      `@${name}`,
+                      "%StringArray*",
+                      SymbolKind.StringArray,
+                      "global",
+                    );
+                    handled = true;
+                    break;
+                  }
+                  if (elementType === "number" || elementType === "boolean") {
+                    ir += `@${name} = global %Array* null` + "\n";
+                    this.globalVariables.set(name, {
+                      llvmType: "%Array*",
+                      kind: SymbolKind.Array,
+                      initialized: false,
+                    });
+                    this.defineVariable(name, `@${name}`, "%Array*", SymbolKind.Array, "global");
+                    handled = true;
+                    break;
+                  }
+                  ir += `@${name} = global %ObjectArray* null` + "\n";
+                  this.globalVariables.set(name, {
+                    llvmType: "%ObjectArray*",
+                    kind: SymbolKind.ObjectArray,
+                    initialized: false,
+                  });
+                  this.defineVariableWithMetadata(
+                    name,
+                    `@${name}`,
+                    "%ObjectArray*",
+                    SymbolKind.ObjectArray,
+                    "global",
+                    createInterfaceMetadata(elementType),
+                  );
+                  this.symbolTable.setRawInterfaceType(name, elementType);
+                  handled = true;
+                  break;
+                }
                 if (this.isTypeAlias(rt)) {
                   const commonProps = this.getTypeAliasCommonProperties(rt);
                   if (commonProps) {
@@ -2197,8 +2268,21 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           this.defineVariable(name, `@${name}`, llvmType, kind, "global");
           continue;
         } else if (isClassInstance) {
-          // Resolve import alias for default imports (e.g., import Foo from './bar' → BarClass)
-          const className = this.resolveImportAlias((stmt.value as NewNode).className);
+          let className = "";
+          const stmtValueType = (stmt.value as { type: string }).type;
+          if (stmtValueType === "new") {
+            className = this.resolveImportAlias((stmt.value as NewNode).className);
+          } else if (stmtValueType === "call") {
+            const callExpr = stmt.value as CallNode;
+            const func = callExpr.name
+              ? this.ast.functions.find((f) => f && f.name === callExpr.name && f.returnType)
+              : null;
+            className = func
+              ? this.resolveImportAlias(stripNullable(func.returnType!))
+              : resolved!.base;
+          } else {
+            className = resolved!.base;
+          }
           const fields = this.classGen ? this.classGen.getClassFields(className) || [] : [];
           llvmType = fields.length > 0 ? `%${className}_struct*` : "i32*";
           kind = SymbolKind.Class;

--- a/tests/fixtures/classes/class-return-deep-access.ts
+++ b/tests/fixtures/classes/class-return-deep-access.ts
@@ -1,0 +1,52 @@
+// @test-description: class with self-referential fields returned from function
+
+class TreeNode {
+  value: string;
+  left: TreeNode;
+  right: TreeNode;
+  constructor(v: string) {
+    this.value = v;
+  }
+  setLeft(n: TreeNode): void {
+    this.left = n;
+  }
+  setRight(n: TreeNode): void {
+    this.right = n;
+  }
+}
+
+function buildTree(): TreeNode {
+  const root = new TreeNode("root");
+  const l = new TreeNode("left");
+  const r = new TreeNode("right");
+  const ll = new TreeNode("left-left");
+  const lr = new TreeNode("left-right");
+  root.setLeft(l);
+  root.setRight(r);
+  l.setLeft(ll);
+  l.setRight(lr);
+  return root;
+}
+
+const tree = buildTree();
+if (tree.value !== "root") {
+  console.log("FAIL: root");
+  process.exit(1);
+}
+if (tree.left.value !== "left") {
+  console.log("FAIL: left");
+  process.exit(1);
+}
+if (tree.right.value !== "right") {
+  console.log("FAIL: right");
+  process.exit(1);
+}
+if (tree.left.left.value !== "left-left") {
+  console.log("FAIL: left-left");
+  process.exit(1);
+}
+if (tree.left.right.value !== "left-right") {
+  console.log("FAIL: left-right");
+  process.exit(1);
+}
+console.log("TEST_PASSED");

--- a/tests/fixtures/classes/class-return-from-function.ts
+++ b/tests/fixtures/classes/class-return-from-function.ts
@@ -1,0 +1,32 @@
+// @test-description: class instance returned from function has correct field access
+
+class Animal {
+  name: string;
+  legs: number;
+  constructor(n: string, l: number) {
+    this.name = n;
+    this.legs = l;
+  }
+}
+
+function createAnimal(n: string, l: number): Animal {
+  return new Animal(n, l);
+}
+
+const cat = createAnimal("cat", 4);
+console.log(cat.name);
+console.log(cat.legs.toString());
+
+function test(): void {
+  const dog = createAnimal("dog", 4);
+  if (dog.name !== "dog") {
+    console.log("FAIL: local name");
+    process.exit(1);
+  }
+  if (dog.legs !== 4) {
+    console.log("FAIL: local legs");
+    process.exit(1);
+  }
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/interfaces/interface-array-from-function.ts
+++ b/tests/fixtures/interfaces/interface-array-from-function.ts
@@ -1,0 +1,42 @@
+// @test-description: interface array returned from function with element access
+
+interface KV {
+  key: string;
+  value: string;
+}
+
+function buildPairs(n: number): KV[] {
+  const result: KV[] = [];
+  for (let i = 0; i < n; i++) {
+    result.push({ key: "key-" + i.toString(), value: "val-" + i.toString() });
+  }
+  return result;
+}
+
+const pairs = buildPairs(50);
+const last = pairs[49];
+if (last.key !== "key-49") {
+  console.log("FAIL: last key " + last.key);
+  process.exit(1);
+}
+if (last.value !== "val-49") {
+  console.log("FAIL: last value");
+  process.exit(1);
+}
+
+const filtered: KV[] = [];
+for (let i = 0; i < pairs.length; i++) {
+  const p = pairs[i];
+  if (p.key === "key-25") {
+    filtered.push(p);
+  }
+}
+if (filtered.length !== 1) {
+  console.log("FAIL: filtered length");
+  process.exit(1);
+}
+if (filtered[0].value !== "val-25") {
+  console.log("FAIL: filtered value");
+  process.exit(1);
+}
+console.log("TEST_PASSED");


### PR DESCRIPTION
Functions returning class instances or typed arrays (e.g. `KV[]`) previously caused segfaults or LLVM errors because the compiler lost type information at the call site.

**What was broken:**
- `const x = makeObj()` where `makeObj()` returns a class → segfault (field access read wrong memory)
- `const tree = buildTree()` with self-referential class fields → segfault on deep member access
- `const pairs = buildPairs(50)` returning `KV[]` → LLVM opt error (ptr vs double type mismatch)

**Root cause:** The variable allocator and global variable declarations didn't handle `call` expressions that return class instances or typed arrays — only `new` and `method_call` were supported.

**Fix:**
- `allocateClassInstance` now handles `call` by looking up the function's return type to determine the class name
- Global variable declarations now detect class and array return types from function calls
- Added 3 test fixtures covering all crash patterns