### PR TITLE
fix: use zext instead of sext for map/splice size calculations

### DIFF
--- a/src/codegen/types/collections/array/splice.ts
+++ b/src/codegen/types/collections/array/splice.ts
@@ -102,7 +102,7 @@ function generateNumericArraySplice(
   const resultArrayTyped = gen.emitBitcast(resultArray, "i8*", "%Array*");
 
   const dcI64 = gen.nextTemp();
-  gen.emit(`${dcI64} = sext i32 ${deleteCount} to i64`);
+  gen.emit(`${dcI64} = zext i32 ${deleteCount} to i64`);
   const resultDataSize = gen.nextTemp();
   gen.emit(`${resultDataSize} = mul i64 ${dcI64}, 8`);
   const resultDataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${resultDataSize}`);
@@ -143,7 +143,7 @@ function generateNumericArraySplice(
   gen.emit(`${moveSrc} = getelementptr inbounds double, double* ${dataPtr}, i32 ${afterStart}`);
   const moveSrcI8 = gen.emitBitcast(moveSrc, "double*", "i8*");
   const moveI64 = gen.nextTemp();
-  gen.emit(`${moveI64} = sext i32 ${elemsAfter} to i64`);
+  gen.emit(`${moveI64} = zext i32 ${elemsAfter} to i64`);
   const moveBytes = gen.nextTemp();
   gen.emit(`${moveBytes} = mul i64 ${moveI64}, 8`);
   gen.emit(
@@ -210,7 +210,7 @@ function generateStringArraySplice(
   const resultArrayTyped = gen.emitBitcast(resultArray, "i8*", "%StringArray*");
 
   const dcI64 = gen.nextTemp();
-  gen.emit(`${dcI64} = sext i32 ${deleteCount} to i64`);
+  gen.emit(`${dcI64} = zext i32 ${deleteCount} to i64`);
   const resultDataSize = gen.nextTemp();
   gen.emit(`${resultDataSize} = mul i64 ${dcI64}, 8`);
   const resultDataMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${resultDataSize}`);
@@ -251,7 +251,7 @@ function generateStringArraySplice(
   gen.emit(`${moveSrc} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${afterStart}`);
   const moveSrcI8 = gen.emitBitcast(moveSrc, "i8**", "i8*");
   const moveI64 = gen.nextTemp();
-  gen.emit(`${moveI64} = sext i32 ${elemsAfter} to i64`);
+  gen.emit(`${moveI64} = zext i32 ${elemsAfter} to i64`);
   const moveBytes = gen.nextTemp();
   gen.emit(`${moveBytes} = mul i64 ${moveI64}, 8`);
   gen.emit(

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -518,7 +518,7 @@ export class MapGenerator {
     const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
 
     const mapSizeI64 = this.nextTemp();
-    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
@@ -578,7 +578,7 @@ export class MapGenerator {
     const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
 
     const mapSizeI64 = this.nextTemp();
-    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
@@ -771,7 +771,7 @@ export class StringMapGenerator {
     const newCapacity = this.nextTemp();
     this.emit(`${newCapacity} = shl i32 ${currentCapacity}, 1`);
     const newCapI64 = this.nextTemp();
-    this.emit(`${newCapI64} = sext i32 ${newCapacity} to i64`);
+    this.emit(`${newCapI64} = zext i32 ${newCapacity} to i64`);
     const newArrSize = this.nextTemp();
     this.emit(`${newArrSize} = mul i64 ${newCapI64}, 8`);
     const newKeysMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${newArrSize}`);
@@ -1025,7 +1025,7 @@ export class StringMapGenerator {
     const capacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
     const capI64 = this.nextTemp();
-    this.emit(`${capI64} = sext i32 ${capacity} to i64`);
+    this.emit(`${capI64} = zext i32 ${capacity} to i64`);
     const arrSize = this.nextTemp();
     this.emit(`${arrSize} = mul i64 ${capI64}, 8`);
 
@@ -1228,7 +1228,7 @@ export class StringMapGenerator {
     const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
 
     const mapSizeI64 = this.nextTemp();
-    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
@@ -1339,7 +1339,7 @@ export class StringMapGenerator {
     const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
 
     const mapSizeI64 = this.nextTemp();
-    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
@@ -1431,7 +1431,7 @@ export class StringMapGenerator {
     const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%StringArray*");
 
     const mapSizeI64 = this.nextTemp();
-    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
@@ -1887,7 +1887,7 @@ export class PointerMapGenerator {
     const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%ObjectArray*");
 
     const mapSizeI64 = this.nextTemp();
-    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
@@ -1978,7 +1978,7 @@ export class PointerMapGenerator {
     const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%ObjectArray*");
 
     const mapSizeI64 = this.nextTemp();
-    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
@@ -2051,7 +2051,7 @@ export class PointerMapGenerator {
     const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%ObjectArray*");
 
     const mapSizeI64 = this.nextTemp();
-    this.emit(`${mapSizeI64} = sext i32 ${mapSize} to i64`);
+    this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);


### PR DESCRIPTION
## Summary
- Replace `sext i32 to i64` with `zext i32 to i64` for size/capacity values in map and splice codegen
- `sext` on a large unsigned i32 (e.g., capacity after `shl i32 cap, 1`) sign-extends to a negative i64, causing massive or negative allocation sizes in `GC_malloc`
- Affected: 9 locations in map.ts (mapSize, capacity extensions), 4 in splice.ts (deleteCount, elemsAfter)
- Same class of bug as PR #268 (which fixed array/string copy size calculations)

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)