### PR TITLE
add keys() and values() for Map<number, number>

### DIFF
--- a/examples/jsonc/bench/jsonc-bun.mjs
+++ b/examples/jsonc/bench/jsonc-bun.mjs
@@ -1,12 +1,15 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from "fs";
 
 const file = process.argv[2];
-if (!file) { console.error('usage: jsonc-bun <file>'); process.exit(1); }
+if (!file) {
+  console.error("usage: jsonc-bun <file>");
+  process.exit(1);
+}
 
-let text = readFileSync(file, 'utf8');
-text = text.replace(/\/\/[^\n]*/g, '');
-text = text.replace(/\/\*[\s\S]*?\*\//g, '');
-text = text.replace(/,\s*([\]}])/g, '$1');
+let text = readFileSync(file, "utf8");
+text = text.replace(/\/\/[^\n]*/g, "");
+text = text.replace(/\/\*[\s\S]*?\*\//g, "");
+text = text.replace(/,\s*([\]}])/g, "$1");
 
 const parsed = JSON.parse(text);
-process.stdout.write(JSON.stringify(parsed) + '\n');
+process.stdout.write(JSON.stringify(parsed) + "\n");

--- a/examples/jsonc/bench/jsonc-node.mjs
+++ b/examples/jsonc/bench/jsonc-node.mjs
@@ -1,12 +1,15 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from "fs";
 
 const file = process.argv[2];
-if (!file) { console.error('usage: jsonc-node <file>'); process.exit(1); }
+if (!file) {
+  console.error("usage: jsonc-node <file>");
+  process.exit(1);
+}
 
-let text = readFileSync(file, 'utf8');
-text = text.replace(/\/\/[^\n]*/g, '');
-text = text.replace(/\/\*[\s\S]*?\*\//g, '');
-text = text.replace(/,\s*([\]}])/g, '$1');
+let text = readFileSync(file, "utf8");
+text = text.replace(/\/\/[^\n]*/g, "");
+text = text.replace(/\/\*[\s\S]*?\*\//g, "");
+text = text.replace(/,\s*([\]}])/g, "$1");
 
 const parsed = JSON.parse(text);
-process.stdout.write(JSON.stringify(parsed) + '\n');
+process.stdout.write(JSON.stringify(parsed) + "\n");

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -818,9 +818,15 @@ export class MethodCallGenerator {
           return this.ctx.mapGen.generateMapHas(expr, params);
         } else if (method === "delete") {
           return this.ctx.mapGen.generateMapDelete(expr, params);
-        } else if (method === "entries" || method === "values" || method === "keys") {
+        } else if (method === "keys") {
+          const mapPtr = this.ctx.generateExpression(expr.object, params);
+          return this.ctx.mapGen.generateMapKeys(mapPtr);
+        } else if (method === "values") {
+          const mapPtr = this.ctx.generateExpression(expr.object, params);
+          return this.ctx.mapGen.generateMapValues(mapPtr);
+        } else if (method === "entries") {
           return this.ctx.emitError(
-            `Map.${method}() only supported for Map<string, *> types`,
+            `Map.entries() not yet supported for Map<number, *> types — use .keys() and .get()`,
             expr.loc,
           );
         } else if (method === "clear") {

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -262,6 +262,8 @@ export interface IMapGenerator {
   generateMapDelete(expr: MethodCallNode, params: string[]): string;
   generateMapClear(expr: MethodCallNode, params: string[]): string;
   generateMapSize(mapPtr: string): string;
+  generateMapKeys(mapPtr: string): string;
+  generateMapValues(mapPtr: string): string;
 }
 
 export interface ISetGenerator {
@@ -1980,6 +1982,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     generateMapDelete: (_expr: MethodCallNode, _params: string[]): string => "%mock_map_delete",
     generateMapClear: (_expr: MethodCallNode, _params: string[]): string => "%mock_map_clear",
     generateMapSize: (_mapPtr: string): string => "%mock_map_size",
+    generateMapKeys: (_mapPtr: string): string => "%mock_map_keys",
+    generateMapValues: (_mapPtr: string): string => "%mock_map_values",
   };
   setGen: ISetGenerator = {
     generateSetLiteral: (_expr: SetNode, _params: string[]): string => "%mock_set_literal",

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -504,6 +504,146 @@ export class MapGenerator {
 
     return result;
   }
+
+  generateMapKeys(mapPtr: string): string {
+    const keysFieldPtr = this.nextTemp();
+    this.emit(`${keysFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 0`);
+    const keysPtr = this.ctx.emitLoad("double*", keysFieldPtr);
+
+    const sizeFieldPtr = this.nextTemp();
+    this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
+
+    const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
+
+    const mapSizeI64 = this.nextTemp();
+    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    const dataSize = this.nextTemp();
+    this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
+    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+    const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "double*");
+
+    const dataPtrField = this.nextTemp();
+    this.emit(
+      `${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`,
+    );
+    this.ctx.emitStore("double*", dataPtr, dataPtrField);
+    const lenFieldPtr = this.nextTemp();
+    this.emit(
+      `${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`,
+    );
+    this.ctx.emitStore("i32", mapSize, lenFieldPtr);
+    const capFieldPtr = this.nextTemp();
+    this.emit(
+      `${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`,
+    );
+    this.ctx.emitStore("i32", mapSize, capFieldPtr);
+
+    const loopLabel = this.nextLabel("map_keys_loop");
+    const bodyLabel = this.nextLabel("map_keys_body");
+    const endLabel = this.nextLabel("map_keys_end");
+
+    const indexReg = this.nextTemp();
+    this.emit(`${indexReg} = alloca i32`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
+
+    this.ctx.emitLabel(bodyLabel);
+    const srcPtr = this.nextTemp();
+    this.emit(
+      `${srcPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${currentIndex}`,
+    );
+    const keyVal = this.ctx.emitLoad("double", srcPtr);
+    const dstPtr = this.nextTemp();
+    this.emit(
+      `${dstPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${currentIndex}`,
+    );
+    this.ctx.emitStore("double", keyVal, dstPtr);
+    const nextIndex = this.nextTemp();
+    this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(endLabel);
+    this.ctx.setVariableType(arrayPtr, "%Array*");
+    return arrayPtr;
+  }
+
+  generateMapValues(mapPtr: string): string {
+    const valuesFieldPtr = this.nextTemp();
+    this.emit(`${valuesFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 1`);
+    const valuesPtr = this.ctx.emitLoad("double*", valuesFieldPtr);
+
+    const sizeFieldPtr = this.nextTemp();
+    this.emit(`${sizeFieldPtr} = getelementptr inbounds %Map, %Map* ${mapPtr}, i32 0, i32 2`);
+    const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
+
+    const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
+
+    const mapSizeI64 = this.nextTemp();
+    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    const dataSize = this.nextTemp();
+    this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
+    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+    const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "double*");
+
+    const dataPtrField = this.nextTemp();
+    this.emit(
+      `${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`,
+    );
+    this.ctx.emitStore("double*", dataPtr, dataPtrField);
+    const lenFieldPtr = this.nextTemp();
+    this.emit(
+      `${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`,
+    );
+    this.ctx.emitStore("i32", mapSize, lenFieldPtr);
+    const capFieldPtr = this.nextTemp();
+    this.emit(
+      `${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`,
+    );
+    this.ctx.emitStore("i32", mapSize, capFieldPtr);
+
+    const loopLabel = this.nextLabel("map_values_loop");
+    const bodyLabel = this.nextLabel("map_values_body");
+    const endLabel = this.nextLabel("map_values_end");
+
+    const indexReg = this.nextTemp();
+    this.emit(`${indexReg} = alloca i32`);
+    this.ctx.emitStore("i32", "0", indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(loopLabel);
+    const currentIndex = this.ctx.emitLoad("i32", indexReg);
+    const cond = this.ctx.emitIcmp("slt", "i32", currentIndex, mapSize);
+    this.ctx.emitBrCond(cond, bodyLabel, endLabel);
+
+    this.ctx.emitLabel(bodyLabel);
+    const srcPtr = this.nextTemp();
+    this.emit(
+      `${srcPtr} = getelementptr inbounds double, double* ${valuesPtr}, i32 ${currentIndex}`,
+    );
+    const val = this.ctx.emitLoad("double", srcPtr);
+    const dstPtr = this.nextTemp();
+    this.emit(
+      `${dstPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${currentIndex}`,
+    );
+    this.ctx.emitStore("double", val, dstPtr);
+    const nextIndex = this.nextTemp();
+    this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
+    this.ctx.emitStore("i32", nextIndex, indexReg);
+    this.ctx.emitBr(loopLabel);
+
+    this.ctx.emitLabel(endLabel);
+    this.ctx.setVariableType(arrayPtr, "%Array*");
+    return arrayPtr;
+  }
 }
 
 export class StringMapGenerator {

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -525,19 +525,13 @@ export class MapGenerator {
     const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "double*");
 
     const dataPtrField = this.nextTemp();
-    this.emit(
-      `${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`,
-    );
+    this.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
     this.ctx.emitStore("double*", dataPtr, dataPtrField);
     const lenFieldPtr = this.nextTemp();
-    this.emit(
-      `${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`,
-    );
+    this.emit(`${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
     this.ctx.emitStore("i32", mapSize, lenFieldPtr);
     const capFieldPtr = this.nextTemp();
-    this.emit(
-      `${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`,
-    );
+    this.emit(`${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`);
     this.ctx.emitStore("i32", mapSize, capFieldPtr);
 
     const loopLabel = this.nextLabel("map_keys_loop");
@@ -556,14 +550,10 @@ export class MapGenerator {
 
     this.ctx.emitLabel(bodyLabel);
     const srcPtr = this.nextTemp();
-    this.emit(
-      `${srcPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${currentIndex}`,
-    );
+    this.emit(`${srcPtr} = getelementptr inbounds double, double* ${keysPtr}, i32 ${currentIndex}`);
     const keyVal = this.ctx.emitLoad("double", srcPtr);
     const dstPtr = this.nextTemp();
-    this.emit(
-      `${dstPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${currentIndex}`,
-    );
+    this.emit(`${dstPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${currentIndex}`);
     this.ctx.emitStore("double", keyVal, dstPtr);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);
@@ -595,19 +585,13 @@ export class MapGenerator {
     const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "double*");
 
     const dataPtrField = this.nextTemp();
-    this.emit(
-      `${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`,
-    );
+    this.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
     this.ctx.emitStore("double*", dataPtr, dataPtrField);
     const lenFieldPtr = this.nextTemp();
-    this.emit(
-      `${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`,
-    );
+    this.emit(`${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
     this.ctx.emitStore("i32", mapSize, lenFieldPtr);
     const capFieldPtr = this.nextTemp();
-    this.emit(
-      `${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`,
-    );
+    this.emit(`${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`);
     this.ctx.emitStore("i32", mapSize, capFieldPtr);
 
     const loopLabel = this.nextLabel("map_values_loop");
@@ -631,9 +615,7 @@ export class MapGenerator {
     );
     const val = this.ctx.emitLoad("double", srcPtr);
     const dstPtr = this.nextTemp();
-    this.emit(
-      `${dstPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${currentIndex}`,
-    );
+    this.emit(`${dstPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${currentIndex}`);
     this.ctx.emitStore("double", val, dstPtr);
     const nextIndex = this.nextTemp();
     this.emit(`${nextIndex} = add i32 ${currentIndex}, 1`);

--- a/tests/fixtures/data-structures/map-numeric-entries-error.ts
+++ b/tests/fixtures/data-structures/map-numeric-entries-error.ts
@@ -1,11 +1,9 @@
-// @test-compile-error: for...of on Map<number, *> is not supported
-// @test-description: compile error for iterating numeric map entries
+// @test-compile-error: Map.entries() not yet supported for Map<number, *> types
+// @test-description: compile error for entries() on numeric map
 function testNumericMapEntries() {
   const m = new Map<number, number>();
   m.set(1, 10);
-  for (const [k, v] of m) {
-    console.log(k);
-  }
+  const e = m.entries();
 }
 
 testNumericMapEntries();

--- a/tests/fixtures/data-structures/map-numeric-keys-values.ts
+++ b/tests/fixtures/data-structures/map-numeric-keys-values.ts
@@ -1,0 +1,44 @@
+function testNumericMapKeysValues() {
+  const m = new Map<number, number>();
+  m.set(10, 100);
+  m.set(20, 200);
+  m.set(30, 300);
+
+  const keys = m.keys();
+  if (keys.length !== 3) {
+    console.log("FAIL: keys length should be 3");
+    process.exit(1);
+  }
+
+  let keySum = 0;
+  let i = 0;
+  while (i < keys.length) {
+    keySum = keySum + keys[i];
+    i = i + 1;
+  }
+  if (keySum !== 60) {
+    console.log("FAIL: key sum should be 60");
+    process.exit(1);
+  }
+
+  const vals = m.values();
+  if (vals.length !== 3) {
+    console.log("FAIL: values length should be 3");
+    process.exit(1);
+  }
+
+  let valSum = 0;
+  let j = 0;
+  while (j < vals.length) {
+    valSum = valSum + vals[j];
+    j = j + 1;
+  }
+  if (valSum !== 600) {
+    console.log("FAIL: value sum should be 600");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testNumericMapKeysValues();


### PR DESCRIPTION
## Summary
- `Map<number, number>` now supports `.keys()` and `.values()` — previously produced compile errors
- Both return `number[]` (packed copies of the map's internal arrays)
- `.entries()` still produces a compile error with improved message suggesting `.keys()` + `.get()` as workaround
- Updated test fixture for new error message

## Test plan
- [x] New test `map-numeric-keys-values.ts` verifies keys/values return correct arrays
- [x] Existing `map-numeric-entries-error.ts` updated for new error message
- [x] All tests pass, self-hosting Stage 1 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)