### PR TITLE
fix: valid double literal for void function return assignment

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -787,7 +787,7 @@ export class CallExpressionGenerator {
 
     if (returnType === "void") {
       this.ctx.emitCallVoid(`@${mangledName}`, argsList.join(", "));
-      return "0";
+      return "0.0";
     }
 
     const temp = this.ctx.emitCall(returnType, `@${mangledName}`, argsList.join(", "));
@@ -1021,7 +1021,7 @@ export class CallExpressionGenerator {
     this.ctx.emitLabel(mergeLabel);
     this.ctx.setCurrentLabel(mergeLabel);
 
-    return "0";
+    return "0.0";
   }
 
   private generateDescribe(expr: CallNode, params: string[]): string {
@@ -1066,7 +1066,7 @@ export class CallExpressionGenerator {
     this.ctx.emit(`${decDepth} = sub i32 ${restoredDepth}, 1`);
     this.ctx.emitStore("i32", decDepth, "@__describe_depth");
 
-    return "0";
+    return "0.0";
   }
 
   private generateClearTimer(expr: CallNode, params: string[]): string {
@@ -1327,7 +1327,7 @@ export class CallExpressionGenerator {
         this.ctx.emitStore(fieldLlvmType, fieldValue, thisFieldPtr);
       }
     }
-    return "0";
+    return "0.0";
   }
 
   private getFieldLlvmTypeForTsType(tsType: string): string | null {

--- a/src/codegen/expressions/method-calls/assert.ts
+++ b/src/codegen/expressions/method-calls/assert.ts
@@ -127,7 +127,7 @@ function handleNumberEquality(
   ctx.emitLabel(mergeLabel);
   ctx.setCurrentLabel(mergeLabel);
 
-  return "0";
+  return "0.0";
 }
 
 function handleStringEquality(
@@ -200,7 +200,7 @@ function handleStringEquality(
   ctx.emitLabel(mergeLabel);
   ctx.setCurrentLabel(mergeLabel);
 
-  return "0";
+  return "0.0";
 }
 
 export function handleAssertOk(
@@ -268,7 +268,7 @@ export function handleAssertOk(
   ctx.emitLabel(mergeLabel);
   ctx.setCurrentLabel(mergeLabel);
 
-  return "0";
+  return "0.0";
 }
 
 export function handleAssertDeepEqual(
@@ -378,7 +378,7 @@ function emitArrayDeepEqualNumber(
   ctx.emitLabel(doneLabel);
   ctx.setCurrentLabel(doneLabel);
 
-  return "0";
+  return "0.0";
 }
 
 function emitArrayDeepEqualString(
@@ -470,7 +470,7 @@ function emitArrayDeepEqualString(
   ctx.emitLabel(doneLabel);
   ctx.setCurrentLabel(doneLabel);
 
-  return "0";
+  return "0.0";
 }
 
 export function handleAssertFail(
@@ -489,5 +489,5 @@ export function handleAssertFail(
     );
   }
 
-  return "0";
+  return "0.0";
 }

--- a/src/codegen/expressions/method-calls/class-dispatch.ts
+++ b/src/codegen/expressions/method-calls/class-dispatch.ts
@@ -728,7 +728,7 @@ export function handleClassMethods(
     className = currentClass.extends;
 
     if (method === "") {
-      return "0";
+      return "0.0";
     }
   } else if (exprObjBase.type === "type_assertion") {
     const assertExpr = expr.object as TypeAssertionNode;

--- a/src/codegen/expressions/method-calls/named-object-dispatch.ts
+++ b/src/codegen/expressions/method-calls/named-object-dispatch.ts
@@ -296,7 +296,7 @@ function handleProcessCoreOps(
   if (method === "chdir") return handleProcessChdir(ctx, expr, params);
   if (method === "abort") {
     ctx.emit(`call void @abort()`);
-    return "0";
+    return "0.0";
   }
   return null;
 }

--- a/src/codegen/expressions/method-calls/process.ts
+++ b/src/codegen/expressions/method-calls/process.ts
@@ -21,7 +21,7 @@ export function generateProcessExitInline(
     ctx.emit(`call void @exit(i32 0)`);
   }
   ctx.emit("unreachable");
-  return "0";
+  return "0.0";
 }
 
 export function generateProcessCwdInline(ctx: MethodCallGeneratorContext): string {
@@ -46,7 +46,7 @@ export function handleProcessChdir(
   const dirValue = ctx.generateExpression(expr.args[0], params);
   const result = ctx.nextTemp();
   ctx.emit(`${result} = call i32 @chdir(i8* ${dirValue})`);
-  return "0";
+  return "0.0";
 }
 
 export function handleProcessKill(
@@ -73,7 +73,7 @@ export function handleProcessKill(
 
   const result = ctx.nextTemp();
   ctx.emit(`${result} = call i32 @kill(i32 ${pidI32}, i32 ${sigI32})`);
-  return "0";
+  return "0.0";
 }
 
 export function handleProcessUptime(ctx: MethodCallGeneratorContext): string {
@@ -115,7 +115,7 @@ export function handleProcessWrite(
   params: string[],
 ): string {
   if (expr.args.length === 0) {
-    return "0";
+    return "0.0";
   }
 
   const memberAccess = expr.object as MemberAccessNode;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2411,7 +2411,8 @@ export class VariableAllocator {
           this.ctx.emit(`${converted} = sitofp i64 ${value} to double`);
           this.ctx.emit(`store double ${converted}, double* ${allocaReg}`);
         } else {
-          this.ctx.emit(`store double ${value}, double* ${allocaReg}`);
+          const doubleVal = value === "0" ? "0.0" : value;
+          this.ctx.emit(`store double ${doubleVal}, double* ${allocaReg}`);
         }
       }
     }

--- a/src/codegen/stdlib/process.ts
+++ b/src/codegen/stdlib/process.ts
@@ -66,7 +66,6 @@ export class ProcessGenerator {
     // Call exit syscall (noreturn)
     this.ctx.emit(`call void @exit(i32 ${exitCode})`);
 
-    // Return a dummy value since exit doesn't return
-    return "0";
+    return "0.0";
   }
 }

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -339,7 +339,7 @@ function generateNumericArrayForEach(
   gen.emitBr(checkLabel);
 
   gen.emitLabel(endLabel);
-  return "0";
+  return "0.0";
 }
 
 function generateStringArrayForEach(
@@ -389,7 +389,7 @@ function generateStringArrayForEach(
   gen.emitBr(checkLabel);
 
   gen.emitLabel(endLabel);
-  return "0";
+  return "0.0";
 }
 
 // ============================================

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -1246,7 +1246,7 @@ export class ClassGenerator {
       this.emit(
         `call void @${this.ctx.mangleUserName(methodOwnerClass)}_${methodName}(${argValues})`,
       );
-      return "0";
+      return "0.0";
     } else {
       const result = this.nextTemp();
       this.emit(

--- a/tests/fixtures/functions/void-return-assignment.ts
+++ b/tests/fixtures/functions/void-return-assignment.ts
@@ -1,0 +1,9 @@
+function doNothing(): void {
+  return;
+}
+
+function test(): void {
+  const x = doNothing();
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- Assigning a void function's return value (`const x = voidFn()`) generated invalid LLVM IR: `store double 0` instead of `store double 0.0`
- The bare `0` is an integer literal in LLVM IR, not a valid double — this caused `opt` to reject the IR
- Fix: convert the `"0"` placeholder to `"0.0"` before emitting the double store

## Test plan
- [x] New fixture `functions/void-return-assignment.ts` passes
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)