### PR TITLE
fix: emit compile error for global-scope map instead of segfaulting

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2107,48 +2107,12 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             continue;
           }
         } else if (isMap) {
-          let isStringMap = false;
-          let mapValueType = "string";
-          if (stmt.declaredType) {
-            const dt = stmt.declaredType;
-            if (dt.indexOf("Map<string") !== -1) {
-              isStringMap = true;
-              const parsed = parseMapTypeString(dt);
-              if (parsed) mapValueType = parsed.valueType;
-            }
-          }
-          if (!isStringMap && stmt.value) {
-            const mapNode = stmt.value as MapNode;
-            if (mapNode.keyType === "string") {
-              isStringMap = true;
-              mapValueType = mapNode.valueType || "string";
-            }
-          }
-          if (isStringMap) {
-            llvmType = "%StringMap*";
-            kind = SymbolKind.Map;
-            defaultValue = "null";
-            const llvmValueType = mapValueType === "number" ? "double" : "i8*";
-            ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
-            this.globalVariables.set(name, { llvmType, kind, initialized: false });
-            this.defineVariableWithMetadata(
-              name,
-              `@${name}`,
-              llvmType,
-              kind,
-              "global",
-              createMapMetadataSymbol({
-                keyType: "string",
-                valueType: mapValueType,
-                llvmKeyType: "i8*",
-                llvmValueType,
-              }),
-            );
-            continue;
-          }
-          llvmType = "%Map*";
-          kind = SymbolKind.Map;
-          defaultValue = "null";
+          this.emitError(
+            "Map operations at the top level are not supported — wrap in a function",
+            undefined,
+            "function main() { const " + name + " = new Map(...); ... } main();",
+          );
+          return "";
         } else if (isSet) {
           let isStringSet = false;
           if (stmt.declaredType) {

--- a/tests/fixtures/data-structures/map-global-scope-error.ts
+++ b/tests/fixtures/data-structures/map-global-scope-error.ts
@@ -1,0 +1,5 @@
+// @test-compile-error: Map operations at the top level are not supported
+// @test-description: compile error for global scope map usage
+const m = new Map<string, string>();
+m.set("k", "v");
+console.log(m.get("k"));


### PR DESCRIPTION
## Problem

`const m = new Map<string, string>(); m.set("k", "v");` at the top level (global scope) segfaults at runtime. This is because global maps are stored as `global %StringMap* null` (pointer-to-pointer), but `m.set()` treats them as direct struct pointers (like local `alloca %StringMap`). The calling convention mismatch causes memory corruption.

Maps inside functions work fine. Sets at global scope also work fine (different allocation path).

## Fix

Emit a clear compile error instead of silently generating wrong code:

```
error: Map operations at the top level are not supported — wrap in a function
  = help: function main() { const m = new Map(...); ... } main();
```

This is the safe approach — a proper fix would require changing how global map variables are stored and loaded (using an indirection layer), which is a larger change.

## Test plan
- New fixture: `map-global-scope-error.ts` (expects compile error)
- All 460 tests pass