### PR TITLE
fix: propagate arrow function return types and fix lambda pointer codegen

### DIFF
--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -178,6 +178,7 @@ export interface ArrowFunctionNode {
   async?: boolean;
   captures?: { name: string; llvmType: string }[];
   loc?: SourceLocation;
+  returnType?: string;
 }
 
 export interface AwaitExpressionNode {

--- a/src/codegen/expressions/arrow-functions.ts
+++ b/src/codegen/expressions/arrow-functions.ts
@@ -211,6 +211,14 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
   /**
    * Get closure info for a specific lambda by name.
    */
+  getLiftedFunctionByName(name: string): LiftedFunction | undefined {
+    for (let i = 0; i < this.liftedFunctions.length; i++) {
+      const f = this.liftedFunctions[i] as LiftedFunction;
+      if (f.name === name) return f;
+    }
+    return undefined;
+  }
+
   getClosureInfoForLambda(lambdaName: string): ClosureInfo | undefined {
     let funcResult: LiftedFunction | null = null;
     for (let i = 0; i < this.liftedFunctions.length; i++) {
@@ -317,6 +325,14 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
                 stmtTyped.value.type === "template_literal"
               ) {
                 return "string";
+              }
+              if (stmtTyped.value.type === "binary") {
+                const retBin = stmtTyped.value as BinaryNode;
+                if (retBin.op === "+") {
+                  const lt = this.inferReturnTypeFromBody(retBin.left as ArrowFunctionNode["body"]);
+                  const rt = this.inferReturnTypeFromBody(retBin.right as ArrowFunctionNode["body"]);
+                  if (lt === "string" || rt === "string") return "string";
+                }
               }
             }
           }

--- a/src/codegen/expressions/arrow-functions.ts
+++ b/src/codegen/expressions/arrow-functions.ts
@@ -330,7 +330,9 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
                 const retBin = stmtTyped.value as BinaryNode;
                 if (retBin.op === "+") {
                   const lt = this.inferReturnTypeFromBody(retBin.left as ArrowFunctionNode["body"]);
-                  const rt = this.inferReturnTypeFromBody(retBin.right as ArrowFunctionNode["body"]);
+                  const rt = this.inferReturnTypeFromBody(
+                    retBin.right as ArrowFunctionNode["body"],
+                  );
                   if (lt === "string" || rt === "string") return "string";
                 }
               }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -823,7 +823,12 @@ export class CallExpressionGenerator {
     const envPtrRegister = closureMetadata.envPtrRegister;
     const captures = closureMetadata.captures;
 
-    const returnType = "double";
+    let returnType = "double";
+    if (closureMetadata.returnType === "string") {
+      returnType = "i8*";
+    } else if (closureMetadata.returnType === "void") {
+      returnType = "void";
+    }
 
     const argsList: string[] = [];
     if (captures && captures.length > 0) {
@@ -839,7 +844,15 @@ export class CallExpressionGenerator {
       argsList.push(`double ${coerced}`);
     }
 
+    if (returnType === "void") {
+      this.ctx.emitCallVoid(`@${lambdaName}`, argsList.join(", "));
+      return "0.0";
+    }
+
     const temp = this.ctx.emitCall(returnType, `@${lambdaName}`, argsList.join(", "));
+    if (returnType === "i8*") {
+      this.ctx.setVariableType(temp, "i8*");
+    }
 
     return temp;
   }

--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -215,6 +215,9 @@ export class ExpressionGenerator {
       const hintParamTypes: string[] | undefined = cbParamType ? [cbParamType] : undefined;
       typeHints = { paramTypes: hintParamTypes, returnType: cbReturnType || undefined };
     }
+    if (!typeHints && expr.returnType) {
+      typeHints = { returnType: expr.returnType };
+    }
     const lambdaName = this.arrowFunctionGen.generateArrowFunction(
       expr,
       params,

--- a/src/codegen/infrastructure/symbol-table.ts
+++ b/src/codegen/infrastructure/symbol-table.ts
@@ -89,6 +89,7 @@ export interface ClosureMetadata {
   envStructName: string; // The environment struct type name
   envPtrRegister: string; // Register holding the environment pointer
   captures: { name: string; llvmType: string }[]; // Captured variables
+  returnType?: string;
 }
 
 /**

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -124,6 +124,7 @@ interface ArrowFunctionGeneratorLike {
     scopeVarTypes?: string[],
   ): string;
   getClosureInfoForLambda(lambdaName: string): ClosureInfoResult | null;
+  getLiftedFunctionByName(name: string): { returnType?: string } | undefined;
 }
 
 interface ClosureInfoResult {
@@ -2412,6 +2413,12 @@ export class VariableAllocator {
     }
   }
 
+  private getLambdaReturnType(lambdaName: string): string | undefined {
+    const lifted = this.ctx.arrowFunctionGen.getLiftedFunctionByName(lambdaName);
+    if (lifted && lifted.returnType) return lifted.returnType;
+    return undefined;
+  }
+
   private allocateArrowFunction(stmt: VariableDeclaration, params: string[]): void {
     if (!stmt.value) return;
     const scopeVarsResult = this.ctx.symbolTable.getScopeVarsArraysForClosure();
@@ -2476,6 +2483,7 @@ export class VariableAllocator {
           envStructName: closureInfo.envStructName,
           envPtrRegister: envMemReg,
           captures: captures,
+          returnType: this.getLambdaReturnType(lambdaName),
         }),
       );
     } else {
@@ -2491,6 +2499,7 @@ export class VariableAllocator {
           envStructName: "",
           envPtrRegister: "null",
           captures: [],
+          returnType: this.getLambdaReturnType(lambdaName),
         }),
       );
     }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -3427,6 +3427,31 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
           if (this.currentFunctionReturnType === "void") {
             this.emit(`ret void`);
+          } else if (
+            lastValue.startsWith("__lambda_") &&
+            this.currentFunctionReturnType === "i8*"
+          ) {
+            const liftedFunc = this.exprGen.arrowFunctionGen.getLiftedFunctionByName(lastValue);
+            if (liftedFunc) {
+              const retType = liftedFunc.returnType || "";
+              const llvmRet =
+                retType === "string" || retType === "i8*"
+                  ? "i8*"
+                  : retType === "void"
+                    ? "void"
+                    : "double";
+              const paramCount = liftedFunc.params ? liftedFunc.params.length : 0;
+              let funcType = `${llvmRet} (i8*`;
+              for (let pi = 0; pi < paramCount; pi++) {
+                funcType += ", double";
+              }
+              funcType += ")*";
+              const castPtr = this.nextTemp();
+              this.emit(`${castPtr} = bitcast ${funcType} @${lastValue} to i8*`);
+              this.emit(`ret i8* ${castPtr}`);
+            } else {
+              this.emit(`ret ${this.currentFunctionReturnType} ${lastValue}`);
+            }
           } else {
             this.emit(`ret ${this.currentFunctionReturnType} ${lastValue}`);
           }

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -622,12 +622,18 @@ function transformArrowFunction(
 
   const isAsync = node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) || false;
 
+  let returnType: string | undefined = undefined;
+  if (node.type) {
+    returnType = node.type.getText();
+  }
+
   return {
     type: "arrow_function",
     params,
     body,
     async: isAsync || undefined,
     loc: getLoc(node),
+    returnType,
   };
 }
 


### PR DESCRIPTION
## Summary
- Arrow functions with explicit return type annotations (e.g., `(): string => { ... }`) now propagate the return type through the codegen pipeline
- Parser extracts return type from arrow function declarations and stores in `ArrowFunctionNode.returnType`
- `inferReturnTypeFromBody` now handles binary string concat in return statements
- Closure calls use correct return type instead of hardcoded `double` — string-returning closures now call with `i8*` return type
- Return statements properly bitcast lambda function pointers to `i8*` instead of emitting bare function names

Previously, `return (): string => { return "hello"; }` would emit `ret i8* __lambda_0` (invalid LLVM IR — missing `@` prefix and type mismatch). Now emits proper bitcast.

## Test plan
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 1)
- [x] No regressions in existing closure tests