### PR TITLE
fix: use correct llvm types for super() constructor args

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7,6 +7,7 @@ import {
   VariableNode,
   FunctionParameter,
   ClassNode,
+  ClassMethod,
 } from "../../ast/types.js";
 import { IGeneratorContext } from "../infrastructure/generator-context.js";
 import {
@@ -1255,13 +1256,37 @@ export class CallExpressionGenerator {
     const parentClassName = currentClass.extends;
     const parentStructType = `%${parentClassName}_struct*`;
 
+    let parentConstructor: ClassMethod | null = null;
+    for (let ci = 0; ci < ast.classes.length; ci++) {
+      const pc = ast.classes[ci] as ClassNode;
+      if (pc.name === parentClassName) {
+        for (let mi = 0; mi < pc.methods.length; mi++) {
+          const m = pc.methods[mi] as ClassMethod;
+          if (m && m.isConstructor) {
+            parentConstructor = m;
+            break;
+          }
+        }
+        break;
+      }
+    }
+    const parentParamTypes = parentConstructor ? parentConstructor.paramTypes || [] : [];
+
     const argValues: string[] = [];
     for (let i = 0; i < expr.args.length; i++) {
       argValues.push(this.ctx.generateExpression(expr.args[i], params));
     }
     const argsWithTypesParts: string[] = [];
     for (let ai = 0; ai < argValues.length; ai++) {
-      argsWithTypesParts.push("i8* " + argValues[ai]);
+      const llvmType =
+        ai < parentParamTypes.length
+          ? mapParamTypeToLLVM(parentParamTypes[ai], "arg", false, false)
+          : "i8*";
+      if (llvmType === "double") {
+        argsWithTypesParts.push("double " + this.ctx.ensureDouble(argValues[ai]));
+      } else {
+        argsWithTypesParts.push(llvmType + " " + argValues[ai]);
+      }
     }
     const argsWithTypes = argsWithTypesParts.join(", ");
     const parentObj = this.ctx.emitCall(

--- a/tests/fixtures/classes/class-super-numeric.ts
+++ b/tests/fixtures/classes/class-super-numeric.ts
@@ -1,0 +1,33 @@
+class Vehicle {
+  name: string;
+  speed: number;
+  constructor(name: string, speed: number) {
+    this.name = name;
+    this.speed = speed;
+  }
+  describe(): string {
+    return this.name;
+  }
+}
+
+class Car extends Vehicle {
+  doors: number;
+  constructor(name: string, speed: number, doors: number) {
+    super(name, speed);
+    this.doors = doors;
+  }
+}
+
+const car = new Car("Sedan", 120, 4);
+if (car.name === "Sedan" && car.speed === 120 && car.doors === 4) {
+  console.log("TEST_PASSED");
+} else {
+  console.log(
+    "FAILED: name=" +
+      car.name +
+      " speed=" +
+      car.speed.toString() +
+      " doors=" +
+      car.doors.toString(),
+  );
+}


### PR DESCRIPTION
## Summary
- super() calls previously hardcoded all arguments as `i8*`, causing compile failures when parent constructors take numeric parameters
- now looks up parent constructor's paramTypes and uses mapParamTypeToLLVM for correct types
- adds ensureDouble coercion for numeric args passed to super()

## Test plan
- [x] new test fixture: `classes/class-super-numeric.ts` — Vehicle(string, number) + Car extends Vehicle
- [x] verify:quick passes (tests + stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)