### PR TITLE
fix: isNaN() returns true for non-numeric strings instead of false

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -512,9 +512,41 @@ export class CallExpressionGenerator {
     let doubleValue: string;
     if (this.ctx.isStringExpression(arg)) {
       const strValue = this.ctx.generateExpression(arg, params);
-      const nullPtr = this.ctx.nextTemp();
-      this.ctx.emit(`${nullPtr} = inttoptr i32 0 to i8**`);
-      doubleValue = this.ctx.emitCall("double", "@strtod", `i8* ${strValue}, i8** ${nullPtr}`);
+      const endPtrPtr = this.ctx.nextTemp();
+      this.ctx.emit(`${endPtrPtr} = alloca i8*`);
+      const rawResult = this.ctx.emitCall(
+        "double",
+        "@strtod",
+        `i8* ${strValue}, i8** ${endPtrPtr}`,
+      );
+
+      const endPtr = this.ctx.emitLoad("i8*", endPtrPtr);
+      const noCharsConsumed = this.ctx.emitIcmp("eq", "i8*", endPtr, strValue);
+
+      const numericLabel = this.ctx.nextLabel("isnan_numeric");
+      const nonNumericLabel = this.ctx.nextLabel("isnan_nonnumeric");
+      const endLabel = this.ctx.nextLabel("isnan_end");
+
+      this.ctx.emitBrCond(noCharsConsumed, nonNumericLabel, numericLabel);
+
+      this.ctx.emitLabel(numericLabel);
+      const cmpNumeric = this.ctx.nextTemp();
+      this.ctx.emit(`${cmpNumeric} = fcmp uno double ${rawResult}, ${rawResult}`);
+      const numericI32 = this.ctx.nextTemp();
+      this.ctx.emit(`${numericI32} = zext i1 ${cmpNumeric} to i32`);
+      const numericDouble = this.ctx.nextTemp();
+      this.ctx.emit(`${numericDouble} = sitofp i32 ${numericI32} to double`);
+      this.ctx.emitBr(endLabel);
+
+      this.ctx.emitLabel(nonNumericLabel);
+      this.ctx.emitBr(endLabel);
+
+      this.ctx.emitLabel(endLabel);
+      const result = this.ctx.nextTemp();
+      this.ctx.emit(
+        `${result} = phi double [${numericDouble}, %${numericLabel}], [1.0, %${nonNumericLabel}]`,
+      );
+      return result;
     } else {
       doubleValue = this.ctx.generateExpression(arg, params);
       doubleValue = this.ctx.ensureDouble(doubleValue);

--- a/tests/fixtures/builtins/isnan-string.ts
+++ b/tests/fixtures/builtins/isnan-string.ts
@@ -1,0 +1,13 @@
+let passed = true;
+
+if (isNaN("abc") !== true) passed = false;
+if (isNaN("hello world") !== true) passed = false;
+if (isNaN("42") !== false) passed = false;
+if (isNaN("-3.14") !== false) passed = false;
+if (isNaN("0") !== false) passed = false;
+if (isNaN(NaN) !== true) passed = false;
+if (isNaN(42) !== false) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `isNaN("abc")` now correctly returns `true` instead of `false`
- Uses strtod endptr check to detect non-parseable strings (same pattern as #257, #258)
- For numeric strings like `"42"`, still does proper NaN check on the parsed value

## Test plan
- [x] `npm run verify:quick` passes
- [x] New test `builtins/isnan-string` exercises string args, numeric strings, NaN, and numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)