### PR TITLE
fix: Number.isInteger() returns false for Infinity/-Infinity

### DIFF
--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -609,9 +609,21 @@ export function handleNumberIsInteger(
 ): string {
   const value = ctx.generateExpression(expr.args[0], params);
   const dblValue = ctx.ensureDouble(value);
+  const isFinite = ctx.nextTemp();
+  ctx.emit(`${isFinite} = fcmp ord double ${dblValue}, 0.0`);
+  const posInf = ctx.nextTemp();
+  ctx.emit(`${posInf} = fcmp one double ${dblValue}, 0x7FF0000000000000`);
+  const negInf = ctx.nextTemp();
+  ctx.emit(`${negInf} = fcmp one double ${dblValue}, 0xFFF0000000000000`);
+  const notInf = ctx.nextTemp();
+  ctx.emit(`${notInf} = and i1 ${posInf}, ${negInf}`);
+  const finiteCheck = ctx.nextTemp();
+  ctx.emit(`${finiteCheck} = and i1 ${isFinite}, ${notInf}`);
   const truncated = ctx.emitCall("double", "@llvm.trunc.f64", `double ${dblValue}`);
+  const truncEq = ctx.nextTemp();
+  ctx.emit(`${truncEq} = fcmp oeq double ${dblValue}, ${truncated}`);
   const isInt = ctx.nextTemp();
-  ctx.emit(`${isInt} = fcmp oeq double ${dblValue}, ${truncated}`);
+  ctx.emit(`${isInt} = and i1 ${finiteCheck}, ${truncEq}`);
   const result = ctx.nextTemp();
   ctx.emit(`${result} = uitofp i1 ${isInt} to double`);
   return result;

--- a/tests/fixtures/builtins/number-isinteger.ts
+++ b/tests/fixtures/builtins/number-isinteger.ts
@@ -1,0 +1,13 @@
+let passed = true;
+
+if (Number.isInteger(42) !== true) passed = false;
+if (Number.isInteger(0) !== true) passed = false;
+if (Number.isInteger(-5) !== true) passed = false;
+if (Number.isInteger(3.14) !== false) passed = false;
+if (Number.isInteger(NaN) !== false) passed = false;
+if (Number.isInteger(Infinity) !== false) passed = false;
+if (Number.isInteger(-Infinity) !== false) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `Number.isInteger(Infinity)` and `Number.isInteger(-Infinity)` now correctly return `false`
- Bug: `trunc(Inf) == Inf` is true, so the old check thought Infinity was an integer
- Fix: add finite check (not NaN, not +/-Infinity) before the trunc equality check

## Test plan
- [x] `npm run verify:quick` passes
- [x] New test `builtins/number-isinteger` covers integers, floats, NaN, +/-Infinity

🤖 Generated with [Claude Code](https://claude.com/claude-code)