### PR TITLE
replace 8 inline type assertions with named ast types

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -16,6 +16,7 @@ import {
   FunctionParameter,
   CallNode,
   FunctionNode,
+  ClassField,
   SourceLocation,
 } from "../../../ast/types.js";
 import type { SymbolTable } from "../../infrastructure/symbol-table.js";
@@ -902,7 +903,7 @@ export class MemberAccessGenerator {
           if (!c || !c.fields) continue;
           let hasField = false;
           for (let fi = 0; fi < c.fields.length; fi++) {
-            const f = c.fields[fi] as { name: string };
+            const f = c.fields[fi] as ClassField;
             if (f.name === fieldName) {
               hasField = true;
               break;

--- a/src/codegen/expressions/arrow-functions.ts
+++ b/src/codegen/expressions/arrow-functions.ts
@@ -215,7 +215,7 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
     let funcResult: LiftedFunction | null = null;
     for (let i = 0; i < this.liftedFunctions.length; i++) {
       const fRaw = this.liftedFunctions[i];
-      const f = fRaw as { name: string };
+      const f = fRaw as LiftedFunction;
       if (f.name === lambdaName) {
         funcResult = fRaw as LiftedFunction;
         break;

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -7,6 +7,7 @@ import {
   IndexAccessNode,
   AST,
   ClassNode,
+  ClassField,
   AssignmentStatement,
   SourceLocation,
 } from "../../ast/types.js";
@@ -127,7 +128,7 @@ export class AssignmentGenerator {
           const c = classes[ci] as ClassNode;
           let hasField = false;
           for (let fi = 0; fi < c.fields.length; fi++) {
-            const f = c.fields[fi] as { name: string };
+            const f = c.fields[fi] as ClassField;
             if (f.name === property) {
               hasField = true;
               break;

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -16,6 +16,7 @@ import {
   Statement,
   InterfaceDeclaration,
   InterfaceField,
+  ClassNode,
 } from "../../ast/types.js";
 import {
   SymbolKind,
@@ -311,7 +312,7 @@ export class FunctionGenerator {
           let classDefName: string = "";
           const classes = ast ? ast.classes || [] : [];
           for (let jc = 0; jc < classes.length; jc++) {
-            const cls = classes[jc] as { name: string };
+            const cls = classes[jc] as ClassNode;
             if (!cls || !cls.name) continue;
             if (cls.name === paramTypes[i]) {
               classDefName = cls.name;

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -280,7 +280,7 @@ export class ClassGenerator {
     if (fields) {
       let index: number = -1;
       for (let i = 0; i < fields.length; i++) {
-        const f = fields[i] as { name: string; fieldType: string; tsType: string };
+        const f = fields[i] as ClassField;
         if (f.name === fieldName) {
           index = i;
           break;
@@ -1487,11 +1487,11 @@ export class ClassGenerator {
       }
     }
 
-    let classDef: { name: string } | null = null;
+    let classDef: ClassNode | null = null;
     const ast3 = this.ctx.getAst();
     const classes = ast3 ? ast3.classes || [] : [];
     for (let i = 0; i < classes.length; i++) {
-      const cls = classes[i] as { name: string };
+      const cls = classes[i] as ClassNode;
       if (!cls) continue;
       if (!cls.name) continue;
       if (cls.name === tsType) {


### PR DESCRIPTION
## Summary
- Replace `as { name: string; fieldType: string; tsType: string }` with `as ClassField` in class.ts
- Replace `as { name: string }` on class fields with `as ClassField` in assignment-generator.ts, member.ts
- Replace `as { name: string }` on class arrays with `as ClassNode` in function-generator.ts, class.ts
- Replace `as { name: string }` on lifted functions with `as LiftedFunction` in arrow-functions.ts

## Test plan
- [x] npm run build passes
- [x] npm run verify:quick passes (tests + stage 1 self-hosting)