### PR TITLE
add complete Map<Interface, T> support (has, delete, size, entries, keys, values)

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -36,6 +36,7 @@ import type {
   IStringGenerator,
   IMapGenerator,
   IStringMapGenerator,
+  IPointerMapGenerator,
   ISetGenerator,
   IStringSetGenerator,
   IResponseGenerator,
@@ -184,6 +185,7 @@ export interface MemberAccessGeneratorContext {
   readonly responseGen: IResponseGenerator;
   readonly mapGen: IMapGenerator;
   readonly stringMapGen: IStringMapGenerator;
+  readonly pointerMapGen: IPointerMapGenerator;
   readonly setGen: ISetGenerator;
   readonly stringSetGen: IStringSetGenerator;
   readonly interfaceStructGen?: InterfaceStructGenerator;

--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -384,6 +384,9 @@ export function handleSizeProperty(
     if (mapMeta && mapMeta.keyType === "string") {
       return ctx.stringMapGen.generateStringMapSize(mapPtr);
     }
+    if (mapMeta && mapMeta.keyType !== "number") {
+      return ctx.pointerMapGen.generatePointerMapSize(mapPtr);
+    }
     return ctx.mapGen.generateMapSize(mapPtr);
   }
   if (exprObjType === "variable" && ctx.symbolTable.isSet((expr.object as VariableNode).name)) {
@@ -414,8 +417,10 @@ export function handleSizeProperty(
             return ctx.setGen.generateSetSize(ptr);
           } else if (fieldInfo.tsType.indexOf("Map<string") !== -1) {
             return ctx.stringMapGen.generateStringMapSize(ptr);
-          } else {
+          } else if (fieldInfo.tsType.indexOf("Map<number") !== -1) {
             return ctx.mapGen.generateMapSize(ptr);
+          } else {
+            return ctx.pointerMapGen.generatePointerMapSize(ptr);
           }
         }
       }

--- a/src/codegen/expressions/literals.ts
+++ b/src/codegen/expressions/literals.ts
@@ -147,6 +147,9 @@ export class LiteralExpressionGenerator {
       if (mapParsed && mapParsed.keyType === "string") {
         return this.ctx.stringMapGen.generateEmptyStringMap();
       }
+      if (mapParsed && mapParsed.keyType !== "number") {
+        return this.ctx.stringMapGen.generateEmptyStringMap();
+      }
     }
 
     return this.ctx.mapGen.generateMapLiteral(expr, params);

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -774,6 +774,42 @@ export class MethodCallGenerator {
           );
         }
 
+        if (mapMeta && mapMeta.keyType !== "number") {
+          let mapAlloca = this.ctx.symbolTable.getAlloca(varName);
+          if (mapAlloca) {
+            if (mapAlloca.startsWith("@")) {
+              mapAlloca = this.ctx.emitLoad("%StringMap*", mapAlloca);
+            }
+            if (method === "set") {
+              const keyValue = this.ctx.generateExpression(expr.args[0], params);
+              const valueValue = this.ctx.generateExpression(expr.args[1], params);
+              return this.ctx.pointerMapGen.generatePointerMapSet(mapAlloca, keyValue, valueValue);
+            } else if (method === "get") {
+              const keyValue = this.ctx.generateExpression(expr.args[0], params);
+              return this.ctx.pointerMapGen.generatePointerMapGet(mapAlloca, keyValue, "i8*");
+            } else if (method === "has") {
+              const keyValue = this.ctx.generateExpression(expr.args[0], params);
+              return this.ctx.pointerMapGen.generatePointerMapHas(mapAlloca, keyValue);
+            } else if (method === "delete") {
+              const keyValue = this.ctx.generateExpression(expr.args[0], params);
+              return this.ctx.pointerMapGen.generatePointerMapDelete(mapAlloca, keyValue);
+            } else if (method === "entries") {
+              return this.ctx.pointerMapGen.generatePointerMapEntries(mapAlloca);
+            } else if (method === "values") {
+              return this.ctx.pointerMapGen.generatePointerMapValues(mapAlloca);
+            } else if (method === "keys") {
+              return this.ctx.pointerMapGen.generatePointerMapKeys(mapAlloca);
+            } else if (method === "clear") {
+              return this.ctx.pointerMapGen.generatePointerMapClear(mapAlloca);
+            } else {
+              return this.ctx.emitError(
+                `Map<${mapMeta.keyType}, *>.${method}() is not supported`,
+                expr.loc,
+              );
+            }
+          }
+        }
+
         if (method === "set") {
           return this.ctx.mapGen.generateMapSet(expr, params);
         } else if (method === "get") {
@@ -837,6 +873,18 @@ export class MethodCallGenerator {
               return this.ctx.pointerMapGen.generatePointerMapGet(mapPtr, keyValue, "i8*");
             } else if (method === "clear") {
               return this.ctx.pointerMapGen.generatePointerMapClear(mapPtr);
+            } else if (method === "has") {
+              const keyValue = this.ctx.generateExpression(expr.args[0], params);
+              return this.ctx.pointerMapGen.generatePointerMapHas(mapPtr, keyValue);
+            } else if (method === "delete") {
+              const keyValue = this.ctx.generateExpression(expr.args[0], params);
+              return this.ctx.pointerMapGen.generatePointerMapDelete(mapPtr, keyValue);
+            } else if (method === "entries") {
+              return this.ctx.pointerMapGen.generatePointerMapEntries(mapPtr);
+            } else if (method === "keys") {
+              return this.ctx.pointerMapGen.generatePointerMapKeys(mapPtr);
+            } else if (method === "values") {
+              return this.ctx.pointerMapGen.generatePointerMapValues(mapPtr);
             } else {
               return this.ctx.emitError(
                 `Map.${method}() not supported for Map<${paramMapInfo.keyType}, *> parameter types`,
@@ -894,6 +942,18 @@ export class MethodCallGenerator {
             return this.ctx.pointerMapGen.generatePointerMapGet(mapPtr, keyValue, "i8*");
           } else if (method === "clear") {
             return this.ctx.pointerMapGen.generatePointerMapClear(mapPtr);
+          } else if (method === "has") {
+            const keyValue = this.ctx.generateExpression(expr.args[0], params);
+            return this.ctx.pointerMapGen.generatePointerMapHas(mapPtr, keyValue);
+          } else if (method === "delete") {
+            const keyValue = this.ctx.generateExpression(expr.args[0], params);
+            return this.ctx.pointerMapGen.generatePointerMapDelete(mapPtr, keyValue);
+          } else if (method === "entries") {
+            return this.ctx.pointerMapGen.generatePointerMapEntries(mapPtr);
+          } else if (method === "keys") {
+            return this.ctx.pointerMapGen.generatePointerMapKeys(mapPtr);
+          } else if (method === "values") {
+            return this.ctx.pointerMapGen.generatePointerMapValues(mapPtr);
           } else {
             return this.ctx.emitError(
               `Map.${method}() not supported for Map<${thisFieldMapKeyType}, *> types`,

--- a/src/codegen/expressions/variables.ts
+++ b/src/codegen/expressions/variables.ts
@@ -82,8 +82,7 @@ export class VariableExpressionGenerator {
     if (this.ctx.symbolTable.isMap(name)) {
       let allocaReg = this.ctx.getVariableAlloca(name)!;
       const mapMeta = this.ctx.symbolTable.getMapMetadata(name);
-      const mapType =
-        mapMeta && mapMeta.keyType !== "number" ? "%StringMap*" : "%Map*";
+      const mapType = mapMeta && mapMeta.keyType !== "number" ? "%StringMap*" : "%Map*";
       if (allocaReg.startsWith("@")) {
         const loaded = this.ctx.nextTemp();
         this.ctx.emit(`${loaded} = load ${mapType}, ${mapType}* ${allocaReg}`);

--- a/src/codegen/expressions/variables.ts
+++ b/src/codegen/expressions/variables.ts
@@ -82,7 +82,8 @@ export class VariableExpressionGenerator {
     if (this.ctx.symbolTable.isMap(name)) {
       let allocaReg = this.ctx.getVariableAlloca(name)!;
       const mapMeta = this.ctx.symbolTable.getMapMetadata(name);
-      const mapType = mapMeta && mapMeta.keyType === "string" ? "%StringMap*" : "%Map*";
+      const mapType =
+        mapMeta && mapMeta.keyType !== "number" ? "%StringMap*" : "%Map*";
       if (allocaReg.startsWith("@")) {
         const loaded = this.ctx.nextTemp();
         this.ctx.emit(`${loaded} = load ${mapType}, ${mapType}* ${allocaReg}`);

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -284,6 +284,12 @@ export interface IPointerMapGenerator {
   generatePointerMapSet(mapPtr: string, keyValue: string, valueValue: string): string;
   generatePointerMapGet(mapPtr: string, keyValue: string, valueType: string): string;
   generatePointerMapClear(mapPtr: string): string;
+  generatePointerMapHas(mapPtr: string, keyToFind: string): string;
+  generatePointerMapDelete(mapPtr: string, keyToFind: string): string;
+  generatePointerMapSize(mapPtr: string): string;
+  generatePointerMapEntries(mapPtr: string): string;
+  generatePointerMapKeys(mapPtr: string): string;
+  generatePointerMapValues(mapPtr: string): string;
 }
 
 export interface IArrayGenerator {
@@ -1998,6 +2004,14 @@ export class MockGeneratorContext implements IGeneratorContext {
     generatePointerMapGet: (_mapPtr: string, _keyValue: string, _valueType: string): string =>
       "%mock_pointer_map_get",
     generatePointerMapClear: (_mapPtr: string): string => "%mock_pointer_map_clear",
+    generatePointerMapHas: (_mapPtr: string, _keyToFind: string): string =>
+      "%mock_pointer_map_has",
+    generatePointerMapDelete: (_mapPtr: string, _keyToFind: string): string =>
+      "%mock_pointer_map_delete",
+    generatePointerMapSize: (_mapPtr: string): string => "%mock_pointer_map_size",
+    generatePointerMapEntries: (_mapPtr: string): string => "%mock_pointer_map_entries",
+    generatePointerMapKeys: (_mapPtr: string): string => "%mock_pointer_map_keys",
+    generatePointerMapValues: (_mapPtr: string): string => "%mock_pointer_map_values",
   };
   embedGen: IEmbedGenerator = {
     generateEmbedFile: (_expr: MethodCallNode, _params: string[]): string => "%mock_embed_file",

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -2004,8 +2004,7 @@ export class MockGeneratorContext implements IGeneratorContext {
     generatePointerMapGet: (_mapPtr: string, _keyValue: string, _valueType: string): string =>
       "%mock_pointer_map_get",
     generatePointerMapClear: (_mapPtr: string): string => "%mock_pointer_map_clear",
-    generatePointerMapHas: (_mapPtr: string, _keyToFind: string): string =>
-      "%mock_pointer_map_has",
+    generatePointerMapHas: (_mapPtr: string, _keyToFind: string): string => "%mock_pointer_map_has",
     generatePointerMapDelete: (_mapPtr: string, _keyToFind: string): string =>
       "%mock_pointer_map_delete",
     generatePointerMapSize: (_mapPtr: string): string => "%mock_pointer_map_size",

--- a/src/codegen/infrastructure/symbol-table.ts
+++ b/src/codegen/infrastructure/symbol-table.ts
@@ -95,10 +95,10 @@ export interface ClosureMetadata {
  * Map-specific metadata for typed Maps
  */
 export interface MapMetadata {
-  keyType: "string" | "number"; // TypeScript key type
-  valueType: string; // TypeScript value type (string, number, or interface name)
-  llvmKeyType: string; // LLVM type for keys (i8* for string, double for number)
-  llvmValueType: string; // LLVM type for values
+  keyType: string;
+  valueType: string;
+  llvmKeyType: string;
+  llvmValueType: string;
 }
 
 /**

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1808,6 +1808,10 @@ export class VariableAllocator {
         this.allocateStringMap(stmt, params, mapTypeInfo);
         return;
       }
+      if (mapTypeInfo.keyType !== "number") {
+        this.allocatePointerMap(stmt, params, mapTypeInfo);
+        return;
+      }
     }
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
     this.ctx.defineVariable(stmt.name, allocaReg, "%Map*", SymbolKind.Map, "local");
@@ -1838,6 +1842,39 @@ export class VariableAllocator {
         valueType: mapTypeInfo.valueType,
         llvmKeyType: "i8*",
         llvmValueType,
+      }),
+    );
+    this.ctx.emit(`${allocaReg} = alloca %StringMap`);
+
+    const declaredMapType =
+      stmt.declaredType || `Map<${mapTypeInfo.keyType}, ${mapTypeInfo.valueType}>`;
+    this.ctx.setCurrentDeclaredMapType(declaredMapType);
+    const value = this.ctx.generateExpression(stmt.value!, params);
+    this.ctx.setCurrentDeclaredMapType(undefined);
+
+    const loadedMap = this.ctx.nextTemp();
+    this.ctx.emit(`${loadedMap} = load %StringMap, %StringMap* ${value}`);
+    this.ctx.emit(`store %StringMap ${loadedMap}, %StringMap* ${allocaReg}`);
+  }
+
+  private allocatePointerMap(
+    stmt: VariableDeclaration,
+    params: string[],
+    mapTypeInfo: MapTypeInfo,
+  ): void {
+    const allocaReg = this.ctx.nextAllocaReg(stmt.name);
+
+    this.ctx.defineVariableWithMetadata(
+      stmt.name,
+      allocaReg,
+      "%StringMap*",
+      SymbolKind.Map,
+      "local",
+      createMapMetadataSymbol({
+        keyType: mapTypeInfo.keyType,
+        valueType: mapTypeInfo.valueType,
+        llvmKeyType: "i8*",
+        llvmValueType: "i8*",
       }),
     );
     this.ctx.emit(`${allocaReg} = alloca %StringMap`);

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2217,6 +2217,38 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             );
             continue;
           }
+          let isPointerMap = false;
+          let pointerMapKeyType = "";
+          let pointerMapValueType = "string";
+          if (stmt.declaredType) {
+            const parsed = parseMapTypeString(stmt.declaredType);
+            if (parsed && parsed.keyType !== "string" && parsed.keyType !== "number") {
+              isPointerMap = true;
+              pointerMapKeyType = parsed.keyType;
+              pointerMapValueType = parsed.valueType;
+            }
+          }
+          if (isPointerMap) {
+            llvmType = "%StringMap*";
+            kind = SymbolKind.Map;
+            defaultValue = "null";
+            ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
+            this.globalVariables.set(name, { llvmType, kind, initialized: false });
+            this.defineVariableWithMetadata(
+              name,
+              `@${name}`,
+              llvmType,
+              kind,
+              "global",
+              createMapMetadataSymbol({
+                keyType: pointerMapKeyType,
+                valueType: pointerMapValueType,
+                llvmKeyType: "i8*",
+                llvmValueType: "i8*",
+              }),
+            );
+            continue;
+          }
           llvmType = "%Map*";
           kind = SymbolKind.Map;
           defaultValue = "null";

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -1591,4 +1591,384 @@ export class PointerMapGenerator {
     this.ctx.emitStore("i32", "0", sizeFieldPtr);
     return "0.0";
   }
+
+  generatePointerMapHas(mapPtr: string, keyToFind: string): string {
+    const keysFieldPtr = this.nextTemp();
+    this.emit(
+      `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
+    );
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
+
+    const sizeFieldPtr = this.nextTemp();
+    this.emit(
+      `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
+    );
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
+
+    const resultReg = this.nextTemp();
+    this.emit(`${resultReg} = alloca double`);
+    this.ctx.emitStore("double", "0.0", resultReg);
+
+    const loopLabel = this.nextLabel("ptrmap_has_loop");
+    const bodyLabel = this.nextLabel("ptrmap_has_body");
+    const foundLabel = this.nextLabel("ptrmap_has_found");
+    const endLabel = this.nextLabel("ptrmap_has_end");
+
+    const indexReg = this.nextTemp();
+    this.emit(`${indexReg} = alloca i32`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
+
+    this.ctx.emitLabel(bodyLabel);
+    const keyElemPtr = this.nextTemp();
+    this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`);
+    const keyValue = this.ctx.emitLoad("i8*", keyElemPtr);
+    const keyCmp = this.ctx.emitCall("i32", "@strcmp", `i8* ${keyValue}, i8* ${keyToFind}`);
+    const keyMatch = this.ctx.emitIcmp("eq", "i32", keyCmp, "0");
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${loopLabel}_next`);
+
+    this.ctx.emitLabel(foundLabel);
+    this.ctx.emitStore("double", "1.0", resultReg);
+    this.ctx.emitBr(endLabel);
+
+    this.ctx.emitLabel(`${loopLabel}_next`);
+    const nextIndex = this.nextTemp();
+    this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.emitLoad("double", resultReg);
+    this.ctx.setVariableType(result, "double");
+    return result;
+  }
+
+  generatePointerMapDelete(mapPtr: string, keyToFind: string): string {
+    const keysFieldPtr = this.nextTemp();
+    this.emit(
+      `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
+    );
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
+
+    const valuesFieldPtr = this.nextTemp();
+    this.emit(
+      `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
+    );
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
+
+    const sizeFieldPtr = this.nextTemp();
+    this.emit(
+      `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
+    );
+    const currentSize = this.ctx.emitLoad("i32", sizeFieldPtr);
+
+    const resultReg = this.nextTemp();
+    this.emit(`${resultReg} = alloca double`);
+    this.ctx.emitStore("double", "0.0", resultReg);
+
+    const loopLabel = this.nextLabel("ptrmap_del_loop");
+    const bodyLabel = this.nextLabel("ptrmap_del_body");
+    const foundLabel = this.nextLabel("ptrmap_del_found");
+    const endLabel = this.nextLabel("ptrmap_del_end");
+
+    const indexReg = this.nextTemp();
+    this.emit(`${indexReg} = alloca i32`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, currentSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
+
+    this.ctx.emitLabel(bodyLabel);
+    const keyElemPtr = this.nextTemp();
+    this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`);
+    const keyValue = this.ctx.emitLoad("i8*", keyElemPtr);
+    const keyCmp = this.ctx.emitCall("i32", "@strcmp", `i8* ${keyValue}, i8* ${keyToFind}`);
+    const keyMatch = this.ctx.emitIcmp("eq", "i32", keyCmp, "0");
+    this.ctx.emitBrCond(keyMatch, foundLabel, `${loopLabel}_next`);
+
+    this.ctx.emitLabel(foundLabel);
+    this.ctx.emitStore("double", "1.0", resultReg);
+    const lastIdx = this.nextTemp();
+    this.emit(`${lastIdx} = sub i32 ${currentSize}, 1`);
+    const lastKeyPtr = this.nextTemp();
+    this.emit(`${lastKeyPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${lastIdx}`);
+    const lastKey = this.ctx.emitLoad("i8*", lastKeyPtr);
+    this.ctx.emitStore("i8*", lastKey, keyElemPtr);
+    const valElemPtr = this.nextTemp();
+    this.emit(`${valElemPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${currentIndex}`);
+    const lastValPtr = this.nextTemp();
+    this.emit(`${lastValPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${lastIdx}`);
+    const lastVal = this.ctx.emitLoad("i8*", lastValPtr);
+    this.ctx.emitStore("i8*", lastVal, valElemPtr);
+    this.ctx.emitStore("i32", lastIdx, sizeFieldPtr);
+    this.ctx.emitBr(endLabel);
+
+    this.ctx.emitLabel(`${loopLabel}_next`);
+    const nextIndex = this.nextTemp();
+    this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.emitLoad("double", resultReg);
+    this.ctx.setVariableType(result, "double");
+    return result;
+  }
+
+  generatePointerMapSize(mapPtr: string): string {
+    const sizeFieldPtr = this.nextTemp();
+    this.emit(
+      `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
+    );
+    const sizeI32 = this.ctx.emitLoad("i32", sizeFieldPtr);
+    const size = this.nextTemp();
+    this.emit(`${size} = sitofp i32 ${sizeI32} to double`);
+    this.ctx.setVariableType(size, "double");
+    return size;
+  }
+
+  generatePointerMapEntries(mapPtr: string): string {
+    const keysFieldPtr = this.nextTemp();
+    this.emit(
+      `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
+    );
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
+
+    const valuesFieldPtr = this.nextTemp();
+    this.emit(
+      `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
+    );
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
+
+    const sizeFieldPtr = this.nextTemp();
+    this.emit(
+      `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
+    );
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
+
+    const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
+
+    const mapSizeI64 = this.nextTemp();
+    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    const dataSize = this.nextTemp();
+    this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
+    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
+    const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
+
+    const lenFieldPtr = this.nextTemp();
+    this.emit(`${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
+    this.ctx.emitStore("i32", mapSize, lenFieldPtr);
+    const capFieldPtr = this.nextTemp();
+    this.emit(`${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
+    this.ctx.emitStore("i32", mapSize, capFieldPtr);
+    const dataFieldPtr = this.nextTemp();
+    this.emit(`${dataFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`);
+    const dataCast = this.ctx.emitBitcast(dataPtr, "i8**", "double*");
+    this.ctx.emitStore("double*", dataCast, dataFieldPtr);
+
+    const loopLabel = this.nextLabel("ptrmap_entries_loop");
+    const bodyLabel = this.nextLabel("ptrmap_entries_body");
+    const endLabel = this.nextLabel("ptrmap_entries_end");
+
+    const indexReg = this.nextTemp();
+    this.emit(`${indexReg} = alloca i32`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
+
+    this.ctx.emitLabel(bodyLabel);
+    const keyElemPtr = this.nextTemp();
+    this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`);
+    const keyValue = this.ctx.emitLoad("i8*", keyElemPtr);
+    const valueElemPtr = this.nextTemp();
+    this.emit(
+      `${valueElemPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${currentIndex}`,
+    );
+    const valueValue = this.ctx.emitLoad("i8*", valueElemPtr);
+
+    const entryMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 16");
+    const entryKvPtr = this.ctx.emitBitcast(entryMem, "i8*", "{ i8*, i8* }*");
+    const keySlot = this.nextTemp();
+    this.emit(
+      `${keySlot} = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* ${entryKvPtr}, i32 0, i32 0`,
+    );
+    this.ctx.emitStore("i8*", keyValue, keySlot);
+    const valueSlot = this.nextTemp();
+    this.emit(
+      `${valueSlot} = getelementptr inbounds { i8*, i8* }, { i8*, i8* }* ${entryKvPtr}, i32 0, i32 1`,
+    );
+    this.ctx.emitStore("i8*", valueValue, valueSlot);
+
+    const entrySlot = this.nextTemp();
+    this.emit(`${entrySlot} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${currentIndex}`);
+    this.ctx.emitStore("i8*", entryMem, entrySlot);
+
+    const nextIndex = this.nextTemp();
+    this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(endLabel);
+
+    return arrayPtr;
+  }
+
+  generatePointerMapKeys(mapPtr: string): string {
+    const keysFieldPtr = this.nextTemp();
+    this.emit(
+      `${keysFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 0`,
+    );
+    const keysPtr = this.ctx.emitLoad("i8**", keysFieldPtr);
+
+    const sizeFieldPtr = this.nextTemp();
+    this.emit(
+      `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
+    );
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
+
+    const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%ObjectArray*");
+
+    const mapSizeI64 = this.nextTemp();
+    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    const dataSize = this.nextTemp();
+    this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
+    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
+
+    const dataPtrField = this.nextTemp();
+    this.emit(
+      `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+    );
+    this.ctx.emitStore("i8*", dataMem, dataPtrField);
+    const lenFieldPtr = this.nextTemp();
+    this.emit(
+      `${lenFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
+    );
+    this.ctx.emitStore("i32", mapSize, lenFieldPtr);
+    const capFieldPtr = this.nextTemp();
+    this.emit(
+      `${capFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 2`,
+    );
+    this.ctx.emitStore("i32", mapSize, capFieldPtr);
+
+    const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
+
+    const loopLabel = this.nextLabel("ptrmap_keys_loop");
+    const bodyLabel = this.nextLabel("ptrmap_keys_body");
+    const endLabel = this.nextLabel("ptrmap_keys_end");
+
+    const indexReg = this.nextTemp();
+    this.emit(`${indexReg} = alloca i32`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
+
+    this.ctx.emitLabel(bodyLabel);
+    const keyElemPtr = this.nextTemp();
+    this.emit(`${keyElemPtr} = getelementptr inbounds i8*, i8** ${keysPtr}, i32 ${currentIndex}`);
+    const keyVal = this.ctx.emitLoad("i8*", keyElemPtr);
+    const destElemPtr = this.nextTemp();
+    this.emit(`${destElemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${currentIndex}`);
+    this.ctx.emitStore("i8*", keyVal, destElemPtr);
+
+    const nextIndex = this.nextTemp();
+    this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(endLabel);
+
+    return arrayPtr;
+  }
+
+  generatePointerMapValues(mapPtr: string): string {
+    const valuesFieldPtr = this.nextTemp();
+    this.emit(
+      `${valuesFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 1`,
+    );
+    const valuesPtr = this.ctx.emitLoad("i8**", valuesFieldPtr);
+
+    const sizeFieldPtr = this.nextTemp();
+    this.emit(
+      `${sizeFieldPtr} = getelementptr inbounds %StringMap, %StringMap* ${mapPtr}, i32 0, i32 2`,
+    );
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
+
+    const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%ObjectArray*");
+
+    const mapSizeI64 = this.nextTemp();
+    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    const dataSize = this.nextTemp();
+    this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
+    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
+
+    const dataPtrField = this.nextTemp();
+    this.emit(
+      `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+    );
+    this.ctx.emitStore("i8*", dataMem, dataPtrField);
+    const lenFieldPtr = this.nextTemp();
+    this.emit(
+      `${lenFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
+    );
+    this.ctx.emitStore("i32", mapSize, lenFieldPtr);
+    const capFieldPtr = this.nextTemp();
+    this.emit(
+      `${capFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 2`,
+    );
+    this.ctx.emitStore("i32", mapSize, capFieldPtr);
+
+    const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
+
+    const loopLabel = this.nextLabel("ptrmap_values_loop");
+    const bodyLabel = this.nextLabel("ptrmap_values_body");
+    const endLabel = this.nextLabel("ptrmap_values_end");
+
+    const indexReg = this.nextTemp();
+    this.emit(`${indexReg} = alloca i32`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
+
+    this.ctx.emitLabel(bodyLabel);
+    const valueElemPtr = this.nextTemp();
+    this.emit(
+      `${valueElemPtr} = getelementptr inbounds i8*, i8** ${valuesPtr}, i32 ${currentIndex}`,
+    );
+    const valueVal = this.ctx.emitLoad("i8*", valueElemPtr);
+    const destElemPtr = this.nextTemp();
+    this.emit(`${destElemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${currentIndex}`);
+    this.ctx.emitStore("i8*", valueVal, destElemPtr);
+
+    const nextIndex = this.nextTemp();
+    this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(endLabel);
+
+    return arrayPtr;
+  }
 }

--- a/tests/fixtures/data-structures/pointer-map-methods.ts
+++ b/tests/fixtures/data-structures/pointer-map-methods.ts
@@ -1,0 +1,52 @@
+interface Item {
+  name: string;
+  value: number;
+}
+
+const map: Map<Item, string> = new Map();
+const a: Item = { name: "alpha", value: 1 };
+const b: Item = { name: "beta", value: 2 };
+const c: Item = { name: "gamma", value: 3 };
+
+map.set(a, "first");
+map.set(b, "second");
+map.set(c, "third");
+
+if (map.size !== 3) {
+  console.log("FAIL: size should be 3");
+  process.exit(1);
+}
+
+if (!map.has(a)) {
+  console.log("FAIL: should have key a");
+  process.exit(1);
+}
+
+if (!map.has(b)) {
+  console.log("FAIL: should have key b");
+  process.exit(1);
+}
+
+const got = map.get(a);
+if (got !== "first") {
+  console.log("FAIL: get(a) should be first");
+  process.exit(1);
+}
+
+map.delete(b);
+if (map.size !== 2) {
+  console.log("FAIL: size should be 2 after delete");
+  process.exit(1);
+}
+
+if (map.has(b)) {
+  console.log("FAIL: should not have key b after delete");
+  process.exit(1);
+}
+
+if (!map.has(c)) {
+  console.log("FAIL: should still have key c after deleting b");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- Map<Interface, T> (PointerMap) now supports all standard Map methods: `has`, `delete`, `size`, `entries`, `keys`, `values`
- Previously only `get`, `set`, and `clear` were supported — all other methods produced compile errors
- PointerMap uses linear scan with `strcmp` for key comparison, packed array storage (no hash table)
- `delete` uses swap-with-last for O(1) removal from the packed array

## Test plan
- [x] New test fixture `pointer-map-methods.ts` covers set/get/has/delete/size with interface keys
- [x] All existing tests pass
- [x] Self-hosting Stage 1 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)