### PR TITLE
feat: support optional fromindex in string lastindexof

### DIFF
--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -320,11 +320,21 @@ export function handleLastIndexOf(
 ): string {
   const strPtr = ctx.generateExpression(expr.object, params);
 
-  if (expr.args.length !== 1) {
-    return ctx.emitError(`lastIndexOf() expects 1 argument, got ${expr.args.length}`, expr.loc);
+  if (expr.args.length < 1 || expr.args.length > 2) {
+    return ctx.emitError(
+      `lastIndexOf() expects 1 or 2 arguments, got ${expr.args.length}`,
+      expr.loc,
+    );
   }
 
   const substring = ctx.generateExpression(expr.args[0], params);
+
+  if (expr.args.length === 2) {
+    const fromIndexDouble = ctx.generateExpression(expr.args[1], params);
+    const fromIndex = convertToI32(ctx, fromIndexDouble);
+    return ctx.stringGen.doGenerateLastIndexOfFrom(strPtr, substring, fromIndex);
+  }
+
   return ctx.stringGen.doGenerateLastIndexOf(strPtr, substring);
 }
 

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -91,6 +91,7 @@ export interface IStringGenerator {
   doGenerateIndexOf(strPtr: string, substring: string): string;
   doGenerateIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string;
   doGenerateLastIndexOf(strPtr: string, substring: string): string;
+  doGenerateLastIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string;
   doGenerateIncludes(strPtr: string, substring: string): string;
   doGenerateSlice(strPtr: string, start: string, end: string | null): string;
   doGenerateCharAt(strPtr: string, index: string): string;
@@ -1702,6 +1703,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     doGenerateIndexOfFrom: (_strPtr: string, _substring: string, _fromIndex: string): string =>
       "%0",
     doGenerateLastIndexOf: (_strPtr: string, _substring: string): string => "%0",
+    doGenerateLastIndexOfFrom: (_strPtr: string, _substring: string, _fromIndex: string): string =>
+      "%0",
     doGenerateIncludes: (_strPtr: string, _substring: string): string => "%0",
     doGenerateSlice: (_strPtr: string, _start: string, _end: string | null): string => "%0",
     doGenerateCharAt: (_strPtr: string, _index: string): string => "%0",

--- a/src/codegen/types/collections/string.ts
+++ b/src/codegen/types/collections/string.ts
@@ -29,6 +29,7 @@ import {
   generateIndexOf,
   generateIndexOfFrom,
   generateLastIndexOf,
+  generateLastIndexOfFrom,
   generateIncludes,
   generateEndsWith,
 } from "./string/search.js";
@@ -143,6 +144,10 @@ export class StringGenerator implements IStringGenerator {
 
   doGenerateLastIndexOf(strPtr: string, substring: string): string {
     return generateLastIndexOf(this.ctx, strPtr, substring);
+  }
+
+  doGenerateLastIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string {
+    return generateLastIndexOfFrom(this.ctx, strPtr, substring, fromIndex);
   }
 
   doGenerateIncludes(strPtr: string, substring: string): string {

--- a/src/codegen/types/collections/string/search.ts
+++ b/src/codegen/types/collections/string/search.ts
@@ -248,6 +248,79 @@ export function generateIndexOfFrom(
   return result;
 }
 
+export function generateLastIndexOfFrom(
+  ctx: IGeneratorContext,
+  strPtr: string,
+  substring: string,
+  fromIndex: string,
+): string {
+  const isNeg = ctx.emitIcmp("slt", "i32", fromIndex, "0");
+
+  const negLabel = ctx.nextLabel("lastindexof_from_neg");
+  const searchLabel = ctx.nextLabel("lastindexof_from_search");
+  const endAllLabel = ctx.nextLabel("lastindexof_from_endall");
+  ctx.emitBrCond(isNeg, negLabel, searchLabel);
+
+  ctx.emitLabel(negLabel);
+  ctx.emitBr(endAllLabel);
+
+  ctx.emitLabel(searchLabel);
+
+  const lastPosPtr = ctx.nextAllocaReg("lastpos");
+  ctx.emit(`${lastPosPtr} = alloca i32`);
+  ctx.emitStore("i32", "-1", lastPosPtr);
+
+  const curPtrStorage = ctx.nextAllocaReg("curptr");
+  ctx.emit(`${curPtrStorage} = alloca i8*`);
+  ctx.emitStore("i8*", strPtr, curPtrStorage);
+
+  const strPtrInt = ctx.nextTemp();
+  ctx.emit(`${strPtrInt} = ptrtoint i8* ${strPtr} to i64`);
+
+  const loopLabel = ctx.nextLabel("lastindexof_from_loop");
+  const foundLabel = ctx.nextLabel("lastindexof_from_found");
+  const withinLabel = ctx.nextLabel("lastindexof_from_within");
+  const endLabel = ctx.nextLabel("lastindexof_from_end");
+
+  ctx.emitBr(loopLabel);
+
+  ctx.emitLabel(loopLabel);
+  const curPtr = ctx.emitLoad("i8*", curPtrStorage);
+  const foundPtr = ctx.emitCall("i8*", "@strstr", `i8* ${curPtr}, i8* ${substring}`);
+  const isNull = ctx.emitIcmp("eq", "i8*", foundPtr, "null");
+  ctx.emitBrCond(isNull, endLabel, foundLabel);
+
+  ctx.emitLabel(foundLabel);
+  const foundPtrInt = ctx.nextTemp();
+  ctx.emit(`${foundPtrInt} = ptrtoint i8* ${foundPtr} to i64`);
+  const indexI64 = ctx.nextTemp();
+  ctx.emit(`${indexI64} = sub i64 ${foundPtrInt}, ${strPtrInt}`);
+  const indexI32 = ctx.nextTemp();
+  ctx.emit(`${indexI32} = trunc i64 ${indexI64} to i32`);
+  const pastLimit = ctx.emitIcmp("sgt", "i32", indexI32, fromIndex);
+  ctx.emitBrCond(pastLimit, endLabel, withinLabel);
+
+  ctx.emitLabel(withinLabel);
+  ctx.emitStore("i32", indexI32, lastPosPtr);
+  const advancedPtr = ctx.nextTemp();
+  ctx.emit(`${advancedPtr} = getelementptr inbounds i8, i8* ${foundPtr}, i64 1`);
+  ctx.emitStore("i8*", advancedPtr, curPtrStorage);
+  ctx.emitBr(loopLabel);
+
+  ctx.emitLabel(endLabel);
+  const resultI32Search = ctx.emitLoad("i32", lastPosPtr);
+  ctx.emitBr(endAllLabel);
+
+  ctx.emitLabel(endAllLabel);
+  const resultI32 = ctx.nextTemp();
+  ctx.emit(`${resultI32} = phi i32 [ -1, %${negLabel} ], [ ${resultI32Search}, %${endLabel} ]`);
+  const result = ctx.nextTemp();
+  ctx.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  ctx.setVariableType(result, "double");
+
+  return result;
+}
+
 export function generateLastIndexOf(
   ctx: IGeneratorContext,
   strPtr: string,

--- a/tests/fixtures/strings/string-lastindexof-fromindex.ts
+++ b/tests/fixtures/strings/string-lastindexof-fromindex.ts
@@ -1,0 +1,16 @@
+let passed = true;
+
+const s = "hello world hello";
+
+if (s.lastIndexOf("hello") !== 12) passed = false;
+if (s.lastIndexOf("hello", 11) !== 0) passed = false;
+if (s.lastIndexOf("hello", 0) !== 0) passed = false;
+if (s.lastIndexOf("hello", 12) !== 12) passed = false;
+if (s.lastIndexOf("xyz") !== -1) passed = false;
+if (s.lastIndexOf("hello", -1) !== -1) passed = false;
+if (s.lastIndexOf("o", 4) !== 4) passed = false;
+if (s.lastIndexOf("o", 3) !== -1) passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `str.lastIndexOf("x", 5)` now works instead of erroring with "expects 1 argument, got 2"
- Searches backwards from the given position, matching JS spec behavior
- Negative fromIndex returns -1 (nothing found before position 0)

## Test plan
- [x] New test fixture `string-lastindexof-fromindex.ts` covers various fromIndex values
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)