### PR TITLE
fix: pointer map setVariableType + clear/reset test coverage

### DIFF
--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -1488,7 +1488,6 @@ export class StringMapGenerator {
 
     this.ctx.emitLabel(endLabel);
 
-    // emitBitcast already set arrayPtr type to %StringArray*
     return arrayPtr;
   }
 }
@@ -1877,7 +1876,7 @@ export class PointerMapGenerator {
     const mapSize = this.ctx.emitLoad("i32", sizeFieldPtr);
 
     const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
-    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%ObjectArray*");
 
     const mapSizeI64 = this.nextTemp();
     this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
@@ -1886,16 +1885,21 @@ export class PointerMapGenerator {
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
     const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
 
+    const dataPtrField = this.nextTemp();
+    this.emit(
+      `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+    );
+    this.ctx.emitStore("i8*", dataMem, dataPtrField);
     const lenFieldPtr = this.nextTemp();
-    this.emit(`${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
+    this.emit(
+      `${lenFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
+    );
     this.ctx.emitStore("i32", mapSize, lenFieldPtr);
     const capFieldPtr = this.nextTemp();
-    this.emit(`${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
+    this.emit(
+      `${capFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 2`,
+    );
     this.ctx.emitStore("i32", mapSize, capFieldPtr);
-    const dataFieldPtr = this.nextTemp();
-    this.emit(`${dataFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`);
-    const dataCast = this.ctx.emitBitcast(dataPtr, "i8**", "double*");
-    this.ctx.emitStore("double*", dataCast, dataFieldPtr);
 
     const loopLabel = this.nextLabel("ptrmap_entries_loop");
     const bodyLabel = this.nextLabel("ptrmap_entries_body");
@@ -1945,6 +1949,7 @@ export class PointerMapGenerator {
 
     this.ctx.emitLabel(endLabel);
 
+    this.ctx.setVariableType(arrayPtr, "%ObjectArray*");
     return arrayPtr;
   }
 
@@ -2017,6 +2022,7 @@ export class PointerMapGenerator {
 
     this.ctx.emitLabel(endLabel);
 
+    this.ctx.setVariableType(arrayPtr, "%ObjectArray*");
     return arrayPtr;
   }
 
@@ -2091,6 +2097,7 @@ export class PointerMapGenerator {
 
     this.ctx.emitLabel(endLabel);
 
+    this.ctx.setVariableType(arrayPtr, "%ObjectArray*");
     return arrayPtr;
   }
 }

--- a/tests/fixtures/data-structures/pointer-map-entries.ts
+++ b/tests/fixtures/data-structures/pointer-map-entries.ts
@@ -1,0 +1,62 @@
+interface Item {
+  name: string;
+  value: number;
+}
+
+function testPointerMapClearAndReset() {
+  const map: Map<Item, string> = new Map();
+  const a: Item = { name: "alpha", value: 1 };
+  const b: Item = { name: "beta", value: 2 };
+  const c: Item = { name: "gamma", value: 3 };
+
+  map.set(a, "first");
+  map.set(b, "second");
+  map.set(c, "third");
+
+  if (map.size !== 3) {
+    console.log("FAIL: size should be 3");
+    process.exit(1);
+  }
+
+  map.clear();
+  if (map.size !== 0) {
+    console.log("FAIL: size should be 0 after clear");
+    process.exit(1);
+  }
+
+  if (map.has(a)) {
+    console.log("FAIL: should not have key a after clear");
+    process.exit(1);
+  }
+
+  map.set(a, "restored");
+  if (map.size !== 1) {
+    console.log("FAIL: size should be 1 after re-add");
+    process.exit(1);
+  }
+
+  const val = map.get(a);
+  if (val !== "restored") {
+    console.log("FAIL: get(a) should be 'restored'");
+    process.exit(1);
+  }
+
+  map.set(b, "also-restored");
+  map.set(c, "and-this");
+  if (map.size !== 3) {
+    console.log("FAIL: size should be 3 after re-adding all");
+    process.exit(1);
+  }
+
+  map.delete(a);
+  map.delete(b);
+  map.delete(c);
+  if (map.size !== 0) {
+    console.log("FAIL: size should be 0 after deleting all");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testPointerMapClearAndReset();


### PR DESCRIPTION
## Summary
- Add missing `setVariableType` calls in `generatePointerMapEntries/Keys/Values` — fixes `.length` access and type tracking for pointer map iteration results
- Fix `generatePointerMapEntries` to use `%ObjectArray*` struct (was incorrectly using `%Array*` with `double*` data for `i8*` entries)
- Add `pointer-map-entries.ts` test: clear, re-add, delete-all flow for `Map<Interface, T>`

## Test plan
- [x] `npm run verify:quick` passes
- [x] Pointer map entries test passes with node compiler