### PR TITLE
fix: typeof correctly returns type for functions, undefined, and literals

### DIFF
--- a/src/codegen/expressions/operators/unary.ts
+++ b/src/codegen/expressions/operators/unary.ts
@@ -36,6 +36,10 @@ export class UnaryExpressionGenerator {
       return this.generatePreIncDec(op, operand, params);
     }
 
+    if (op === "typeof") {
+      return this.generateTypeof(operand, params);
+    }
+
     const operandValue = this.ctx.generateExpression(operand, params);
 
     if (op === "!") {
@@ -48,10 +52,6 @@ export class UnaryExpressionGenerator {
 
     if (op === "+") {
       return operandValue;
-    }
-
-    if (op === "typeof") {
-      return this.generateTypeof(operand, operandValue);
     }
 
     if (op === "~") {
@@ -259,8 +259,7 @@ export class UnaryExpressionGenerator {
     return result;
   }
 
-  private generateTypeof(operand: Expression, operandValue: string): string {
-    const operandType = this.ctx.getVariableType(operandValue);
+  private generateTypeof(operand: Expression, params: string[]): string {
     let typeString: string;
 
     if (operand.type === "string") {
@@ -269,6 +268,10 @@ export class UnaryExpressionGenerator {
       typeString = "number";
     } else if (operand.type === "boolean") {
       typeString = "boolean";
+    } else if (operand.type === "null") {
+      typeString = "object";
+    } else if (operand.type === "undefined") {
+      typeString = "undefined";
     } else if (operand.type === "arrow_function") {
       typeString = "function";
     } else if (operand.type === "variable") {
@@ -279,15 +282,25 @@ export class UnaryExpressionGenerator {
         typeString = "string";
       } else if (this.ctx.symbolTable.isBoolean(varName)) {
         typeString = "boolean";
-      } else if (operandType === "double" || operandType === "i64") {
+      } else if (this.ctx.symbolTable.isClosure(varName)) {
+        typeString = "function";
+      } else {
+        const operandValue = this.ctx.generateExpression(operand, params);
+        const operandType = this.ctx.getVariableType(operandValue);
+        if (operandType === "double" || operandType === "i64") {
+          typeString = "number";
+        } else {
+          typeString = "object";
+        }
+      }
+    } else {
+      const operandValue = this.ctx.generateExpression(operand, params);
+      const operandType = this.ctx.getVariableType(operandValue);
+      if (operandType === "double" || operandType === "i64") {
         typeString = "number";
       } else {
         typeString = "object";
       }
-    } else if (operandType === "double" || operandType === "i64") {
-      typeString = "number";
-    } else {
-      typeString = "object";
     }
 
     const strPtr = this.ctx.stringGen.doCreateStringConstant(typeString);

--- a/tests/fixtures/types/typeof-function.ts
+++ b/tests/fixtures/types/typeof-function.ts
@@ -1,0 +1,30 @@
+function test(): void {
+  const fn = (x: number): number => x * 2;
+  if (typeof fn !== "function") {
+    console.log("FAIL arrow: " + typeof fn);
+    return;
+  }
+  const t = true;
+  if (typeof t !== "boolean") {
+    console.log("FAIL bool: " + typeof t);
+    return;
+  }
+  if (typeof 42 !== "number") {
+    console.log("FAIL number");
+    return;
+  }
+  if (typeof "hello" !== "string") {
+    console.log("FAIL string");
+    return;
+  }
+  if (typeof null !== "object") {
+    console.log("FAIL null: " + typeof null);
+    return;
+  }
+  if (typeof undefined !== "undefined") {
+    console.log("FAIL undefined: " + typeof undefined);
+    return;
+  }
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- `typeof fn` where `fn` is an arrow function now returns `"function"` instead of crashing with undefined value error
- `typeof undefined` now returns `"undefined"` instead of `"object"` (was missing `UndefinedNode` AST type check)
- Moved typeof evaluation before `generateExpression` so non-capturing closures (which have no alloca) aren't loaded
- Added `isClosure()` check in symbol table to detect function variables without generating IR

## Test plan
- [x] New test fixture `types/typeof-function.ts` covers: arrow functions, booleans, numbers, strings, null, undefined
- [x] All 544 tests pass
- [x] Self-hosting Stage 1 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)