### PR TITLE
fix: parseInt/parseFloat return NaN for non-numeric strings

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -430,7 +430,9 @@ export class CallExpressionGenerator {
 
     this.ctx.emitLabel(endLabel);
     const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = phi double [${resultDouble}, %${validLabel}], [0x7FF8000000000000, %${nanLabel}]`);
+    this.ctx.emit(
+      `${result} = phi double [${resultDouble}, %${validLabel}], [0x7FF8000000000000, %${nanLabel}]`,
+    );
 
     return result;
   }
@@ -462,7 +464,9 @@ export class CallExpressionGenerator {
 
     this.ctx.emitLabel(endLabel);
     const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = phi double [${rawResult}, %${validLabel}], [0x7FF8000000000000, %${nanLabel}]`);
+    this.ctx.emit(
+      `${result} = phi double [${rawResult}, %${validLabel}], [0x7FF8000000000000, %${nanLabel}]`,
+    );
     return result;
   }
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -402,22 +402,37 @@ export class CallExpressionGenerator {
       radixValue = "10";
     }
 
-    // Call strtol(str, null, radix)
-    // strtol returns i64, we'll truncate to i32 and then convert to double
-    const nullPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nullPtr} = inttoptr i32 0 to i8**`);
+    const endPtrPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${endPtrPtr} = alloca i8*`);
 
     const resultI64 = this.ctx.emitCall(
       "i64",
       "@strtol",
-      `i8* ${strValue}, i8** ${nullPtr}, i32 ${radixValue}`,
+      `i8* ${strValue}, i8** ${endPtrPtr}, i32 ${radixValue}`,
     );
 
-    // Convert i64 to double for compatibility with ChadScript's numeric type
+    const endPtr = this.ctx.emitLoad("i8*", endPtrPtr);
+    const noCharsConsumed = this.ctx.emitIcmp("eq", "i8*", endPtr, strValue);
+
+    const validLabel = this.ctx.nextLabel("parseint_valid");
+    const nanLabel = this.ctx.nextLabel("parseint_nan");
+    const endLabel = this.ctx.nextLabel("parseint_end");
+
+    this.ctx.emitBrCond(noCharsConsumed, nanLabel, validLabel);
+
+    this.ctx.emitLabel(validLabel);
     const resultDouble = this.ctx.nextTemp();
     this.ctx.emit(`${resultDouble} = sitofp i64 ${resultI64} to double`);
+    this.ctx.emitBr(endLabel);
 
-    return resultDouble;
+    this.ctx.emitLabel(nanLabel);
+    this.ctx.emitBr(endLabel);
+
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = phi double [${resultDouble}, %${validLabel}], [0x7FF8000000000000, %${nanLabel}]`);
+
+    return result;
   }
 
   private generateParseFloat(expr: CallNode, params: string[]): string {
@@ -426,9 +441,28 @@ export class CallExpressionGenerator {
     }
 
     const strValue = this.ctx.generateExpression(expr.args[0], params);
-    const nullPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${nullPtr} = inttoptr i32 0 to i8**`);
-    const result = this.ctx.emitCall("double", "@strtod", `i8* ${strValue}, i8** ${nullPtr}`);
+    const endPtrPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${endPtrPtr} = alloca i8*`);
+    const rawResult = this.ctx.emitCall("double", "@strtod", `i8* ${strValue}, i8** ${endPtrPtr}`);
+
+    const endPtr = this.ctx.emitLoad("i8*", endPtrPtr);
+    const noCharsConsumed = this.ctx.emitIcmp("eq", "i8*", endPtr, strValue);
+
+    const validLabel = this.ctx.nextLabel("parsefloat_valid");
+    const nanLabel = this.ctx.nextLabel("parsefloat_nan");
+    const endLabel = this.ctx.nextLabel("parsefloat_end");
+
+    this.ctx.emitBrCond(noCharsConsumed, nanLabel, validLabel);
+
+    this.ctx.emitLabel(validLabel);
+    this.ctx.emitBr(endLabel);
+
+    this.ctx.emitLabel(nanLabel);
+    this.ctx.emitBr(endLabel);
+
+    this.ctx.emitLabel(endLabel);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = phi double [${rawResult}, %${validLabel}], [0x7FF8000000000000, %${nanLabel}]`);
     return result;
   }
 

--- a/tests/fixtures/builtins/parseint-nan.ts
+++ b/tests/fixtures/builtins/parseint-nan.ts
@@ -1,0 +1,46 @@
+function test(): void {
+  const a = parseInt("42");
+  if (a !== 42) {
+    console.log("FAIL basic: " + a.toString());
+    return;
+  }
+
+  const b = parseInt("-7");
+  if (b !== -7) {
+    console.log("FAIL negative: " + b.toString());
+    return;
+  }
+
+  const c = parseInt("abc");
+  if (!isNaN(c)) {
+    console.log("FAIL NaN for abc: " + c.toString());
+    return;
+  }
+
+  const d = parseInt("");
+  if (!isNaN(d)) {
+    console.log("FAIL NaN for empty: " + d.toString());
+    return;
+  }
+
+  const e = parseInt("0");
+  if (e !== 0) {
+    console.log("FAIL zero: " + e.toString());
+    return;
+  }
+
+  const f = parseFloat("3.14");
+  if (f !== 3.14) {
+    console.log("FAIL parseFloat basic");
+    return;
+  }
+
+  const g = parseFloat("xyz");
+  if (!isNaN(g)) {
+    console.log("FAIL parseFloat NaN: " + g.toString());
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+test();


### PR DESCRIPTION
## Summary
- `parseInt("abc")` returned `0` instead of `NaN` — now correctly returns `NaN`
- `parseFloat("xyz")` had the same bug — also fixed
- Root cause: `strtol`/`strtod` return 0 for unparseable input; we now check the endptr to detect if any characters were consumed
- `parseInt("")` also now correctly returns `NaN`

## Test plan
- [x] New test fixture `builtins/parseint-nan.ts` covers valid, invalid, empty, negative, and zero inputs
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)