### PR TITLE
fix: resolve negative fromindex in array indexof to prevent oob access (#265)

### DIFF
--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -354,9 +354,17 @@ export function handleStringArrayIndexOf(
   ctx.emitBrCond(dataPtrIsNull, notfoundLabel, `${checkLabel}_start`);
 
   ctx.emitLabel(`${checkLabel}_start`);
+  const isNeg = ctx.emitIcmp("slt", "i32", fromIndex, "0");
+  const adjusted = ctx.nextTemp();
+  ctx.emit(`${adjusted} = add i32 ${fromIndex}, ${length}`);
+  const resolved = ctx.nextTemp();
+  ctx.emit(`${resolved} = select i1 ${isNeg}, i32 ${adjusted}, i32 ${fromIndex}`);
+  const stillNeg = ctx.emitIcmp("slt", "i32", resolved, "0");
+  const clampedFrom = ctx.nextTemp();
+  ctx.emit(`${clampedFrom} = select i1 ${stillNeg}, i32 0, i32 ${resolved}`);
   const counterPtr = ctx.nextTemp();
   ctx.emit(`${counterPtr} = alloca i32`);
-  ctx.emitStore("i32", fromIndex, counterPtr);
+  ctx.emitStore("i32", clampedFrom, counterPtr);
 
   ctx.emitBr(checkLabel);
 

--- a/src/codegen/types/collections/array/search.ts
+++ b/src/codegen/types/collections/array/search.ts
@@ -31,6 +31,7 @@ export function generateArrayIndexOf(
   const searchValue = gen.generateExpression(expr.args[0], params);
 
   // Optional fromIndex (2nd arg) — defaults to 0
+  // Negative fromIndex is resolved as max(0, length + fromIndex) per JS spec
   let fromIndex: string | null = null;
   if (expr.args.length === 2) {
     const fromRaw = gen.generateExpression(expr.args[1], params);
@@ -58,6 +59,18 @@ export function generateArrayIndexOf(
   return generateNumericArrayIndexOf(gen, arrayPtr, searchValue, fromIndex);
 }
 
+function resolveFromIndex(gen: IGeneratorContext, fromIndex: string, length: string): string {
+  const isNeg = gen.emitIcmp("slt", "i32", fromIndex, "0");
+  const adjusted = gen.nextTemp();
+  gen.emit(`${adjusted} = add i32 ${fromIndex}, ${length}`);
+  const resolved = gen.nextTemp();
+  gen.emit(`${resolved} = select i1 ${isNeg}, i32 ${adjusted}, i32 ${fromIndex}`);
+  const stillNeg = gen.emitIcmp("slt", "i32", resolved, "0");
+  const clamped = gen.nextTemp();
+  gen.emit(`${clamped} = select i1 ${stillNeg}, i32 0, i32 ${resolved}`);
+  return clamped;
+}
+
 function generateNumericArrayIndexOf(
   gen: IGeneratorContext,
   arrayPtr: string,
@@ -74,13 +87,15 @@ function generateNumericArrayIndexOf(
   const dataPtr = gen.nextTemp();
   gen.emit(`${dataPtr} = load double*, double** ${dataPtrField}`);
 
+  const startIndex = fromIndex ? resolveFromIndex(gen, fromIndex, length) : null;
+
   const resultPtr = gen.nextTemp();
   gen.emit(`${resultPtr} = alloca i32`);
   gen.emitStore("i32", "-1", resultPtr);
 
   const loopPtr = gen.nextTemp();
   gen.emit(`${loopPtr} = alloca i32`);
-  gen.emitStore("i32", fromIndex ?? "0", loopPtr);
+  gen.emitStore("i32", startIndex ?? "0", loopPtr);
 
   const checkLabel = gen.nextLabel("indexof_check");
   const bodyLabel = gen.nextLabel("indexof_body");
@@ -143,13 +158,15 @@ function generateStringArrayIndexOf(
   const dataPtr = gen.nextTemp();
   gen.emit(`${dataPtr} = load i8**, i8*** ${dataPtrField}`);
 
+  const startIndex = fromIndex ? resolveFromIndex(gen, fromIndex, length) : null;
+
   const resultPtr = gen.nextTemp();
   gen.emit(`${resultPtr} = alloca i32`);
   gen.emitStore("i32", "-1", resultPtr);
 
   const loopPtr = gen.nextTemp();
   gen.emit(`${loopPtr} = alloca i32`);
-  gen.emitStore("i32", fromIndex ?? "0", loopPtr);
+  gen.emitStore("i32", startIndex ?? "0", loopPtr);
 
   const checkLabel = gen.nextLabel("indexof_check");
   const bodyLabel = gen.nextLabel("indexof_body");

--- a/tests/fixtures/arrays/indexof-negative-fromindex.ts
+++ b/tests/fixtures/arrays/indexof-negative-fromindex.ts
@@ -1,0 +1,20 @@
+let passed = true;
+
+const arr = [10, 20, 30, 40, 50];
+if (arr.indexOf(30, -3) !== 2) passed = false;
+if (arr.indexOf(10, -5) !== 0) passed = false;
+if (arr.indexOf(50, -1) !== 4) passed = false;
+if (arr.indexOf(10, -1) !== -1) passed = false;
+if (arr.indexOf(30, -100) !== 2) passed = false;
+if (arr.indexOf(30, 0) !== 2) passed = false;
+if (arr.indexOf(30, 3) !== -1) passed = false;
+
+const strs = ["a", "b", "c", "d"];
+if (strs.indexOf("c", -2) !== 2) passed = false;
+if (strs.indexOf("a", -1) !== -1) passed = false;
+if (strs.indexOf("d", -1) !== 3) passed = false;
+if (strs.indexOf("a", -100) !== 0) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `arr.indexOf(val, -N)` with negative `fromIndex` was using the raw negative value as the loop start index, causing out-of-bounds memory access via GEP with negative index
- Fix resolves negative indices as `max(0, length + index)` per JS spec, in both numeric and string array indexOf paths
- Affected two separate code paths: `search.ts` (numeric arrays) and `string-methods.ts` (string arrays dispatched via string-dispatch.ts)

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] New test: `arrays/indexof-negative-fromindex.ts` covers both number[] and string[] with negative, zero, positive, and very-negative fromIndex values

🤖 Generated with [Claude Code](https://claude.com/claude-code)