### PR TITLE
fix: untrack node_modules symlink causing circular reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependencies
-node_modules/
+node_modules
 
 # Generated
 src/version.ts

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/csmith/git/ChadScript/node_modules


### PR DESCRIPTION
## Summary
- Removes the `node_modules` symlink from git tracking — it was a self-referencing circular symlink that broke `tsc` and `npm` on every fresh checkout
- Changes `.gitignore` from `node_modules/` to `node_modules` so it matches both directories and symlinks, preventing re-tracking

## Test plan
- [ ] Fresh clone should not have `node_modules` tracked
- [ ] `git checkout` / `git pull` no longer restores a circular symlink
- [ ] CI passes (no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)