### PR TITLE
fix: handle boolean values correctly in template literal interpolation

### DIFF
--- a/src/codegen/expressions/templates.ts
+++ b/src/codegen/expressions/templates.ts
@@ -14,12 +14,24 @@
  * - With interpolation: `Hello ${name}` -> concatenate "Hello " with name value
  */
 
-import { Expression, TemplateLiteralNode, StringNode } from "../../ast/types.js";
+import {
+  Expression,
+  TemplateLiteralNode,
+  StringNode,
+  BinaryNode,
+  UnaryNode,
+} from "../../ast/types.js";
 import { IGeneratorContext } from "../infrastructure/generator-context.js";
 import {
   createStringConstant,
   convertNumberToString,
 } from "../types/collections/string/constants.js";
+
+function isComparisonOp(op: string): boolean {
+  if (op === "===" || op === "!==" || op === "==" || op === "!=") return true;
+  if (op === "<" || op === ">" || op === "<=" || op === ">=") return true;
+  return false;
+}
 
 export class TemplateLiteralGenerator {
   constructor(private ctx: IGeneratorContext) {}
@@ -27,8 +39,16 @@ export class TemplateLiteralGenerator {
   private booleanToString(boolValue: string): string {
     const trueStr = createStringConstant(this.ctx, "true");
     const falseStr = createStringConstant(this.ctx, "false");
+    const varType = this.ctx.getVariableType(boolValue);
     const cmp = this.ctx.nextTemp();
-    this.ctx.emit(`${cmp} = fcmp one double ${boolValue}, 0.0`);
+    if (varType === "i1") {
+      this.ctx.emit(`${cmp} = select i1 ${boolValue}, i8* ${trueStr}, i8* ${falseStr}`);
+      return cmp;
+    } else if (varType === "i64") {
+      this.ctx.emit(`${cmp} = icmp ne i64 ${boolValue}, 0`);
+    } else {
+      this.ctx.emit(`${cmp} = fcmp one double ${boolValue}, 0.0`);
+    }
     const selected = this.ctx.nextTemp();
     this.ctx.emit(`${selected} = select i1 ${cmp}, i8* ${trueStr}, i8* ${falseStr}`);
     return selected;
@@ -79,12 +99,15 @@ export class TemplateLiteralGenerator {
         const exprPart = part as Expression;
         const exprPartTyped = exprPart as { type: string };
         const exprValue = this.ctx.generateExpression(exprPart, params);
-        if (exprPartTyped.type === "boolean") {
+        const varType = this.ctx.getVariableType(exprValue);
+        const isBoolExpr =
+          exprPartTyped.type === "boolean" ||
+          varType === "i1" ||
+          (exprPartTyped.type === "binary" && isComparisonOp((exprPart as BinaryNode).op)) ||
+          (exprPartTyped.type === "unary" && (exprPart as UnaryNode).op === "!");
+        if (isBoolExpr) {
           partValue = this.booleanToString(exprValue);
-        } else if (
-          this.ctx.isStringExpression(exprPart) ||
-          this.ctx.getVariableType(exprValue) === "i8*"
-        ) {
+        } else if (this.ctx.isStringExpression(exprPart) || varType === "i8*") {
           partValue = this.nullSafeString(exprValue);
         } else {
           partValue = convertNumberToString(this.ctx, exprValue);

--- a/tests/fixtures/strings/template-literal-boolean.ts
+++ b/tests/fixtures/strings/template-literal-boolean.ts
@@ -1,0 +1,24 @@
+function test(): void {
+  const s1 = `val=${true}`;
+  if (s1 !== "val=true") {
+    console.log("FAIL literal true: " + s1);
+    return;
+  }
+  const s2 = `val=${false}`;
+  if (s2 !== "val=false") {
+    console.log("FAIL literal false: " + s2);
+    return;
+  }
+  const s3 = `cmp=${1 > 0}`;
+  if (s3 !== "cmp=true") {
+    console.log("FAIL comparison: " + s3);
+    return;
+  }
+  const s4 = `neg=${1 < 0}`;
+  if (s4 !== "neg=false") {
+    console.log("FAIL false comparison: " + s4);
+    return;
+  }
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- Template literals like `` `val=${true}` `` and `` `cmp=${1 > 0}` `` now correctly produce `"val=true"` and `"cmp=true"` instead of `"val=1"` and `"cmp=1"`
- `booleanToString()` now handles all LLVM boolean types (i1, i64, double) instead of assuming double
- Comparison operators and `!` in template interpolation are now detected and routed through boolean-to-string conversion

## Test plan
- [x] New fixture `strings/template-literal-boolean.ts` tests literal `true`/`false` and comparison expressions
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)
- [x] Both JS and native compilers produce correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)