### PR TITLE
feat: implement Array.at() with negative index support

### DIFF
--- a/src/codegen/expressions/method-calls/string-dispatch.ts
+++ b/src/codegen/expressions/method-calls/string-dispatch.ts
@@ -160,7 +160,12 @@ function dispatchStringReplaceCase(
     if (err) return err;
     return handleCharAt(ctx, expr, params);
   }
-  if (method === "at") {
+  if (
+    method === "at" &&
+    !ctx.isArrayExpression(expr.object) &&
+    !ctx.isStringArrayExpression(expr.object) &&
+    !ctx.isObjectArrayExpression(expr.object)
+  ) {
     const err = rejectNonString(ctx, method, expr);
     if (err) return err;
     return handleStringAt(ctx, expr, params);
@@ -328,5 +333,12 @@ export function dispatchArrayMethod(
     return ctx.arrayGen.generateArrayConcat(expr, params);
   const reorder = dispatchArrayReorder(ctx, method, expr, params);
   if (reorder) return reorder;
+  if (
+    method === "at" &&
+    (ctx.isArrayExpression(expr.object) ||
+      ctx.isStringArrayExpression(expr.object) ||
+      ctx.isObjectArrayExpression(expr.object))
+  )
+    return ctx.arrayGen.generateArrayAt(expr, params);
   return null;
 }

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -315,6 +315,7 @@ export interface IArrayGenerator {
   generateArrayShift(expr: MethodCallNode, params: string[]): string;
   generateArrayUnshift(expr: MethodCallNode, params: string[]): string;
   generateArrayIndexOf(expr: MethodCallNode, params: string[]): string;
+  generateArrayAt(expr: MethodCallNode, params: string[]): string;
   generateArrayFindIndex(expr: MethodCallNode, params: string[]): string;
   generateArraySort(expr: MethodCallNode, params: string[]): string;
   generateArraySplice(expr: MethodCallNode, params: string[]): string;
@@ -2065,6 +2066,7 @@ export class MockGeneratorContext implements IGeneratorContext {
       "%mock_array_unshift",
     generateArrayIndexOf: (_expr: MethodCallNode, _params: string[]): string =>
       "%mock_array_indexof",
+    generateArrayAt: (_expr: MethodCallNode, _params: string[]): string => "%mock_array_at",
     generateArrayFindIndex: (_expr: MethodCallNode, _params: string[]): string =>
       "%mock_array_findindex",
     generateArraySort: (_expr: MethodCallNode, _params: string[]): string => "%mock_array_sort",

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -387,9 +387,14 @@ export class TypeInference {
       method === "trimEnd" ||
       method === "toFixed" ||
       method === "normalize" ||
-      method === "at" ||
       method === "getVariableType"
     ) {
+      return this.ctx.typeContext.stringType;
+    }
+
+    if (method === "at") {
+      if (this.isArrayExpression(expr.object)) return this.ctx.typeContext.numberType;
+      if (this.isStringArrayExpression(expr.object)) return this.ctx.typeContext.stringType;
       return this.ctx.typeContext.stringType;
     }
 

--- a/src/codegen/types/collections/array.ts
+++ b/src/codegen/types/collections/array.ts
@@ -11,7 +11,7 @@ import { IGeneratorContext } from "../../infrastructure/generator-context.js";
 import { generateArrayLiteral } from "./array/literal.js";
 import { generateArrayPush, generateArrayPop } from "./array/mutators.js";
 import { generateArrayReverse, generateArrayShift, generateArrayUnshift } from "./array/reorder.js";
-import { generateArrayIndexOf, generateArrayFindIndex } from "./array/search.js";
+import { generateArrayIndexOf, generateArrayFindIndex, generateArrayAt } from "./array/search.js";
 import { generateArraySplice } from "./array/splice.js";
 import { generateArraySort } from "./array/sort.js";
 import {
@@ -121,6 +121,10 @@ export class ArrayGenerator {
 
   generateArrayIndexOf(expr: MethodCallNode, params: string[]): string {
     return generateArrayIndexOf(this.ctx, expr, params);
+  }
+
+  generateArrayAt(expr: MethodCallNode, params: string[]): string {
+    return generateArrayAt(this.ctx, expr, params);
   }
 
   generateArrayFindIndex(expr: MethodCallNode, params: string[]): string {

--- a/src/codegen/types/collections/array/search.ts
+++ b/src/codegen/types/collections/array/search.ts
@@ -376,3 +376,183 @@ function generateStringArrayFindIndex(
   gen.setVariableType(result, "double");
   return result;
 }
+
+export function generateArrayAt(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+): string {
+  if (expr.args.length !== 1) {
+    return gen.emitError("at() expects 1 argument, got " + expr.args.length, expr.loc);
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  const indexRaw = gen.generateExpression(expr.args[0], params);
+  const indexDouble = gen.ensureDouble(indexRaw);
+
+  let isStringArray = false;
+  let isObjectArray = false;
+  const exprObjBase = expr.object as ExprBase;
+  if (exprObjBase.type === "variable") {
+    const varName = (expr.object as VariableNode).name;
+    const varType = gen.getVariableType(varName);
+    isStringArray = varType === "%StringArray*" || varType === "%StringArray";
+    isObjectArray = varType === "%ObjectArray*" || varType === "%ObjectArray";
+  }
+  if (!isStringArray && !isObjectArray) {
+    const ptrType = gen.getVariableType(arrayPtr);
+    if (ptrType === "%StringArray*" || ptrType === "%StringArray") isStringArray = true;
+    if (ptrType === "%ObjectArray*" || ptrType === "%ObjectArray") isObjectArray = true;
+  }
+
+  if (isStringArray) return generateStringArrayAt(gen, arrayPtr, indexDouble);
+  if (isObjectArray) return generateObjectArrayAt(gen, arrayPtr, indexDouble);
+  return generateNumericArrayAt(gen, arrayPtr, indexDouble);
+}
+
+function resolveNegativeIndex(gen: IGeneratorContext, indexDouble: string, length: string): string {
+  const indexI32 = gen.nextTemp();
+  gen.emit(`${indexI32} = fptosi double ${indexDouble} to i32`);
+  const isNeg = gen.emitIcmp("slt", "i32", indexI32, "0");
+  const adjusted = gen.nextTemp();
+  gen.emit(`${adjusted} = add i32 ${indexI32}, ${length}`);
+  const resolved = gen.nextTemp();
+  gen.emit(`${resolved} = select i1 ${isNeg}, i32 ${adjusted}, i32 ${indexI32}`);
+  return resolved;
+}
+
+function generateNumericArrayAt(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  indexDouble: string,
+): string {
+  const lenPtr = gen.nextTemp();
+  gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
+  const length = gen.emitLoad("i32", lenPtr);
+  const resolved = resolveNegativeIndex(gen, indexDouble, length);
+
+  const inLow = gen.emitIcmp("sge", "i32", resolved, "0");
+  const inHigh = gen.emitIcmp("slt", "i32", resolved, length);
+  const inBounds = gen.nextTemp();
+  gen.emit(`${inBounds} = and i1 ${inLow}, ${inHigh}`);
+
+  const validLabel = gen.nextLabel("at_valid");
+  const oobLabel = gen.nextLabel("at_oob");
+  const endLabel = gen.nextLabel("at_end");
+  gen.emitBrCond(inBounds, validLabel, oobLabel);
+
+  gen.emitLabel(validLabel);
+  const dataPtrField = gen.nextTemp();
+  gen.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
+  const dataPtr = gen.emitLoad("double*", dataPtrField);
+  const indexI64 = gen.nextTemp();
+  gen.emit(`${indexI64} = sext i32 ${resolved} to i64`);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i64 ${indexI64}`);
+  const validVal = gen.emitLoad("double", elemPtr);
+  gen.emitBr(endLabel);
+
+  gen.emitLabel(oobLabel);
+  gen.emitBr(endLabel);
+
+  gen.emitLabel(endLabel);
+  const resultNum = gen.nextTemp();
+  gen.emit(
+    `${resultNum} = phi double [${validVal}, %${validLabel}], [0x7FF8000000000000, %${oobLabel}]`,
+  );
+  gen.setVariableType(resultNum, "double");
+  return resultNum;
+}
+
+function generateStringArrayAt(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  indexDouble: string,
+): string {
+  const lenPtr = gen.nextTemp();
+  gen.emit(
+    `${lenPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
+  );
+  const length = gen.emitLoad("i32", lenPtr);
+  const resolved = resolveNegativeIndex(gen, indexDouble, length);
+
+  const inLow = gen.emitIcmp("sge", "i32", resolved, "0");
+  const inHigh = gen.emitIcmp("slt", "i32", resolved, length);
+  const inBounds = gen.nextTemp();
+  gen.emit(`${inBounds} = and i1 ${inLow}, ${inHigh}`);
+
+  const validLabel = gen.nextLabel("at_valid");
+  const oobLabel = gen.nextLabel("at_oob");
+  const endLabel = gen.nextLabel("at_end");
+  gen.emitBrCond(inBounds, validLabel, oobLabel);
+
+  gen.emitLabel(validLabel);
+  const dataPtrField = gen.nextTemp();
+  gen.emit(
+    `${dataPtrField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
+  );
+  const dataPtr = gen.emitLoad("i8**", dataPtrField);
+  const indexI64 = gen.nextTemp();
+  gen.emit(`${indexI64} = sext i32 ${resolved} to i64`);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i64 ${indexI64}`);
+  const validVal = gen.emitLoad("i8*", elemPtr);
+  gen.emitBr(endLabel);
+
+  gen.emitLabel(oobLabel);
+  const emptyStr = gen.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  gen.emitStore("i8", "0", emptyStr);
+  gen.emitBr(endLabel);
+
+  gen.emitLabel(endLabel);
+  const resultStr = gen.nextTemp();
+  gen.emit(`${resultStr} = phi i8* [${validVal}, %${validLabel}], [${emptyStr}, %${oobLabel}]`);
+  return resultStr;
+}
+
+function generateObjectArrayAt(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  indexDouble: string,
+): string {
+  const lenPtr = gen.nextTemp();
+  gen.emit(
+    `${lenPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
+  );
+  const length = gen.emitLoad("i32", lenPtr);
+  const resolved = resolveNegativeIndex(gen, indexDouble, length);
+
+  const inLow = gen.emitIcmp("sge", "i32", resolved, "0");
+  const inHigh = gen.emitIcmp("slt", "i32", resolved, length);
+  const inBounds = gen.nextTemp();
+  gen.emit(`${inBounds} = and i1 ${inLow}, ${inHigh}`);
+
+  const validLabel = gen.nextLabel("at_valid");
+  const oobLabel = gen.nextLabel("at_oob");
+  const endLabel = gen.nextLabel("at_end");
+  gen.emitBrCond(inBounds, validLabel, oobLabel);
+
+  gen.emitLabel(validLabel);
+  const dataPtrField = gen.nextTemp();
+  gen.emit(
+    `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+  );
+  const rawDataPtr = gen.emitLoad("i8*", dataPtrField);
+  const dataPtr = gen.emitBitcast(rawDataPtr, "i8*", "i8**");
+  const indexI64 = gen.nextTemp();
+  gen.emit(`${indexI64} = sext i32 ${resolved} to i64`);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i64 ${indexI64}`);
+  const validVal = gen.emitLoad("i8*", elemPtr);
+  gen.emitBr(endLabel);
+
+  gen.emitLabel(oobLabel);
+  const nullPtr = gen.nextTemp();
+  gen.emit(`${nullPtr} = inttoptr i64 0 to i8*`);
+  gen.emitBr(endLabel);
+
+  gen.emitLabel(endLabel);
+  const resultObj = gen.nextTemp();
+  gen.emit(`${resultObj} = phi i8* [${validVal}, %${validLabel}], [${nullPtr}, %${oobLabel}]`);
+  return resultObj;
+}

--- a/tests/fixtures/arrays/array-at.ts
+++ b/tests/fixtures/arrays/array-at.ts
@@ -1,0 +1,50 @@
+function test(): void {
+  const nums: number[] = [10, 20, 30, 40, 50];
+
+  const a = nums.at(0);
+  if (a !== 10) {
+    console.log("FAIL at(0)");
+    return;
+  }
+
+  const b = nums.at(4);
+  if (b !== 50) {
+    console.log("FAIL at(4)");
+    return;
+  }
+
+  const c = nums.at(-1);
+  if (c !== 50) {
+    console.log("FAIL at(-1)");
+    return;
+  }
+
+  const d = nums.at(-5);
+  if (d !== 10) {
+    console.log("FAIL at(-5)");
+    return;
+  }
+
+  const strs: string[] = ["a", "b", "c"];
+
+  const e = strs.at(0);
+  if (e !== "a") {
+    console.log("FAIL str at(0): " + e);
+    return;
+  }
+
+  const f = strs.at(-1);
+  if (f !== "c") {
+    console.log("FAIL str at(-1): " + f);
+    return;
+  }
+
+  const g = strs.at(3);
+  if (g !== "") {
+    console.log("FAIL str at(3) oob");
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- Implement `Array.at()` ES2022 method for number[], string[], and object[] arrays
- Supports negative indices: `arr.at(-1)` returns last element, `arr.at(-2)` second-to-last, etc.
- Out-of-bounds returns NaN for number arrays, empty string for string arrays, null for object arrays
- Previously, calling `.at()` on an array gave a confusing "only available on strings" error

## Test plan
- [x] New test fixture `arrays/array-at.ts` covers positive, negative, and OOB indices for number and string arrays
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)