### PR TITLE
fix: recognize NaN and Infinity as built-in globals in semantic analyzer

### DIFF
--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -721,6 +721,9 @@ export class SemanticAnalyzer {
       if (varExpr.name === "null" || varExpr.name === "undefined") {
         return { name: varExpr.name, type: "null", llvmType: "i8*" };
       }
+      if (varExpr.name === "NaN" || varExpr.name === "Infinity") {
+        return { name: varExpr.name, type: "number", llvmType: "double" };
+      }
       const symbol = this.symbols.get(varExpr.name);
       if (!symbol) {
         this.errors.push({

--- a/tests/fixtures/edge-cases/comprehensive-safety.ts
+++ b/tests/fixtures/edge-cases/comprehensive-safety.ts
@@ -1,0 +1,62 @@
+function test(): void {
+  const nums: number[] = [10, 20, 30];
+  nums[0] = 100;
+  if (nums[0] !== 100) {
+    console.log("FAIL array assign");
+    return;
+  }
+
+  const strs: string[] = ["a", "b", "c"];
+  strs[1] = "x";
+  if (strs[1] !== "x") {
+    console.log("FAIL string array assign");
+    return;
+  }
+
+  const s = "hello world";
+  const sub1 = s.substr(6);
+  if (sub1 !== "world") {
+    console.log("FAIL substr: " + sub1);
+    return;
+  }
+
+  const sub2 = s.slice(-5);
+  if (sub2 !== "world") {
+    console.log("FAIL slice neg: " + sub2);
+    return;
+  }
+
+  const r = "ab".repeat(3);
+  if (r !== "ababab") {
+    console.log("FAIL repeat: " + r);
+    return;
+  }
+
+  const mod1 = 10 % 3;
+  if (mod1 !== 1) {
+    console.log("FAIL modulo: " + mod1.toString());
+    return;
+  }
+
+  const x = 42;
+  const y = parseInt(x.toString());
+  if (y !== 42) {
+    console.log("FAIL parseInt: " + y.toString());
+    return;
+  }
+
+  const inf = Infinity;
+  if (inf <= 0) {
+    console.log("FAIL Infinity");
+    return;
+  }
+
+  const nan = NaN;
+  if (!isNaN(nan)) {
+    console.log("FAIL NaN");
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- Programs using `NaN` or `Infinity` were rejected with "Reference to undeclared variable" by the semantic analyzer
- Added recognition of these two JavaScript built-in globals so they pass semantic analysis
- Added comprehensive safety test exercising array assignment, substr, slice, repeat, modulo, parseInt, Infinity, and NaN

## Test plan
- [x] New test fixture `edge-cases/comprehensive-safety.ts` passes
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)