### PR TITLE
fix: Math.max/min/sign correctly handle NaN values

### DIFF
--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -66,6 +66,8 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "declare i64 @time(i8*)\n";
   ir += "declare double @llvm.maxnum.f64(double, double)\n";
   ir += "declare double @llvm.minnum.f64(double, double)\n";
+  ir += "declare double @llvm.maximum.f64(double, double)\n";
+  ir += "declare double @llvm.minimum.f64(double, double)\n";
   ir += "\n";
 
   ir += "declare i8* @cs_regex_alloc()\n";

--- a/src/codegen/stdlib/math.ts
+++ b/src/codegen/stdlib/math.ts
@@ -195,7 +195,7 @@ export class MathGenerator {
     const dblA = this.ctx.ensureDouble(a);
     const dblB = this.ctx.ensureDouble(b);
     const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.maxnum.f64(double ${dblA}, double ${dblB})`);
+    this.ctx.emit(`${result} = call double @llvm.maximum.f64(double ${dblA}, double ${dblB})`);
     return result;
   }
 
@@ -276,7 +276,7 @@ export class MathGenerator {
     const dblA = this.ctx.ensureDouble(a);
     const dblB = this.ctx.ensureDouble(b);
     const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.minnum.f64(double ${dblA}, double ${dblB})`);
+    this.ctx.emit(`${result} = call double @llvm.minimum.f64(double ${dblA}, double ${dblB})`);
     return result;
   }
 }

--- a/src/codegen/stdlib/math.ts
+++ b/src/codegen/stdlib/math.ts
@@ -223,6 +223,8 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
+    const isNaN = this.ctx.nextTemp();
+    this.ctx.emit(`${isNaN} = fcmp uno double ${dblArg}, ${dblArg}`);
     const isPos = this.ctx.nextTemp();
     this.ctx.emit(`${isPos} = fcmp ogt double ${dblArg}, 0.0`);
     const isNeg = this.ctx.nextTemp();
@@ -231,7 +233,9 @@ export class MathGenerator {
     this.ctx.emit(`${posVal} = select i1 ${isPos}, double 1.0, double 0.0`);
     const negVal = this.ctx.nextTemp();
     this.ctx.emit(`${negVal} = select i1 ${isNeg}, double -1.0, double ${posVal}`);
-    return negVal;
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = select i1 ${isNaN}, double 0x7FF8000000000000, double ${negVal}`);
+    return result;
   }
 
   private generateLog(expr: MethodCallNode, params: string[]): string {

--- a/tests/fixtures/math/math-max-min-nan.ts
+++ b/tests/fixtures/math/math-max-min-nan.ts
@@ -1,0 +1,14 @@
+let passed = true;
+
+if (Math.max(1, 5) !== 5) passed = false;
+if (Math.min(1, 5) !== 1) passed = false;
+if (!isNaN(Math.max(1, NaN))) passed = false;
+if (!isNaN(Math.min(1, NaN))) passed = false;
+if (!isNaN(Math.max(NaN, NaN))) passed = false;
+if (!isNaN(Math.min(NaN, NaN))) passed = false;
+if (Math.max(-3, -1) !== -1) passed = false;
+if (Math.min(-3, -1) !== -3) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/math/math-sign-nan.ts
+++ b/tests/fixtures/math/math-sign-nan.ts
@@ -1,0 +1,10 @@
+let passed = true;
+
+if (Math.sign(5) !== 1) passed = false;
+if (Math.sign(-5) !== -1) passed = false;
+if (Math.sign(0) !== 0) passed = false;
+if (!isNaN(Math.sign(NaN))) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `Math.max(1, NaN)` and `Math.min(1, NaN)` now correctly return `NaN` (was returning the non-NaN value)
- `Math.sign(NaN)` now correctly returns `NaN` (was returning 0)
- Max/min: switched from `llvm.maxnum.f64`/`llvm.minnum.f64` to `llvm.maximum.f64`/`llvm.minimum.f64` which propagate NaN per IEEE 754-2019
- Sign: added NaN check before the positive/negative/zero select chain

## Test plan
- [x] `npm run verify:quick` passes
- [x] New test `math/math-max-min-nan` covers normal values, negatives, and NaN propagation
- [x] New test `math/math-sign-nan` covers positive, negative, zero, and NaN

🤖 Generated with [Claude Code](https://claude.com/claude-code)