### PR TITLE
add test fixtures for array.concat

### DIFF
--- a/tests/fixtures/arrays/array-concat-empty.ts
+++ b/tests/fixtures/arrays/array-concat-empty.ts
@@ -1,0 +1,34 @@
+function testConcatEmpty(): void {
+  const a: number[] = [1, 2, 3];
+  const empty: number[] = [];
+
+  const r1 = a.concat(empty);
+  if (r1.length !== 3) {
+    console.log("FAIL: concat with empty should preserve length, got " + r1.length);
+    process.exit(1);
+  }
+  if (r1[0] !== 1 || r1[2] !== 3) {
+    console.log("FAIL: concat with empty values wrong");
+    process.exit(1);
+  }
+
+  const r2 = empty.concat(a);
+  if (r2.length !== 3) {
+    console.log("FAIL: empty concat should have length 3, got " + r2.length);
+    process.exit(1);
+  }
+  if (r2[0] !== 1 || r2[2] !== 3) {
+    console.log("FAIL: empty concat values wrong");
+    process.exit(1);
+  }
+
+  const r3 = empty.concat(empty);
+  if (r3.length !== 0) {
+    console.log("FAIL: empty concat empty should be 0, got " + r3.length);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testConcatEmpty();

--- a/tests/fixtures/arrays/array-concat-strings.ts
+++ b/tests/fixtures/arrays/array-concat-strings.ts
@@ -1,0 +1,22 @@
+function testStringConcat(): void {
+  const a: string[] = ["hello", "world"];
+  const b: string[] = ["foo", "bar", "baz"];
+  const c = a.concat(b);
+  if (c.length !== 5) {
+    console.log("FAIL: concat length should be 5, got " + c.length);
+    process.exit(1);
+  }
+  if (c[0] !== "hello" || c[2] !== "foo" || c[4] !== "baz") {
+    console.log("FAIL: concat values wrong");
+    process.exit(1);
+  }
+
+  if (a.length !== 2 || b.length !== 3) {
+    console.log("FAIL: original arrays should not be modified");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testStringConcat();

--- a/tests/fixtures/arrays/array-concat.ts
+++ b/tests/fixtures/arrays/array-concat.ts
@@ -1,0 +1,22 @@
+function testNumericConcat(): void {
+  const a: number[] = [1, 2, 3];
+  const b: number[] = [4, 5, 6];
+  const c = a.concat(b);
+  if (c.length !== 6) {
+    console.log("FAIL: concat length should be 6, got " + c.length);
+    process.exit(1);
+  }
+  if (c[0] !== 1 || c[3] !== 4 || c[5] !== 6) {
+    console.log("FAIL: concat values wrong");
+    process.exit(1);
+  }
+
+  if (a.length !== 3 || b.length !== 3) {
+    console.log("FAIL: original arrays should not be modified");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testNumericConcat();


### PR DESCRIPTION
## Summary
- `array.concat()` was the only array method with zero test coverage. Adds fixtures for numeric, string, and empty-array edge cases.
- All tests pass including empty-to-empty concat (0-length memcpy).

## Test plan
- [x] `array-concat.ts` — numeric array concat, verifies values and immutability
- [x] `array-concat-strings.ts` — string array concat
- [x] `array-concat-empty.ts` — empty array edge cases (concat with empty, empty with non-empty, empty with empty)
- [x] `npm run verify:quick` passes