### PR TITLE
fix: hoist alloca out of loop in custom sort comparator

### DIFF
--- a/src/codegen/types/collections/array/sort.ts
+++ b/src/codegen/types/collections/array/sort.ts
@@ -180,6 +180,9 @@ function generateNumericSortWithFn(
   gen.emit(`${iPtr} = alloca i32`);
   gen.emit(`store i32 0, i32* ${iPtr}`);
 
+  const jPtr = gen.nextTemp();
+  gen.emit(`${jPtr} = alloca i32`);
+
   const lenMinus1 = gen.nextTemp();
   gen.emit(`${lenMinus1} = sub i32 ${length}, 1`);
 
@@ -193,8 +196,6 @@ function generateNumericSortWithFn(
   gen.emit(`br i1 ${outerCond}, label %${outerBody}, label %${endLabel}`);
 
   gen.emit(`${outerBody}:`);
-  const jPtr = gen.nextTemp();
-  gen.emit(`${jPtr} = alloca i32`);
   gen.emit(`store i32 0, i32* ${jPtr}`);
 
   const remaining = gen.nextTemp();


### PR DESCRIPTION
## Summary
- The inner loop counter (`jPtr`) in `generateNumericSortWithFn` was allocated with `alloca` inside the outer loop body. Each iteration created a new stack allocation, violating LLVM's "hoist allocas to entry block" rule and risking stack overflow on large arrays.
- Moved the `alloca` before the loop; the outer body now just resets it with a `store`.

## Test plan
- [x] Existing sort tests pass
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)