### PR TITLE
fix: clamp negative deletecount in splice, fix assert.notequal nan (#266)

### DIFF
--- a/src/codegen/expressions/method-calls/assert.ts
+++ b/src/codegen/expressions/method-calls/assert.ts
@@ -101,7 +101,7 @@ function handleNumberEquality(
   if (expectEqual) {
     ctx.emit(`${cmp} = fcmp oeq double ${dblActual}, ${dblExpected}`);
   } else {
-    ctx.emit(`${cmp} = fcmp one double ${dblActual}, ${dblExpected}`);
+    ctx.emit(`${cmp} = fcmp une double ${dblActual}, ${dblExpected}`);
   }
 
   const passLabel = ctx.nextLabel("assert_pass");

--- a/src/codegen/types/collections/array/splice.ts
+++ b/src/codegen/types/collections/array/splice.ts
@@ -85,11 +85,14 @@ function generateNumericArraySplice(
     const dcDouble = gen.ensureDouble(dcExpr);
     const dcRaw = gen.nextTemp();
     gen.emit(`${dcRaw} = fptosi double ${dcDouble} to i32`);
+    const dcNeg = gen.emitIcmp("slt", "i32", dcRaw, "0");
+    const dcClamped = gen.nextTemp();
+    gen.emit(`${dcClamped} = select i1 ${dcNeg}, i32 0, i32 ${dcRaw}`);
     const remaining = gen.nextTemp();
     gen.emit(`${remaining} = sub i32 ${length}, ${start}`);
-    const dcTooMany = gen.emitIcmp("sgt", "i32", dcRaw, remaining);
+    const dcTooMany = gen.emitIcmp("sgt", "i32", dcClamped, remaining);
     deleteCount = gen.nextTemp();
-    gen.emit(`${deleteCount} = select i1 ${dcTooMany}, i32 ${remaining}, i32 ${dcRaw}`);
+    gen.emit(`${deleteCount} = select i1 ${dcTooMany}, i32 ${remaining}, i32 ${dcClamped}`);
   } else {
     deleteCount = gen.nextTemp();
     gen.emit(`${deleteCount} = sub i32 ${length}, ${start}`);
@@ -99,7 +102,7 @@ function generateNumericArraySplice(
   const resultArrayTyped = gen.emitBitcast(resultArray, "i8*", "%Array*");
 
   const dcI64 = gen.nextTemp();
-  gen.emit(`${dcI64} = zext i32 ${deleteCount} to i64`);
+  gen.emit(`${dcI64} = sext i32 ${deleteCount} to i64`);
   const resultDataSize = gen.nextTemp();
   gen.emit(`${resultDataSize} = mul i64 ${dcI64}, 8`);
   const resultDataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${resultDataSize}`);
@@ -140,7 +143,7 @@ function generateNumericArraySplice(
   gen.emit(`${moveSrc} = getelementptr inbounds double, double* ${dataPtr}, i32 ${afterStart}`);
   const moveSrcI8 = gen.emitBitcast(moveSrc, "double*", "i8*");
   const moveI64 = gen.nextTemp();
-  gen.emit(`${moveI64} = zext i32 ${elemsAfter} to i64`);
+  gen.emit(`${moveI64} = sext i32 ${elemsAfter} to i64`);
   const moveBytes = gen.nextTemp();
   gen.emit(`${moveBytes} = mul i64 ${moveI64}, 8`);
   gen.emit(
@@ -190,11 +193,14 @@ function generateStringArraySplice(
     const dcDouble = gen.ensureDouble(dcExpr);
     const dcRaw = gen.nextTemp();
     gen.emit(`${dcRaw} = fptosi double ${dcDouble} to i32`);
+    const dcNeg = gen.emitIcmp("slt", "i32", dcRaw, "0");
+    const dcClamped = gen.nextTemp();
+    gen.emit(`${dcClamped} = select i1 ${dcNeg}, i32 0, i32 ${dcRaw}`);
     const remaining = gen.nextTemp();
     gen.emit(`${remaining} = sub i32 ${length}, ${start}`);
-    const dcTooMany = gen.emitIcmp("sgt", "i32", dcRaw, remaining);
+    const dcTooMany = gen.emitIcmp("sgt", "i32", dcClamped, remaining);
     deleteCount = gen.nextTemp();
-    gen.emit(`${deleteCount} = select i1 ${dcTooMany}, i32 ${remaining}, i32 ${dcRaw}`);
+    gen.emit(`${deleteCount} = select i1 ${dcTooMany}, i32 ${remaining}, i32 ${dcClamped}`);
   } else {
     deleteCount = gen.nextTemp();
     gen.emit(`${deleteCount} = sub i32 ${length}, ${start}`);
@@ -204,7 +210,7 @@ function generateStringArraySplice(
   const resultArrayTyped = gen.emitBitcast(resultArray, "i8*", "%StringArray*");
 
   const dcI64 = gen.nextTemp();
-  gen.emit(`${dcI64} = zext i32 ${deleteCount} to i64`);
+  gen.emit(`${dcI64} = sext i32 ${deleteCount} to i64`);
   const resultDataSize = gen.nextTemp();
   gen.emit(`${resultDataSize} = mul i64 ${dcI64}, 8`);
   const resultDataMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${resultDataSize}`);
@@ -245,7 +251,7 @@ function generateStringArraySplice(
   gen.emit(`${moveSrc} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${afterStart}`);
   const moveSrcI8 = gen.emitBitcast(moveSrc, "i8**", "i8*");
   const moveI64 = gen.nextTemp();
-  gen.emit(`${moveI64} = zext i32 ${elemsAfter} to i64`);
+  gen.emit(`${moveI64} = sext i32 ${elemsAfter} to i64`);
   const moveBytes = gen.nextTemp();
   gen.emit(`${moveBytes} = mul i64 ${moveI64}, 8`);
   gen.emit(

--- a/tests/fixtures/arrays/splice-negative-deletecount.ts
+++ b/tests/fixtures/arrays/splice-negative-deletecount.ts
@@ -1,0 +1,25 @@
+let passed = true;
+
+const arr1 = [1, 2, 3, 4, 5];
+arr1.splice(1, -1);
+if (arr1.length !== 5) passed = false;
+
+const arr2 = [10, 20, 30];
+arr2.splice(0, 2);
+if (arr2.length !== 1) passed = false;
+if (arr2[0] !== 30) passed = false;
+
+const arr3 = [1, 2, 3];
+arr3.splice(1, 0);
+if (arr3.length !== 3) passed = false;
+
+const arr4 = [1, 2, 3, 4];
+arr4.splice(-2, 1);
+if (arr4.length !== 3) passed = false;
+if (arr4[0] !== 1) passed = false;
+if (arr4[1] !== 2) passed = false;
+if (arr4[2] !== 4) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `arr.splice(i, -1)` with negative deleteCount was passed through as-is, then `zext i32 -1 to i64` produced 0xFFFFFFFF (4GB), causing massive memcpy and memory corruption. Now clamped to 0.
- Also changed `zext` to `sext` for splice size calculations (safety against any remaining negative edge cases)
- Fixed `assert.notEqual` using `fcmp one` instead of `fcmp une` — `assert.notEqual(NaN, NaN)` incorrectly failed because `one` returns false when either operand is NaN

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] New test: `arrays/splice-negative-deletecount.ts` — splice with -1, 0, positive, and negative start

🤖 Generated with [Claude Code](https://claude.com/claude-code)