### PR TITLE
fix: prevent crash when concatenating null strings with + operator

### DIFF
--- a/src/codegen/types/collections/string/concatenation.ts
+++ b/src/codegen/types/collections/string/concatenation.ts
@@ -2,7 +2,7 @@ import { Expression, BinaryNode, UnaryNode } from "../../../../ast/types.js";
 import { IGeneratorContext } from "../../../infrastructure/generator-context.js";
 import { convertNumberToString, createStringConstant } from "./constants.js";
 
-function isComparisonOp(op: string): boolean {
+function isConcatComparisonOp(op: string): boolean {
   if (op === "===" || op === "!==" || op === "==" || op === "!=") return true;
   if (op === "<" || op === ">" || op === "<=" || op === ">=") return true;
   return false;
@@ -11,7 +11,7 @@ function isComparisonOp(op: string): boolean {
 function isBooleanExpr(expr: Expression, valueType: string | null | undefined): boolean {
   if (expr.type === "boolean") return true;
   if (valueType === "i1") return true;
-  if (expr.type === "binary" && isComparisonOp((expr as BinaryNode).op)) return true;
+  if (expr.type === "binary" && isConcatComparisonOp((expr as BinaryNode).op)) return true;
   if (expr.type === "unary" && (expr as UnaryNode).op === "!") return true;
   return false;
 }
@@ -36,9 +36,29 @@ function convertBooleanToString(ctx: IGeneratorContext, boolValue: string): stri
   return selected;
 }
 
+function nullSafeStr(ctx: IGeneratorContext, value: string, expr: Expression): string {
+  if (expr.type === "null") {
+    return createStringConstant(ctx, "null");
+  }
+  if (expr.type === "undefined") {
+    return createStringConstant(ctx, "undefined");
+  }
+  const varType = ctx.getVariableType(value);
+  if (varType === "i8*" || value.startsWith("@.str")) {
+    const nullStr = createStringConstant(ctx, "null");
+    const isNull = ctx.nextTemp();
+    ctx.emit(`${isNull} = icmp eq i8* ${value}, null`);
+    const safe = ctx.nextTemp();
+    ctx.emit(`${safe} = select i1 ${isNull}, i8* ${nullStr}, i8* ${value}`);
+    ctx.setVariableType(safe, "i8*");
+    return safe;
+  }
+  return value;
+}
+
 function toStringValue(ctx: IGeneratorContext, expr: Expression, value: string): string {
   const varType = ctx.getVariableType(value);
-  if (ctx.isStringExpression(expr) || varType === "i8*") return value;
+  if (ctx.isStringExpression(expr) || varType === "i8*") return nullSafeStr(ctx, value, expr);
   if (isBooleanExpr(expr, varType)) return convertBooleanToString(ctx, value);
   return convertNumberToString(ctx, value);
 }

--- a/tests/fixtures/strings/string-concat-null.ts
+++ b/tests/fixtures/strings/string-concat-null.ts
@@ -1,0 +1,21 @@
+function test(): void {
+  const n: string | null = null;
+  const s1 = "val: " + n;
+  if (s1 !== "val: null") {
+    console.log("FAIL null: " + s1);
+    return;
+  }
+  const s2 = "hi " + "world";
+  if (s2 !== "hi world") {
+    console.log("FAIL normal: " + s2);
+    return;
+  }
+  const x: string | null = "hello";
+  const s3 = "val: " + x;
+  if (s3 !== "val: hello") {
+    console.log("FAIL non-null: " + s3);
+    return;
+  }
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- `"val: " + nullString` now correctly produces `"val: null"` instead of crashing (segfault from `strlen(null)`)
- Null literal and undefined literal expressions produce `"null"` and `"undefined"` strings directly
- Nullable string variables are null-checked at runtime with a `select` instruction

## Test plan
- [x] New fixture `strings/string-concat-null.ts` tests null, non-null, and normal string concatenation
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)