### PR TITLE
add test fixtures for comparisons, closures, collections, default params, and more

### DIFF
--- a/tests/fixtures/closures/closure-capture-in-reduce.ts
+++ b/tests/fixtures/closures/closure-capture-in-reduce.ts
@@ -1,0 +1,27 @@
+function testClosureCapture(): void {
+  const prefix: string = "item-";
+  const nums: number[] = [1, 2, 3, 4, 5];
+
+  const sum: number = nums.reduce((acc: number, val: number): number => {
+    return acc + val;
+  }, 0);
+
+  if (sum !== 15) {
+    console.log("FAIL: sum should be 15, got " + sum);
+    process.exit(1);
+  }
+
+  const strs: string[] = ["a", "b", "c"];
+  const filtered: string[] = strs.filter((s: string): boolean => {
+    return s !== "b";
+  });
+
+  if (filtered.length !== 2) {
+    console.log("FAIL: filtered length should be 2, got " + filtered.length);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testClosureCapture();

--- a/tests/fixtures/collections/map-string-string.ts
+++ b/tests/fixtures/collections/map-string-string.ts
@@ -1,0 +1,31 @@
+function testStringMap(): void {
+  const m = new Map<string, string>();
+  m.set("name", "alice");
+  m.set("role", "admin");
+
+  if (m.size !== 2) {
+    console.log("FAIL: size should be 2, got " + m.size);
+    process.exit(1);
+  }
+
+  const name: string = m.get("name");
+  if (name !== "alice") {
+    console.log("FAIL: name should be alice, got " + name);
+    process.exit(1);
+  }
+
+  if (!m.has("role")) {
+    console.log("FAIL: should have role");
+    process.exit(1);
+  }
+
+  m.delete("role");
+  if (m.size !== 1) {
+    console.log("FAIL: size after delete should be 1, got " + m.size);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testStringMap();

--- a/tests/fixtures/collections/set-string-operations.ts
+++ b/tests/fixtures/collections/set-string-operations.ts
@@ -1,0 +1,26 @@
+// @test-skip
+function testStringSet(): void {
+  const s = new Set<string>();
+  s.add("hello");
+  s.add("world");
+  s.add("hello");
+
+  if (s.size !== 2) {
+    console.log("FAIL: size should be 2, got " + s.size);
+    process.exit(1);
+  }
+
+  if (!s.has("hello")) {
+    console.log("FAIL: should have hello");
+    process.exit(1);
+  }
+
+  if (s.has("missing")) {
+    console.log("FAIL: should not have missing");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testStringSet();

--- a/tests/fixtures/comparisons/comparison-operators.ts
+++ b/tests/fixtures/comparisons/comparison-operators.ts
@@ -1,19 +1,49 @@
 function testComparisons(): void {
-  if (!(5 > 3)) { console.log("FAIL: 5 > 3"); process.exit(1); }
-  if (!(3 < 5)) { console.log("FAIL: 3 < 5"); process.exit(1); }
-  if (!(5 >= 5)) { console.log("FAIL: 5 >= 5"); process.exit(1); }
-  if (!(5 <= 5)) { console.log("FAIL: 5 <= 5"); process.exit(1); }
-  if (5 > 5) { console.log("FAIL: 5 > 5 should be false"); process.exit(1); }
-  if (5 < 5) { console.log("FAIL: 5 < 5 should be false"); process.exit(1); }
+  if (!(5 > 3)) {
+    console.log("FAIL: 5 > 3");
+    process.exit(1);
+  }
+  if (!(3 < 5)) {
+    console.log("FAIL: 3 < 5");
+    process.exit(1);
+  }
+  if (!(5 >= 5)) {
+    console.log("FAIL: 5 >= 5");
+    process.exit(1);
+  }
+  if (!(5 <= 5)) {
+    console.log("FAIL: 5 <= 5");
+    process.exit(1);
+  }
+  if (5 > 5) {
+    console.log("FAIL: 5 > 5 should be false");
+    process.exit(1);
+  }
+  if (5 < 5) {
+    console.log("FAIL: 5 < 5 should be false");
+    process.exit(1);
+  }
 
-  if (!(10 !== 20)) { console.log("FAIL: 10 !== 20"); process.exit(1); }
-  if (10 !== 10) { console.log("FAIL: 10 === 10"); process.exit(1); }
+  if (!(10 !== 20)) {
+    console.log("FAIL: 10 !== 20");
+    process.exit(1);
+  }
+  if (10 !== 10) {
+    console.log("FAIL: 10 === 10");
+    process.exit(1);
+  }
 
   const a: string = "abc";
   const b: string = "abc";
   const c: string = "xyz";
-  if (a !== b) { console.log("FAIL: string equality"); process.exit(1); }
-  if (a === c) { console.log("FAIL: string inequality"); process.exit(1); }
+  if (a !== b) {
+    console.log("FAIL: string equality");
+    process.exit(1);
+  }
+  if (a === c) {
+    console.log("FAIL: string inequality");
+    process.exit(1);
+  }
 
   console.log("TEST_PASSED");
 }

--- a/tests/fixtures/comparisons/comparison-operators.ts
+++ b/tests/fixtures/comparisons/comparison-operators.ts
@@ -1,0 +1,21 @@
+function testComparisons(): void {
+  if (!(5 > 3)) { console.log("FAIL: 5 > 3"); process.exit(1); }
+  if (!(3 < 5)) { console.log("FAIL: 3 < 5"); process.exit(1); }
+  if (!(5 >= 5)) { console.log("FAIL: 5 >= 5"); process.exit(1); }
+  if (!(5 <= 5)) { console.log("FAIL: 5 <= 5"); process.exit(1); }
+  if (5 > 5) { console.log("FAIL: 5 > 5 should be false"); process.exit(1); }
+  if (5 < 5) { console.log("FAIL: 5 < 5 should be false"); process.exit(1); }
+
+  if (!(10 !== 20)) { console.log("FAIL: 10 !== 20"); process.exit(1); }
+  if (10 !== 10) { console.log("FAIL: 10 === 10"); process.exit(1); }
+
+  const a: string = "abc";
+  const b: string = "abc";
+  const c: string = "xyz";
+  if (a !== b) { console.log("FAIL: string equality"); process.exit(1); }
+  if (a === c) { console.log("FAIL: string inequality"); process.exit(1); }
+
+  console.log("TEST_PASSED");
+}
+
+testComparisons();

--- a/tests/fixtures/functions/default-params.ts
+++ b/tests/fixtures/functions/default-params.ts
@@ -1,0 +1,21 @@
+function greet(name: string, greeting: string = "Hello"): string {
+  return greeting + ", " + name;
+}
+
+function testDefaultParams(): void {
+  const r1: string = greet("Alice", "Hi");
+  if (r1 !== "Hi, Alice") {
+    console.log("FAIL: explicit param got " + r1);
+    process.exit(1);
+  }
+
+  const r2: string = greet("Bob");
+  if (r2 !== "Hello, Bob") {
+    console.log("FAIL: default param got " + r2);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testDefaultParams();

--- a/tests/fixtures/interfaces/interface-method.ts
+++ b/tests/fixtures/interfaces/interface-method.ts
@@ -1,0 +1,34 @@
+interface Shape {
+  kind: string;
+  area(): number;
+}
+
+class Circle {
+  kind: string;
+  radius: number;
+
+  constructor(r: number) {
+    this.kind = "circle";
+    this.radius = r;
+  }
+
+  area(): number {
+    return 3.14159 * this.radius * this.radius;
+  }
+}
+
+function printArea(s: Shape): void {
+  const a: number = s.area();
+  if (a < 78 || a > 79) {
+    console.log("FAIL: area should be ~78.5, got " + a);
+    process.exit(1);
+  }
+}
+
+function testInterfaceMethod(): void {
+  const c = new Circle(5);
+  printArea(c);
+  console.log("TEST_PASSED");
+}
+
+testInterfaceMethod();

--- a/tests/fixtures/logical/logical-and-or.ts
+++ b/tests/fixtures/logical/logical-and-or.ts
@@ -1,0 +1,21 @@
+function testLogical(): void {
+  const t: boolean = true;
+  const f: boolean = false;
+
+  if (!(t && t)) { console.log("FAIL: true && true"); process.exit(1); }
+  if (t && f) { console.log("FAIL: true && false"); process.exit(1); }
+  if (f && t) { console.log("FAIL: false && true"); process.exit(1); }
+  if (f && f) { console.log("FAIL: false && false"); process.exit(1); }
+
+  if (!(t || t)) { console.log("FAIL: true || true"); process.exit(1); }
+  if (!(t || f)) { console.log("FAIL: true || false"); process.exit(1); }
+  if (!(f || t)) { console.log("FAIL: false || true"); process.exit(1); }
+  if (f || f) { console.log("FAIL: false || false"); process.exit(1); }
+
+  if (!(!f)) { console.log("FAIL: !false"); process.exit(1); }
+  if (!t) { console.log("FAIL: !true should be false"); process.exit(1); }
+
+  console.log("TEST_PASSED");
+}
+
+testLogical();

--- a/tests/fixtures/logical/logical-and-or.ts
+++ b/tests/fixtures/logical/logical-and-or.ts
@@ -2,18 +2,48 @@ function testLogical(): void {
   const t: boolean = true;
   const f: boolean = false;
 
-  if (!(t && t)) { console.log("FAIL: true && true"); process.exit(1); }
-  if (t && f) { console.log("FAIL: true && false"); process.exit(1); }
-  if (f && t) { console.log("FAIL: false && true"); process.exit(1); }
-  if (f && f) { console.log("FAIL: false && false"); process.exit(1); }
+  if (!(t && t)) {
+    console.log("FAIL: true && true");
+    process.exit(1);
+  }
+  if (t && f) {
+    console.log("FAIL: true && false");
+    process.exit(1);
+  }
+  if (f && t) {
+    console.log("FAIL: false && true");
+    process.exit(1);
+  }
+  if (f && f) {
+    console.log("FAIL: false && false");
+    process.exit(1);
+  }
 
-  if (!(t || t)) { console.log("FAIL: true || true"); process.exit(1); }
-  if (!(t || f)) { console.log("FAIL: true || false"); process.exit(1); }
-  if (!(f || t)) { console.log("FAIL: false || true"); process.exit(1); }
-  if (f || f) { console.log("FAIL: false || false"); process.exit(1); }
+  if (!(t || t)) {
+    console.log("FAIL: true || true");
+    process.exit(1);
+  }
+  if (!(t || f)) {
+    console.log("FAIL: true || false");
+    process.exit(1);
+  }
+  if (!(f || t)) {
+    console.log("FAIL: false || true");
+    process.exit(1);
+  }
+  if (f || f) {
+    console.log("FAIL: false || false");
+    process.exit(1);
+  }
 
-  if (!(!f)) { console.log("FAIL: !false"); process.exit(1); }
-  if (!t) { console.log("FAIL: !true should be false"); process.exit(1); }
+  if (!!f) {
+    console.log("FAIL: !false");
+    process.exit(1);
+  }
+  if (!t) {
+    console.log("FAIL: !true should be false");
+    process.exit(1);
+  }
 
   console.log("TEST_PASSED");
 }

--- a/tests/fixtures/typed-arrays/uint8array-operations.ts
+++ b/tests/fixtures/typed-arrays/uint8array-operations.ts
@@ -1,0 +1,26 @@
+function testUint8Array(): void {
+  const buf = new Uint8Array(4);
+  buf[0] = 65;
+  buf[1] = 66;
+  buf[2] = 67;
+  buf[3] = 0;
+
+  if (buf[0] !== 65) {
+    console.log("FAIL: buf[0] should be 65, got " + buf[0]);
+    process.exit(1);
+  }
+
+  if (buf.length !== 4) {
+    console.log("FAIL: length should be 4, got " + buf.length);
+    process.exit(1);
+  }
+
+  if (buf[2] !== 67) {
+    console.log("FAIL: buf[2] should be 67, got " + buf[2]);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testUint8Array();


### PR DESCRIPTION
## Summary
- Add 8 test fixtures covering previously untested features: comparison operators, closure capture in reduce/filter, Map<string,string>, Set<string> (skipped - native compiler bug), default function parameters, interface method dispatch, Uint8Array operations, and boolean logical operators
- Set<string> operations test is @test-skip — native compiler generates fcmp for string pointer comparison in StringSet.has()

## Test plan
- [x] All 7 active tests pass with both JS and native compiler
- [x] Set<string> test skipped (native compiler StringSet.has codegen bug)
- [x] verify:quick passes including self-hosting Stage 1