### PR TITLE
fix: map<string, number>.set() and charat/charcodeat default args

### DIFF
--- a/src/codegen/expressions/method-calls/map-dispatch.ts
+++ b/src/codegen/expressions/method-calls/map-dispatch.ts
@@ -144,7 +144,7 @@ function dispatchStringMapMethod(
   if (method === "set") {
     const keyValue = ctx.generateExpression(expr.args[0], params);
     const valueValue = ctx.generateExpression(expr.args[1], params);
-    return ctx.stringMapGen.generateStringMapSet(mapAlloca, keyValue, valueValue);
+    return ctx.stringMapGen.generateStringMapSet(mapAlloca, keyValue, valueValue, valueType);
   } else if (method === "get") {
     const keyValue = ctx.generateExpression(expr.args[0], params);
     const rawResult = ctx.stringMapGen.generateStringMapGet(mapAlloca, keyValue);

--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -710,12 +710,12 @@ export function handleCharAt(
 ): string {
   const strPtr = ctx.generateExpression(expr.object, params);
 
-  if (expr.args.length !== 1) {
-    return ctx.emitError("charAt() expects 1 argument, got " + expr.args.length, expr.loc);
+  if (expr.args.length > 1) {
+    return ctx.emitError("charAt() expects 0 or 1 arguments, got " + expr.args.length, expr.loc);
   }
 
-  const indexDouble = ctx.generateExpression(expr.args[0], params);
-  const indexI32 = convertToI32(ctx, indexDouble);
+  const indexI32 =
+    expr.args.length === 1 ? convertToI32(ctx, ctx.generateExpression(expr.args[0], params)) : "0";
   return ctx.stringGen.doGenerateCharAt(strPtr, indexI32);
 }
 
@@ -742,12 +742,15 @@ export function handleCharCodeAt(
 ): string {
   const strPtr = ctx.generateExpression(expr.object, params);
 
-  if (expr.args.length !== 1) {
-    return ctx.emitError("charCodeAt() expects 1 argument, got " + expr.args.length, expr.loc);
+  if (expr.args.length > 1) {
+    return ctx.emitError(
+      "charCodeAt() expects 0 or 1 arguments, got " + expr.args.length,
+      expr.loc,
+    );
   }
 
-  const indexDouble = ctx.generateExpression(expr.args[0], params);
-  const indexI32 = convertToI32(ctx, indexDouble);
+  const indexI32 =
+    expr.args.length === 1 ? convertToI32(ctx, ctx.generateExpression(expr.args[0], params)) : "0";
   return ctx.stringGen.doGenerateCharCodeAt(strPtr, indexI32);
 }
 

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -247,7 +247,7 @@ export interface IArrowFunctionGenerator {
 }
 
 export interface IStringMapGenerator {
-  generateStringMapSet(mapPtr: string, keyValue: string, valueValue: string): string;
+  generateStringMapSet(mapPtr: string, keyValue: string, valueValue: string, declaredValueType?: string): string;
   generateStringMapGet(mapPtr: string, keyToFind: string): string;
   generateStringMapHas(mapPtr: string, keyToFind: string): string;
   generateStringMapClear(mapPtr: string): string;
@@ -1846,7 +1846,7 @@ export class MockGeneratorContext implements IGeneratorContext {
   }
 
   stringMapGen: IStringMapGenerator = {
-    generateStringMapSet: (_mapPtr: string, _keyValue: string, _valueValue: string): string =>
+    generateStringMapSet: (_mapPtr: string, _keyValue: string, _valueValue: string, _declaredValueType?: string): string =>
       "%mock_set_result",
     generateStringMapGet: (_mapPtr: string, _keyToFind: string): string => "%mock_get_result",
     generateStringMapHas: (_mapPtr: string, _keyToFind: string): string => "%mock_has_result",

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -247,7 +247,12 @@ export interface IArrowFunctionGenerator {
 }
 
 export interface IStringMapGenerator {
-  generateStringMapSet(mapPtr: string, keyValue: string, valueValue: string, declaredValueType?: string): string;
+  generateStringMapSet(
+    mapPtr: string,
+    keyValue: string,
+    valueValue: string,
+    declaredValueType?: string,
+  ): string;
   generateStringMapGet(mapPtr: string, keyToFind: string): string;
   generateStringMapHas(mapPtr: string, keyToFind: string): string;
   generateStringMapClear(mapPtr: string): string;
@@ -1846,8 +1851,12 @@ export class MockGeneratorContext implements IGeneratorContext {
   }
 
   stringMapGen: IStringMapGenerator = {
-    generateStringMapSet: (_mapPtr: string, _keyValue: string, _valueValue: string, _declaredValueType?: string): string =>
-      "%mock_set_result",
+    generateStringMapSet: (
+      _mapPtr: string,
+      _keyValue: string,
+      _valueValue: string,
+      _declaredValueType?: string,
+    ): string => "%mock_set_result",
     generateStringMapGet: (_mapPtr: string, _keyToFind: string): string => "%mock_get_result",
     generateStringMapHas: (_mapPtr: string, _keyToFind: string): string => "%mock_has_result",
     generateStringMapClear: (_mapPtr: string): string => "%mock_clear_result",

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -690,7 +690,12 @@ export class StringMapGenerator {
     return mapPtr;
   }
 
-  generateStringMapSet(mapPtr: string, keyValue: string, valueValue: string, declaredValueType?: string): string {
+  generateStringMapSet(
+    mapPtr: string,
+    keyValue: string,
+    valueValue: string,
+    declaredValueType?: string,
+  ): string {
     let valueType = this.ctx.getVariableType(valueValue);
     if (!valueType && declaredValueType === "number") {
       valueType = "double";

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -690,8 +690,11 @@ export class StringMapGenerator {
     return mapPtr;
   }
 
-  generateStringMapSet(mapPtr: string, keyValue: string, valueValue: string): string {
+  generateStringMapSet(mapPtr: string, keyValue: string, valueValue: string, declaredValueType?: string): string {
     let valueType = this.ctx.getVariableType(valueValue);
+    if (!valueType && declaredValueType === "number") {
+      valueType = "double";
+    }
     if (!valueType && valueValue !== "null") {
       const fc = valueValue.charAt(0);
       if ((fc >= "0" && fc <= "9") || fc === "-" || fc === ".") {

--- a/tests/fixtures/strings/string-charat-default.ts
+++ b/tests/fixtures/strings/string-charat-default.ts
@@ -1,0 +1,27 @@
+const str = "hello";
+
+const first = str.charAt();
+if (first !== "h") {
+  console.log("FAIL: charAt() should return first char, got: " + first);
+  process.exit(1);
+}
+
+const code = str.charCodeAt();
+if (code !== 104) {
+  console.log("FAIL: charCodeAt() should return 104 (h), got: " + code);
+  process.exit(1);
+}
+
+const explicit = str.charAt(0);
+if (explicit !== "h") {
+  console.log("FAIL: charAt(0) should return h");
+  process.exit(1);
+}
+
+const explicitCode = str.charCodeAt(0);
+if (explicitCode !== 104) {
+  console.log("FAIL: charCodeAt(0) should return 104");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- **Map<string, number>.set() regression fix**: The native compiler miscompiled the `charAt(0)` numeric literal detection in `generateStringMapSet`, causing `store i8* 0.5` (invalid IR) instead of boxing the double. Fix: pass the declared value type (`"number"`) from `dispatchStringMapMethod` through to `generateStringMapSet`, bypassing string-based detection entirely.
- **charAt()/charCodeAt() default args**: Per JS spec, both methods default to index 0 when called with no arguments. Previously they required exactly 1 argument.

## Test plan
- [x] `map-string-number-param.ts` now passes with native compiler (was failing with invalid IR)
- [x] New `string-charat-default.ts` fixture tests 0-arg and 1-arg forms
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)