### PR TITLE
fix: prevent divide-by-zero in padstart/padend with empty pad string

### DIFF
--- a/src/codegen/types/collections/string/manipulation.ts
+++ b/src/codegen/types/collections/string/manipulation.ts
@@ -128,7 +128,10 @@ export function generatePadStart(
   const paddingNeeded = ctx.nextTemp();
   ctx.emit(`${paddingNeeded} = sub i32 ${targetLength}, ${strLenI32}`);
 
-  const needsPadding = ctx.emitIcmp("sgt", "i32", paddingNeeded, "0");
+  const needsPaddingRaw = ctx.emitIcmp("sgt", "i32", paddingNeeded, "0");
+  const padNonEmpty = ctx.emitIcmp("sgt", "i32", padLenI32, "0");
+  const needsPadding = ctx.nextTemp();
+  ctx.emit(`${needsPadding} = and i1 ${needsPaddingRaw}, ${padNonEmpty}`);
 
   const noPadLabel = ctx.nextLabel("padstart_nopad");
   const doPadLabel = ctx.nextLabel("padstart_dopad");
@@ -231,7 +234,10 @@ export function generatePadEnd(
   const paddingNeeded = ctx.nextTemp();
   ctx.emit(`${paddingNeeded} = sub i32 ${targetLength}, ${strLenI32}`);
 
-  const needsPadding = ctx.emitIcmp("sgt", "i32", paddingNeeded, "0");
+  const needsPaddingRaw = ctx.emitIcmp("sgt", "i32", paddingNeeded, "0");
+  const padNonEmpty = ctx.emitIcmp("sgt", "i32", padLenI32, "0");
+  const needsPadding = ctx.nextTemp();
+  ctx.emit(`${needsPadding} = and i1 ${needsPaddingRaw}, ${padNonEmpty}`);
 
   const noPadLabel = ctx.nextLabel("padend_nopad");
   const doPadLabel = ctx.nextLabel("padend_dopad");

--- a/tests/fixtures/strings/string-pad-empty.ts
+++ b/tests/fixtures/strings/string-pad-empty.ts
@@ -1,0 +1,37 @@
+function testPadEmpty(): void {
+  const s: string = "hello";
+
+  const r1: string = s.padStart(10, " ");
+  if (r1 !== "     hello") {
+    console.log("FAIL: padStart with space got '" + r1 + "'");
+    process.exit(1);
+  }
+
+  const r2: string = s.padEnd(10, " ");
+  if (r2 !== "hello     ") {
+    console.log("FAIL: padEnd with space got '" + r2 + "'");
+    process.exit(1);
+  }
+
+  const r3: string = s.padStart(10, "");
+  if (r3 !== "hello") {
+    console.log("FAIL: padStart with empty string got '" + r3 + "'");
+    process.exit(1);
+  }
+
+  const r4: string = s.padEnd(10, "");
+  if (r4 !== "hello") {
+    console.log("FAIL: padEnd with empty string got '" + r4 + "'");
+    process.exit(1);
+  }
+
+  const r5: string = s.padStart(3, "x");
+  if (r5 !== "hello") {
+    console.log("FAIL: padStart shorter than string got '" + r5 + "'");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testPadEmpty();


### PR DESCRIPTION
## Summary
- `"hello".padStart(10, "")` previously caused a divide-by-zero crash in the compiled binary
- Added guard: skip padding when pad string is empty (matches JS behavior — returns original string)
- Same fix applied to both `padStart` and `padEnd`

## Test plan
- [x] New test fixture `string-pad-empty.ts` covers padStart/padEnd with empty string, space, and shorter target
- [x] npm run verify:quick passes (tests + stage 1 self-hosting)