### PR TITLE
fix: use SetNode type for Set<string> allocation, fixing native compiler codegen bug

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1929,7 +1929,7 @@ export class VariableAllocator {
           setTypeInfoResult = { valueType: newExpr.typeArgs[0] };
         }
       } else if (valueBase.type === "set") {
-        const setExpr = stmt.value as { valueType?: string };
+        const setExpr = stmt.value as SetNode;
         if (setExpr.valueType) {
           setTypeInfoResult = { valueType: setExpr.valueType };
         }

--- a/tests/fixtures/collections/set-string-operations.ts
+++ b/tests/fixtures/collections/set-string-operations.ts
@@ -1,4 +1,3 @@
-// @test-skip
 function testStringSet(): void {
   const s = new Set<string>();
   s.add("hello");
@@ -17,6 +16,12 @@ function testStringSet(): void {
 
   if (s.has("missing")) {
     console.log("FAIL: should not have missing");
+    process.exit(1);
+  }
+
+  s.delete("world");
+  if (s.size !== 1) {
+    console.log("FAIL: size after delete should be 1, got " + s.size);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- Fix native compiler generating numeric Set codegen for `Set<string>` variables
- Root cause: inline type assertion `as { valueType?: string }` on SetNode reads field at wrong struct index — native compiler accesses index 0 instead of index 2 for `valueType`
- Fix: replace with proper `as SetNode` from ast/types.ts (already imported)
- Un-skip the set-string-operations test — now tests add, has, delete, and size for `Set<string>`

## Test plan
- [x] `set-string-operations.ts` passes with both JS and native compiler
- [x] verify:quick passes including self-hosting Stage 1