### PR TITLE
replace husky/lint-staged with simple pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npx lint-staged

--- a/package.json
+++ b/package.json
@@ -28,10 +28,7 @@
     "coverage:report": "c8 report",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky"
-  },
-  "lint-staged": {
-    "*.{ts,js,json,md,yml,yaml}": "prettier --write"
+    "prepare": "cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
   },
   "keywords": [
     "compiler",
@@ -46,8 +43,6 @@
     "@types/node": "^20.0.0",
     "date-fns": "^4.1.0",
     "c8": "^11.0.0",
-    "husky": "^9.1.7",
-    "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
     "ts-node": "^10.9.0",
     "tsx": "^4.20.6",

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|js)$')
+[ -z "$STAGED" ] && exit 0
+echo "$STAGED" | xargs npx prettier --write
+echo "$STAGED" | xargs git add


### PR DESCRIPTION
## Summary
- Removes husky and lint-staged dependencies in favor of a simple shell script at `scripts/pre-commit`
- The hook runs `prettier --write` on staged `.ts` and `.js` files, then re-stages them
- Installed automatically via `npm prepare` script — no extra setup needed after `npm install`

## Test plan
- [x] `npm run verify:quick` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)