### PR TITLE
fix: add null check to untyped JSON.parse for malformed input

### DIFF
--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -93,6 +93,23 @@ export class JsonGenerator {
   private generateUntypedParse(expr: MethodCallNode, params: string[]): string {
     const jsonStr = this.ctx.generateExpression(expr.args[0], params);
     const jsonRoot = this.ctx.emitCall("i8*", "@csyyjson_parse", `i8* ${jsonStr}`);
+
+    const isNull = this.ctx.emitIcmp("eq", "i8*", jsonRoot, "null");
+    const failLabel = this.ctx.nextLabel("json_parse_fail");
+    const okLabel = this.ctx.nextLabel("json_parse_ok");
+    this.ctx.emitBrCond(isNull, failLabel, okLabel);
+    this.ctx.emitLabel(failLabel);
+    const stderrPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${stderrPtr} = load i8*, i8** @stderr`);
+    const fmtStr = this.ctx.createStringConstant("Error: JSON.parse() failed — invalid JSON input\n");
+    const fprintfResult = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* ${fmtStr})`,
+    );
+    this.ctx.emit("call void @exit(i32 1)");
+    this.ctx.emit("unreachable");
+    this.ctx.emitLabel(okLabel);
+
     return jsonRoot;
   }
 

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -101,7 +101,9 @@ export class JsonGenerator {
     this.ctx.emitLabel(failLabel);
     const stderrPtr = this.ctx.nextTemp();
     this.ctx.emit(`${stderrPtr} = load i8*, i8** @stderr`);
-    const fmtStr = this.ctx.createStringConstant("Error: JSON.parse() failed — invalid JSON input\n");
+    const fmtStr = this.ctx.createStringConstant(
+      "Error: JSON.parse() failed — invalid JSON input\n",
+    );
     const fprintfResult = this.ctx.nextTemp();
     this.ctx.emit(
       `${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* ${fmtStr})`,


### PR DESCRIPTION
## Summary
- Add runtime null check after `csyyjson_parse` in `generateUntypedParse` — malformed JSON now prints a clear error and exits instead of dereferencing null
- Before: `JSON.parse("bad")` on untyped path → null pointer dereference → segfault
- After: `Error: JSON.parse() failed — invalid JSON input` + exit code 1
- Note: this code path is currently unused (typed parse required by error diagnostic), but guards against future use
- Completes yyjson null-check audit: all `csyyjson_parse` call sites now check for null

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)