### PR TITLE
fix: add bounds checking to substr for negative/out-of-range start

### DIFF
--- a/src/codegen/types/collections/string/manipulation.ts
+++ b/src/codegen/types/collections/string/manipulation.ts
@@ -18,7 +18,17 @@ export function generateSubstr(
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
 
-  const startI32 = startIndex;
+  const startIsNeg = ctx.emitIcmp("slt", "i32", startIndex, "0");
+  const negAdjusted = ctx.nextTemp();
+  ctx.emit(`${negAdjusted} = add i32 ${strLenI32}, ${startIndex}`);
+  const afterNeg = ctx.nextTemp();
+  ctx.emit(`${afterNeg} = select i1 ${startIsNeg}, i32 ${negAdjusted}, i32 ${startIndex}`);
+  const stillNeg = ctx.emitIcmp("slt", "i32", afterNeg, "0");
+  const clampedLow = ctx.nextTemp();
+  ctx.emit(`${clampedLow} = select i1 ${stillNeg}, i32 0, i32 ${afterNeg}`);
+  const startTooBig = ctx.emitIcmp("sgt", "i32", clampedLow, strLenI32);
+  const startI32 = ctx.nextTemp();
+  ctx.emit(`${startI32} = select i1 ${startTooBig}, i32 ${strLenI32}, i32 ${clampedLow}`);
 
   let substrLen: string;
   if (length === null) {

--- a/tests/fixtures/strings/substr-bounds.ts
+++ b/tests/fixtures/strings/substr-bounds.ts
@@ -1,0 +1,42 @@
+function test(): void {
+  const s = "hello world";
+
+  const r1 = s.substr(0, 5);
+  if (r1 !== "hello") {
+    console.log("FAIL basic: " + r1);
+    return;
+  }
+
+  const r2 = s.substr(-5);
+  if (r2 !== "world") {
+    console.log("FAIL negative start: " + r2);
+    return;
+  }
+
+  const r3 = s.substr(-100);
+  if (r3 !== "hello world") {
+    console.log("FAIL very negative: " + r3);
+    return;
+  }
+
+  const r4 = s.substr(100);
+  if (r4 !== "") {
+    console.log("FAIL past end: " + r4);
+    return;
+  }
+
+  const r5 = s.substr(6, 5);
+  if (r5 !== "world") {
+    console.log("FAIL mid: " + r5);
+    return;
+  }
+
+  const r6 = s.substr(0, 100);
+  if (r6 !== "hello world") {
+    console.log("FAIL len too long: " + r6);
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- `substr()` with negative start index (e.g. `"hello".substr(-3)`) now correctly wraps around instead of reading out-of-bounds memory
- Start indices beyond string length now return empty string instead of accessing invalid memory
- Same clamping pattern as `slice()` — handles negative, too-small, and too-large indices

## Test plan
- [x] New `substr-bounds.ts` fixture covering: basic, negative start, very negative, past end, mid, length too long
- [x] `npm run verify:quick` passes (tests + self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)