### PR TITLE
fix: handle non-double types when converting to i1 for object boolean fields

### DIFF
--- a/src/codegen/types/objects/object.ts
+++ b/src/codegen/types/objects/object.ts
@@ -239,9 +239,18 @@ export class ObjectGenerator {
         finalValue = valueReg;
         const valueType = this.ctx.getVariableType(valueReg) || "double";
         if (fieldLlvmType === "i1") {
-          const i1Value = this.nextTemp();
-          this.emit(`${i1Value} = fcmp one double ${valueReg}, 0.0`);
-          finalValue = i1Value;
+          if (valueType === "i1") {
+            finalValue = valueReg;
+          } else if (valueType === "i64") {
+            const i1Value = this.nextTemp();
+            this.emit(`${i1Value} = icmp ne i64 ${valueReg}, 0`);
+            finalValue = i1Value;
+          } else {
+            const dbl = this.ctx.ensureDouble(valueReg);
+            const i1Value = this.nextTemp();
+            this.emit(`${i1Value} = fcmp one double ${dbl}, 0.0`);
+            finalValue = i1Value;
+          }
         } else if (fieldLlvmType === "double") {
           if (valueType.indexOf("*") !== -1) {
             const isTreeSitterType =
@@ -345,9 +354,18 @@ export class ObjectGenerator {
 
       let finalValue = valueReg;
       if (llvmType === "i1") {
-        const i1Value = this.nextTemp();
-        this.emit(`${i1Value} = fcmp one double ${valueReg}, 0.0`);
-        finalValue = i1Value;
+        if (generatedType === "i1") {
+          finalValue = valueReg;
+        } else if (generatedType === "i64") {
+          const i1Value = this.nextTemp();
+          this.emit(`${i1Value} = icmp ne i64 ${valueReg}, 0`);
+          finalValue = i1Value;
+        } else {
+          const dbl = this.ctx.ensureDouble(valueReg);
+          const i1Value = this.nextTemp();
+          this.emit(`${i1Value} = fcmp one double ${dbl}, 0.0`);
+          finalValue = i1Value;
+        }
       } else if (llvmType === "double") {
         finalValue = this.ctx.ensureDouble(valueReg);
       }

--- a/tests/fixtures/objects/object-boolean-field.ts
+++ b/tests/fixtures/objects/object-boolean-field.ts
@@ -1,0 +1,13 @@
+function test(): void {
+  const obj = { name: "test", active: true, done: false };
+  if (obj.active !== true) {
+    console.log("FAIL active should be true");
+    return;
+  }
+  if (obj.done !== false) {
+    console.log("FAIL done should be false");
+    return;
+  }
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- Object literal boolean fields (e.g., `{ active: true }`) could produce invalid LLVM IR when the boolean value was `i64` or `i1` type instead of `double`
- Two `fcmp one double` instructions in `object.ts` now properly check the value type first: `i1` passes through directly, `i64` uses `icmp ne`, and only `double` uses `fcmp`
- Same class of bug as #240 (template literal booleans) — `generateBoolean()` returns `i64`, not `double`

## Test plan
- [x] New fixture `objects/object-boolean-field.ts` tests boolean fields in object literals
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)