### PR TITLE
fix: JSON.stringify integers, implement number array join, add NaN/Infinity

### DIFF
--- a/c_bridges/yyjson-bridge.c
+++ b/c_bridges/yyjson-bridge.c
@@ -125,7 +125,11 @@ void csyyjson_arr_add_str(void *doc, void *arr, const char *val) {
 
 void csyyjson_arr_add_num(void *doc, void *arr, double val) {
     if (!doc || !arr) return;
-    yyjson_mut_arr_add_real((yyjson_mut_doc *)doc, (yyjson_mut_val *)arr, val);
+    if (val == (double)(int64_t)val && val >= -9007199254740992.0 && val <= 9007199254740992.0) {
+        yyjson_mut_arr_add_int((yyjson_mut_doc *)doc, (yyjson_mut_val *)arr, (int64_t)val);
+    } else {
+        yyjson_mut_arr_add_real((yyjson_mut_doc *)doc, (yyjson_mut_val *)arr, val);
+    }
 }
 
 void *csyyjson_mut_get_root(void *doc) {
@@ -140,7 +144,11 @@ void csyyjson_obj_add_str(void *doc, void *obj, const char *key, const char *val
 
 void csyyjson_obj_add_num(void *doc, void *obj, const char *key, double val) {
     if (!doc || !obj || !key) return;
-    yyjson_mut_obj_add_real((yyjson_mut_doc *)doc, (yyjson_mut_val *)obj, key, val);
+    if (val == (double)(int64_t)val && val >= -9007199254740992.0 && val <= 9007199254740992.0) {
+        yyjson_mut_obj_add_int((yyjson_mut_doc *)doc, (yyjson_mut_val *)obj, key, (int64_t)val);
+    } else {
+        yyjson_mut_obj_add_real((yyjson_mut_doc *)doc, (yyjson_mut_val *)obj, key, val);
+    }
 }
 
 void csyyjson_obj_add_bool(void *doc, void *obj, const char *key, int val) {

--- a/src/codegen/expressions/variables.ts
+++ b/src/codegen/expressions/variables.ts
@@ -66,6 +66,16 @@ export class VariableExpressionGenerator {
       return temp;
     }
 
+    if (name === "NaN") {
+      this.ctx.setVariableType("0x7FF8000000000000", "double");
+      return "0x7FF8000000000000";
+    }
+
+    if (name === "Infinity") {
+      this.ctx.setVariableType("0x7FF0000000000000", "double");
+      return "0x7FF0000000000000";
+    }
+
     // Check if it's a class instance variable
     if (this.ctx.symbolTable.isClass(name)) {
       const classMeta = this.ctx.symbolTable.getClassInfo(name)!;

--- a/src/codegen/types/collections/array/combine.ts
+++ b/src/codegen/types/collections/array/combine.ts
@@ -387,7 +387,14 @@ export function generateArrayJoin(
     return generateStringArrayJoin(gen, arrayPtr, separator);
   }
 
-  // Numeric array join -- stub that allocates an empty buffer
+  return generateNumericArrayJoin(gen, arrayPtr, separator);
+}
+
+function generateNumericArrayJoin(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  separator: string,
+): string {
   const lenPtr = gen.nextTemp();
   gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
   const length = gen.emitLoad("i32", lenPtr);
@@ -398,11 +405,87 @@ export function generateArrayJoin(
 
   const bufferSize = 8192;
   const resultBuffer = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${bufferSize}`);
+  gen.emitStore("i8", "0", resultBuffer);
 
-  const nullByte = gen.nextTemp();
-  gen.emit(`${nullByte} = getelementptr inbounds i8, i8* ${resultBuffer}, i64 0`);
-  gen.emitStore("i8", "0", nullByte);
+  const offsetPtr = gen.nextAllocaReg("join_off");
+  gen.emit(`${offsetPtr} = alloca i64`);
+  gen.emitStore("i64", "0", offsetPtr);
 
+  const counterPtr = gen.nextAllocaReg("join_idx");
+  gen.emit(`${counterPtr} = alloca i32`);
+  gen.emitStore("i32", "0", counterPtr);
+
+  const sepLen = gen.emitCall("i64", "@strlen", `i8* ${separator}`);
+
+  const fmtInt = gen.createStringConstant("%.0f");
+  const fmtFloat = gen.createStringConstant("%.15g");
+
+  const checkLabel = gen.nextLabel("numjoin_check");
+  const bodyLabel = gen.nextLabel("numjoin_body");
+  const endLabel = gen.nextLabel("numjoin_end");
+
+  gen.emitBr(checkLabel);
+
+  gen.emitLabel(checkLabel);
+  const counter = gen.emitLoad("i32", counterPtr);
+  const cond = gen.emitIcmp("slt", "i32", counter, length);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
+
+  gen.emitLabel(bodyLabel);
+  const offset = gen.emitLoad("i64", offsetPtr);
+
+  const addSepLabel = gen.nextLabel("numjoin_sep");
+  const noSepLabel = gen.nextLabel("numjoin_nosep");
+  const afterSepLabel = gen.nextLabel("numjoin_after_sep");
+  const isFirst = gen.emitIcmp("eq", "i32", counter, "0");
+  gen.emitBrCond(isFirst, noSepLabel, addSepLabel);
+
+  gen.emitLabel(addSepLabel);
+  const sepOffset = gen.emitLoad("i64", offsetPtr);
+  const sepDest = gen.nextTemp();
+  gen.emit(`${sepDest} = getelementptr inbounds i8, i8* ${resultBuffer}, i64 ${sepOffset}`);
+  gen.emitCallVoid("@llvm.memcpy.p0i8.p0i8.i64", `i8* ${sepDest}, i8* ${separator}, i64 ${sepLen}, i1 false`);
+  const sepNewOff = gen.nextTemp();
+  gen.emit(`${sepNewOff} = add i64 ${sepOffset}, ${sepLen}`);
+  gen.emitStore("i64", sepNewOff, offsetPtr);
+  gen.emitBr(afterSepLabel);
+
+  gen.emitLabel(noSepLabel);
+  gen.emitBr(afterSepLabel);
+
+  gen.emitLabel(afterSepLabel);
+  const curOff = gen.emitLoad("i64", offsetPtr);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
+  const elemVal = gen.emitLoad("double", elemPtr);
+
+  const truncated = gen.nextTemp();
+  gen.emit(`${truncated} = fptosi double ${elemVal} to i64`);
+  const backToDouble = gen.nextTemp();
+  gen.emit(`${backToDouble} = sitofp i64 ${truncated} to double`);
+  const isInt = gen.nextTemp();
+  gen.emit(`${isInt} = fcmp oeq double ${elemVal}, ${backToDouble}`);
+  const fmt = gen.nextTemp();
+  gen.emit(`${fmt} = select i1 ${isInt}, i8* ${fmtInt}, i8* ${fmtFloat}`);
+
+  const dest = gen.nextTemp();
+  gen.emit(`${dest} = getelementptr inbounds i8, i8* ${resultBuffer}, i64 ${curOff}`);
+  const remaining = gen.nextTemp();
+  gen.emit(`${remaining} = sub i64 ${bufferSize}, ${curOff}`);
+  const written = gen.nextTemp();
+  gen.emit(`${written} = call i32 (i8*, i64, i8*, ...) @snprintf(i8* ${dest}, i64 ${remaining}, i8* ${fmt}, double ${elemVal})`);
+  const writtenI64 = gen.nextTemp();
+  gen.emit(`${writtenI64} = sext i32 ${written} to i64`);
+  const newOff = gen.nextTemp();
+  gen.emit(`${newOff} = add i64 ${curOff}, ${writtenI64}`);
+  gen.emitStore("i64", newOff, offsetPtr);
+
+  const nextCounter = gen.nextTemp();
+  gen.emit(`${nextCounter} = add i32 ${counter}, 1`);
+  gen.emitStore("i32", nextCounter, counterPtr);
+  gen.emitBr(checkLabel);
+
+  gen.emitLabel(endLabel);
   gen.setVariableType(resultBuffer, "i8*");
   return resultBuffer;
 }

--- a/src/codegen/types/collections/array/combine.ts
+++ b/src/codegen/types/collections/array/combine.ts
@@ -444,7 +444,10 @@ function generateNumericArrayJoin(
   const sepOffset = gen.emitLoad("i64", offsetPtr);
   const sepDest = gen.nextTemp();
   gen.emit(`${sepDest} = getelementptr inbounds i8, i8* ${resultBuffer}, i64 ${sepOffset}`);
-  gen.emitCallVoid("@llvm.memcpy.p0i8.p0i8.i64", `i8* ${sepDest}, i8* ${separator}, i64 ${sepLen}, i1 false`);
+  gen.emitCallVoid(
+    "@llvm.memcpy.p0i8.p0i8.i64",
+    `i8* ${sepDest}, i8* ${separator}, i64 ${sepLen}, i1 false`,
+  );
   const sepNewOff = gen.nextTemp();
   gen.emit(`${sepNewOff} = add i64 ${sepOffset}, ${sepLen}`);
   gen.emitStore("i64", sepNewOff, offsetPtr);
@@ -473,7 +476,9 @@ function generateNumericArrayJoin(
   const remaining = gen.nextTemp();
   gen.emit(`${remaining} = sub i64 ${bufferSize}, ${curOff}`);
   const written = gen.nextTemp();
-  gen.emit(`${written} = call i32 (i8*, i64, i8*, ...) @snprintf(i8* ${dest}, i64 ${remaining}, i8* ${fmt}, double ${elemVal})`);
+  gen.emit(
+    `${written} = call i32 (i8*, i64, i8*, ...) @snprintf(i8* ${dest}, i64 ${remaining}, i8* ${fmt}, double ${elemVal})`,
+  );
   const writtenI64 = gen.nextTemp();
   gen.emit(`${writtenI64} = sext i32 ${written} to i64`);
   const newOff = gen.nextTemp();

--- a/tests/fixtures/arrays/number-array-join.ts
+++ b/tests/fixtures/arrays/number-array-join.ts
@@ -1,0 +1,32 @@
+function test(): void {
+  const arr = [1, 2, 3];
+  const j1 = arr.join(", ");
+  if (j1 !== "1, 2, 3") {
+    console.log("FAIL comma: '" + j1 + "'");
+    return;
+  }
+
+  const floats = [1.5, 2.7, 3.14];
+  const j2 = floats.join("-");
+  if (j2 !== "1.5-2.7-3.14") {
+    console.log("FAIL floats: '" + j2 + "'");
+    return;
+  }
+
+  const empty: number[] = [];
+  const j3 = empty.join(",");
+  if (j3 !== "") {
+    console.log("FAIL empty: '" + j3 + "'");
+    return;
+  }
+
+  const single = [42];
+  const j4 = single.join(",");
+  if (j4 !== "42") {
+    console.log("FAIL single: '" + j4 + "'");
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/builtins/json-stringify-class.ts
+++ b/tests/fixtures/builtins/json-stringify-class.ts
@@ -13,7 +13,7 @@ class User {
 function test() {
   const u = new User("chad", 30, true);
   const result = JSON.stringify(u);
-  if (result === '{"name":"chad","age":30.0,"active":true}') {
+  if (result === '{"name":"chad","age":30,"active":true}') {
     console.log("TEST_PASSED");
   } else {
     console.log("FAIL: " + result);

--- a/tests/fixtures/builtins/json-stringify-integers.ts
+++ b/tests/fixtures/builtins/json-stringify-integers.ts
@@ -1,0 +1,24 @@
+interface Item {
+  name: string;
+  count: number;
+  ratio: number;
+}
+
+function test(): void {
+  const item: Item = { name: "test", count: 42, ratio: 3.14 };
+  const json = JSON.stringify(item);
+  if (json !== '{"name":"test","count":42,"ratio":3.14}') {
+    console.log("FAIL: " + json);
+    return;
+  }
+
+  const arr = [1, 2, 3];
+  const arrJson = JSON.stringify(arr);
+  if (arrJson !== "[1,2,3]") {
+    console.log("FAIL array: " + arrJson);
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/builtins/nan-infinity.ts
+++ b/tests/fixtures/builtins/nan-infinity.ts
@@ -1,0 +1,28 @@
+function test(): void {
+  if (Number.isNaN(NaN) !== true) {
+    console.log("FAIL isNaN NaN");
+    return;
+  }
+  if (Number.isNaN(42) !== false) {
+    console.log("FAIL isNaN 42");
+    return;
+  }
+  if (Number.isFinite(42) !== true) {
+    console.log("FAIL isFinite 42");
+    return;
+  }
+  if (Number.isFinite(Infinity) !== false) {
+    console.log("FAIL isFinite Infinity");
+    return;
+  }
+  if (Number.isInteger(42) !== true) {
+    console.log("FAIL isInteger 42");
+    return;
+  }
+  if (Number.isInteger(42.5) !== false) {
+    console.log("FAIL isInteger 42.5");
+    return;
+  }
+  console.log("TEST_PASSED");
+}
+test();

--- a/tests/fixtures/network/context-json-array.ts
+++ b/tests/fixtures/network/context-json-array.ts
@@ -22,7 +22,7 @@ function test(): void {
     headers: "",
     bodyLen: 0,
   });
-  if (r1.body !== '[{"name":"Alice","age":30.0}]') {
+  if (r1.body !== '[{"name":"Alice","age":30}]') {
     console.log("FAIL literal: " + r1.body);
     process.exit(1);
   }
@@ -35,7 +35,7 @@ function test(): void {
     headers: "",
     bodyLen: 0,
   });
-  if (r2.body !== '[{"name":"Alice","age":30.0}]') {
+  if (r2.body !== '[{"name":"Alice","age":30}]') {
     console.log("FAIL variable: " + r2.body);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- **JSON.stringify integers**: `JSON.stringify({count: 42})` now outputs `42` instead of `42.0`, matching JavaScript behavior. Fixed in yyjson bridge by detecting integer-valued doubles.
- **Number array join**: `[1,2,3].join(", ")` was returning empty string — the numeric join was a stub. Implemented proper loop with snprintf and integer detection.
- **NaN and Infinity globals**: `NaN` and `Infinity` are now recognized as global constants, enabling `Number.isNaN(NaN)`, `Number.isFinite(Infinity)`, etc.

## Test plan
- [x] `builtins/json-stringify-integers.ts` — JSON integer and float formatting
- [x] `arrays/number-array-join.ts` — number array join with commas, floats, empty, single
- [x] `builtins/nan-infinity.ts` — NaN/Infinity with Number.isNaN/isFinite/isInteger
- [x] Updated `json-stringify-class.ts` and `context-json-array.ts` for correct integer format
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)