### PR TITLE
feat: implement string.at() method with negative index support

### DIFF
--- a/src/codegen/expressions/method-calls/string-dispatch.ts
+++ b/src/codegen/expressions/method-calls/string-dispatch.ts
@@ -24,6 +24,7 @@ import {
   handleNumberToString,
   handleNumberToFixed,
   handleCharAt,
+  handleStringAt,
   handleCharCodeAt,
   handleToUpperCase,
   handleToLowerCase,
@@ -158,6 +159,11 @@ function dispatchStringReplaceCase(
     const err = rejectNonString(ctx, method, expr);
     if (err) return err;
     return handleCharAt(ctx, expr, params);
+  }
+  if (method === "at") {
+    const err = rejectNonString(ctx, method, expr);
+    if (err) return err;
+    return handleStringAt(ctx, expr, params);
   }
   if (method === "charCodeAt") {
     const err = rejectNonString(ctx, method, expr);

--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -655,6 +655,22 @@ export function handleCharAt(
   return ctx.stringGen.doGenerateCharAt(strPtr, indexI32);
 }
 
+export function handleStringAt(
+  ctx: MethodCallGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+): string {
+  const strPtr = ctx.generateExpression(expr.object, params);
+
+  if (expr.args.length !== 1) {
+    return ctx.emitError("at() expects 1 argument, got " + expr.args.length, expr.loc);
+  }
+
+  const indexDouble = ctx.generateExpression(expr.args[0], params);
+  const indexI32 = convertToI32(ctx, indexDouble);
+  return ctx.stringGen.doGenerateStringAt(strPtr, indexI32);
+}
+
 export function handleCharCodeAt(
   ctx: MethodCallGeneratorContext,
   expr: MethodCallNode,

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -93,6 +93,7 @@ export interface IStringGenerator {
   doGenerateIncludes(strPtr: string, substring: string): string;
   doGenerateSlice(strPtr: string, start: string, end: string | null): string;
   doGenerateCharAt(strPtr: string, index: string): string;
+  doGenerateStringAt(strPtr: string, index: string): string;
   doGenerateCharCodeAt(strPtr: string, index: string): string;
   doGenerateReplace(strPtr: string, search: string, replace: string): string;
   doGenerateReplaceAll(strPtr: string, search: string, replace: string): string;
@@ -1700,6 +1701,7 @@ export class MockGeneratorContext implements IGeneratorContext {
     doGenerateIncludes: (_strPtr: string, _substring: string): string => "%0",
     doGenerateSlice: (_strPtr: string, _start: string, _end: string | null): string => "%0",
     doGenerateCharAt: (_strPtr: string, _index: string): string => "%0",
+    doGenerateStringAt: (_strPtr: string, _index: string): string => "%0",
     doGenerateCharCodeAt: (_strPtr: string, _index: string): string => "%0",
     doGenerateReplace: (_strPtr: string, _search: string, _replace: string): string => "%0",
     doGenerateReplaceAll: (_strPtr: string, _search: string, _replace: string): string => "%0",

--- a/src/codegen/types/collections/string.ts
+++ b/src/codegen/types/collections/string.ts
@@ -24,6 +24,7 @@ import {
 import {
   generateStartsWith,
   generateCharAt,
+  generateStringAt,
   generateCharCodeAt,
   generateIndexOf,
   generateLastIndexOf,
@@ -121,6 +122,10 @@ export class StringGenerator implements IStringGenerator {
 
   doGenerateCharAt(strPtr: string, index: string): string {
     return generateCharAt(this.ctx, strPtr, index);
+  }
+
+  doGenerateStringAt(strPtr: string, index: string): string {
+    return generateStringAt(this.ctx, strPtr, index);
   }
 
   doGenerateCharCodeAt(strPtr: string, index: string): string {

--- a/src/codegen/types/collections/string/search.ts
+++ b/src/codegen/types/collections/string/search.ts
@@ -65,6 +65,52 @@ export function generateCharAt(ctx: IGeneratorContext, strPtr: string, index: st
   return result;
 }
 
+export function generateStringAt(ctx: IGeneratorContext, strPtr: string, index: string): string {
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
+  const strLenI32 = ctx.nextTemp();
+  ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
+
+  const isNeg = ctx.emitIcmp("slt", "i32", index, "0");
+  const adjusted = ctx.nextTemp();
+  ctx.emit(`${adjusted} = add i32 ${index}, ${strLenI32}`);
+  const resolved = ctx.nextTemp();
+  ctx.emit(`${resolved} = select i1 ${isNeg}, i32 ${adjusted}, i32 ${index}`);
+
+  const inBoundsLow = ctx.emitIcmp("sge", "i32", resolved, "0");
+  const inBoundsHigh = ctx.emitIcmp("slt", "i32", resolved, strLenI32);
+  const inBounds = ctx.nextTemp();
+  ctx.emit(`${inBounds} = and i1 ${inBoundsLow}, ${inBoundsHigh}`);
+
+  const validLabel = ctx.nextLabel("at_valid");
+  const oobLabel = ctx.nextLabel("at_oob");
+  const endLabel = ctx.nextLabel("at_end");
+
+  ctx.emitBrCond(inBounds, validLabel, oobLabel);
+
+  ctx.emitLabel(validLabel);
+  const indexI64 = ctx.nextTemp();
+  ctx.emit(`${indexI64} = sext i32 ${resolved} to i64`);
+  const charPtr = ctx.nextTemp();
+  ctx.emit(`${charPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${indexI64}`);
+  const charI8 = ctx.emitLoad("i8", charPtr);
+  const resultPtr = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 2");
+  ctx.emitStore("i8", charI8, resultPtr);
+  const nullPtr = ctx.nextTemp();
+  ctx.emit(`${nullPtr} = getelementptr inbounds i8, i8* ${resultPtr}, i64 1`);
+  ctx.emitStore("i8", "0", nullPtr);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(oobLabel);
+  const emptyStr = ctx.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  ctx.emitStore("i8", "0", emptyStr);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(endLabel);
+  const result = ctx.nextTemp();
+  ctx.emit(`${result} = phi i8* [${resultPtr}, %${validLabel}], [${emptyStr}, %${oobLabel}]`);
+  return result;
+}
+
 export function generateCharCodeAt(ctx: IGeneratorContext, strPtr: string, index: string): string {
   const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();

--- a/tests/fixtures/strings/string-at.ts
+++ b/tests/fixtures/strings/string-at.ts
@@ -1,0 +1,36 @@
+function test(): void {
+  const s = "hello";
+
+  if (s.at(0) !== "h") {
+    console.log("FAIL at(0): " + s.at(0));
+    return;
+  }
+
+  if (s.at(4) !== "o") {
+    console.log("FAIL at(4): " + s.at(4));
+    return;
+  }
+
+  if (s.at(-1) !== "o") {
+    console.log("FAIL at(-1): " + s.at(-1));
+    return;
+  }
+
+  if (s.at(-5) !== "h") {
+    console.log("FAIL at(-5): " + s.at(-5));
+    return;
+  }
+
+  if (s.at(5) !== "") {
+    console.log("FAIL at(5) oob: " + s.at(5));
+    return;
+  }
+
+  if (s.at(-6) !== "") {
+    console.log("FAIL at(-6) oob: " + s.at(-6));
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- Implement `String.at()` ES2022 method — like `charAt()` but supports negative indices
- `s.at(-1)` returns last character, `s.at(-2)` returns second-to-last, etc.
- Out-of-bounds indices (positive or negative) return empty string
- Full bounds checking with no undefined behavior

## Test plan
- [x] New test fixture `strings/string-at.ts` covers positive, negative, and OOB indices
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)