### PR TITLE
fix: emit error for spread arguments and rest parameters instead of generating invalid ir

### DIFF
--- a/src/parser-ts/handlers/declarations.ts
+++ b/src/parser-ts/handlers/declarations.ts
@@ -39,9 +39,10 @@ export function transformFunctionDeclaration(
     const paramName = ts.isIdentifier(p.name) ? p.name.text : "";
     let paramType = p.type ? extractTypeString(p.type) : undefined;
     const optional = !!p.questionToken;
-    const isRest = !!p.dotDotDotToken;
-    if (isRest && paramType && !paramType.endsWith("[]")) {
-      paramType = paramType + "[]";
+    if (p.dotDotDotToken) {
+      throw new Error(
+        `Rest parameters (...${paramName}) are not yet supported in ChadScript`,
+      );
     }
     let defaultValue = undefined;
     if (p.initializer) {

--- a/src/parser-ts/handlers/declarations.ts
+++ b/src/parser-ts/handlers/declarations.ts
@@ -40,9 +40,7 @@ export function transformFunctionDeclaration(
     let paramType = p.type ? extractTypeString(p.type) : undefined;
     const optional = !!p.questionToken;
     if (p.dotDotDotToken) {
-      throw new Error(
-        `Rest parameters (...${paramName}) are not yet supported in ChadScript`,
-      );
+      throw new Error(`Rest parameters (...${paramName}) are not yet supported in ChadScript`);
     }
     let defaultValue = undefined;
     if (p.initializer) {

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -369,7 +369,7 @@ function transformCallExpression(
 ): CallNode | MethodCallNode {
   const args = node.arguments.map((arg) => {
     if (ts.isSpreadElement(arg)) {
-      return transformExpression(arg.expression, checker);
+      throw new Error("Spread arguments (...) in function calls are not yet supported in ChadScript");
     }
     return transformExpression(arg, checker);
   });

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -369,7 +369,9 @@ function transformCallExpression(
 ): CallNode | MethodCallNode {
   const args = node.arguments.map((arg) => {
     if (ts.isSpreadElement(arg)) {
-      throw new Error("Spread arguments (...) in function calls are not yet supported in ChadScript");
+      throw new Error(
+        "Spread arguments (...) in function calls are not yet supported in ChadScript",
+      );
     }
     return transformExpression(arg, checker);
   });

--- a/tests/fixtures/errors/rest-params.ts
+++ b/tests/fixtures/errors/rest-params.ts
@@ -1,0 +1,5 @@
+// @test-compile-error: Rest parameters (...rest) are not yet supported
+function first(a: number, ...rest: number[]): number {
+  return a;
+}
+console.log(first(1, 2, 3));

--- a/tests/fixtures/errors/spread-args.ts
+++ b/tests/fixtures/errors/spread-args.ts
@@ -1,0 +1,7 @@
+// @test-compile-error: Spread arguments (...) in function calls are not yet supported
+function sum(a: number, b: number): number {
+  return a + b;
+}
+const args = [1, 2];
+const result = sum(...args);
+console.log(result);


### PR DESCRIPTION
## Summary
- `sum(...args)` previously generated invalid LLVM IR (passed array pointer where double expected), causing cryptic `opt` errors
- `function f(a, ...rest)` similarly generated mismatched parameter types
- Both now emit clear compile-time errors: "Spread arguments (...) in function calls are not yet supported" and "Rest parameters (...rest) are not yet supported"
- Array spread literals (`[...a, 4]`) are unaffected and continue to work

## Test plan
- [x] New compile-error test fixtures for spread args and rest params
- [x] `npm run verify:quick` passes (530 tests + Stage 1 self-hosting)
- [x] Array spread in literals still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)