### PR TITLE
consolidate duplicated types across codegen files

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -92,15 +92,8 @@ import {
   handleClassMethods,
   handleObjectMethods,
   getInterfaceFromAST,
+  type InterfaceDefInfo,
 } from "./method-calls/class-dispatch.js";
-
-interface ExprBase {
-  type: string;
-}
-
-interface InterfaceDefInfo {
-  properties: { name: string; type: string }[];
-}
 
 export interface MethodCallGeneratorContext {
   nextTemp(): string;
@@ -275,7 +268,7 @@ export class MethodCallGenerator {
   }
 
   private isClassInstanceExpression(expr: Expression): boolean {
-    const e = expr as ExprBase;
+    const e = expr as { type: string };
     if (e.type !== "variable") return false;
     const varName = (expr as VariableNode).name;
     return this.ctx.symbolTable.isClass(varName);
@@ -285,7 +278,7 @@ export class MethodCallGenerator {
     if (!expr) {
       return false;
     }
-    const e = expr as ExprBase;
+    const e = expr as { type: string };
     const eType = e.type;
     if (eType !== "variable") {
       return false;
@@ -296,7 +289,7 @@ export class MethodCallGenerator {
   }
 
   private getVariableName(expr: Expression): string | null {
-    const e = expr as ExprBase;
+    const e = expr as { type: string };
     if (e.type === "variable") {
       return (expr as VariableNode).name;
     }
@@ -639,7 +632,7 @@ export class MethodCallGenerator {
       return objectResult;
     }
 
-    const exprObjBase = expr.object as ExprBase;
+    const exprObjBase = expr.object as { type: string };
     if (exprObjBase.type === "method_call") {
       return this.ctx.emitError(
         `Method chaining on class instances is not supported. Assign the result to a variable first.`,
@@ -700,10 +693,10 @@ export class MethodCallGenerator {
     if (methodCallExpr) {
       const expr = methodCallExpr.object;
       if (expr) {
-        const e = expr as ExprBase;
+        const e = expr as { type: string };
         if (e.type === "member_access") {
           const memberExpr = expr as MemberAccessNode;
-          const memberObjBase = memberExpr.object as ExprBase;
+          const memberObjBase = memberExpr.object as { type: string };
           if (memberObjBase && memberObjBase.type === "variable") {
             objectDescription = `${(memberExpr.object as VariableNode).name}.${memberExpr.property}`;
           } else {
@@ -737,7 +730,7 @@ export class MethodCallGenerator {
   }
 
   private isLikelyResponseExpression(expr: MethodCallNode): boolean {
-    const exprObj = expr.object as ExprBase;
+    const exprObj = expr.object as { type: string };
     if (exprObj.type === "variable") {
       const varName = (expr.object as VariableNode).name;
       const varType = this.ctx.symbolTable.getType(varName);

--- a/src/codegen/expressions/method-calls/class-dispatch.ts
+++ b/src/codegen/expressions/method-calls/class-dispatch.ts
@@ -9,28 +9,16 @@ import {
   FunctionNode,
   FunctionParameter,
   IndexAccessNode,
+  NewNode,
+  ObjectNode,
+  ClassNode,
 } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
 import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
 
-interface ExprBase {
-  type: string;
-}
-interface InterfaceDefInfo {
+export interface InterfaceDefInfo {
   properties: { name: string; type: string }[];
 }
-
-type NewMeta = { type: "new"; className: string };
-type ObjectNode = { type: "object"; properties: { key: string }[] };
-type ClassNode = {
-  name: string;
-  extends?: string;
-  implements?: string[];
-  fields: { name: string; type: string }[];
-  methods: { name: string; isConstructor?: boolean; isStatic?: boolean }[];
-  loc?: { line: number; column: number };
-  typeParameters?: string[];
-};
 
 export function getInterfaceDecl(
   ctx: MethodCallGeneratorContext,
@@ -313,7 +301,7 @@ export function resolveNestedMemberAccessType(
   ctx: MethodCallGeneratorContext,
   expr: Expression,
 ): string | null {
-  const e = expr as ExprBase;
+  const e = expr as { type: string };
   if (e.type === "this") {
     return ctx.getCurrentClassName();
   }
@@ -447,7 +435,7 @@ export function handleClassMethods(
   let className: string | null = null;
   let instancePtr: string | null = null;
 
-  const exprObjBase = expr.object as ExprBase;
+  const exprObjBase = expr.object as { type: string };
 
   // Static method dispatch: ClassName.staticMethod() — the object is the class name itself
   if (exprObjBase.type === "variable") {
@@ -480,7 +468,7 @@ export function handleClassMethods(
       }
     }
   } else if (exprObjBase.type === "new") {
-    const newExpr = expr.object as NewMeta;
+    const newExpr = expr.object as NewNode;
     className = newExpr.className;
     instancePtr = ctx.generateExpression(expr.object, params);
   } else if (exprObjBase.type === "this") {
@@ -521,7 +509,7 @@ export function handleClassMethods(
     }
   } else if (exprObjBase.type === "member_access") {
     const memberAccess = expr.object as MemberAccessNode;
-    const memberAccessObjBase = memberAccess.object as ExprBase;
+    const memberAccessObjBase = memberAccess.object as { type: string };
     const classNameForField = ctx.getCurrentClassName();
     if (memberAccessObjBase.type === "this" && classNameForField) {
       const fieldInfoResult = ctx.classGenGetFieldInfo(classNameForField, memberAccess.property);
@@ -679,10 +667,10 @@ export function handleClassMethods(
   } else if (exprObjBase.type === "index_access") {
     const indexAccess = expr.object as IndexAccessNode;
     const baseExpr = indexAccess.object;
-    const baseExprBase = baseExpr as ExprBase;
+    const baseExprBase = baseExpr as { type: string };
     if (baseExprBase.type === "member_access") {
       const memberAccess = baseExpr as MemberAccessNode;
-      const memberObjBase = memberAccess.object as ExprBase;
+      const memberObjBase = memberAccess.object as { type: string };
       if (memberObjBase.type === "this") {
         const curClassName = ctx.getCurrentClassName();
         if (curClassName) {
@@ -744,7 +732,7 @@ export function handleClassMethods(
   } else if (exprObjBase.type === "type_assertion") {
     const assertExpr = expr.object as TypeAssertionNode;
     const innerExpr = assertExpr.expression;
-    const innerExprBase = innerExpr as ExprBase;
+    const innerExprBase = innerExpr as { type: string };
     if (innerExprBase.type === "variable") {
       const varName = (innerExpr as VariableNode).name;
       if (ctx.symbolTable.isClass(varName)) {
@@ -812,7 +800,7 @@ export function handleObjectMethods(
   const method = expr.method;
   let isObjectMethod = false;
 
-  const exprObjBase = expr.object as ExprBase;
+  const exprObjBase = expr.object as { type: string };
   if (exprObjBase.type === "variable") {
     const varName = (expr.object as VariableNode).name;
     if (ctx.symbolTable.isObject(varName)) {

--- a/src/codegen/expressions/method-calls/object-static.ts
+++ b/src/codegen/expressions/method-calls/object-static.ts
@@ -1,14 +1,6 @@
 import { MethodCallNode, VariableNode, InterfaceDeclaration } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
-import { getInterfaceFromAST } from "./class-dispatch.js";
-
-interface ExprBase {
-  type: string;
-}
-
-interface InterfaceDefInfo {
-  properties: { name: string; type: string }[];
-}
+import { getInterfaceFromAST, type InterfaceDefInfo } from "./class-dispatch.js";
 
 function getObjectFieldInfo(
   ctx: MethodCallGeneratorContext,
@@ -63,7 +55,7 @@ export function generateObjectKeys(
   }
 
   const arg = expr.args[0];
-  const argBase = arg as ExprBase;
+  const argBase = arg as { type: string };
   if (argBase.type !== "variable") {
     return ctx.emitError("Object.keys() argument must be a variable", expr.loc);
   }
@@ -145,7 +137,7 @@ export function generateObjectValues(
   }
 
   const arg = expr.args[0];
-  const argBase = arg as ExprBase;
+  const argBase = arg as { type: string };
   if (argBase.type !== "variable") {
     return ctx.emitError("Object.values() argument must be a variable", expr.loc);
   }
@@ -315,7 +307,7 @@ export function generateObjectEntries(
   }
 
   const arg = expr.args[0];
-  const argBase = arg as ExprBase;
+  const argBase = arg as { type: string };
   if (argBase.type !== "variable") {
     return ctx.emitError("Object.entries() argument must be a variable", expr.loc);
   }

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -28,7 +28,6 @@ import {
   createMapMetadataSymbol,
   SymbolMetadata,
 } from "./symbol-table.js";
-import type { ClosureInfo } from "./closure-analyzer.js";
 import type { TypeChecker } from "../../typescript/type-checker.js";
 import type { StringGenerator } from "../types/collections/string.js";
 import type { ControlFlowGenerator } from "../statements/control-flow.js";
@@ -40,10 +39,7 @@ import {
   canonicalTypeToLlvm,
 } from "./type-system.js";
 import { findI64EligibleVariables } from "./integer-analysis.js";
-
-interface LiftedFunction extends FunctionNode {
-  closureInfo?: ClosureInfo;
-}
+import type { LiftedFunction } from "../expressions/arrow-functions.js";
 
 export interface FunctionGeneratorContext {
   reset(): void;

--- a/src/codegen/stdlib/response.ts
+++ b/src/codegen/stdlib/response.ts
@@ -12,9 +12,7 @@ interface InterfaceStructGenerator {
   hasInterface(name: string): boolean;
 }
 
-interface InterfaceDefInfo {
-  properties: { name: string; type: string }[];
-}
+import type { InterfaceDefInfo } from "../expressions/method-calls/class-dispatch.js";
 
 interface ResponseGeneratorContext {
   nextTemp(): string;


### PR DESCRIPTION
## Summary
- Consolidated `InterfaceDefInfo` from 4 duplicate definitions into 1 shared export in class-dispatch.ts
- Removed duplicate `LiftedFunction` interface from function-generator.ts (now imports from arrow-functions.ts)
- Replaced local `NewMeta`, `ObjectNode`, `ClassNode` type mirrors with proper AST types from ast/types.ts
- Replaced `ExprBase` interfaces with inline `as { type: string }` casts across 3 files
- Net reduction of ~33 lines

## Test plan
- [x] TypeScript type check passes
- [x] npm run verify:quick passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)