### PR TITLE
fix: substring() swaps args when start > end per js spec

### DIFF
--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -54,18 +54,31 @@ export function handleSubstring(
     return ctx.emitError(`substring() expects 1 or 2 arguments, got ${expr.args.length}`, expr.loc);
   }
 
-  const startIndexDouble = ctx.generateExpression(expr.args[0], params);
-  const startIndex = convertToI32(ctx, startIndexDouble);
+  const startRaw = convertToI32(ctx, ctx.generateExpression(expr.args[0], params));
+
+  const startNeg = ctx.emitIcmp("slt", "i32", startRaw, "0");
+  const startClamped = ctx.nextTemp();
+  ctx.emit(`${startClamped} = select i1 ${startNeg}, i32 0, i32 ${startRaw}`);
 
   let length: string | null = null;
   if (expr.args.length === 2) {
-    const endIndexDouble = ctx.generateExpression(expr.args[1], params);
-    const endIndex = convertToI32(ctx, endIndexDouble);
+    const endRaw = convertToI32(ctx, ctx.generateExpression(expr.args[1], params));
+    const endNeg = ctx.emitIcmp("slt", "i32", endRaw, "0");
+    const endClamped = ctx.nextTemp();
+    ctx.emit(`${endClamped} = select i1 ${endNeg}, i32 0, i32 ${endRaw}`);
+
+    const needSwap = ctx.emitIcmp("sgt", "i32", startClamped, endClamped);
+    const realStart = ctx.nextTemp();
+    ctx.emit(`${realStart} = select i1 ${needSwap}, i32 ${endClamped}, i32 ${startClamped}`);
+    const realEnd = ctx.nextTemp();
+    ctx.emit(`${realEnd} = select i1 ${needSwap}, i32 ${startClamped}, i32 ${endClamped}`);
+
     length = ctx.nextTemp();
-    ctx.emit(`${length} = sub i32 ${endIndex}, ${startIndex}`);
+    ctx.emit(`${length} = sub i32 ${realEnd}, ${realStart}`);
+    return ctx.stringGen.doGenerateSubstr(strPtr, realStart, length);
   }
 
-  return ctx.stringGen.doGenerateSubstr(strPtr, startIndex, length);
+  return ctx.stringGen.doGenerateSubstr(strPtr, startClamped, length);
 }
 
 export function handleConcat(

--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -298,11 +298,18 @@ export function handleIndexOf(
 ): string {
   const strPtr = ctx.generateExpression(expr.object, params);
 
-  if (expr.args.length !== 1) {
-    return ctx.emitError(`indexOf() expects 1 argument, got ${expr.args.length}`, expr.loc);
+  if (expr.args.length < 1 || expr.args.length > 2) {
+    return ctx.emitError(`indexOf() expects 1 or 2 arguments, got ${expr.args.length}`, expr.loc);
   }
 
   const substring = ctx.generateExpression(expr.args[0], params);
+
+  if (expr.args.length === 2) {
+    const fromIndexDouble = ctx.generateExpression(expr.args[1], params);
+    const fromIndex = convertToI32(ctx, fromIndexDouble);
+    return ctx.stringGen.doGenerateIndexOfFrom(strPtr, substring, fromIndex);
+  }
+
   return ctx.stringGen.doGenerateIndexOf(strPtr, substring);
 }
 

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -89,6 +89,7 @@ export interface IStringGenerator {
   doGenerateToUpperCase(strPtr: string): string;
   doGenerateToLowerCase(strPtr: string): string;
   doGenerateIndexOf(strPtr: string, substring: string): string;
+  doGenerateIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string;
   doGenerateLastIndexOf(strPtr: string, substring: string): string;
   doGenerateIncludes(strPtr: string, substring: string): string;
   doGenerateSlice(strPtr: string, start: string, end: string | null): string;
@@ -1698,6 +1699,7 @@ export class MockGeneratorContext implements IGeneratorContext {
     doGenerateToUpperCase: (_strPtr: string): string => "%0",
     doGenerateToLowerCase: (_strPtr: string): string => "%0",
     doGenerateIndexOf: (_strPtr: string, _substring: string): string => "%0",
+    doGenerateIndexOfFrom: (_strPtr: string, _substring: string, _fromIndex: string): string => "%0",
     doGenerateLastIndexOf: (_strPtr: string, _substring: string): string => "%0",
     doGenerateIncludes: (_strPtr: string, _substring: string): string => "%0",
     doGenerateSlice: (_strPtr: string, _start: string, _end: string | null): string => "%0",

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -1699,7 +1699,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     doGenerateToUpperCase: (_strPtr: string): string => "%0",
     doGenerateToLowerCase: (_strPtr: string): string => "%0",
     doGenerateIndexOf: (_strPtr: string, _substring: string): string => "%0",
-    doGenerateIndexOfFrom: (_strPtr: string, _substring: string, _fromIndex: string): string => "%0",
+    doGenerateIndexOfFrom: (_strPtr: string, _substring: string, _fromIndex: string): string =>
+      "%0",
     doGenerateLastIndexOf: (_strPtr: string, _substring: string): string => "%0",
     doGenerateIncludes: (_strPtr: string, _substring: string): string => "%0",
     doGenerateSlice: (_strPtr: string, _start: string, _end: string | null): string => "%0",

--- a/src/codegen/types/collections/string.ts
+++ b/src/codegen/types/collections/string.ts
@@ -27,6 +27,7 @@ import {
   generateStringAt,
   generateCharCodeAt,
   generateIndexOf,
+  generateIndexOfFrom,
   generateLastIndexOf,
   generateIncludes,
   generateEndsWith,
@@ -134,6 +135,10 @@ export class StringGenerator implements IStringGenerator {
 
   doGenerateIndexOf(strPtr: string, substring: string): string {
     return generateIndexOf(this.ctx, strPtr, substring);
+  }
+
+  doGenerateIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string {
+    return generateIndexOfFrom(this.ctx, strPtr, substring, fromIndex);
   }
 
   doGenerateLastIndexOf(strPtr: string, substring: string): string {

--- a/src/codegen/types/collections/string/search.ts
+++ b/src/codegen/types/collections/string/search.ts
@@ -186,6 +186,68 @@ export function generateIndexOf(ctx: IGeneratorContext, strPtr: string, substrin
   return result;
 }
 
+export function generateIndexOfFrom(
+  ctx: IGeneratorContext,
+  strPtr: string,
+  substring: string,
+  fromIndex: string,
+): string {
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
+  const strLenI32 = ctx.nextTemp();
+  ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
+
+  const isNeg = ctx.emitIcmp("slt", "i32", fromIndex, "0");
+  const clamped0 = ctx.nextTemp();
+  ctx.emit(`${clamped0} = select i1 ${isNeg}, i32 0, i32 ${fromIndex}`);
+  const pastEnd = ctx.emitIcmp("sge", "i32", clamped0, strLenI32);
+
+  const searchLabel = ctx.nextLabel("indexof_from_search");
+  const pastEndLabel = ctx.nextLabel("indexof_from_pastend");
+  const endLabel = ctx.nextLabel("indexof_from_end");
+  ctx.emitBrCond(pastEnd, pastEndLabel, searchLabel);
+
+  ctx.emitLabel(pastEndLabel);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(searchLabel);
+  const offsetI64 = ctx.nextTemp();
+  ctx.emit(`${offsetI64} = zext i32 ${clamped0} to i64`);
+  const offsetPtr = ctx.nextTemp();
+  ctx.emit(`${offsetPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${offsetI64}`);
+  const foundPtr = ctx.emitCall("i8*", "@strstr", `i8* ${offsetPtr}, i8* ${substring}`);
+  const isNull = ctx.emitIcmp("eq", "i8*", foundPtr, "null");
+
+  const notFoundLabel = ctx.nextLabel("indexof_from_notfound");
+  const foundLabel = ctx.nextLabel("indexof_from_found");
+  ctx.emitBrCond(isNull, notFoundLabel, foundLabel);
+
+  ctx.emitLabel(notFoundLabel);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(foundLabel);
+  const strPtrInt = ctx.nextTemp();
+  ctx.emit(`${strPtrInt} = ptrtoint i8* ${strPtr} to i64`);
+  const foundPtrInt = ctx.nextTemp();
+  ctx.emit(`${foundPtrInt} = ptrtoint i8* ${foundPtr} to i64`);
+  const indexI64 = ctx.nextTemp();
+  ctx.emit(`${indexI64} = sub i64 ${foundPtrInt}, ${strPtrInt}`);
+  const indexI32 = ctx.nextTemp();
+  ctx.emit(`${indexI32} = trunc i64 ${indexI64} to i32`);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(endLabel);
+  const resultI32 = ctx.nextTemp();
+  ctx.emit(
+    `${resultI32} = phi i32 [ -1, %${pastEndLabel} ], [ -1, %${notFoundLabel} ], [ ${indexI32}, %${foundLabel} ]`,
+  );
+
+  const result = ctx.nextTemp();
+  ctx.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  ctx.setVariableType(result, "double");
+
+  return result;
+}
+
 export function generateLastIndexOf(
   ctx: IGeneratorContext,
   strPtr: string,

--- a/tests/fixtures/strings/string-indexof-fromindex.ts
+++ b/tests/fixtures/strings/string-indexof-fromindex.ts
@@ -1,0 +1,16 @@
+let passed = true;
+
+const s = "hello world hello";
+
+if (s.indexOf("hello") !== 0) passed = false;
+if (s.indexOf("hello", 1) !== 12) passed = false;
+if (s.indexOf("hello", 12) !== 12) passed = false;
+if (s.indexOf("hello", 13) !== -1) passed = false;
+if (s.indexOf("world", 0) !== 6) passed = false;
+if (s.indexOf("xyz", 0) !== -1) passed = false;
+if (s.indexOf("hello", -5) !== 0) passed = false;
+if (s.indexOf("hello", 100) !== -1) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/strings/string-substring-swap.ts
+++ b/tests/fixtures/strings/string-substring-swap.ts
@@ -1,0 +1,14 @@
+let passed = true;
+
+const s = "ABCDE";
+
+if (s.substring(1, 3) !== "BC") passed = false;
+if (s.substring(3, 1) !== "BC") passed = false;
+if (s.substring(0, 5) !== "ABCDE") passed = false;
+if (s.substring(2) !== "CDE") passed = false;
+if (s.substring(0, 0) !== "") passed = false;
+if (s.substring(2, 2) !== "") passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `"ABCDE".substring(3, 1)` now correctly returns "BC" instead of empty string
- Per JS spec, substring() should swap start/end when start > end, and clamp negatives to 0
- Previously, negative length from `end - start` when start > end caused empty/wrong results

## Test plan
- [x] New test fixture `string-substring-swap.ts` covers swapped args, equal args, single arg
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)