### PR TITLE
fix: remove nnan/ninf fast-math flags from arithmetic to fix nan propagation (#263)

### DIFF
--- a/src/codegen/expressions/operators/binary.ts
+++ b/src/codegen/expressions/operators/binary.ts
@@ -59,10 +59,10 @@ export class BinaryExpressionGenerator {
 
     // Arithmetic operators (floating-point)
     const arithMap: { [key: string]: string } = {
-      "+": "fadd fast",
-      "-": "fsub fast",
-      "*": "fmul fast",
-      "/": "fdiv fast",
+      "+": "fadd nsz arcp contract reassoc afn",
+      "-": "fsub nsz arcp contract reassoc afn",
+      "*": "fmul nsz arcp contract reassoc afn",
+      "/": "fdiv nsz arcp contract reassoc afn",
     };
 
     // Bitwise operators (need to convert double -> i64 -> operate -> double)

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -151,7 +151,10 @@ describe(`ChadScript Compiler (${compilerLabel})`, () => {
         );
         assert.ok(llContent.includes("define i32 @main"), "Should define main function");
         assert.ok(llContent.includes("ret"), "Should have return statements");
-        assert.ok(llContent.includes("fadd fast double"), "Should have add instruction");
+        assert.ok(
+          llContent.includes("fadd") && llContent.includes("double"),
+          "Should have add instruction",
+        );
       } finally {
         // Clean up
         try {

--- a/tests/fixtures/arithmetic/nan-arithmetic.ts
+++ b/tests/fixtures/arithmetic/nan-arithmetic.ts
@@ -1,0 +1,15 @@
+let passed = true;
+
+if (!isNaN(NaN + 1)) passed = false;
+if (!isNaN(NaN - 1)) passed = false;
+if (!isNaN(NaN * 2)) passed = false;
+if (!isNaN(NaN / 2)) passed = false;
+if (!isNaN(1 + NaN)) passed = false;
+if (!isNaN(0 * NaN)) passed = false;
+
+const x = 3 + 4;
+if (x !== 7) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Replace `fast` flag on `fadd`/`fsub`/`fmul`/`fdiv` with `nsz arcp contract reassoc afn` (keeps perf, removes `nnan`/`ninf` that made NaN/Infinity arithmetic UB)
- Update IR smoke test to not require `fadd fast`
- Add `nan-arithmetic.ts` test fixture verifying NaN propagation through all four operators

## Test plan
- [x] `npm run verify:quick` passes locally
- [x] NaN arithmetic test passes (NaN + 1, NaN - 1, NaN * 2, NaN / 2 all produce NaN)
- [x] Normal arithmetic still works (3 + 4 === 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)