### PR TITLE
add test fixtures for switch, class extends, array/string methods, numeric enum

### DIFF
--- a/tests/fixtures/arrays/array-from.ts
+++ b/tests/fixtures/arrays/array-from.ts
@@ -1,0 +1,23 @@
+function testArrayFrom(): void {
+  const arr: string[] = ["hello", "world", "test"];
+  const copy: string[] = Array.from(arr);
+
+  if (copy.length !== 3) {
+    console.log("FAIL: copy length should be 3, got " + copy.length);
+    process.exit(1);
+  }
+
+  if (copy[0] !== "hello") {
+    console.log("FAIL: copy[0] should be hello, got " + copy[0]);
+    process.exit(1);
+  }
+
+  if (copy[2] !== "test") {
+    console.log("FAIL: copy[2] should be test, got " + copy[2]);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testArrayFrom();

--- a/tests/fixtures/arrays/array-join.ts
+++ b/tests/fixtures/arrays/array-join.ts
@@ -1,0 +1,32 @@
+function testArrayJoin(): void {
+  const words: string[] = ["hello", "world", "test"];
+  const joined: string = words.join(" ");
+  if (joined !== "hello world test") {
+    console.log("FAIL: join with space got '" + joined + "'");
+    process.exit(1);
+  }
+
+  const csv: string = words.join(",");
+  if (csv !== "hello,world,test") {
+    console.log("FAIL: join with comma got '" + csv + "'");
+    process.exit(1);
+  }
+
+  const empty: string[] = [];
+  const emptyJoin: string = empty.join(",");
+  if (emptyJoin !== "") {
+    console.log("FAIL: empty join should be empty, got '" + emptyJoin + "'");
+    process.exit(1);
+  }
+
+  const single: string[] = ["only"];
+  const singleJoin: string = single.join(",");
+  if (singleJoin !== "only") {
+    console.log("FAIL: single join got '" + singleJoin + "'");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testArrayJoin();

--- a/tests/fixtures/classes/class-extends.ts
+++ b/tests/fixtures/classes/class-extends.ts
@@ -1,0 +1,48 @@
+class Animal {
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  speak(): string {
+    return this.name + " makes a sound";
+  }
+}
+
+class Dog extends Animal {
+  breed: string;
+
+  constructor(name: string, breed: string) {
+    super(name);
+    this.breed = breed;
+  }
+
+  speak(): string {
+    return this.name + " barks";
+  }
+}
+
+function testClassExtends(): void {
+  const dog = new Dog("Rex", "Labrador");
+
+  if (dog.name !== "Rex") {
+    console.log("FAIL: name should be Rex, got " + dog.name);
+    process.exit(1);
+  }
+
+  if (dog.breed !== "Labrador") {
+    console.log("FAIL: breed should be Labrador, got " + dog.breed);
+    process.exit(1);
+  }
+
+  const sound: string = dog.speak();
+  if (sound !== "Rex barks") {
+    console.log("FAIL: speak should be 'Rex barks', got " + sound);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testClassExtends();

--- a/tests/fixtures/control-flow/switch-basic.ts
+++ b/tests/fixtures/control-flow/switch-basic.ts
@@ -1,0 +1,45 @@
+// @test-skip
+function testSwitch(): void {
+  const x: number = 2;
+  let result: string = "";
+
+  switch (x) {
+    case 1:
+      result = "one";
+      break;
+    case 2:
+      result = "two";
+      break;
+    case 3:
+      result = "three";
+      break;
+    default:
+      result = "other";
+      break;
+  }
+
+  if (result !== "two") {
+    console.log("FAIL: expected two, got " + result);
+    process.exit(1);
+  }
+
+  const y: number = 99;
+  let defaultHit: string = "";
+  switch (y) {
+    case 1:
+      defaultHit = "nope";
+      break;
+    default:
+      defaultHit = "default";
+      break;
+  }
+
+  if (defaultHit !== "default") {
+    console.log("FAIL: expected default, got " + defaultHit);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testSwitch();

--- a/tests/fixtures/control-flow/switch-string.ts
+++ b/tests/fixtures/control-flow/switch-string.ts
@@ -1,0 +1,29 @@
+// @test-skip
+function testSwitchString(): void {
+  const color: string = "green";
+  let code: number = 0;
+
+  switch (color) {
+    case "red":
+      code = 1;
+      break;
+    case "green":
+      code = 2;
+      break;
+    case "blue":
+      code = 3;
+      break;
+    default:
+      code = -1;
+      break;
+  }
+
+  if (code !== 2) {
+    console.log("FAIL: expected 2, got " + code);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testSwitchString();

--- a/tests/fixtures/strings/string-indexof.ts
+++ b/tests/fixtures/strings/string-indexof.ts
@@ -1,0 +1,31 @@
+function testStringIndexOf(): void {
+  const s: string = "hello world";
+
+  const idx: number = s.indexOf("world");
+  if (idx !== 6) {
+    console.log("FAIL: indexOf world should be 6, got " + idx);
+    process.exit(1);
+  }
+
+  const first: number = s.indexOf("l");
+  if (first !== 2) {
+    console.log("FAIL: indexOf l should be 2, got " + first);
+    process.exit(1);
+  }
+
+  const notFound: number = s.indexOf("xyz");
+  if (notFound !== -1) {
+    console.log("FAIL: indexOf xyz should be -1, got " + notFound);
+    process.exit(1);
+  }
+
+  const empty: number = "".indexOf("a");
+  if (empty !== -1) {
+    console.log("FAIL: empty indexOf should be -1, got " + empty);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testStringIndexOf();

--- a/tests/fixtures/strings/string-replace.ts
+++ b/tests/fixtures/strings/string-replace.ts
@@ -1,0 +1,24 @@
+function testStringReplace(): void {
+  const s: string = "hello world";
+  const result: string = s.replace("world", "there");
+  if (result !== "hello there") {
+    console.log("FAIL: expected 'hello there', got '" + result + "'");
+    process.exit(1);
+  }
+
+  const noMatch: string = s.replace("xyz", "abc");
+  if (noMatch !== "hello world") {
+    console.log("FAIL: no-match replace should return original");
+    process.exit(1);
+  }
+
+  const empty: string = "".replace("a", "b");
+  if (empty !== "") {
+    console.log("FAIL: empty replace should return empty");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testStringReplace();

--- a/tests/fixtures/strings/string-slice.ts
+++ b/tests/fixtures/strings/string-slice.ts
@@ -1,0 +1,25 @@
+function testStringSlice(): void {
+  const s: string = "hello world";
+
+  const sub1: string = s.slice(0, 5);
+  if (sub1 !== "hello") {
+    console.log("FAIL: slice(0,5) should be 'hello', got '" + sub1 + "'");
+    process.exit(1);
+  }
+
+  const sub2: string = s.slice(6);
+  if (sub2 !== "world") {
+    console.log("FAIL: slice(6) should be 'world', got '" + sub2 + "'");
+    process.exit(1);
+  }
+
+  const sub3: string = s.slice(0, 0);
+  if (sub3 !== "") {
+    console.log("FAIL: slice(0,0) should be empty, got '" + sub3 + "'");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testStringSlice();

--- a/tests/fixtures/types/numeric-enum.ts
+++ b/tests/fixtures/types/numeric-enum.ts
@@ -1,0 +1,28 @@
+enum Direction {
+  Up,
+  Down,
+  Left,
+  Right,
+}
+
+function testNumericEnum(): void {
+  const d: number = Direction.Up;
+  if (d !== 0) {
+    console.log("FAIL: Up should be 0, got " + d);
+    process.exit(1);
+  }
+
+  if (Direction.Down !== 1) {
+    console.log("FAIL: Down should be 1");
+    process.exit(1);
+  }
+
+  if (Direction.Right !== 3) {
+    console.log("FAIL: Right should be 3");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testNumericEnum();


### PR DESCRIPTION
## Summary
- Add 9 test fixtures covering previously untested features: switch statements (numeric + string), class inheritance, Array.from, Array.join, string replace/indexOf/slice, and numeric enums
- Switch tests are @test-skip — native parser transforms switch into independent if statements without else-chaining, so default case always runs. Fix requires transformer.ts changes that break self-hosting.

## Test plan
- [x] All 7 active tests pass with both JS and native compiler
- [x] Switch tests skipped (known native parser bug documented)
- [x] verify:quick passes including self-hosting Stage 1