### PR TITLE
fix: add missing setUsesJson flags in json access paths

### DIFF
--- a/src/codegen/expressions/access/chained-access.ts
+++ b/src/codegen/expressions/access/chained-access.ts
@@ -47,6 +47,7 @@ export function extractJsonFieldValue(
   ctx: MemberAccessGeneratorContext,
   fieldItem: string,
 ): string {
+  ctx.setUsesJson(true);
   const fieldExists = ctx.emitIcmp("ne", "i8*", fieldItem, "null");
 
   const hasFieldLabel = ctx.nextLabel("json_has_field");
@@ -90,6 +91,7 @@ export function extractNestedJsonFieldValue(
   ctx: MemberAccessGeneratorContext,
   fieldItem: string,
 ): string {
+  ctx.setUsesJson(true);
   const isNumber = ctx.emitCall("i32", "@csyyjson_is_num", `i8* ${fieldItem}`);
   const isNumBool = ctx.emitIcmp("ne", "i32", isNumber, "0");
 

--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -428,7 +428,7 @@ export class IndexAccessGenerator {
   }
 
   private generateJSONArrayIndex(expr: IndexAccessNode, params: string[]): string {
-    // Load JSON array pointer
+    this.ctx.setUsesJson(true);
     const varName = (expr.object as VariableNode).name;
     const jsonPtrPtr = this.ctx.getVariableAlloca(varName)!;
     const jsonPtr = this.ctx.nextTemp();

--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -223,6 +223,7 @@ export function handleMemberAccessLength(
       return getArrayLengthFromPtr(ctx, arrayPtr, "%ObjectArray");
     }
     if (ctx.symbolTable.isJSON(varName)) {
+      ctx.setUsesJson(true);
       const arraySize = ctx.nextTemp();
       ctx.emit(`${arraySize} = call i32 @csyyjson_arr_size(i8* ${arrayPtr})`);
       const sizeDouble = ctx.nextTemp();


### PR DESCRIPTION
## Summary
- Add missing `setUsesJson(true)` calls in 4 JSON codegen paths that emit `@csyyjson_*` bridge calls without setting the feature flag
- Affected paths: `extractJsonFieldValue`, `extractNestedJsonFieldValue` (chained-access.ts), `generateJSONArrayIndex` (index.ts), JSON array `.length` (property-handlers.ts)
- Without the flag, these paths could produce "undefined value" linker errors if they're the only JSON codegen path hit in a program (CLAUDE.md rule #9)

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)