### PR TITLE
fix: emit error for object spread instead of silently dropping

### DIFF
--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -40,7 +40,11 @@ export function createResolvedType(
 ): ResolvedType {
   return {
     base,
-    qualifiers: { ...DEFAULT_QUALIFIERS, ...qualifiers },
+    qualifiers: {
+      isNullable: qualifiers.isNullable || false,
+      isOptional: qualifiers.isOptional || false,
+      numericKind: qualifiers.numericKind,
+    },
     arrayDepth,
     typeParams,
   };

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -1132,6 +1132,8 @@ function transformObjectExpression(node: TreeSitterNode): ObjectNode {
     } else if (c.type === "shorthand_property_identifier") {
       const key = c.text;
       properties.push({ key, value: { type: "variable", name: key } });
+    } else if (c.type === "spread_element") {
+      throw new Error("Object spread (...) is not yet supported in ChadScript");
     } else if (c.type === "method_definition") {
       const nameNode = getChildByFieldName(child, "name");
       const paramsNode = getChildByFieldName(child, "parameters");

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -509,6 +509,8 @@ function transformObjectLiteral(
       const key = prop.name.text;
       const value: VariableNode = { type: "variable", name: key };
       properties.push({ key, value });
+    } else if (ts.isSpreadAssignment(prop)) {
+      throw new Error("Object spread (...) is not yet supported in ChadScript");
     } else if (ts.isMethodDeclaration(prop)) {
       const key = ts.isIdentifier(prop.name) ? prop.name.text : prop.name.getText();
       const body = prop.body


### PR DESCRIPTION
## Summary
- object spread (`{ ...obj, key: val }`) was silently dropped by both TS and native parsers, producing wrong values
- now both parsers detect spread elements and emit a clear error message
- also removed the one object spread usage in the compiler source (type-system.ts `createResolvedType`) to maintain self-hosting compatibility

## Test plan
- [x] verify:quick passes (tests + stage 1 self-hosting)
- [x] confirmed no other object spread usage in compiler source

🤖 Generated with [Claude Code](https://claude.com/claude-code)