### PR TITLE
fix global-scope optional chaining on nullable interface fields

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -1061,6 +1061,10 @@ export class TypeInference {
   private getFieldTypeFromType(typeName: string, fieldName: string): string | null {
     if (!typeName) return null;
     if (!fieldName) return null;
+    const stripped = stripNullable(typeName);
+    if (stripped !== typeName) {
+      return this.getFieldTypeFromType(stripped, fieldName);
+    }
     const cls = this.getClass(typeName);
     if (cls) {
       const fieldTsType = this.ctx.classGenGetFieldTsType(typeName, fieldName);

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2538,22 +2538,41 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               exprNodeType === "index_access" ||
               exprNodeType === "member_access"
             ) {
-              // Use i64 for integer-eligible globals to avoid double conversion overhead
-              let isI64 = false;
-              for (let ei = 0; ei < i64Eligible.length; ei++) {
-                if (i64Eligible[ei] === name) {
-                  isI64 = true;
-                  break;
+              let isNumber = true;
+              const resolved = stmt.value
+                ? this.typeInference.resolveExpressionType(stmt.value)
+                : null;
+              if (resolved) {
+                const base = resolved.base;
+                if (base === "string") {
+                  llvmType = "i8*";
+                  kind = SymbolKind.String;
+                  defaultValue = "null";
+                  isNumber = false;
+                } else if (base === "boolean") {
+                  llvmType = "i1";
+                  kind = SymbolKind.Boolean;
+                  defaultValue = "0";
+                  isNumber = false;
                 }
               }
-              if (isI64) {
-                llvmType = "i64";
-                kind = SymbolKind.Number;
-                defaultValue = "0";
-              } else {
-                llvmType = "double";
-                kind = SymbolKind.Number;
-                defaultValue = "0.0";
+              if (isNumber) {
+                let isI64 = false;
+                for (let ei = 0; ei < i64Eligible.length; ei++) {
+                  if (i64Eligible[ei] === name) {
+                    isI64 = true;
+                    break;
+                  }
+                }
+                if (isI64) {
+                  llvmType = "i64";
+                  kind = SymbolKind.Number;
+                  defaultValue = "0";
+                } else {
+                  llvmType = "double";
+                  kind = SymbolKind.Number;
+                  defaultValue = "0.0";
+                }
               }
             } else {
               return this.emitError(

--- a/tests/fixtures/optional-chaining/global-optional-chain.ts
+++ b/tests/fixtures/optional-chaining/global-optional-chain.ts
@@ -1,0 +1,19 @@
+interface Config {
+  db: DbConfig | null;
+}
+interface DbConfig {
+  host: string;
+  port: number;
+}
+const config: Config = { db: null };
+const host = config.db?.host;
+if (host === null || host === undefined) {
+  console.log("null case works");
+}
+
+const config2: Config = { db: { host: "localhost", port: 5432 } };
+const host2 = config2.db?.host;
+if (host2 !== null && host2 !== undefined) {
+  console.log(host2);
+}
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `const host = config.db?.host` at global scope no longer crashes with LLVM type mismatch
- Root cause: `getFieldTypeFromType` didn't strip nullable from intermediate types (`DbConfig | null` → `DbConfig`)
- Also adds type inference fallback in global var declarations to detect string/boolean types from `resolveExpressionType`

## Test plan
- [ ] `npm run verify:quick` passes
- [ ] New fixture `optional-chaining/global-optional-chain.ts` tests both null and non-null paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)