### PR TITLE
fix: emit error for x++/x-- at global scope instead of silently dropping

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -351,6 +351,10 @@ function handleExpressionStatement(node: TreeSitterNode, ast: AST): void {
     ast.topLevelExpressions.push(expr as CallNode | NewNode | MethodCallNode);
     ast.topLevelItems!.push(expr as TopLevelItem);
     ast.topLevelItemTypes!.push(e.type);
+  } else if (e.type === "unary") {
+    throw new Error(
+      "Increment/decrement (++/--) at global scope is not supported. Use x = x + 1 instead, or wrap in a function.",
+    );
   } else if (e.type === "binary") {
     const binExprTyped = expr as { type: string; op: string; left: Expression; right: Expression };
     if (binExprTyped.op === "=") {

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -283,6 +283,10 @@ function transformTopLevelStatement(
       ) {
         ast.topLevelExpressions.push(expr as CallNode | NewNode | MethodCallNode);
         ast.topLevelItems!.push(expr as TopLevelItem);
+      } else if (expr.type === "unary") {
+        throw new Error(
+          "Increment/decrement (++/--) at global scope is not supported. Use x = x + 1 instead, or wrap in a function.",
+        );
       } else if (isAssignmentExpression(exprStmt.expression)) {
         const binExpr = exprStmt.expression as ts.BinaryExpression;
         const assignment = transformAssignmentExpression(binExpr, checker);


### PR DESCRIPTION
## Summary
- `x++` and `x--` at global scope were silently dropped by both parsers, producing wrong values (variable unchanged)
- now both parsers detect unary expressions at global scope and emit a clear error with workaround suggestion
- increment/decrement works correctly inside functions — this only affects top-level code

## Test plan
- [x] verify:quick passes (tests + stage 1 self-hosting)
- [x] confirmed compiler source doesn't use x++/x-- at global scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)