### PR TITLE
feat: support all compound assignment operators (%=, &=, |=, ^=, <<=, >>=, >>>=, **=)

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -1483,7 +1483,9 @@ function transformAugmentedAssignmentExpression(node: TreeSitterNode): Expressio
     const c = child as NodeBase;
     if (!c.isNamed) {
       const t = c.type;
-      if (["+=", "-=", "*=", "/=", "%=", "|=", "&=", "^=", "<<=", ">>="].includes(t)) {
+      if (
+        ["+=", "-=", "*=", "/=", "%=", "|=", "&=", "^=", "<<=", ">>=", ">>>=", "**="].includes(t)
+      ) {
         op = t.slice(0, t.length - 1);
         break;
       }

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -177,7 +177,6 @@ function transformBinaryExpression(
 ): Expression {
   const left = transformExpression(node.left, checker);
   const right = transformExpression(node.right, checker);
-  const op = getBinaryOperator(node.operatorToken.kind);
 
   if (isAssignmentOperator(node.operatorToken.kind)) {
     const compoundOp = getCompoundOperator(node.operatorToken.kind);
@@ -188,6 +187,7 @@ function transformBinaryExpression(
     return createAssignment(node.left, right, checker);
   }
 
+  const op = getBinaryOperator(node.operatorToken.kind);
   return { type: "binary", op, left, right, loc: getLoc(node) };
 }
 
@@ -226,8 +226,14 @@ function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
     kind === ts.SyntaxKind.MinusEqualsToken ||
     kind === ts.SyntaxKind.AsteriskEqualsToken ||
     kind === ts.SyntaxKind.SlashEqualsToken ||
+    kind === ts.SyntaxKind.PercentEqualsToken ||
     kind === ts.SyntaxKind.BarEqualsToken ||
-    kind === ts.SyntaxKind.AmpersandEqualsToken
+    kind === ts.SyntaxKind.AmpersandEqualsToken ||
+    kind === ts.SyntaxKind.CaretEqualsToken ||
+    kind === ts.SyntaxKind.LessThanLessThanEqualsToken ||
+    kind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
+    kind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
+    kind === ts.SyntaxKind.AsteriskAsteriskEqualsToken
   );
 }
 
@@ -241,10 +247,22 @@ function getCompoundOperator(kind: ts.SyntaxKind): string | null {
       return "*";
     case ts.SyntaxKind.SlashEqualsToken:
       return "/";
+    case ts.SyntaxKind.PercentEqualsToken:
+      return "%";
     case ts.SyntaxKind.BarEqualsToken:
       return "|";
     case ts.SyntaxKind.AmpersandEqualsToken:
       return "&";
+    case ts.SyntaxKind.CaretEqualsToken:
+      return "^";
+    case ts.SyntaxKind.LessThanLessThanEqualsToken:
+      return "<<";
+    case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:
+      return ">>";
+    case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
+      return ">>>";
+    case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
+      return "**";
     default:
       return null;
   }

--- a/src/parser-ts/handlers/statements.ts
+++ b/src/parser-ts/handlers/statements.ts
@@ -312,7 +312,15 @@ function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
     kind === ts.SyntaxKind.PlusEqualsToken ||
     kind === ts.SyntaxKind.MinusEqualsToken ||
     kind === ts.SyntaxKind.AsteriskEqualsToken ||
-    kind === ts.SyntaxKind.SlashEqualsToken
+    kind === ts.SyntaxKind.SlashEqualsToken ||
+    kind === ts.SyntaxKind.PercentEqualsToken ||
+    kind === ts.SyntaxKind.BarEqualsToken ||
+    kind === ts.SyntaxKind.AmpersandEqualsToken ||
+    kind === ts.SyntaxKind.CaretEqualsToken ||
+    kind === ts.SyntaxKind.LessThanLessThanEqualsToken ||
+    kind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
+    kind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
+    kind === ts.SyntaxKind.AsteriskAsteriskEqualsToken
   );
 }
 
@@ -375,6 +383,22 @@ function getCompoundOperator(op: ts.SyntaxKind): string | null {
       return "*";
     case ts.SyntaxKind.SlashEqualsToken:
       return "/";
+    case ts.SyntaxKind.PercentEqualsToken:
+      return "%";
+    case ts.SyntaxKind.BarEqualsToken:
+      return "|";
+    case ts.SyntaxKind.AmpersandEqualsToken:
+      return "&";
+    case ts.SyntaxKind.CaretEqualsToken:
+      return "^";
+    case ts.SyntaxKind.LessThanLessThanEqualsToken:
+      return "<<";
+    case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:
+      return ">>";
+    case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
+      return ">>>";
+    case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
+      return "**";
     default:
       return null;
   }

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -444,6 +444,22 @@ function getCompoundOperator(op: ts.SyntaxKind): string | null {
       return "*";
     case ts.SyntaxKind.SlashEqualsToken:
       return "/";
+    case ts.SyntaxKind.PercentEqualsToken:
+      return "%";
+    case ts.SyntaxKind.BarEqualsToken:
+      return "|";
+    case ts.SyntaxKind.AmpersandEqualsToken:
+      return "&";
+    case ts.SyntaxKind.CaretEqualsToken:
+      return "^";
+    case ts.SyntaxKind.LessThanLessThanEqualsToken:
+      return "<<";
+    case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:
+      return ">>";
+    case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
+      return ">>>";
+    case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
+      return "**";
     default:
       return null;
   }

--- a/tests/fixtures/arithmetic/compound-assignment.ts
+++ b/tests/fixtures/arithmetic/compound-assignment.ts
@@ -1,31 +1,64 @@
 function test(): void {
   let x = 10;
   x += 5;
-  if (x !== 15) { console.log("FAIL +="); return; }
+  if (x !== 15) {
+    console.log("FAIL +=");
+    return;
+  }
   x -= 3;
-  if (x !== 12) { console.log("FAIL -="); return; }
+  if (x !== 12) {
+    console.log("FAIL -=");
+    return;
+  }
   x *= 2;
-  if (x !== 24) { console.log("FAIL *="); return; }
+  if (x !== 24) {
+    console.log("FAIL *=");
+    return;
+  }
   x /= 4;
-  if (x !== 6) { console.log("FAIL /="); return; }
+  if (x !== 6) {
+    console.log("FAIL /=");
+    return;
+  }
   x %= 4;
-  if (x !== 2) { console.log("FAIL %="); return; }
+  if (x !== 2) {
+    console.log("FAIL %=");
+    return;
+  }
 
   let y = 15;
   y &= 6;
-  if (y !== 6) { console.log("FAIL &="); return; }
+  if (y !== 6) {
+    console.log("FAIL &=");
+    return;
+  }
   y |= 8;
-  if (y !== 14) { console.log("FAIL |="); return; }
+  if (y !== 14) {
+    console.log("FAIL |=");
+    return;
+  }
   y ^= 3;
-  if (y !== 13) { console.log("FAIL ^="); return; }
+  if (y !== 13) {
+    console.log("FAIL ^=");
+    return;
+  }
   y <<= 2;
-  if (y !== 52) { console.log("FAIL <<="); return; }
+  if (y !== 52) {
+    console.log("FAIL <<=");
+    return;
+  }
   y >>= 1;
-  if (y !== 26) { console.log("FAIL >>="); return; }
+  if (y !== 26) {
+    console.log("FAIL >>=");
+    return;
+  }
 
   let s = "hello";
   s += " world";
-  if (s !== "hello world") { console.log("FAIL str+="); return; }
+  if (s !== "hello world") {
+    console.log("FAIL str+=");
+    return;
+  }
 
   console.log("TEST_PASSED");
 }

--- a/tests/fixtures/arithmetic/compound-assignment.ts
+++ b/tests/fixtures/arithmetic/compound-assignment.ts
@@ -1,0 +1,32 @@
+function test(): void {
+  let x = 10;
+  x += 5;
+  if (x !== 15) { console.log("FAIL +="); return; }
+  x -= 3;
+  if (x !== 12) { console.log("FAIL -="); return; }
+  x *= 2;
+  if (x !== 24) { console.log("FAIL *="); return; }
+  x /= 4;
+  if (x !== 6) { console.log("FAIL /="); return; }
+  x %= 4;
+  if (x !== 2) { console.log("FAIL %="); return; }
+
+  let y = 15;
+  y &= 6;
+  if (y !== 6) { console.log("FAIL &="); return; }
+  y |= 8;
+  if (y !== 14) { console.log("FAIL |="); return; }
+  y ^= 3;
+  if (y !== 13) { console.log("FAIL ^="); return; }
+  y <<= 2;
+  if (y !== 52) { console.log("FAIL <<="); return; }
+  y >>= 1;
+  if (y !== 26) { console.log("FAIL >>="); return; }
+
+  let s = "hello";
+  s += " world";
+  if (s !== "hello world") { console.log("FAIL str+="); return; }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- `x %= 4`, `x &= 6`, `x |= 8`, `x ^= 3`, `x <<= 2`, `x >>= 1`, `x >>>= 1`, `x **= 2` now work correctly
- Previously, `%=` and others crashed with "Unknown binary operator" because `getBinaryOperator()` was called before the assignment check
- Fixed ordering: check `isAssignmentOperator` first, then call `getBinaryOperator` only for non-assignment binary expressions
- Updated all three parser locations (expressions.ts, statements.ts, transformer.ts) and the native parser

## Test plan
- [x] New fixture: `tests/fixtures/arithmetic/compound-assignment.ts` testing `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`, string `+=`
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)
- [x] `**=` works in TS parser but crashes native compiler (excluded from test, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)