### PR TITLE
fix: typeof returns 'boolean' for boolean variables instead of 'number'

### DIFF
--- a/src/codegen/expressions/operators/unary.ts
+++ b/src/codegen/expressions/operators/unary.ts
@@ -277,6 +277,8 @@ export class UnaryExpressionGenerator {
         typeString = "undefined";
       } else if (this.ctx.symbolTable.isString(varName)) {
         typeString = "string";
+      } else if (this.ctx.symbolTable.isBoolean(varName)) {
+        typeString = "boolean";
       } else if (operandType === "double" || operandType === "i64") {
         typeString = "number";
       } else {

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -343,6 +343,7 @@ export class TypeInference {
 
   private resolveFromSymbolKind(name: string): ResolvedType | null {
     if (this.ctx.symbolTable.isString(name)) return this.ctx.typeContext.stringType;
+    if (this.ctx.symbolTable.isBoolean(name)) return this.ctx.typeContext.booleanType;
     if (this.ctx.symbolTable.isNumberArray(name))
       return this.ctx.typeContext.getArrayType("number");
     if (this.ctx.symbolTable.isMap(name))

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -567,7 +567,7 @@ export class VariableAllocator {
         this.ctx.emit(`${allocaReg} = alloca i8*`);
         this.ctx.emit(`store i8* null, i8** ${allocaReg}`);
       } else if (baseType === "boolean") {
-        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Number, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Boolean, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);
         this.ctx.emit(`store double 0.0, double* ${allocaReg}`);
       } else if (baseType === "number") {
@@ -2276,7 +2276,7 @@ export class VariableAllocator {
         return;
       }
       if (baseType === "boolean") {
-        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Number, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Boolean, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);
         this.ctx.emit(`store double 0.0, double* ${allocaReg}`);
         return;
@@ -2391,12 +2391,16 @@ export class VariableAllocator {
       this.ctx.emit(`store ${valueType} ${value}, ${valueType}* ${allocaReg}`);
     } else {
       const allocaReg = this.ctx.nextAllocaReg(stmt.name);
+      const isBoolVal =
+        stmt.value!.type === "boolean" ||
+        (stmt.declaredType && stripNullable(stmt.declaredType) === "boolean");
+      const symKind = isBoolVal ? SymbolKind.Boolean : SymbolKind.Number;
       if (valueType === "i64" && this.isI64Eligible(stmt.name)) {
-        this.ctx.defineVariable(stmt.name, allocaReg, "i64", SymbolKind.Number, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "i64", symKind, "local");
         this.ctx.emit(`${allocaReg} = alloca i64`);
         this.ctx.emit(`store i64 ${value}, i64* ${allocaReg}`);
       } else {
-        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Number, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "double", symKind, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);
         if (valueType === "i32") {
           const converted = this.ctx.nextTemp();

--- a/src/codegen/types/collections/string/concatenation.ts
+++ b/src/codegen/types/collections/string/concatenation.ts
@@ -2,7 +2,7 @@ import { Expression, BinaryNode, UnaryNode } from "../../../../ast/types.js";
 import { IGeneratorContext } from "../../../infrastructure/generator-context.js";
 import { convertNumberToString, createStringConstant } from "./constants.js";
 
-function isComparisonOp(op: string): boolean {
+function isConcatComparisonOp(op: string): boolean {
   if (op === "===" || op === "!==" || op === "==" || op === "!=") return true;
   if (op === "<" || op === ">" || op === "<=" || op === ">=") return true;
   return false;
@@ -11,7 +11,7 @@ function isComparisonOp(op: string): boolean {
 function isBooleanExpr(expr: Expression, valueType: string | null | undefined): boolean {
   if (expr.type === "boolean") return true;
   if (valueType === "i1") return true;
-  if (expr.type === "binary" && isComparisonOp((expr as BinaryNode).op)) return true;
+  if (expr.type === "binary" && isConcatComparisonOp((expr as BinaryNode).op)) return true;
   if (expr.type === "unary" && (expr as UnaryNode).op === "!") return true;
   return false;
 }

--- a/tests/fixtures/builtins/console-log-boolean.ts
+++ b/tests/fixtures/builtins/console-log-boolean.ts
@@ -1,0 +1,16 @@
+function test(): void {
+  const t = true;
+  const f = false;
+  const result = t;
+  if (result !== true) {
+    console.log("FAIL basic bool");
+    return;
+  }
+  const x: boolean = 5 > 3;
+  if (x !== true) {
+    console.log("FAIL comparison bool");
+    return;
+  }
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/types/typeof-boolean.ts
+++ b/tests/fixtures/types/typeof-boolean.ts
@@ -1,0 +1,35 @@
+function test(): void {
+  const t = true;
+  const f = false;
+  if (typeof t !== "boolean") {
+    console.log("FAIL typeof true: " + typeof t);
+    return;
+  }
+  if (typeof f !== "boolean") {
+    console.log("FAIL typeof false: " + typeof f);
+    return;
+  }
+  if (typeof true !== "boolean") {
+    console.log("FAIL typeof literal true: " + typeof true);
+    return;
+  }
+  if (typeof false !== "boolean") {
+    console.log("FAIL typeof literal false: " + typeof false);
+    return;
+  }
+  const x: boolean = 5 > 3;
+  if (typeof x !== "boolean") {
+    console.log("FAIL typeof comparison: " + typeof x);
+    return;
+  }
+  if (typeof 42 !== "number") {
+    console.log("FAIL typeof number");
+    return;
+  }
+  if (typeof "hello" !== "string") {
+    console.log("FAIL typeof string");
+    return;
+  }
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- `typeof boolVar` now correctly returns `"boolean"` instead of `"number"`
- Boolean variables were tracked as `SymbolKind.Number` in the variable allocator — changed to `SymbolKind.Boolean` in all allocation paths (null-initialized, declared-type, and literal-initialized)
- Added `isBoolean()` check in `generateTypeof()` so typeof dispatches correctly for boolean variables
- Fixed duplicate `isComparisonOp` function name collision between templates.ts and concatenation.ts that broke self-hosting

## Test plan
- [x] New test fixture `types/typeof-boolean.ts` covers literal booleans, boolean variables, and comparison results
- [x] All existing tests pass
- [x] Self-hosting Stage 1 passes