### PR TITLE
fix: propagate declared interface type for nested inline object literals

### DIFF
--- a/src/codegen/types/objects/object.ts
+++ b/src/codegen/types/objects/object.ts
@@ -134,8 +134,22 @@ export class ObjectGenerator {
         } else if (tsType === "string[]") {
           this.ctx.setExpectedArrayElementType("string");
         }
+        const savedDeclaredInterface = this.ctx.getCurrentDeclaredInterfaceType();
+        if (tsType && valueExpr.type === "object") {
+          let resolvedFieldType = tsType;
+          if (resolvedFieldType.endsWith(" | null")) {
+            resolvedFieldType = resolvedFieldType.slice(0, resolvedFieldType.length - 7);
+          }
+          if (resolvedFieldType.endsWith(" | undefined")) {
+            resolvedFieldType = resolvedFieldType.slice(0, resolvedFieldType.length - 12);
+          }
+          if (this.ctx.interfaceStructGen?.hasInterface(resolvedFieldType)) {
+            this.ctx.setCurrentDeclaredInterfaceType(resolvedFieldType);
+          }
+        }
         finalValue = this.ctx.generateExpression(valueExpr, params);
         this.ctx.setExpectedArrayElementType(savedExpectedType);
+        this.ctx.setCurrentDeclaredInterfaceType(savedDeclaredInterface);
       }
 
       orderedFields.push({ key: field.name, llvmType, value: finalValue });
@@ -222,6 +236,7 @@ export class ObjectGenerator {
         }
       } else {
         const savedExpectedType = this.ctx.getExpectedArrayElementType();
+        const savedDeclaredInterface = this.ctx.getCurrentDeclaredInterfaceType();
         const tsType = fieldTsType;
         if (
           tsType &&
@@ -234,8 +249,21 @@ export class ObjectGenerator {
         } else if (tsType === "string[]") {
           this.ctx.setExpectedArrayElementType("string");
         }
+        if (tsType && valueExpr.type === "object") {
+          let resolvedFieldType = tsType;
+          if (resolvedFieldType.endsWith(" | null")) {
+            resolvedFieldType = resolvedFieldType.slice(0, resolvedFieldType.length - 7);
+          }
+          if (resolvedFieldType.endsWith(" | undefined")) {
+            resolvedFieldType = resolvedFieldType.slice(0, resolvedFieldType.length - 12);
+          }
+          if (this.ctx.interfaceStructGen?.hasInterface(resolvedFieldType)) {
+            this.ctx.setCurrentDeclaredInterfaceType(resolvedFieldType);
+          }
+        }
         const valueReg = this.ctx.generateExpression(valueExpr, params);
         this.ctx.setExpectedArrayElementType(savedExpectedType);
+        this.ctx.setCurrentDeclaredInterfaceType(savedDeclaredInterface);
         finalValue = valueReg;
         const valueType = this.ctx.getVariableType(valueReg) || "double";
         if (fieldLlvmType === "i1") {

--- a/tests/fixtures/objects/nested-inline-object.ts
+++ b/tests/fixtures/objects/nested-inline-object.ts
@@ -1,0 +1,43 @@
+// @test-skip
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface Line {
+  start: Point;
+  end: Point;
+}
+
+interface Inner {
+  value: string;
+}
+
+interface Outer {
+  inner: Inner | null;
+}
+
+function test(): void {
+  const line: Line = { start: { x: 10, y: 20 }, end: { x: 30, y: 40 } };
+  if (line.start.x !== 10 || line.start.y !== 20) {
+    console.log("FAIL start: " + line.start.x.toString() + "," + line.start.y.toString());
+    return;
+  }
+  if (line.end.x !== 30 || line.end.y !== 40) {
+    console.log("FAIL end");
+    return;
+  }
+
+  const o: Outer = { inner: { value: "hello" } };
+  if (o.inner === null) {
+    console.log("FAIL inner is null");
+    return;
+  }
+  if (o.inner.value !== "hello") {
+    console.log("FAIL inner value: " + o.inner.value);
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- Nested inline object literals (e.g. `{ start: { x: 10, y: 20 } }`) now correctly resolve the inner object's interface type instead of inheriting the parent's struct type
- Fixes codegen generating wrong struct allocation for inner objects, which caused all inner field values to be stored as zeros
- Test is @test-skip because the native compiler doesn't yet propagate `currentDeclaredInterfaceType` through the self-hosted path — JS compiler works correctly

## Test plan
- [x] `npm run verify:quick` passes
- [x] JS compiler correctly compiles nested inline object test
- [x] Self-hosting Stage 0 + Stage 1 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)