### PR TITLE
feat: support optional position param in string includes() and endswith()

### DIFF
--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -241,11 +241,18 @@ export function handleEndsWith(
 ): string {
   const strPtr = ctx.generateExpression(expr.object, params);
 
-  if (expr.args.length !== 1) {
-    return ctx.emitError(`endsWith() expects 1 argument, got ${expr.args.length}`, expr.loc);
+  if (expr.args.length < 1 || expr.args.length > 2) {
+    return ctx.emitError(`endsWith() expects 1 or 2 arguments, got ${expr.args.length}`, expr.loc);
   }
 
   const suffix = ctx.generateExpression(expr.args[0], params);
+
+  if (expr.args.length === 2) {
+    const endPosDouble = ctx.generateExpression(expr.args[1], params);
+    const endPosition = convertToI32(ctx, endPosDouble);
+    return ctx.stringGen.doGenerateEndsWithPosition(strPtr, suffix, endPosition);
+  }
+
   return ctx.stringGen.doGenerateEndsWith(strPtr, suffix);
 }
 
@@ -492,11 +499,18 @@ export function handleStringIncludes(
     );
   }
 
-  if (expr.args.length !== 1) {
-    return ctx.emitError(`includes() expects 1 argument, got ${expr.args.length}`, expr.loc);
+  if (expr.args.length < 1 || expr.args.length > 2) {
+    return ctx.emitError(`includes() expects 1 or 2 arguments, got ${expr.args.length}`, expr.loc);
   }
 
   const substring = ctx.generateExpression(expr.args[0], params);
+
+  if (expr.args.length === 2) {
+    const fromIndexDouble = ctx.generateExpression(expr.args[1], params);
+    const fromIndex = convertToI32(ctx, fromIndexDouble);
+    return ctx.stringGen.doGenerateIncludesFrom(strPtr, substring, fromIndex);
+  }
+
   return ctx.stringGen.doGenerateIncludes(strPtr, substring);
 }
 

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -83,6 +83,7 @@ export interface IStringGenerator {
   doGenerateSplit(strPtr: string, delimiter: string): string;
   doGenerateStartsWith(strPtr: string, prefix: string): string;
   doGenerateEndsWith(strPtr: string, suffix: string): string;
+  doGenerateEndsWithPosition(strPtr: string, suffix: string, endPosition: string): string;
   doGenerateTrim(strPtr: string): string;
   doGenerateTrimStart(strPtr: string): string;
   doGenerateTrimEnd(strPtr: string): string;
@@ -93,6 +94,7 @@ export interface IStringGenerator {
   doGenerateLastIndexOf(strPtr: string, substring: string): string;
   doGenerateLastIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string;
   doGenerateIncludes(strPtr: string, substring: string): string;
+  doGenerateIncludesFrom(strPtr: string, substring: string, fromIndex: string): string;
   doGenerateSlice(strPtr: string, start: string, end: string | null): string;
   doGenerateCharAt(strPtr: string, index: string): string;
   doGenerateStringAt(strPtr: string, index: string): string;
@@ -1694,6 +1696,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     doGenerateSplit: (_strPtr: string, _delimiter: string): string => "%0",
     doGenerateStartsWith: (_strPtr: string, _prefix: string): string => "%0",
     doGenerateEndsWith: (_strPtr: string, _suffix: string): string => "%0",
+    doGenerateEndsWithPosition: (_strPtr: string, _suffix: string, _endPosition: string): string =>
+      "%0",
     doGenerateTrim: (_strPtr: string): string => "%0",
     doGenerateTrimStart: (_strPtr: string): string => "%0",
     doGenerateTrimEnd: (_strPtr: string): string => "%0",
@@ -1706,6 +1710,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     doGenerateLastIndexOfFrom: (_strPtr: string, _substring: string, _fromIndex: string): string =>
       "%0",
     doGenerateIncludes: (_strPtr: string, _substring: string): string => "%0",
+    doGenerateIncludesFrom: (_strPtr: string, _substring: string, _fromIndex: string): string =>
+      "%0",
     doGenerateSlice: (_strPtr: string, _start: string, _end: string | null): string => "%0",
     doGenerateCharAt: (_strPtr: string, _index: string): string => "%0",
     doGenerateStringAt: (_strPtr: string, _index: string): string => "%0",

--- a/src/codegen/types/collections/string.ts
+++ b/src/codegen/types/collections/string.ts
@@ -31,7 +31,9 @@ import {
   generateLastIndexOf,
   generateLastIndexOfFrom,
   generateIncludes,
+  generateIncludesFrom,
   generateEndsWith,
+  generateEndsWithPosition,
 } from "./string/search.js";
 import { generateSplit } from "./string/split.js";
 
@@ -154,8 +156,16 @@ export class StringGenerator implements IStringGenerator {
     return generateIncludes(this.ctx, strPtr, substring);
   }
 
+  doGenerateIncludesFrom(strPtr: string, substring: string, fromIndex: string): string {
+    return generateIncludesFrom(this.ctx, strPtr, substring, fromIndex);
+  }
+
   doGenerateEndsWith(strPtr: string, suffix: string): string {
     return generateEndsWith(this.ctx, strPtr, suffix);
+  }
+
+  doGenerateEndsWithPosition(strPtr: string, suffix: string, endPosition: string): string {
+    return generateEndsWithPosition(this.ctx, strPtr, suffix, endPosition);
   }
 
   // ============================================

--- a/src/codegen/types/collections/string/search.ts
+++ b/src/codegen/types/collections/string/search.ts
@@ -463,9 +463,7 @@ export function generateIncludesFrom(
 
   ctx.emitLabel(endLabel);
   const resultI32 = ctx.nextTemp();
-  ctx.emit(
-    `${resultI32} = phi i32 [ 0, %${pastEndLabel} ], [ ${foundI32}, %${searchLabel} ]`,
-  );
+  ctx.emit(`${resultI32} = phi i32 [ 0, %${pastEndLabel} ], [ ${foundI32}, %${searchLabel} ]`);
 
   const result = ctx.nextTemp();
   ctx.emit(`${result} = sitofp i32 ${resultI32} to double`);
@@ -511,7 +509,11 @@ export function generateEndsWithPosition(
   ctx.emit(`${startPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${startI64}`);
   const suffixLenI64 = ctx.nextTemp();
   ctx.emit(`${suffixLenI64} = zext i32 ${suffixLenI32} to i64`);
-  const cmpResult = ctx.emitCall("i32", "@strncmp", `i8* ${startPtr}, i8* ${suffix}, i64 ${suffixLenI64}`);
+  const cmpResult = ctx.emitCall(
+    "i32",
+    "@strncmp",
+    `i8* ${startPtr}, i8* ${suffix}, i64 ${suffixLenI64}`,
+  );
   const matches = ctx.emitIcmp("eq", "i32", cmpResult, "0");
   const matchesI32 = ctx.nextTemp();
   ctx.emit(`${matchesI32} = zext i1 ${matches} to i32`);
@@ -524,7 +526,9 @@ export function generateEndsWithPosition(
 
   ctx.emitLabel(endLabel);
   const resultEnd = ctx.nextTemp();
-  ctx.emit(`${resultEnd} = phi double [ ${matchesDouble}, %${checkLabel} ], [ 0.0, %${falseLabel} ]`);
+  ctx.emit(
+    `${resultEnd} = phi double [ ${matchesDouble}, %${checkLabel} ], [ 0.0, %${falseLabel} ]`,
+  );
   ctx.setVariableType(resultEnd, "double");
 
   return resultEnd;

--- a/src/codegen/types/collections/string/search.ts
+++ b/src/codegen/types/collections/string/search.ts
@@ -426,3 +426,106 @@ export function generateEndsWith(ctx: IGeneratorContext, strPtr: string, suffix:
 
   return result;
 }
+
+export function generateIncludesFrom(
+  ctx: IGeneratorContext,
+  strPtr: string,
+  substring: string,
+  fromIndex: string,
+): string {
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
+  const strLenI32 = ctx.nextTemp();
+  ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
+
+  const isNeg = ctx.emitIcmp("slt", "i32", fromIndex, "0");
+  const clamped0 = ctx.nextTemp();
+  ctx.emit(`${clamped0} = select i1 ${isNeg}, i32 0, i32 ${fromIndex}`);
+  const pastEnd = ctx.emitIcmp("sge", "i32", clamped0, strLenI32);
+
+  const searchLabel = ctx.nextLabel("includes_from_search");
+  const pastEndLabel = ctx.nextLabel("includes_from_pastend");
+  const endLabel = ctx.nextLabel("includes_from_end");
+  ctx.emitBrCond(pastEnd, pastEndLabel, searchLabel);
+
+  ctx.emitLabel(pastEndLabel);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(searchLabel);
+  const offsetI64 = ctx.nextTemp();
+  ctx.emit(`${offsetI64} = zext i32 ${clamped0} to i64`);
+  const offsetPtr = ctx.nextTemp();
+  ctx.emit(`${offsetPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${offsetI64}`);
+  const foundPtr = ctx.emitCall("i8*", "@strstr", `i8* ${offsetPtr}, i8* ${substring}`);
+  const isNotNull = ctx.emitIcmp("ne", "i8*", foundPtr, "null");
+  const foundI32 = ctx.nextTemp();
+  ctx.emit(`${foundI32} = zext i1 ${isNotNull} to i32`);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(endLabel);
+  const resultI32 = ctx.nextTemp();
+  ctx.emit(
+    `${resultI32} = phi i32 [ 0, %${pastEndLabel} ], [ ${foundI32}, %${searchLabel} ]`,
+  );
+
+  const result = ctx.nextTemp();
+  ctx.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  ctx.setVariableType(result, "double");
+
+  return result;
+}
+
+export function generateEndsWithPosition(
+  ctx: IGeneratorContext,
+  strPtr: string,
+  suffix: string,
+  endPosition: string,
+): string {
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
+  const strLenI32 = ctx.nextTemp();
+  ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
+
+  const isNeg = ctx.emitIcmp("slt", "i32", endPosition, "0");
+  const clamped0 = ctx.nextTemp();
+  ctx.emit(`${clamped0} = select i1 ${isNeg}, i32 0, i32 ${endPosition}`);
+  const pastEnd = ctx.emitIcmp("sgt", "i32", clamped0, strLenI32);
+  const clampedEnd = ctx.nextTemp();
+  ctx.emit(`${clampedEnd} = select i1 ${pastEnd}, i32 ${strLenI32}, i32 ${clamped0}`);
+
+  const suffixLen = ctx.emitCall("i64", "@strlen", `i8* ${suffix}`);
+  const suffixLenI32 = ctx.nextTemp();
+  ctx.emit(`${suffixLenI32} = trunc i64 ${suffixLen} to i32`);
+
+  const suffixLonger = ctx.emitIcmp("sgt", "i32", suffixLenI32, clampedEnd);
+
+  const checkLabel = ctx.nextLabel("endswith_pos_check");
+  const falseLabel = ctx.nextLabel("endswith_pos_false");
+  const endLabel = ctx.nextLabel("endswith_pos_end");
+  ctx.emitBrCond(suffixLonger, falseLabel, checkLabel);
+
+  ctx.emitLabel(checkLabel);
+  const startIdx = ctx.nextTemp();
+  ctx.emit(`${startIdx} = sub i32 ${clampedEnd}, ${suffixLenI32}`);
+  const startI64 = ctx.nextTemp();
+  ctx.emit(`${startI64} = zext i32 ${startIdx} to i64`);
+  const startPtr = ctx.nextTemp();
+  ctx.emit(`${startPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${startI64}`);
+  const suffixLenI64 = ctx.nextTemp();
+  ctx.emit(`${suffixLenI64} = zext i32 ${suffixLenI32} to i64`);
+  const cmpResult = ctx.emitCall("i32", "@strncmp", `i8* ${startPtr}, i8* ${suffix}, i64 ${suffixLenI64}`);
+  const matches = ctx.emitIcmp("eq", "i32", cmpResult, "0");
+  const matchesI32 = ctx.nextTemp();
+  ctx.emit(`${matchesI32} = zext i1 ${matches} to i32`);
+  const matchesDouble = ctx.nextTemp();
+  ctx.emit(`${matchesDouble} = sitofp i32 ${matchesI32} to double`);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(falseLabel);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(endLabel);
+  const resultEnd = ctx.nextTemp();
+  ctx.emit(`${resultEnd} = phi double [ ${matchesDouble}, %${checkLabel} ], [ 0.0, %${falseLabel} ]`);
+  ctx.setVariableType(resultEnd, "double");
+
+  return resultEnd;
+}

--- a/tests/fixtures/strings/string-endswith-position.ts
+++ b/tests/fixtures/strings/string-endswith-position.ts
@@ -1,0 +1,38 @@
+const str = "hello world";
+
+if (!str.endsWith("hello", 5)) {
+  console.log("FAIL: endsWith hello at position 5");
+  process.exit(1);
+}
+
+if (str.endsWith("world", 5)) {
+  console.log("FAIL: endsWith world at position 5 should be false");
+  process.exit(1);
+}
+
+if (!str.endsWith("world", 11)) {
+  console.log("FAIL: endsWith world at position 11 (full length)");
+  process.exit(1);
+}
+
+if (str.endsWith("hello", 3)) {
+  console.log("FAIL: endsWith hello at position 3 should be false (suffix longer than substring)");
+  process.exit(1);
+}
+
+if (!str.endsWith("lo", 5)) {
+  console.log("FAIL: endsWith lo at position 5");
+  process.exit(1);
+}
+
+if (!str.endsWith("world", 100)) {
+  console.log("FAIL: endsWith with position past end should clamp to string length");
+  process.exit(1);
+}
+
+if (str.endsWith("hello", -1)) {
+  console.log("FAIL: endsWith with negative position should be false");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/strings/string-includes-position.ts
+++ b/tests/fixtures/strings/string-includes-position.ts
@@ -1,0 +1,33 @@
+const str = "hello world hello";
+
+if (!str.includes("world", 0)) {
+  console.log("FAIL: includes world from 0");
+  process.exit(1);
+}
+
+if (str.includes("hello", 6)) {
+  if (str.includes("hello", 13)) {
+    console.log("FAIL: includes hello from 13 should be false");
+    process.exit(1);
+  }
+} else {
+  console.log("FAIL: includes hello from 6 should be true");
+  process.exit(1);
+}
+
+if (str.includes("world", 20)) {
+  console.log("FAIL: includes from past end should be false");
+  process.exit(1);
+}
+
+if (!str.includes("hello", -5)) {
+  console.log("FAIL: includes with negative position should search from 0");
+  process.exit(1);
+}
+
+if (str.includes("xyz", 0)) {
+  console.log("FAIL: includes non-existent should be false");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `string.includes(search, position)` now accepts optional `position` parameter per JS spec (was rejecting with error)
- `string.endsWith(search, endPosition)` now accepts optional `endPosition` parameter per JS spec (was rejecting with error)
- Position is clamped to valid range (negative → 0, past end → string length)

## Test plan
- [x] `tests/fixtures/strings/string-includes-position.ts` — position=0, mid-string, past end, negative, non-existent
- [x] `tests/fixtures/strings/string-endswith-position.ts` — substring match at position, suffix longer than position, clamp past end, negative
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)