### PR TITLE
refactor: replace 5 inline type assertions with named ast types

### DIFF
--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -4,6 +4,7 @@ import {
   StringNode,
   VariableNode,
   BinaryNode,
+  UnaryNode,
 } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
 
@@ -538,7 +539,7 @@ function emitSingleArg(
   }
 
   if (arg.type === "unary") {
-    const unaryArg = arg as { type: string; op: string };
+    const unaryArg = arg as UnaryNode;
     if (unaryArg.op === "!") {
       emitBooleanPrint(ctx, useStderr, argValue);
       return;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -555,7 +555,7 @@ export class VariableAllocator {
       return;
     }
 
-    const stmtValueAsVar = stmt.value as { type?: string; name?: string };
+    const stmtValueAsVar = stmt.value as VariableNode;
     const isAstNullLiteral =
       stmtValueAsVar && stmtValueAsVar.type === "variable" && stmtValueAsVar.name === "null";
     if (stmt.value === null || isAstNullLiteral) {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -37,6 +37,7 @@ import {
   ReturnStatement,
   StringNode,
   MemberAccessNode,
+  EnumDeclaration,
 } from "../ast/types.js";
 import { BaseGenerator, SymbolKind, SymbolTable } from "./infrastructure/base-generator.js";
 import {
@@ -690,7 +691,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     for (let i = 0; i < this.ast.enums.length; i++) {
       const eRaw = this.ast.enums[i];
       if (!eRaw) continue;
-      const e = eRaw as { name: string };
+      const e = eRaw as EnumDeclaration;
       if (e.name === name) return true;
     }
     return false;

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -24,6 +24,7 @@ import {
   ThrowStatement,
   ArrayNode,
   ForStatement,
+  CallNode,
 } from "../../ast/types.js";
 import { IGeneratorContext } from "../infrastructure/generator-context.js";
 import {
@@ -929,7 +930,7 @@ export class ControlFlowGenerator {
     }
 
     if (iterable.type === "call") {
-      const callNode = iterable as { type: string; name: string };
+      const callNode = iterable as CallNode;
       const ast = this.ctx.getAst();
       if (ast && ast.functions) {
         for (let fi = 0; fi < ast.functions.length; fi++) {

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -327,7 +327,7 @@ export class ClassGenerator {
     const ast = this.ctx.getAst();
     if (ast && ast.classes) {
       for (let ci = 0; ci < ast.classes.length; ci++) {
-        const c = ast.classes[ci] as { name: string };
+        const c = ast.classes[ci] as ClassNode;
         if (!c) continue;
         if (!c.name) continue;
         if (c.name === className) {


### PR DESCRIPTION
## Summary
- Replace 5 `as { ... }` inline type assertions with proper named AST types from ast/types.ts
- Prevents potential native compiler struct misalignment bugs (same class of bug as Set<string> fix in #222)
- Files: console.ts (UnaryNode), control-flow.ts (CallNode), variable-allocator.ts (VariableNode), llvm-generator.ts (EnumDeclaration), class.ts (ClassNode)

## Test plan
- [x] verify:quick passes including self-hosting Stage 1
- [x] No behavioral change — all casts happened to have correct field ordering already