### PR TITLE
fix: emit runtime error for array.reduce on empty array with no initial value

### DIFF
--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -476,6 +476,21 @@ function generateNumericArrayReduce(
     gen.emitStore("double", dblInit, accPtr);
     gen.emitStore("i32", "0", counterPtr);
   } else {
+    const isEmpty = gen.emitIcmp("eq", "i32", length, "0");
+    const emptyLabel = gen.nextLabel("reduce_empty");
+    const okLabel = gen.nextLabel("reduce_has_elems");
+    gen.emitBrCond(isEmpty, emptyLabel, okLabel);
+    gen.emitLabel(emptyLabel);
+    const stderrPtr = gen.nextTemp();
+    gen.emit(`${stderrPtr} = load i8*, i8** @stderr`);
+    const fmtStr = gen.createStringConstant("Error: reduce of empty array with no initial value\n");
+    const fprintfResult = gen.nextTemp();
+    gen.emit(
+      `${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* ${fmtStr})`,
+    );
+    gen.emit("call void @exit(i32 1)");
+    gen.emit("unreachable");
+    gen.emitLabel(okLabel);
     const firstElemPtr = gen.nextTemp();
     gen.emit(`${firstElemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 0`);
     const firstElem = gen.emitLoad("double", firstElemPtr);
@@ -548,6 +563,21 @@ function generateStringArrayReduce(
     gen.emit(`store i8* ${initialValue}, i8** ${accPtr}`);
     gen.emitStore("i32", "0", counterPtr);
   } else {
+    const isEmpty = gen.emitIcmp("eq", "i32", length, "0");
+    const emptyLabel = gen.nextLabel("reduce_empty");
+    const okLabel = gen.nextLabel("reduce_has_elems");
+    gen.emitBrCond(isEmpty, emptyLabel, okLabel);
+    gen.emitLabel(emptyLabel);
+    const stderrPtr = gen.nextTemp();
+    gen.emit(`${stderrPtr} = load i8*, i8** @stderr`);
+    const fmtStr = gen.createStringConstant("Error: reduce of empty array with no initial value\n");
+    const fprintfResult = gen.nextTemp();
+    gen.emit(
+      `${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* ${fmtStr})`,
+    );
+    gen.emit("call void @exit(i32 1)");
+    gen.emit("unreachable");
+    gen.emitLabel(okLabel);
     const firstElemPtr = gen.nextTemp();
     gen.emit(`${firstElemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 0`);
     const firstElem = gen.nextTemp();

--- a/tests/fixtures/arrays/array-reduce-empty.ts
+++ b/tests/fixtures/arrays/array-reduce-empty.ts
@@ -1,0 +1,8 @@
+// @test-exit-code: 1
+function add(acc: number, x: number): number {
+  return acc + x;
+}
+
+const empty: number[] = [];
+const result = empty.reduce(add);
+console.log("should not reach here: " + result);


### PR DESCRIPTION
## Summary
- `[1,2,3].reduce(fn)` (no initial value) on an **empty** array previously read uninitialized memory (segfault/UB). Now emits a clear runtime error: `Error: reduce of empty array with no initial value` and exits with code 1 — matching V8/Node behavior.
- Guards added to both numeric and string array reduce paths.

## Test plan
- [x] New fixture `array-reduce-empty.ts` asserts exit code 1
- [x] Existing `array-reduce.ts` (with initial value + non-empty no-init) still passes
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)