### PR TITLE
feat: console.log/JSON.stringify for all types, for...of on strings

### DIFF
--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -446,6 +446,18 @@ function emitSingleArg(
     return;
   }
 
+  if (arg.type === "null") {
+    const str = ctx.stringGen.doCreateStringConstant("null");
+    emitPrintStrNoNl(ctx, useStderr, str);
+    return;
+  }
+
+  if (arg.type === "undefined") {
+    const str = ctx.stringGen.doCreateStringConstant("undefined");
+    emitPrintStrNoNl(ctx, useStderr, str);
+    return;
+  }
+
   if (arg.type === "variable") {
     const varName = (arg as VariableNode).name;
     const ifaceType =

--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -1,4 +1,4 @@
-import { Expression, MethodCallNode, StringNode } from "../../../ast/types.js";
+import { Expression, MethodCallNode, StringNode, VariableNode } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
 
 function emitPrint(
@@ -157,6 +157,243 @@ function emitArrayPrint(
   ctx.emitLabel(doneLabel);
 }
 
+function emitMapPrint(
+  ctx: MethodCallGeneratorContext,
+  useStderr: boolean,
+  mapPtr: string,
+  mapType: string,
+  valueType: string = "string",
+): void {
+  const isString = mapType === "%StringMap*";
+  const structType = isString ? "%StringMap" : "%Map";
+
+  const sizePtr = ctx.nextTemp();
+  ctx.emit(`${sizePtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 2`);
+  const size = ctx.emitLoad("i32", sizePtr);
+  const capPtr = ctx.nextTemp();
+  ctx.emit(`${capPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 3`);
+  const capacity = ctx.emitLoad("i32", capPtr);
+
+  const headerStr = ctx.stringGen.doCreateStringConstant("Map(");
+  emitPrintStrNoNl(ctx, useStderr, headerStr);
+  const sizeDouble = ctx.nextTemp();
+  ctx.emit(`${sizeDouble} = sitofp i32 ${size} to double`);
+  emitPrintNumNoNl(ctx, useStderr, sizeDouble);
+  const openStr = ctx.stringGen.doCreateStringConstant(") { ");
+  const closeStr = ctx.stringGen.doCreateStringConstant(" }");
+  const emptyCloseStr = ctx.stringGen.doCreateStringConstant(") {}");
+  const separator = ctx.stringGen.doCreateStringConstant(", ");
+  const arrow = ctx.stringGen.doCreateStringConstant(" => ");
+
+  const isEmpty = ctx.emitIcmp("eq", "i32", size, "0");
+  const emptyLabel = ctx.nextLabel("map_empty");
+  const nonEmptyLabel = ctx.nextLabel("map_nonempty");
+  const doneLabel = ctx.nextLabel("map_done");
+
+  ctx.emitBrCond(isEmpty, emptyLabel, nonEmptyLabel);
+
+  ctx.emitLabel(emptyLabel);
+  emitPrintStrNoNl(ctx, useStderr, emptyCloseStr);
+  ctx.emitBr(doneLabel);
+
+  ctx.emitLabel(nonEmptyLabel);
+  emitPrintStrNoNl(ctx, useStderr, openStr);
+
+  const keysFieldPtr = ctx.nextTemp();
+  ctx.emit(`${keysFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 0`);
+  const valsFieldPtr = ctx.nextTemp();
+  ctx.emit(`${valsFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 1`);
+  const keys = ctx.emitLoad(isString ? "i8**" : "double*", keysFieldPtr);
+  const vals = ctx.emitLoad(isString ? "i8**" : "double*", valsFieldPtr);
+
+  const iAlloca = ctx.nextTemp();
+  ctx.emit(`${iAlloca} = alloca i32`);
+  ctx.emitStore("i32", "0", iAlloca);
+  const printedAlloca = ctx.nextTemp();
+  ctx.emit(`${printedAlloca} = alloca i32`);
+  ctx.emitStore("i32", "0", printedAlloca);
+
+  const loopLabel = ctx.nextLabel("map_loop");
+  const checkSlotLabel = ctx.nextLabel("map_check");
+  const bodyLabel = ctx.nextLabel("map_body");
+  const sepLabel = ctx.nextLabel("map_sep");
+  const skipLabel = ctx.nextLabel("map_skip");
+  const latchLabel = ctx.nextLabel("map_latch");
+  const endLabel = ctx.nextLabel("map_end");
+
+  ctx.emitBr(loopLabel);
+
+  ctx.emitLabel(loopLabel);
+  const i = ctx.emitLoad("i32", iAlloca);
+  const reachedCap = ctx.emitIcmp("sge", "i32", i, capacity);
+  ctx.emitBrCond(reachedCap, endLabel, checkSlotLabel);
+
+  ctx.emitLabel(checkSlotLabel);
+  if (isString) {
+    const keyElemPtr = ctx.nextTemp();
+    ctx.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keys}, i32 ${i}`);
+    const keyAtSlot = ctx.emitLoad("i8*", keyElemPtr);
+    const isNull = ctx.emitIcmp("eq", "i8*", keyAtSlot, "null");
+    ctx.emitBrCond(isNull, latchLabel, bodyLabel);
+  } else {
+    ctx.emitBr(bodyLabel);
+  }
+
+  ctx.emitLabel(bodyLabel);
+  const printed = ctx.emitLoad("i32", printedAlloca);
+  const isFirstPrint = ctx.emitIcmp("eq", "i32", printed, "0");
+  ctx.emitBrCond(isFirstPrint, skipLabel, sepLabel);
+
+  ctx.emitLabel(sepLabel);
+  emitPrintStrNoNl(ctx, useStderr, separator);
+  ctx.emitBr(skipLabel);
+
+  ctx.emitLabel(skipLabel);
+  if (isString) {
+    const keyElemPtr2 = ctx.nextTemp();
+    ctx.emit(`${keyElemPtr2} = getelementptr inbounds i8*, i8** ${keys}, i32 ${i}`);
+    const key = ctx.emitLoad("i8*", keyElemPtr2);
+    emitPrintStrNoNl(ctx, useStderr, key);
+  } else {
+    const keyElemPtr2 = ctx.nextTemp();
+    ctx.emit(`${keyElemPtr2} = getelementptr inbounds double, double* ${keys}, i32 ${i}`);
+    const key = ctx.emitLoad("double", keyElemPtr2);
+    emitPrintNumNoNl(ctx, useStderr, key);
+  }
+  emitPrintStrNoNl(ctx, useStderr, arrow);
+  if (isString) {
+    const valElemPtr = ctx.nextTemp();
+    ctx.emit(`${valElemPtr} = getelementptr inbounds i8*, i8** ${vals}, i32 ${i}`);
+    const val = ctx.emitLoad("i8*", valElemPtr);
+    if (valueType === "number") {
+      const asI64 = ctx.nextTemp();
+      ctx.emit(`${asI64} = ptrtoint i8* ${val} to i64`);
+      const asDouble = ctx.nextTemp();
+      ctx.emit(`${asDouble} = bitcast i64 ${asI64} to double`);
+      emitPrintNumNoNl(ctx, useStderr, asDouble);
+    } else {
+      emitPrintStrNoNl(ctx, useStderr, val);
+    }
+  } else {
+    const valElemPtr = ctx.nextTemp();
+    ctx.emit(`${valElemPtr} = getelementptr inbounds double, double* ${vals}, i32 ${i}`);
+    const val = ctx.emitLoad("double", valElemPtr);
+    emitPrintNumNoNl(ctx, useStderr, val);
+  }
+
+  const printedCurrent = ctx.emitLoad("i32", printedAlloca);
+  const printedNext = ctx.nextTemp();
+  ctx.emit(`${printedNext} = add i32 ${printedCurrent}, 1`);
+  ctx.emitStore("i32", printedNext, printedAlloca);
+
+  ctx.emitBr(latchLabel);
+
+  ctx.emitLabel(latchLabel);
+  const iCurrent = ctx.emitLoad("i32", iAlloca);
+  const iNext = ctx.nextTemp();
+  ctx.emit(`${iNext} = add i32 ${iCurrent}, 1`);
+  ctx.emitStore("i32", iNext, iAlloca);
+  ctx.emitBr(loopLabel);
+
+  ctx.emitLabel(endLabel);
+  emitPrintStrNoNl(ctx, useStderr, closeStr);
+  ctx.emitBr(doneLabel);
+
+  ctx.emitLabel(doneLabel);
+}
+
+function emitSetPrint(
+  ctx: MethodCallGeneratorContext,
+  useStderr: boolean,
+  setPtr: string,
+  setType: string,
+): void {
+  const isString = setType === "%StringSet*";
+  const structType = isString ? "%StringSet" : "%Set";
+
+  const sizePtr = ctx.nextTemp();
+  ctx.emit(`${sizePtr} = getelementptr inbounds ${structType}, ${structType}* ${setPtr}, i32 0, i32 1`);
+  const size = ctx.emitLoad("i32", sizePtr);
+
+  const headerStr = ctx.stringGen.doCreateStringConstant("Set(");
+  emitPrintStrNoNl(ctx, useStderr, headerStr);
+  const sizeDouble = ctx.nextTemp();
+  ctx.emit(`${sizeDouble} = sitofp i32 ${size} to double`);
+  emitPrintNumNoNl(ctx, useStderr, sizeDouble);
+  const openStr = ctx.stringGen.doCreateStringConstant(") { ");
+  const closeStr = ctx.stringGen.doCreateStringConstant(" }");
+  const emptyCloseStr = ctx.stringGen.doCreateStringConstant(") {}");
+  const separator = ctx.stringGen.doCreateStringConstant(", ");
+
+  const isEmpty = ctx.emitIcmp("eq", "i32", size, "0");
+  const emptyLabel = ctx.nextLabel("set_empty");
+  const nonEmptyLabel = ctx.nextLabel("set_nonempty");
+  const doneLabel = ctx.nextLabel("set_done");
+
+  ctx.emitBrCond(isEmpty, emptyLabel, nonEmptyLabel);
+
+  ctx.emitLabel(emptyLabel);
+  emitPrintStrNoNl(ctx, useStderr, emptyCloseStr);
+  ctx.emitBr(doneLabel);
+
+  ctx.emitLabel(nonEmptyLabel);
+  emitPrintStrNoNl(ctx, useStderr, openStr);
+
+  const dataFieldPtr = ctx.nextTemp();
+  ctx.emit(`${dataFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${setPtr}, i32 0, i32 0`);
+  const data = ctx.emitLoad(isString ? "i8**" : "double*", dataFieldPtr);
+
+  const iAlloca = ctx.nextTemp();
+  ctx.emit(`${iAlloca} = alloca i32`);
+  ctx.emitStore("i32", "0", iAlloca);
+
+  const loopLabel = ctx.nextLabel("set_loop");
+  const bodyLabel = ctx.nextLabel("set_body");
+  const sepLabel = ctx.nextLabel("set_sep");
+  const latchLabel = ctx.nextLabel("set_latch");
+  const endLabel = ctx.nextLabel("set_end");
+
+  ctx.emitBr(loopLabel);
+
+  ctx.emitLabel(loopLabel);
+  const i = ctx.emitLoad("i32", iAlloca);
+  const isFirst = ctx.emitIcmp("eq", "i32", i, "0");
+  ctx.emitBrCond(isFirst, bodyLabel, sepLabel);
+
+  ctx.emitLabel(sepLabel);
+  emitPrintStrNoNl(ctx, useStderr, separator);
+  ctx.emitBr(bodyLabel);
+
+  ctx.emitLabel(bodyLabel);
+  if (isString) {
+    const elemPtr = ctx.nextTemp();
+    ctx.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${data}, i32 ${i}`);
+    const elem = ctx.emitLoad("i8*", elemPtr);
+    emitPrintStrNoNl(ctx, useStderr, elem);
+  } else {
+    const elemPtr = ctx.nextTemp();
+    ctx.emit(`${elemPtr} = getelementptr inbounds double, double* ${data}, i32 ${i}`);
+    const elem = ctx.emitLoad("double", elemPtr);
+    emitPrintNumNoNl(ctx, useStderr, elem);
+  }
+
+  ctx.emitBr(latchLabel);
+
+  ctx.emitLabel(latchLabel);
+  const iCurrent = ctx.emitLoad("i32", iAlloca);
+  const iNext = ctx.nextTemp();
+  ctx.emit(`${iNext} = add i32 ${iCurrent}, 1`);
+  ctx.emitStore("i32", iNext, iAlloca);
+  const done = ctx.emitIcmp("eq", "i32", iNext, size);
+  ctx.emitBrCond(done, endLabel, loopLabel);
+
+  ctx.emitLabel(endLabel);
+  emitPrintStrNoNl(ctx, useStderr, closeStr);
+  ctx.emitBr(doneLabel);
+
+  ctx.emitLabel(doneLabel);
+}
+
 function emitSingleArg(
   ctx: MethodCallGeneratorContext,
   useStderr: boolean,
@@ -206,6 +443,19 @@ function emitSingleArg(
   const varType = ctx.getVariableType(argValue);
   if (varType === "i8*") {
     emitPrintStrNoNl(ctx, useStderr, argValue);
+    return;
+  }
+  if (varType === "%StringMap*" || varType === "%Map*") {
+    let valueType = "string";
+    if (arg.type === "variable") {
+      const mapMeta = ctx.symbolTable.getMapMetadata((arg as VariableNode).name);
+      if (mapMeta) valueType = mapMeta.valueType || "string";
+    }
+    emitMapPrint(ctx, useStderr, argValue, varType, valueType);
+    return;
+  }
+  if (varType === "%StringSet*" || varType === "%Set*") {
+    emitSetPrint(ctx, useStderr, argValue, varType);
     return;
   }
   if (varType && varType.endsWith("*")) {

--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -394,6 +394,19 @@ function emitSetPrint(
   ctx.emitLabel(doneLabel);
 }
 
+function emitClassInstancePrint(
+  ctx: MethodCallGeneratorContext,
+  useStderr: boolean,
+  arg: Expression,
+  params: string[],
+  className: string,
+): void {
+  const headerStr = ctx.stringGen.doCreateStringConstant(className + " ");
+  emitPrintStrNoNl(ctx, useStderr, headerStr);
+  const jsonStr = ctx.jsonGen.generateStringifyExpr(arg, params);
+  emitPrintStrNoNl(ctx, useStderr, jsonStr);
+}
+
 function emitSingleArg(
   ctx: MethodCallGeneratorContext,
   useStderr: boolean,
@@ -458,7 +471,19 @@ function emitSingleArg(
     emitSetPrint(ctx, useStderr, argValue, varType);
     return;
   }
+  if (varType && varType.endsWith("_struct*") && varType.startsWith("%")) {
+    const className = varType.slice(1, -8);
+    emitClassInstancePrint(ctx, useStderr, arg, params, className);
+    return;
+  }
   if (varType && varType.endsWith("*")) {
+    if (arg.type === "variable") {
+      const cn = ctx.symbolTable.getClassName((arg as VariableNode).name);
+      if (cn) {
+        emitClassInstancePrint(ctx, useStderr, arg, params, cn);
+        return;
+      }
+    }
     const objStr = ctx.stringGen.doCreateStringConstant("[object Object]");
     emitPrintStrNoNl(ctx, useStderr, objStr);
     return;

--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -439,6 +439,13 @@ function emitSingleArg(
     return;
   }
 
+  if (arg.type === "boolean") {
+    const boolNode = arg as { type: string; value: boolean };
+    const str = ctx.stringGen.doCreateStringConstant(boolNode.value ? "true" : "false");
+    emitPrintStrNoNl(ctx, useStderr, str);
+    return;
+  }
+
   if (arg.type === "variable") {
     const varName = (arg as VariableNode).name;
     const ifaceType =

--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -439,6 +439,22 @@ function emitSingleArg(
     return;
   }
 
+  if (arg.type === "variable") {
+    const varName = (arg as VariableNode).name;
+    const ifaceType =
+      ctx.symbolTable.getInterfaceType(varName) || ctx.symbolTable.getRawInterfaceType(varName);
+    if (ifaceType) {
+      const jsonStr = ctx.jsonGen.generateStringifyExpr(arg, params);
+      emitPrintStrNoNl(ctx, useStderr, jsonStr);
+      return;
+    }
+    const cn = ctx.symbolTable.getClassName(varName);
+    if (cn) {
+      emitClassInstancePrint(ctx, useStderr, arg, params, cn);
+      return;
+    }
+  }
+
   const argValue = ctx.generateExpression(arg, params);
 
   const isString = ctx.isStringExpression(arg);
@@ -490,7 +506,8 @@ function emitSingleArg(
   }
   if (varType && varType.endsWith("*")) {
     if (arg.type === "variable") {
-      const cn = ctx.symbolTable.getClassName((arg as VariableNode).name);
+      const varName = (arg as VariableNode).name;
+      const cn = ctx.symbolTable.getClassName(varName);
       if (cn) {
         emitClassInstancePrint(ctx, useStderr, arg, params, cn);
         return;

--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -168,10 +168,14 @@ function emitMapPrint(
   const structType = isString ? "%StringMap" : "%Map";
 
   const sizePtr = ctx.nextTemp();
-  ctx.emit(`${sizePtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 2`);
+  ctx.emit(
+    `${sizePtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 2`,
+  );
   const size = ctx.emitLoad("i32", sizePtr);
   const capPtr = ctx.nextTemp();
-  ctx.emit(`${capPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 3`);
+  ctx.emit(
+    `${capPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 3`,
+  );
   const capacity = ctx.emitLoad("i32", capPtr);
 
   const headerStr = ctx.stringGen.doCreateStringConstant("Map(");
@@ -200,9 +204,13 @@ function emitMapPrint(
   emitPrintStrNoNl(ctx, useStderr, openStr);
 
   const keysFieldPtr = ctx.nextTemp();
-  ctx.emit(`${keysFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 0`);
+  ctx.emit(
+    `${keysFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 0`,
+  );
   const valsFieldPtr = ctx.nextTemp();
-  ctx.emit(`${valsFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 1`);
+  ctx.emit(
+    `${valsFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${mapPtr}, i32 0, i32 1`,
+  );
   const keys = ctx.emitLoad(isString ? "i8**" : "double*", keysFieldPtr);
   const vals = ctx.emitLoad(isString ? "i8**" : "double*", valsFieldPtr);
 
@@ -312,7 +320,9 @@ function emitSetPrint(
   const structType = isString ? "%StringSet" : "%Set";
 
   const sizePtr = ctx.nextTemp();
-  ctx.emit(`${sizePtr} = getelementptr inbounds ${structType}, ${structType}* ${setPtr}, i32 0, i32 1`);
+  ctx.emit(
+    `${sizePtr} = getelementptr inbounds ${structType}, ${structType}* ${setPtr}, i32 0, i32 1`,
+  );
   const size = ctx.emitLoad("i32", sizePtr);
 
   const headerStr = ctx.stringGen.doCreateStringConstant("Set(");
@@ -340,7 +350,9 @@ function emitSetPrint(
   emitPrintStrNoNl(ctx, useStderr, openStr);
 
   const dataFieldPtr = ctx.nextTemp();
-  ctx.emit(`${dataFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${setPtr}, i32 0, i32 0`);
+  ctx.emit(
+    `${dataFieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${setPtr}, i32 0, i32 0`,
+  );
   const data = ctx.emitLoad(isString ? "i8**" : "double*", dataFieldPtr);
 
   const iAlloca = ctx.nextTemp();

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -437,10 +437,7 @@ export class ControlFlowGenerator {
 
     const isStringIterable = this.ctx.isStringExpression(forOfStmt.iterable);
     if (isStringIterable) {
-      return this.ctx.emitError(
-        "for...of on strings is not yet supported — use a for loop with str[i] or str.charCodeAt(i) instead",
-        stmt.loc,
-      );
+      return this.generateStringForOf(stmt as ForOfStatement, params);
     }
 
     const iterableValue = this.ctx.generateExpression(forOfStmt.iterable, params);
@@ -2135,6 +2132,73 @@ export class ControlFlowGenerator {
     }
 
     return { valueType };
+  }
+
+  private generateStringForOf(stmt: ForOfStatement, params: string[]): string {
+    const strValue = this.ctx.generateExpression(stmt.iterable, params);
+
+    const strLen = this.ctx.emitCall("i64", "@strlen", `i8* ${strValue}`);
+    const lenI32 = this.nextTemp();
+    this.emit(`${lenI32} = trunc i64 ${strLen} to i32`);
+
+    const indexAlloca = this.ctx.nextAllocaReg("__forof_idx");
+    this.emit(`${indexAlloca} = alloca i32`);
+    this.ctx.emitStore("i32", "0", indexAlloca);
+
+    const elemAlloca = this.ctx.nextAllocaReg(stmt.variableName);
+    this.emit(`${elemAlloca} = alloca i8*`);
+    this.ctx.emitStore("i8*", "null", elemAlloca);
+
+    this.ctx.defineVariable(stmt.variableName, elemAlloca, "i8*", SymbolKind.String, "local");
+
+    const condLabel = this.nextLabel("forof_str_cond");
+    const bodyLabel = this.nextLabel("forof_str_body");
+    const updateLabel = this.nextLabel("forof_str_update");
+    const endLabel = this.nextLabel("forof_str_end");
+
+    this.ctx.emitBr(condLabel);
+
+    this.ctx.emitLabel(condLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexAlloca);
+    const condBool = this.ctx.emitIcmp("slt", "i32", currentIndex, lenI32);
+    this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
+
+    this.ctx.emitLabel(bodyLabel);
+    this.ctx.setCurrentLabel(bodyLabel);
+
+    const charBuf = this.ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 2");
+    const idxI64 = this.nextTemp();
+    this.emit(`${idxI64} = sext i32 ${currentIndex} to i64`);
+    const charPtr = this.nextTemp();
+    this.emit(`${charPtr} = getelementptr inbounds i8, i8* ${strValue}, i64 ${idxI64}`);
+    const charVal = this.ctx.emitLoad("i8", charPtr);
+    this.ctx.emitStore("i8", charVal, charBuf);
+    const nullPtr = this.nextTemp();
+    this.emit(`${nullPtr} = getelementptr inbounds i8, i8* ${charBuf}, i64 1`);
+    this.ctx.emitStore("i8", "0", nullPtr);
+    this.ctx.emitStore("i8*", charBuf, elemAlloca);
+
+    this.loopContinueLabels.push(updateLabel);
+    this.loopBreakLabels.push(endLabel);
+    this.ctx.generateBlock(stmt.body, params);
+    this.loopContinueLabels.pop();
+    this.loopBreakLabels.pop();
+
+    const bodyHasTerminator = this.ctx.lastInstructionIsTerminator();
+    if (!bodyHasTerminator) {
+      this.ctx.emitBr(updateLabel);
+    }
+
+    this.ctx.emitLabel(updateLabel);
+    const loadedIndex = this.ctx.emitLoad("i32", indexAlloca);
+    const nextIndex = this.nextTemp();
+    this.emit(`${nextIndex} = add i32 ${loadedIndex}, 1`);
+    this.ctx.emitStore("i32", nextIndex, indexAlloca);
+    this.ctx.emitBr(condLabel);
+
+    this.ctx.emitLabel(endLabel);
+
+    return "0";
   }
 
   private generateMapEntriesForOf(stmt: ForOfStatement, params: string[]): string {

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -8,6 +8,7 @@ import {
   NumberNode,
   IndexAccessNode,
   MemberAccessNode,
+  SourceLocation,
 } from "../../ast/types.js";
 import { stringifyObjectArrayLiteral, stringifyObjectArrayWithMeta } from "./json-array.js";
 
@@ -589,14 +590,113 @@ export class JsonGenerator {
       ) {
         return this.stringifyNumber(arg, params);
       }
+      if (this.ctx.symbolTable.isMap(varNode.name)) {
+        return this.stringifyMap(arg, params, varNode.name, spaces);
+      }
       return this.ctx.emitError(
-        `JSON.stringify: unsupported type for variable '${varNode.name}' — only string, number, boolean, interface, string[], number[], and object[] are supported`,
+        `JSON.stringify: unsupported type for variable '${varNode.name}' — only string, number, boolean, interface, string[], number[], object[], and Map are supported`,
       );
     }
 
     return this.ctx.emitError(
       "JSON.stringify: unsupported argument type — only string, number, boolean, interface, string[], number[], and object[] are supported",
     );
+  }
+
+  private stringifyMap(
+    arg: Expression,
+    params: string[],
+    varName: string,
+    spaces: number = 0,
+  ): string {
+    const mapMeta = this.ctx.symbolTable.getMapMetadata(varName);
+    if (!mapMeta || mapMeta.keyType !== "string") {
+      return this.ctx.emitError(
+        "JSON.stringify: only Map<string, *> is supported",
+        (arg as { loc?: SourceLocation }).loc,
+      );
+    }
+
+    const mapPtr = this.ctx.generateExpression(arg, params);
+    this.ctx.setUsesJson(true);
+
+    const capPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${capPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 3`,
+    );
+    const capacity = this.ctx.emitLoad("i32", capPtr);
+    const keysFieldPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
+    );
+    const valsFieldPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${valsFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
+    );
+    const keys = this.ctx.emitLoad("i8**", keysFieldPtr);
+    const vals = this.ctx.emitLoad("i8**", valsFieldPtr);
+
+    const jsonDoc = this.ctx.emitCall("i8*", "@csyyjson_create_obj", "");
+    const jsonObj = this.ctx.emitCall("i8*", "@csyyjson_mut_get_root", `i8* ${jsonDoc}`);
+
+    const counterAlloca = this.ctx.nextTemp();
+    this.ctx.emit(`${counterAlloca} = alloca i32`);
+    this.ctx.emitStore("i32", "0", counterAlloca);
+
+    const loopCond = this.ctx.nextLabel("json_map_cond");
+    const loopCheck = this.ctx.nextLabel("json_map_check");
+    const loopBody = this.ctx.nextLabel("json_map_body");
+    const loopLatch = this.ctx.nextLabel("json_map_latch");
+    const loopEnd = this.ctx.nextLabel("json_map_end");
+
+    this.ctx.emitBr(loopCond);
+    this.ctx.emitLabel(loopCond);
+    const i = this.ctx.emitLoad("i32", counterAlloca);
+    const cond = this.ctx.emitIcmp("slt", "i32", i, capacity);
+    this.ctx.emitBrCond(cond, loopCheck, loopEnd);
+
+    this.ctx.emitLabel(loopCheck);
+    const keyElemPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keys}, i32 ${i}`);
+    const keyAtSlot = this.ctx.emitLoad("i8*", keyElemPtr);
+    const isNull = this.ctx.emitIcmp("eq", "i8*", keyAtSlot, "null");
+    this.ctx.emitBrCond(isNull, loopLatch, loopBody);
+
+    this.ctx.emitLabel(loopBody);
+    const valElemPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${valElemPtr} = getelementptr inbounds i8*, i8** ${vals}, i32 ${i}`);
+    const valAtSlot = this.ctx.emitLoad("i8*", valElemPtr);
+
+    const isNumValue = mapMeta.valueType === "number";
+    if (isNumValue) {
+      const asI64 = this.ctx.nextTemp();
+      this.ctx.emit(`${asI64} = ptrtoint i8* ${valAtSlot} to i64`);
+      const asDouble = this.ctx.nextTemp();
+      this.ctx.emit(`${asDouble} = bitcast i64 ${asI64} to double`);
+      this.ctx.emitCallVoid(
+        "@csyyjson_obj_add_num",
+        `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${keyAtSlot}, double ${asDouble}`,
+      );
+    } else {
+      this.ctx.emitCallVoid(
+        "@csyyjson_obj_add_str",
+        `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${keyAtSlot}, i8* ${valAtSlot}`,
+      );
+    }
+
+    this.ctx.emitBr(loopLatch);
+
+    this.ctx.emitLabel(loopLatch);
+    const iCurrent = this.ctx.emitLoad("i32", counterAlloca);
+    const iNext = this.ctx.nextTemp();
+    this.ctx.emit(`${iNext} = add i32 ${iCurrent}, 1`);
+    this.ctx.emitStore("i32", iNext, counterAlloca);
+    this.ctx.emitBr(loopCond);
+
+    this.ctx.emitLabel(loopEnd);
+    const result = this.emitStringify(jsonDoc, spaces);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
   }
 
   private extractInterfaceFromLlvmType(llvmType: string): string | null {

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -599,6 +599,12 @@ export class JsonGenerator {
           return this.stringifyClassInstance(arg, params, className, spaces);
         }
       }
+      if (this.ctx.symbolTable.isSet(varNode.name)) {
+        return this.ctx.emitError(
+          `JSON.stringify: Set is not JSON-serializable. Convert to array first: JSON.stringify([...set])`,
+          (arg as { loc?: SourceLocation }).loc,
+        );
+      }
       return this.ctx.emitError(
         `JSON.stringify: unsupported type for variable '${varNode.name}' — only string, number, boolean, interface, class, string[], number[], object[], and Map are supported`,
       );

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -593,8 +593,14 @@ export class JsonGenerator {
       if (this.ctx.symbolTable.isMap(varNode.name)) {
         return this.stringifyMap(arg, params, varNode.name, spaces);
       }
+      if (this.ctx.symbolTable.isClass(varNode.name)) {
+        const className = this.ctx.symbolTable.getConcreteClass(varNode.name);
+        if (className) {
+          return this.stringifyClassInstance(arg, params, className, spaces);
+        }
+      }
       return this.ctx.emitError(
-        `JSON.stringify: unsupported type for variable '${varNode.name}' — only string, number, boolean, interface, string[], number[], object[], and Map are supported`,
+        `JSON.stringify: unsupported type for variable '${varNode.name}' — only string, number, boolean, interface, class, string[], number[], object[], and Map are supported`,
       );
     }
 
@@ -694,6 +700,78 @@ export class JsonGenerator {
     this.ctx.emitBr(loopCond);
 
     this.ctx.emitLabel(loopEnd);
+    const result = this.emitStringify(jsonDoc, spaces);
+    this.ctx.setVariableType(result, "i8*");
+    return result;
+  }
+
+  private stringifyClassInstance(
+    arg: Expression,
+    params: string[],
+    className: string,
+    spaces: number = 0,
+  ): string {
+    const fields = this.ctx.classGenGetClassFields(className);
+    if (fields.length === 0) {
+      this.ctx.setUsesJson(true);
+      const jsonDoc = this.ctx.emitCall("i8*", "@csyyjson_create_obj", "");
+      const result = this.emitStringify(jsonDoc, spaces);
+      this.ctx.setVariableType(result, "i8*");
+      return result;
+    }
+
+    const llvmFieldTypes: string[] = [];
+    for (let fi = 0; fi < fields.length; fi++) {
+      const ft = fields[fi].fieldType;
+      if (ft === "string" || ft === "i8*") {
+        llvmFieldTypes.push("i8*");
+      } else {
+        llvmFieldTypes.push("double");
+      }
+    }
+    const structType = `{ ${llvmFieldTypes.join(", ")} }`;
+
+    const objPtr = this.ctx.generateExpression(arg, params);
+    const typedPtr = this.ctx.emitBitcast(objPtr, "i8*", `${structType}*`);
+
+    this.ctx.setUsesJson(true);
+    const jsonDoc = this.ctx.emitCall("i8*", "@csyyjson_create_obj", "");
+    const jsonObj = this.ctx.emitCall("i8*", "@csyyjson_mut_get_root", `i8* ${jsonDoc}`);
+
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i];
+      const llvmType = llvmFieldTypes[i];
+      const fieldPtr = this.ctx.nextTemp();
+      this.ctx.emit(
+        `${fieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${typedPtr}, i32 0, i32 ${i}`,
+      );
+      const nameConst = this.ctx.createStringConstant(field.name);
+
+      if (llvmType === "i8*") {
+        const val = this.ctx.emitLoad("i8*", fieldPtr);
+        this.ctx.emitCallVoid(
+          "@csyyjson_obj_add_str",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i8* ${val}`,
+        );
+      } else if (field.fieldType === "boolean") {
+        const val = this.ctx.emitLoad("double", fieldPtr);
+        const boolCmp = this.ctx.nextTemp();
+        this.ctx.emit(`${boolCmp} = fcmp une double ${val}, 0.0`);
+        const boolInt = this.ctx.nextTemp();
+        this.ctx.emit(`${boolInt} = zext i1 ${boolCmp} to i32`);
+        this.ctx.emitCallVoid(
+          "@csyyjson_obj_add_bool",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, i32 ${boolInt}`,
+        );
+      } else {
+        const val = this.ctx.emitLoad("double", fieldPtr);
+        this.ctx.emitCallVoid(
+          "@csyyjson_obj_add_num",
+          `i8* ${jsonDoc}, i8* ${jsonObj}, i8* ${nameConst}, double ${val}`,
+        );
+      }
+    }
+
     const result = this.emitStringify(jsonDoc, spaces);
     this.ctx.setVariableType(result, "i8*");
     return result;

--- a/tests/fixtures/builtins/console-log-class.ts
+++ b/tests/fixtures/builtins/console-log-class.ts
@@ -1,0 +1,16 @@
+// @test-description: console.log prints class instance fields
+class Point {
+  x: number;
+  y: number;
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+}
+
+function test() {
+  const p = new Point(10, 20);
+  console.log(p);
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/builtins/console-log-interface.ts
+++ b/tests/fixtures/builtins/console-log-interface.ts
@@ -1,0 +1,12 @@
+// @test-description: console.log prints interface objects as json
+interface Point {
+  x: number;
+  y: number;
+}
+
+function test() {
+  const p: Point = { x: 10, y: 20 };
+  console.log(p);
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/builtins/console-log-map.ts
+++ b/tests/fixtures/builtins/console-log-map.ts
@@ -1,0 +1,13 @@
+// @test-description: console.log prints map contents
+function test() {
+  const m = new Map<string, string>();
+  m.set("a", "1");
+  m.set("b", "2");
+  console.log(m);
+
+  const empty = new Map<string, string>();
+  console.log(empty);
+
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/builtins/console-log-set.ts
+++ b/tests/fixtures/builtins/console-log-set.ts
@@ -1,0 +1,11 @@
+// @test-description: console.log prints set contents
+function test() {
+  const s = new Set<number>();
+  s.add(10);
+  s.add(20);
+  s.add(30);
+  console.log(s);
+
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/builtins/json-stringify-class.ts
+++ b/tests/fixtures/builtins/json-stringify-class.ts
@@ -1,0 +1,22 @@
+// @test-description: json stringify class instance with string, number, boolean fields
+class User {
+  name: string;
+  age: number;
+  active: boolean;
+  constructor(name: string, age: number, active: boolean) {
+    this.name = name;
+    this.age = age;
+    this.active = active;
+  }
+}
+
+function test() {
+  const u = new User("chad", 30, true);
+  const result = JSON.stringify(u);
+  if (result === '{"name":"chad","age":30.0,"active":true}') {
+    console.log("TEST_PASSED");
+  } else {
+    console.log("FAIL: " + result);
+  }
+}
+test();

--- a/tests/fixtures/builtins/json-stringify-unsupported-map.ts
+++ b/tests/fixtures/builtins/json-stringify-unsupported-map.ts
@@ -1,4 +1,10 @@
-// @test-compile-error: unsupported type — only string, number, boolean, interface, string[], number[], and object[] are supported
-const m: Map<string, number> = new Map();
-m.set("key", 42);
-JSON.stringify(m);
+// @test-description: json stringify map produces correct json
+function test() {
+  const m = new Map<string, string>();
+  m.set("hello", "world");
+  const result = JSON.stringify(m);
+  if (result === '{"hello":"world"}') {
+    console.log("TEST_PASSED");
+  }
+}
+test();

--- a/tests/fixtures/strings/string-for-of.ts
+++ b/tests/fixtures/strings/string-for-of.ts
@@ -1,0 +1,34 @@
+// @test-description: for...of iterates over string characters
+function test() {
+  const s = "hello";
+  let result = "";
+  for (const ch of s) {
+    result = result + ch;
+  }
+  if (result !== "hello") {
+    console.log("FAIL: concat = " + result);
+    return;
+  }
+
+  let count = 0;
+  for (const c of "abc") {
+    count = count + 1;
+  }
+  if (count !== 3) {
+    console.log("FAIL: count = " + count);
+    return;
+  }
+
+  let first = "";
+  for (const ch of "xyz") {
+    first = ch;
+    break;
+  }
+  if (first !== "x") {
+    console.log("FAIL: first = " + first);
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- **console.log** now works on Maps, Sets, class instances, and interfaces (was `[object Object]` or empty)
- **JSON.stringify** now works on Maps (`Map<string, *>`) and class instances with correct boolean handling
- **for...of on strings** now works (`for (const ch of str)`) instead of compile error
- JSON.stringify on Sets gives helpful compile error with suggestion to convert to array

## Details
- Map printing uses open-addressing hash table iteration (skip null slots)
- Set printing uses linear iteration
- Class instance fields: boolean stored as `double` in struct, converted via `fcmp une`
- String for-of: allocates 2-byte GC buffer per character, null-terminated
- Interface console.log delegates to JSON.stringify

## Test plan
- [x] `console-log-map.ts` — Map(2) { a => 1, b => 2 }
- [x] `console-log-set.ts` — Set(3) { 10, 20, 30 }
- [x] `console-log-class.ts` — Point {"x":10.0,"y":20.0}
- [x] `console-log-interface.ts` — {"x":10.0,"y":20.0}
- [x] `json-stringify-unsupported-map.ts` — Map stringify works
- [x] `json-stringify-class.ts` — class instance with boolean fields
- [x] `string-for-of.ts` — iterate, concat, break
- [x] Self-hosting passes (Stage 0 + Stage 1)
- [x] All 470 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)