### PR TITLE
fix: prevent i32 overflow in array/string copy size calculations

### DIFF
--- a/src/codegen/stdlib/promise.ts
+++ b/src/codegen/stdlib/promise.ts
@@ -504,8 +504,8 @@ export class PromiseGenerator {
     ir += "  ; Allocate results array (ObjectArray: {i8*, i32, i32})\n";
     ir += "  %results_arr_mem = call i8* @GC_malloc(i64 16)\n";
     ir += "  %results_arr = bitcast i8* %results_arr_mem to %ObjectArray*\n";
-    ir += "  %results_data_size = mul i32 %len, 8\n";
-    ir += "  %results_data_size_i64 = sext i32 %results_data_size to i64\n";
+    ir += "  %results_len_i64 = zext i32 %len to i64\n";
+    ir += "  %results_data_size_i64 = mul i64 %results_len_i64, 8\n";
     ir += "  %results_data_mem = call i8* @GC_malloc(i64 %results_data_size_i64)\n";
     ir +=
       "  %results_data_field = getelementptr inbounds %ObjectArray, %ObjectArray* %results_arr, i32 0, i32 0\n";
@@ -810,8 +810,8 @@ export class PromiseGenerator {
     ir += "  store i32 0, i32* %rejected\n";
     ir += "  %results_arr_mem = call i8* @GC_malloc(i64 16)\n";
     ir += "  %results_arr = bitcast i8* %results_arr_mem to %ObjectArray*\n";
-    ir += "  %results_data_size = mul i32 %len, 8\n";
-    ir += "  %results_data_size_i64 = sext i32 %results_data_size to i64\n";
+    ir += "  %results_len_i64 = zext i32 %len to i64\n";
+    ir += "  %results_data_size_i64 = mul i64 %results_len_i64, 8\n";
     ir += "  %results_data_mem = call i8* @GC_malloc(i64 %results_data_size_i64)\n";
     ir +=
       "  %results_data_field = getelementptr inbounds %ObjectArray, %ObjectArray* %results_arr, i32 0, i32 0\n";

--- a/src/codegen/types/collections/array/mutators.ts
+++ b/src/codegen/types/collections/array/mutators.ts
@@ -473,26 +473,22 @@ function generateStringArrayPush(gen: IGeneratorContext, arrayPtr: string, value
 
   const oldDataI8 = gen.emitBitcast(oldDataPtr, "i8**", "i8*");
   const newDataI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
-  const copySize = gen.nextTemp();
-  gen.emit(`${copySize} = mul i32 ${currentLen}, 8`); // 8 bytes per pointer
+  const currentLenI64 = gen.nextTemp();
+  gen.emit(`${currentLenI64} = zext i32 ${currentLen} to i64`);
   const copySizeI64 = gen.nextTemp();
-  gen.emit(`${copySizeI64} = zext i32 ${copySize} to i64`);
+  gen.emit(`${copySizeI64} = mul i64 ${currentLenI64}, 8`);
   gen.emit(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newDataI8}, i8* ${oldDataI8}, i64 ${copySizeI64}, i1 false)`,
   );
 
-  // Update pointer (GC will free old data)
   gen.emitStore("i8**", newDataPtr, dataPtrField);
 
-  // Update capacity
   gen.emitStore("i32", newCap, capPtr);
 
   gen.emitBr(continueLabel);
 
-  // Continue block
   gen.emitLabel(continueLabel);
 
-  // Get current data pointer (may have been updated)
   const dataPtrField2 = gen.nextTemp();
   gen.emit(
     `${dataPtrField2} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
@@ -561,10 +557,10 @@ function generatePointerArrayPush(
 
   const oldDataI8 = gen.emitBitcast(oldDataPtr, "i8**", "i8*");
   const newDataI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
-  const copySize = gen.nextTemp();
-  gen.emit(`${copySize} = mul i32 ${currentLen}, 8`);
+  const currentLenI64 = gen.nextTemp();
+  gen.emit(`${currentLenI64} = zext i32 ${currentLen} to i64`);
   const copySizeI64 = gen.nextTemp();
-  gen.emit(`${copySizeI64} = zext i32 ${copySize} to i64`);
+  gen.emit(`${copySizeI64} = mul i64 ${currentLenI64}, 8`);
   gen.emit(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newDataI8}, i8* ${oldDataI8}, i64 ${copySizeI64}, i1 false)`,
   );
@@ -649,10 +645,10 @@ function generateObjectArrayPush(
 
   const oldDataI8 = gen.emitBitcast(oldDataPtr, "i8**", "i8*");
   const newDataI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
-  const copySize = gen.nextTemp();
-  gen.emit(`${copySize} = mul i32 ${currentLen}, 8`);
+  const currentLenI64 = gen.nextTemp();
+  gen.emit(`${currentLenI64} = zext i32 ${currentLen} to i64`);
   const copySizeI64 = gen.nextTemp();
-  gen.emit(`${copySizeI64} = zext i32 ${copySize} to i64`);
+  gen.emit(`${copySizeI64} = mul i64 ${currentLenI64}, 8`);
   gen.emit(
     `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newDataI8}, i8* ${oldDataI8}, i64 ${copySizeI64}, i1 false)`,
   );

--- a/src/codegen/types/collections/string/split.ts
+++ b/src/codegen/types/collections/string/split.ts
@@ -30,10 +30,10 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   const emptyArrMem = ctx.emitCall("i8*", "@GC_malloc", "i64 24");
   const emptyArrPtr = ctx.emitBitcast(emptyArrMem, "i8*", "%StringArray*");
 
-  const emptyDataSize = ctx.nextTemp();
-  ctx.emit(`${emptyDataSize} = mul i32 ${strLenI32}, 8`);
+  const strLenI64 = ctx.nextTemp();
+  ctx.emit(`${strLenI64} = zext i32 ${strLenI32} to i64`);
   const emptyDataSizeI64 = ctx.nextTemp();
-  ctx.emit(`${emptyDataSizeI64} = zext i32 ${emptyDataSize} to i64`);
+  ctx.emit(`${emptyDataSizeI64} = mul i64 ${strLenI64}, 8`);
   const emptyDataMem = ctx.emitCall("i8*", "@GC_malloc", `i64 ${emptyDataSizeI64}`);
   const emptyDataPtr = ctx.emitBitcast(emptyDataMem, "i8*", "i8**");
 
@@ -161,10 +161,10 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   const arrayMem = ctx.emitCall("i8*", "@GC_malloc", "i64 24");
   const arrayPtr = ctx.emitBitcast(arrayMem, "i8*", "%StringArray*");
 
-  const dataSize = ctx.nextTemp();
-  ctx.emit(`${dataSize} = mul i32 ${totalParts}, 8`);
+  const totalPartsI64 = ctx.nextTemp();
+  ctx.emit(`${totalPartsI64} = zext i32 ${totalParts} to i64`);
   const dataSizeI64 = ctx.nextTemp();
-  ctx.emit(`${dataSizeI64} = zext i32 ${dataSize} to i64`);
+  ctx.emit(`${dataSizeI64} = mul i64 ${totalPartsI64}, 8`);
   const dataMem = ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSizeI64}`);
   const dataPtr = ctx.emitBitcast(dataMem, "i8*", "i8**");
 


### PR DESCRIPTION
## Summary
- Fixes integer overflow when computing memcpy sizes for large arrays: `mul i32 len, 8` overflows for arrays with >268M elements, causing wrong-sized copies and potential memory corruption
- Pattern: zext i32 to i64 first, then multiply in 64-bit — matches the correct pattern already used in numeric array push
- Fixed in 3 files: array mutators (string/object array push expand), string split allocation, promise.all/race result allocation

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] No behavioral change for normal-sized arrays — only prevents overflow for very large ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)