### PR TITLE
replace local type definitions with ast types in array and embed codegen

### DIFF
--- a/src/codegen/stdlib/embed.ts
+++ b/src/codegen/stdlib/embed.ts
@@ -2,17 +2,8 @@
  * Reads files as raw Buffers (not UTF-8) to preserve binary content like images. */
 import * as fs from "fs";
 import * as path from "path";
-import { MethodCallNode } from "../../ast/types.js";
+import { MethodCallNode, StringNode } from "../../ast/types.js";
 import { IGeneratorContext } from "../infrastructure/generator-context.js";
-
-interface ExprBase {
-  type: string;
-}
-
-interface StringLiteralNode {
-  type: "string";
-  value: string;
-}
 
 export class EmbedGenerator {
   private embeddedKeys: string[] = [];
@@ -153,7 +144,7 @@ export class EmbedGenerator {
       return this.ctx.emitError("ChadScript.embedFile() requires 1 argument (file path)", expr.loc);
     }
 
-    const argBase = expr.args[0] as ExprBase;
+    const argBase = expr.args[0] as { type: string };
     if (argBase.type !== "string") {
       return this.ctx.emitError(
         "ChadScript.embedFile() argument must be a string literal",
@@ -161,7 +152,7 @@ export class EmbedGenerator {
       );
     }
 
-    const relPath = (expr.args[0] as StringLiteralNode).value;
+    const relPath = (expr.args[0] as StringNode).value;
     const absPath = path.resolve(this.entryDir, relPath);
 
     if (!fs.existsSync(absPath)) {
@@ -205,7 +196,7 @@ export class EmbedGenerator {
       );
     }
 
-    const argBase = expr.args[0] as ExprBase;
+    const argBase = expr.args[0] as { type: string };
     if (argBase.type !== "string") {
       return this.ctx.emitError(
         "ChadScript.embedDir() argument must be a string literal",
@@ -213,7 +204,7 @@ export class EmbedGenerator {
       );
     }
 
-    const relPath = (expr.args[0] as StringLiteralNode).value;
+    const relPath = (expr.args[0] as StringNode).value;
     const absPath = path.resolve(this.entryDir, relPath);
 
     if (!fs.existsSync(absPath)) {

--- a/src/codegen/types/collections/array/combine.ts
+++ b/src/codegen/types/collections/array/combine.ts
@@ -3,19 +3,12 @@
 
 import {
   Expression,
+  ArrayNode,
   MethodCallNode,
   VariableNode,
   SpreadElementNode,
 } from "../../../../ast/types.js";
 import { IGeneratorContext, loadArrayMeta } from "./context.js";
-
-interface ExprBase {
-  type: string;
-}
-interface ArrayExpr {
-  type: string;
-  elements: Expression[];
-}
 
 // ============================================
 // spread literals
@@ -23,12 +16,12 @@ interface ArrayExpr {
 
 export function generateArrayLiteralWithSpread(
   gen: IGeneratorContext,
-  arrExpr: ArrayExpr,
+  arrExpr: ArrayNode,
   params: string[],
 ): string {
   let isStringArray = false;
   for (let i = 0; i < arrExpr.elements.length; i++) {
-    const el = arrExpr.elements[i] as ExprBase;
+    const el = arrExpr.elements[i] as { type: string };
     if (el.type === "string") {
       isStringArray = true;
       break;
@@ -49,7 +42,7 @@ export function generateArrayLiteralWithSpread(
 
   let literalCount = 0;
   for (let i = 0; i < arrExpr.elements.length; i++) {
-    const el = arrExpr.elements[i] as ExprBase;
+    const el = arrExpr.elements[i] as { type: string };
     if (el.type.indexOf("spread:") !== 0 && el.type !== "spread_element") {
       literalCount = literalCount + 1;
     }
@@ -58,7 +51,7 @@ export function generateArrayLiteralWithSpread(
   // Compute total length by summing literal count + each spread array's length
   let totalLen = `${literalCount}`;
   for (let i = 0; i < arrExpr.elements.length; i++) {
-    const el = arrExpr.elements[i] as ExprBase;
+    const el = arrExpr.elements[i] as { type: string };
     if (el.type.indexOf("spread:") === 0) {
       const varName = el.type.substr(7);
       const alloca = gen.getVariableAlloca(varName)!;
@@ -96,7 +89,7 @@ export function generateArrayLiteralWithSpread(
   gen.emitStore("i32", "0", offsetPtr);
 
   for (let i = 0; i < arrExpr.elements.length; i++) {
-    const el = arrExpr.elements[i] as ExprBase;
+    const el = arrExpr.elements[i] as { type: string };
     if (el.type.indexOf("spread:") === 0) {
       const varName = el.type.substr(7);
       const alloca = gen.getVariableAlloca(varName)!;
@@ -213,14 +206,14 @@ export function generateArrayLiteralWithSpread(
 
 function generateStringArrayLiteralWithSpread(
   gen: IGeneratorContext,
-  arrExpr: ArrayExpr,
+  arrExpr: ArrayNode,
   params: string[],
 ): string {
   const spreadSources: { index: number; ptr: string }[] = [];
   const literalValues: { index: number; value: string }[] = [];
 
   for (let i = 0; i < arrExpr.elements.length; i++) {
-    const el = arrExpr.elements[i] as ExprBase;
+    const el = arrExpr.elements[i] as { type: string };
     if (el.type.indexOf("spread:") === 0) {
       const varName = el.type.substr(7);
       const alloca = gen.getVariableAlloca(varName)!;
@@ -270,7 +263,7 @@ function generateStringArrayLiteralWithSpread(
   let spreadIdx = 0;
   let litIdx = 0;
   for (let i = 0; i < arrExpr.elements.length; i++) {
-    const el = arrExpr.elements[i] as ExprBase;
+    const el = arrExpr.elements[i] as { type: string };
     if (el.type === "spread_element" || el.type.indexOf("spread:") === 0) {
       const src = spreadSources[spreadIdx];
       spreadIdx++;
@@ -377,7 +370,7 @@ export function generateArrayJoin(
   }
 
   let isStringArray = false;
-  const exprObjBase = expr.object as ExprBase;
+  const exprObjBase = expr.object as { type: string };
   if (exprObjBase.type === "variable") {
     const varName = (expr.object as VariableNode).name;
     const varType = gen.getVariableType(varName);
@@ -598,7 +591,7 @@ export function generateArraySlice(
 
   let isStringArray = false;
   let isObjectArray = false;
-  const exprObjBase = expr.object as ExprBase;
+  const exprObjBase = expr.object as { type: string };
   if (exprObjBase.type === "variable") {
     const varName = (expr.object as VariableNode).name;
     const varType = gen.getVariableType(varName);
@@ -799,7 +792,7 @@ export function generateArrayConcat(
 
   let isStringArray = false;
   let isObjectArray = false;
-  const exprObjBase = expr.object as ExprBase;
+  const exprObjBase = expr.object as { type: string };
   if (exprObjBase.type === "variable") {
     const varName = (expr.object as VariableNode).name;
     const varType = gen.getVariableType(varName);

--- a/src/codegen/types/collections/array/literal.ts
+++ b/src/codegen/types/collections/array/literal.ts
@@ -1,26 +1,11 @@
-import { Expression } from "../../../../ast/types.js";
+import {
+  Expression,
+  ArrayNode,
+  VariableNode,
+  MethodCallNode,
+  CallNode,
+} from "../../../../ast/types.js";
 import { IGeneratorContext } from "./context.js";
-
-interface ExprBase {
-  type: string;
-}
-interface ArrayExpr {
-  type: string;
-  elements: Expression[];
-}
-interface VariableExpr {
-  type: string;
-  name: string;
-}
-interface MethodCallExpr {
-  type: string;
-  object: Expression;
-  method: string;
-}
-interface CallExpr {
-  type: string;
-  name: string;
-}
 
 /**
  * Array literal generation
@@ -31,12 +16,12 @@ export function generateArrayLiteral(
   expr: Expression,
   params: string[],
 ): string {
-  const e = expr as ExprBase;
+  const e = expr as { type: string };
   if (e.type !== "array") {
     return gen.emitError("Expected array literal");
   }
 
-  const arrExpr = expr as ArrayExpr;
+  const arrExpr = expr as ArrayNode;
   const length = arrExpr.elements.length;
 
   // Determine if this is a string array:
@@ -46,7 +31,7 @@ export function generateArrayLiteral(
   if (length > 0) {
     let allStrings = true;
     for (let i = 0; i < arrExpr.elements.length; i++) {
-      const el = arrExpr.elements[i] as ExprBase;
+      const el = arrExpr.elements[i] as { type: string };
       if (el.type !== "string") {
         allStrings = false;
         break;
@@ -74,9 +59,9 @@ export function generateArrayLiteral(
     if (!isPointerArray && !isStringArray) {
       for (let i = 0; i < arrExpr.elements.length; i++) {
         const elem = arrExpr.elements[i];
-        const el = elem as ExprBase;
+        const el = elem as { type: string };
         if (el.type === "variable") {
-          const varExpr = elem as VariableExpr;
+          const varExpr = elem as VariableNode;
           const varName = varExpr.name;
           const varType = gen.getVariableType(varName);
           if (varType && (varType.indexOf("%Promise") !== -1 || varType.indexOf("*") !== -1)) {
@@ -85,11 +70,11 @@ export function generateArrayLiteral(
           }
         }
         if (el.type === "method_call") {
-          const mcExpr = elem as MethodCallExpr;
+          const mcExpr = elem as MethodCallNode;
           const obj = mcExpr.object;
-          const objBase = obj as ExprBase;
+          const objBase = obj as { type: string };
           if (obj && objBase.type === "variable") {
-            const objVar = obj as VariableExpr;
+            const objVar = obj as VariableNode;
             if (objVar.name === "Promise") {
               isPointerArray = true;
               break;
@@ -97,7 +82,7 @@ export function generateArrayLiteral(
           }
         }
         if (el.type === "call") {
-          const callExpr = elem as CallExpr;
+          const callExpr = elem as CallNode;
           const callName = callExpr.name;
           if (callName === "fetch") {
             isPointerArray = true;


### PR DESCRIPTION
## Summary
- Replaces 9 local interface definitions in array/literal.ts, array/combine.ts, and embed.ts with proper AST types from src/ast/types.ts
- Reduces code by ~30 lines while improving type safety and native compiler compatibility
- Uses ArrayNode, VariableNode, MethodCallNode, CallNode, and StringNode instead of hand-rolled ExprBase, ArrayExpr, etc.

## Test plan
- [x] TypeScript type check passes
- [x] npm run verify:quick passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)