### PR TITLE
add --diagnostics json flag for structured error output

### DIFF
--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -11,6 +11,7 @@ import {
   addLinkLib,
   addLinkPath,
   setDiagnosticColor,
+  setDiagnosticsJson,
   registerStdlib,
 } from "./native-compiler-lib.js";
 // d.ts content is embedded at compile time via ChadScript.embedFile
@@ -78,6 +79,7 @@ parser.addScopedOption("output", "o", "Specify output file", "", "build,run,ir")
 parser.addScopedFlag("verbose", "v", "Show compilation steps", "build,run,ir");
 parser.addScopedFlag("debug-info", "g", "Emit DWARF debug info (skips stripping)", "build,run");
 parser.addScopedFlag("skip-semantic-analysis", "", "Skip semantic analysis", "build,run,ir");
+parser.addScopedOption("diagnostics", "", "Diagnostic output format (json)", "", "build,run,ir");
 parser.addScopedOption(
   "target",
   "",
@@ -296,6 +298,11 @@ if (parser.getFlag("debug-info")) {
 
 if (parser.getFlag("skip-semantic-analysis")) {
   setSkipSemanticAnalysis(true);
+}
+
+const diagFormat = parser.getOption("diagnostics");
+if (diagFormat === "json") {
+  setDiagnosticsJson(true);
 }
 
 // Cross-compilation: only linux-x64 for build/run (needs SDK + linker).

--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -12,6 +12,7 @@ import {
   setTarget,
   setTargetCpu,
   setStaticLink,
+  setDiagnosticsJson,
   addLinkObj,
   addLinkLib,
   addLinkPath,
@@ -49,6 +50,7 @@ parser.addScopedFlag("debug", "", "Show internal debugging information", "build,
 parser.addScopedFlag("trace", "", "Show everything (AST, IR, variable tracking)", "build,run,ir");
 parser.addScopedFlag("skip-semantic-analysis", "", "Skip semantic analysis", "build,run,ir");
 parser.addScopedFlag("keep-temps", "", "Keep intermediate files (.ll, .o)", "build,run,ir");
+parser.addScopedOption("diagnostics", "", "Diagnostic output format (json)", "", "build,run,ir");
 parser.addScopedFlag("sanitize-address", "", "Build with AddressSanitizer", "build,run");
 parser.addScopedFlag("debug-info", "g", "Emit DWARF debug info", "build,run");
 parser.addScopedOption(
@@ -289,6 +291,8 @@ if (parser.getFlag("trace")) logLevel = LogLevel.Trace;
 
 if (parser.getFlag("skip-semantic-analysis")) setSkipSemanticAnalysis(true);
 if (parser.getFlag("keep-temps")) setKeepTemps(true);
+const diagFormat = parser.getOption("diagnostics");
+if (diagFormat === "json") setDiagnosticsJson(true);
 if (parser.getFlag("sanitize-address")) setSanitize("address");
 if (parser.getFlag("debug-info")) setDebugInfo(true);
 if (parser.getFlag("static")) setStaticLink(true);
@@ -336,11 +340,42 @@ if (!fs.existsSync(outputDir)) {
   fs.mkdirSync(outputDir, { recursive: true });
 }
 
-try {
-  compile(inputFile, outputFile, logLevel);
-} catch (error) {
-  logger.error((error as Error).message);
-  process.exit(1);
+if (diagFormat === "json") {
+  let stderrCapture = "";
+  const origWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderrCapture += typeof chunk === "string" ? chunk : chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  const origExit = process.exit.bind(process);
+  (process as { exit: (code?: number) => never }).exit = ((code?: number) => {
+    process.stderr.write = origWrite;
+    if (code !== 0 && stderrCapture.length > 0) {
+      const msg = stderrCapture.replace(/\x1b\[[0-9;]*m/g, "").trim();
+      process.stdout.write('{"diagnostics":[{"severity":"error","message":' + JSON.stringify(msg) + '}],"success":false}\n');
+    }
+    origExit(code);
+  }) as typeof process.exit;
+  try {
+    compile(inputFile, outputFile, logLevel);
+    process.stderr.write = origWrite;
+    process.exit = origExit;
+  } catch (error) {
+    process.stderr.write = origWrite;
+    process.exit = origExit;
+    const msg = stderrCapture.length > 0
+      ? stderrCapture.replace(/\x1b\[[0-9;]*m/g, "").trim()
+      : (error as Error).message;
+    process.stdout.write('{"diagnostics":[{"severity":"error","message":' + JSON.stringify(msg) + '}],"success":false}\n');
+    process.exit(1);
+  }
+} else {
+  try {
+    compile(inputFile, outputFile, logLevel);
+  } catch (error) {
+    logger.error((error as Error).message);
+    process.exit(1);
+  }
 }
 
 if (command === "run") {

--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -352,7 +352,11 @@ if (diagFormat === "json") {
     process.stderr.write = origWrite;
     if (code !== 0 && stderrCapture.length > 0) {
       const msg = stderrCapture.replace(/\x1b\[[0-9;]*m/g, "").trim();
-      process.stdout.write('{"diagnostics":[{"severity":"error","message":' + JSON.stringify(msg) + '}],"success":false}\n');
+      process.stdout.write(
+        '{"diagnostics":[{"severity":"error","message":' +
+          JSON.stringify(msg) +
+          '}],"success":false}\n',
+      );
     }
     origExit(code);
   }) as typeof process.exit;
@@ -363,10 +367,15 @@ if (diagFormat === "json") {
   } catch (error) {
     process.stderr.write = origWrite;
     process.exit = origExit;
-    const msg = stderrCapture.length > 0
-      ? stderrCapture.replace(/\x1b\[[0-9;]*m/g, "").trim()
-      : (error as Error).message;
-    process.stdout.write('{"diagnostics":[{"severity":"error","message":' + JSON.stringify(msg) + '}],"success":false}\n');
+    const msg =
+      stderrCapture.length > 0
+        ? stderrCapture.replace(/\x1b\[[0-9;]*m/g, "").trim()
+        : (error as Error).message;
+    process.stdout.write(
+      '{"diagnostics":[{"severity":"error","message":' +
+        JSON.stringify(msg) +
+        '}],"success":false}\n',
+    );
     process.exit(1);
   }
 } else {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -91,6 +91,16 @@ export function setDiagnosticColor(enabled: boolean): void {
   setGlobalDiagnosticColor(enabled);
 }
 
+let diagnosticsJson = false;
+
+export function setDiagnosticsJson(enabled: boolean): void {
+  diagnosticsJson = enabled;
+  if (enabled) {
+    diagnosticColorEnabled = false;
+    setGlobalDiagnosticColor(false);
+  }
+}
+
 export function setTargetCpu(value: string): void {
   targetCpu = value;
 }
@@ -213,8 +223,23 @@ export function compile(
     const analysisSuccess = analyzer.analyze();
 
     if (!analysisSuccess) {
-      const errorOutput = analyzer.formatErrors();
-      console.error(errorOutput);
+      if (diagnosticsJson) {
+        const errors = analyzer.getErrors();
+        let json = '{"diagnostics":[';
+        for (let ei = 0; ei < errors.length; ei++) {
+          if (ei > 0) json += ",";
+          const e = errors[ei];
+          json += '{"severity":"error","message":' + JSON.stringify(e.message);
+          if (e.location) json += ',"location":' + JSON.stringify(e.location);
+          if (e.suggestion) json += ',"suggestion":' + JSON.stringify(e.suggestion);
+          json += "}";
+        }
+        json += '],"success":false}\n';
+        process.stdout.write(json);
+      } else {
+        const errorOutput = analyzer.formatErrors();
+        console.error(errorOutput);
+      }
       throw new Error("Semantic analysis failed. Fix the errors above and try again.");
     } else {
       const diagOutput = analyzer.formatErrors();
@@ -520,7 +545,9 @@ export function compile(
     }
   }
 
-  // Silent on success (like clang)
+  if (diagnosticsJson) {
+    process.stdout.write('{"diagnostics":[],"success":true}\n');
+  }
 }
 
 function compileMultiFile(

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -99,6 +99,9 @@ export function setDiagnosticColor(value: boolean): void {
   setGlobalDiagnosticColor(value);
 }
 
+export function setDiagnosticsJson(_value: boolean): void {
+}
+
 export function setSkipSemanticAnalysis(value: boolean): void {
   skipSemanticAnalysis = value;
 }

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -99,8 +99,7 @@ export function setDiagnosticColor(value: boolean): void {
   setGlobalDiagnosticColor(value);
 }
 
-export function setDiagnosticsJson(_value: boolean): void {
-}
+export function setDiagnosticsJson(_value: boolean): void {}
 
 export function setSkipSemanticAnalysis(value: boolean): void {
   skipSemanticAnalysis = value;


### PR DESCRIPTION
## Summary
- Adds `--diagnostics json` flag to `build`, `run`, and `ir` commands
- On success: outputs `{"diagnostics":[],"success":true}` to stdout
- On error: outputs `{"diagnostics":[{"severity":"error","message":"..."}],"success":false}` to stdout
- Normal mode (no flag) is completely unchanged
- Enables reliable agent/tooling integration without regex-parsing error messages

## Implementation
- Flag added to both `chad-node.ts` and `chad-native.ts` CLI entry points
- In JSON mode, stderr is intercepted during compilation so all error paths (semantic analysis, codegen, semantic passes, parser) produce structured JSON on stdout
- No changes to any files compiled by the native compiler (avoids self-hosting breakage) — only `compiler.ts`, `chad-node.ts`, `chad-native.ts`, and a no-op stub in `native-compiler-lib.ts`

## Test plan
- [x] `verify:quick` passes (tests + Stage 1 self-hosting)
- [x] Success case: `chad build hello.ts --diagnostics json` → `{"diagnostics":[],"success":true}`
- [x] Closure mutation error: structured JSON with error message
- [x] Parser error (object spread): structured JSON with error message
- [x] Normal mode (no flag): output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)