### PR TITLE
fix: prevent infinite loop in replaceall with empty search string

### DIFF
--- a/src/codegen/types/collections/string/manipulation.ts
+++ b/src/codegen/types/collections/string/manipulation.ts
@@ -813,6 +813,18 @@ export function generateReplaceAll(
   searchPtr: string,
   replacePtr: string,
 ): string {
+  const searchLen = ctx.emitCall("i64", "@strlen", `i8* ${searchPtr}`);
+  const isEmpty = ctx.emitIcmp("eq", "i64", searchLen, "0");
+  const emptyLabel = ctx.nextLabel("replaceall_empty");
+  const doReplaceLabel = ctx.nextLabel("replaceall_do");
+  const doneLabel = ctx.nextLabel("replaceall_done");
+  ctx.emitBrCond(isEmpty, emptyLabel, doReplaceLabel);
+
+  ctx.emitLabel(emptyLabel);
+  const origDup = ctx.emitCall("i8*", "@strdup", `i8* ${strPtr}`);
+  ctx.emitBr(doneLabel);
+
+  ctx.emitLabel(doReplaceLabel);
   const resultPtr = ctx.nextTemp();
   ctx.emit(`${resultPtr} = alloca i8*`);
   ctx.emitStore("i8*", strPtr, resultPtr);
@@ -835,7 +847,15 @@ export function generateReplaceAll(
   ctx.emitBr(loopLabel);
 
   ctx.emitLabel(endLabel);
-  const result = ctx.emitLoad("i8*", resultPtr);
+  const loopResult = ctx.emitLoad("i8*", resultPtr);
+  ctx.emitBr(doneLabel);
+
+  ctx.emitLabel(doneLabel);
+  const result = ctx.nextTemp();
+  ctx.emit(
+    `${result} = phi i8* [ ${origDup}, %${emptyLabel} ], [ ${loopResult}, %${endLabel} ]`,
+  );
+  ctx.setVariableType(result, "i8*");
 
   return result;
 }

--- a/src/codegen/types/collections/string/manipulation.ts
+++ b/src/codegen/types/collections/string/manipulation.ts
@@ -852,9 +852,7 @@ export function generateReplaceAll(
 
   ctx.emitLabel(doneLabel);
   const result = ctx.nextTemp();
-  ctx.emit(
-    `${result} = phi i8* [ ${origDup}, %${emptyLabel} ], [ ${loopResult}, %${endLabel} ]`,
-  );
+  ctx.emit(`${result} = phi i8* [ ${origDup}, %${emptyLabel} ], [ ${loopResult}, %${endLabel} ]`);
   ctx.setVariableType(result, "i8*");
 
   return result;

--- a/tests/fixtures/strings/string-replaceall-empty.ts
+++ b/tests/fixtures/strings/string-replaceall-empty.ts
@@ -1,0 +1,18 @@
+function testReplaceAllEmpty(): void {
+  const s = "hello";
+  const result = s.replaceAll("", "x");
+  if (result !== "hello") {
+    console.log("FAIL: replaceAll with empty search should return original, got: " + result);
+    process.exit(1);
+  }
+
+  const normal = "aabbcc".replaceAll("bb", "X");
+  if (normal !== "aaXcc") {
+    console.log("FAIL: normal replaceAll should work, got: " + normal);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testReplaceAllEmpty();


### PR DESCRIPTION
## Summary
- `str.replaceAll("", "x")` previously caused an infinite loop — `strstr` always matches an empty string at the current position, so the replace loop never terminates.
- Now checks search string length before entering the loop. Empty search returns the original string unchanged.

## Test plan
- [x] New fixture `string-replaceall-empty.ts` tests empty search + normal replaceAll
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)