### PR TITLE
fix: add missing setVariableType calls and remove remaining fast-math flags (#264)

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -689,7 +689,7 @@ export class MemberAccessGenerator {
     const result = this.ctx.nextTemp();
     const valueStr = String(value);
     const formattedValue = valueStr.indexOf(".") === -1 ? valueStr + ".0" : valueStr;
-    this.ctx.emit(`${result} = fadd fast double ${formattedValue}, 0.0`);
+    this.ctx.emit(`${result} = fadd nsz arcp contract reassoc afn double ${formattedValue}, 0.0`);
     this.ctx.setVariableType(result, "double");
     return result;
   }

--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -675,6 +675,7 @@ export function generateConsoleTimeEnd(
   ctx.emit(`${diffDbl} = uitofp i64 ${diffNs} to double`);
   const diffMs = ctx.nextTemp();
   ctx.emit(`${diffMs} = fdiv double ${diffDbl}, 1000000.0`);
+  ctx.setVariableType(diffMs, "double");
 
   const fmtStr = ctx.stringGen.doCreateStringConstant("%s: %.3fms\n");
   const printResult = ctx.nextTemp();

--- a/src/codegen/expressions/method-calls/process.ts
+++ b/src/codegen/expressions/method-calls/process.ts
@@ -83,7 +83,8 @@ export function handleProcessUptime(ctx: MethodCallGeneratorContext): string {
   const nsDouble = ctx.nextTemp();
   ctx.emit(`${nsDouble} = uitofp i64 ${ns} to double`);
   const seconds = ctx.nextTemp();
-  ctx.emit(`${seconds} = fdiv fast double ${nsDouble}, 1000000000.0`);
+  ctx.emit(`${seconds} = fdiv nsz arcp contract reassoc afn double ${nsDouble}, 1000000000.0`);
+  ctx.setVariableType(seconds, "double");
   return seconds;
 }
 

--- a/src/codegen/expressions/operators/binary.ts
+++ b/src/codegen/expressions/operators/binary.ts
@@ -293,7 +293,7 @@ export class BinaryExpressionGenerator {
 
     this.ctx.emitLabel(floatModLabel);
     const fremResult = this.ctx.nextTemp();
-    this.ctx.emit(`${fremResult} = frem fast double ${left}, ${right}`);
+    this.ctx.emit(`${fremResult} = frem nsz arcp contract reassoc afn double ${left}, ${right}`);
     const floatBranchEnd = this.ctx.getCurrentLabel();
     this.ctx.emitBr(mergeLabel);
 

--- a/src/codegen/expressions/operators/unary.ts
+++ b/src/codegen/expressions/operators/unary.ts
@@ -102,7 +102,10 @@ export class UnaryExpressionGenerator {
 
     const delta = op === "post++" ? "1.0" : "-1.0";
     const newValue = this.ctx.nextTemp();
-    this.ctx.emit(`${newValue} = fadd fast double ${originalValue}, ${delta}`);
+    this.ctx.emit(
+      `${newValue} = fadd nsz arcp contract reassoc afn double ${originalValue}, ${delta}`,
+    );
+    this.ctx.setVariableType(newValue, "double");
 
     this.ctx.emit(`store double ${newValue}, double* ${allocaReg}`);
 
@@ -145,7 +148,9 @@ export class UnaryExpressionGenerator {
 
     const delta = op === "++" ? "1.0" : "-1.0";
     const newValue = this.ctx.nextTemp();
-    this.ctx.emit(`${newValue} = fadd fast double ${originalValue}, ${delta}`);
+    this.ctx.emit(
+      `${newValue} = fadd nsz arcp contract reassoc afn double ${originalValue}, ${delta}`,
+    );
     this.ctx.setVariableType(newValue, "double");
 
     this.ctx.emit(`store double ${newValue}, double* ${allocaReg}`);
@@ -196,6 +201,7 @@ export class UnaryExpressionGenerator {
     const dblOperand = this.ctx.ensureDouble(operand);
     const result = this.ctx.nextTemp();
     this.ctx.emit(`${result} = fneg double ${dblOperand}`);
+    this.ctx.setVariableType(result, "double");
     return result;
   }
 
@@ -236,7 +242,9 @@ export class UnaryExpressionGenerator {
     const isIncrement = op === "post++" || op === "++";
     const delta = isIncrement ? "1.0" : "-1.0";
     const newValue = this.ctx.nextTemp();
-    this.ctx.emit(`${newValue} = fadd fast double ${originalValue}, ${delta}`);
+    this.ctx.emit(
+      `${newValue} = fadd nsz arcp contract reassoc afn double ${originalValue}, ${delta}`,
+    );
     this.ctx.setVariableType(newValue, "double");
 
     this.ctx.emit(`store double ${newValue}, double* ${fieldPtr}`);

--- a/src/codegen/stdlib/date.ts
+++ b/src/codegen/stdlib/date.ts
@@ -35,7 +35,7 @@ export class DateGenerator {
 
     // Convert ms → seconds as i64 for localtime_r / gmtime_r
     const secDbl = this.ctx.nextTemp();
-    this.ctx.emit(`${secDbl} = fdiv fast double ${msVal}, 1.000000e+03`);
+    this.ctx.emit(`${secDbl} = fdiv nsz arcp contract reassoc afn double ${msVal}, 1.000000e+03`);
     const secI64 = this.ctx.nextTemp();
     this.ctx.emit(`${secI64} = fptosi double ${secDbl} to i64`);
 
@@ -89,7 +89,7 @@ export class DateGenerator {
 
     if (method === "getFullYear") {
       const result = this.ctx.nextTemp();
-      this.ctx.emit(`${result} = fadd fast double ${fieldDbl}, 1900.0`);
+      this.ctx.emit(`${result} = fadd nsz arcp contract reassoc afn double ${fieldDbl}, 1900.0`);
       this.ctx.setVariableType(result, "double");
       return result;
     }


### PR DESCRIPTION
## Summary
- Add missing `setVariableType(result, "double")` after `fneg` (negation), `fadd` (post-increment), `fdiv` (process.uptime, console.timeEnd) — prevents downstream type inference failures
- Replace remaining `fadd fast`/`fdiv fast`/`frem fast` with safe flags `nsz arcp contract reassoc afn` in unary.ts, date.ts, member.ts, binary.ts (modulo) — PR #263 only fixed the arithmetic map in binary.ts, these were missed

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] No functional change to output — just type tracking + flag consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)