### PR TITLE
fix: add bounds checking to array index assignment

### DIFF
--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -684,6 +684,11 @@ export class IndexAccessGenerator {
   ): string {
     const arrayPtr = this.ctx.generateExpression(expr.object, params);
 
+    const indexDouble = this.ctx.generateExpression(expr.index, params);
+    const index = this.toI32Index(indexDouble);
+
+    this.emitBoundsCheck(arrayPtr, "%StringArray", index);
+
     const dataFieldPtr = this.ctx.nextTemp();
     this.ctx.emit(
       `${dataFieldPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
@@ -691,16 +696,6 @@ export class IndexAccessGenerator {
     const dataPtr = this.ctx.nextTemp();
     this.ctx.emit(`${dataPtr} = load i8**, i8*** ${dataFieldPtr}`);
 
-    const indexDouble = this.ctx.generateExpression(expr.index, params);
-    const indexType = this.ctx.getVariableType(indexDouble);
-    let index = indexDouble;
-    if (indexType === "double") {
-      index = this.ctx.nextTemp();
-      this.ctx.emit(`${index} = fptosi double ${indexDouble} to i32`);
-    } else if (indexType === "i64") {
-      index = this.ctx.nextTemp();
-      this.ctx.emit(`${index} = trunc i64 ${indexDouble} to i32`);
-    }
     const indexI64 = this.ctx.nextTemp();
     this.ctx.emit(`${indexI64} = sext i32 ${index} to i64`);
 
@@ -719,6 +714,11 @@ export class IndexAccessGenerator {
   ): string {
     const arrayPtr = this.ctx.generateExpression(expr.object, params);
 
+    const indexDouble = this.ctx.generateExpression(expr.index, params);
+    const index = this.toI32Index(indexDouble);
+
+    this.emitBoundsCheck(arrayPtr, "%ObjectArray", index);
+
     const dataFieldPtr = this.ctx.nextTemp();
     this.ctx.emit(
       `${dataFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
@@ -728,16 +728,6 @@ export class IndexAccessGenerator {
     const dataAsPtrs = this.ctx.nextTemp();
     this.ctx.emit(`${dataAsPtrs} = bitcast i8* ${data} to i8**`);
 
-    const indexDouble = this.ctx.generateExpression(expr.index, params);
-    const indexType = this.ctx.getVariableType(indexDouble);
-    let index = indexDouble;
-    if (indexType === "double") {
-      index = this.ctx.nextTemp();
-      this.ctx.emit(`${index} = fptosi double ${indexDouble} to i32`);
-    } else if (indexType === "i64") {
-      index = this.ctx.nextTemp();
-      this.ctx.emit(`${index} = trunc i64 ${indexDouble} to i32`);
-    }
     const indexI64 = this.ctx.nextTemp();
     this.ctx.emit(`${indexI64} = sext i32 ${index} to i64`);
 
@@ -758,6 +748,11 @@ export class IndexAccessGenerator {
   ): string {
     const arrayPtr = this.ctx.generateExpression(expr.object, params);
 
+    const indexDouble = this.ctx.generateExpression(expr.index, params);
+    const index = this.toI32Index(indexDouble);
+
+    this.emitBoundsCheck(arrayPtr, "%Array", index);
+
     const dataFieldPtr = this.ctx.nextTemp();
     this.ctx.emit(
       `${dataFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`,
@@ -765,16 +760,6 @@ export class IndexAccessGenerator {
     const dataPtr = this.ctx.nextTemp();
     this.ctx.emit(`${dataPtr} = load double*, double** ${dataFieldPtr}`);
 
-    const indexDouble = this.ctx.generateExpression(expr.index, params);
-    const indexType = this.ctx.getVariableType(indexDouble);
-    let index = indexDouble;
-    if (indexType === "double") {
-      index = this.ctx.nextTemp();
-      this.ctx.emit(`${index} = fptosi double ${indexDouble} to i32`);
-    } else if (indexType === "i64") {
-      index = this.ctx.nextTemp();
-      this.ctx.emit(`${index} = trunc i64 ${indexDouble} to i32`);
-    }
     const indexI64 = this.ctx.nextTemp();
     this.ctx.emit(`${indexI64} = sext i32 ${index} to i64`);
 

--- a/tests/fixtures/arrays/assignment-bounds.ts
+++ b/tests/fixtures/arrays/assignment-bounds.ts
@@ -1,0 +1,17 @@
+// @test-exit-code: 1
+function test(): void {
+  const arr: number[] = [1, 2, 3];
+  arr[0] = 10;
+  if (arr[0] !== 10) {
+    console.log("FAIL basic assignment");
+    return;
+  }
+  arr[2] = 30;
+  if (arr[2] !== 30) {
+    console.log("FAIL index 2 assignment");
+    return;
+  }
+  arr[5] = 99;
+  console.log("FAIL should have crashed on out-of-bounds write");
+}
+test();


### PR DESCRIPTION
## Summary
- Array index writes (`arr[i] = val`) now have the same bounds checking as reads — previously only reads had `@__cs_bounds_check`, writes could silently corrupt memory
- Applies to all three array types: `number[]`, `string[]`, and `object[]`
- Also refactored assignment index conversion to use shared `toI32Index` helper

## Test plan
- [x] New `assignment-bounds.ts` fixture: verifies valid writes work and out-of-bounds write triggers error
- [x] `npm run verify:quick` passes (tests + self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)