### PR TITLE
add bitwise not, unsigned right shift, and exponentiation operators

### DIFF
--- a/src/codegen/expressions/operators/binary.ts
+++ b/src/codegen/expressions/operators/binary.ts
@@ -72,6 +72,7 @@ export class BinaryExpressionGenerator {
       "^": "xor",
       "<<": "shl",
       ">>": "ashr", // arithmetic shift right (preserves sign)
+      ">>>": "lshr", // logical shift right (zero-fill)
     };
 
     // Comparison operators (fcmp returns i1, need to extend to i32)
@@ -86,7 +87,9 @@ export class BinaryExpressionGenerator {
       "!==": "one", // Strict inequality (same as != for double)
     };
 
-    if (op === "%") {
+    if (op === "**") {
+      return this.generateExponentiation(leftValue, rightValue);
+    } else if (op === "%") {
       return this.generateModulo(leftValue, rightValue, left, right);
     } else if (arithMap[op]) {
       return this.generateArithmetic(op, arithMap[op], leftValue, rightValue);
@@ -286,6 +289,15 @@ export class BinaryExpressionGenerator {
     this.ctx.emit(`${resultInt} = ${llvmOp} i64 ${leftInt}, ${rightInt}`);
     this.ctx.setVariableType(resultInt, "i64");
     return resultInt;
+  }
+
+  private generateExponentiation(left: string, right: string): string {
+    const dblLeft = this.ctx.ensureDouble(left);
+    const dblRight = this.ctx.ensureDouble(right);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = call double @llvm.pow.f64(double ${dblLeft}, double ${dblRight})`);
+    this.ctx.setVariableType(result, "double");
+    return result;
   }
 
   private generateComparison(

--- a/src/codegen/expressions/operators/unary.ts
+++ b/src/codegen/expressions/operators/unary.ts
@@ -54,10 +54,14 @@ export class UnaryExpressionGenerator {
       return this.generateTypeof(operand, operandValue);
     }
 
+    if (op === "~") {
+      return this.generateBitwiseNot(operandValue);
+    }
+
     return this.ctx.emitError(
       "Unknown unary operator: " + op,
       undefined,
-      "supported operators: !, -, +, typeof, ++, --",
+      "supported operators: !, -, +, ~, typeof, ++, --",
     );
   }
 
@@ -238,6 +242,21 @@ export class UnaryExpressionGenerator {
     this.ctx.emit(`store double ${newValue}, double* ${fieldPtr}`);
 
     return isPost ? originalValue : newValue;
+  }
+
+  private generateBitwiseNot(operand: string): string {
+    const operandType = this.ctx.getVariableType(operand);
+    let intVal: string;
+    if (operandType === "i64") {
+      intVal = operand;
+    } else {
+      intVal = this.ctx.nextTemp();
+      this.ctx.emit(`${intVal} = fptosi double ${operand} to i64`);
+    }
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = xor i64 ${intVal}, -1`);
+    this.ctx.setVariableType(result, "i64");
+    return result;
   }
 
   private generateTypeof(operand: Expression, operandValue: string): string {

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -842,6 +842,7 @@ function transformBinaryExpression(node: TreeSitterNode): BinaryNode {
           "<<",
           ">>",
           ">>>",
+          "**",
         ].includes(t)
       ) {
         op = t;

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -262,6 +262,8 @@ function getBinaryOperator(kind: ts.SyntaxKind): string {
       return "/";
     case ts.SyntaxKind.PercentToken:
       return "%";
+    case ts.SyntaxKind.AsteriskAsteriskToken:
+      return "**";
     case ts.SyntaxKind.LessThanToken:
       return "<";
     case ts.SyntaxKind.GreaterThanToken:

--- a/tests/fixtures/arithmetic/exponentiation.ts
+++ b/tests/fixtures/arithmetic/exponentiation.ts
@@ -1,0 +1,16 @@
+let passed = true;
+
+if (2 ** 3 !== 8) passed = false;
+if (3 ** 2 !== 9) passed = false;
+if (2 ** 0 !== 1) passed = false;
+if (2 ** 10 !== 1024) passed = false;
+
+const base = 5;
+const exp = 3;
+if (base ** exp !== 125) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAILED");
+}

--- a/tests/fixtures/bitwise/basic-bitwise.ts
+++ b/tests/fixtures/bitwise/basic-bitwise.ts
@@ -1,4 +1,3 @@
-// @test-skip
 let passed = true;
 
 if ((5 & 3) !== 1) passed = false;


### PR DESCRIPTION
## Summary
- Implement `~` (bitwise NOT) unary operator — `~0` now correctly returns `-1`
- Implement `>>>` (unsigned/logical right shift) binary operator — `255 >>> 4` returns `15`
- Implement `**` (exponentiation) binary operator — `2 ** 3` returns `8`, uses `llvm.pow.f64`
- Add `**` to both TS and native parsers
- Unskip `bitwise/basic-bitwise.ts` test (all bitwise ops now work)
- Add `arithmetic/exponentiation.ts` test fixture

## Test plan
- [x] `npm run verify:quick` passes
- [x] Both JS and native compilers pass all new tests
- [x] Self-hosting Stage 1 passes