### PR TITLE
fix: set core.hookspath in prepare script to override global config

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coverage:report": "c8 report",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
+    "prepare": "git config core.hooksPath .git/hooks && cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
   },
   "keywords": [
     "compiler",


### PR DESCRIPTION
## Summary
- The `prepare` script now sets `git config core.hooksPath .git/hooks` before copying the pre-commit hook
- Fixes: global `core.hooksPath` (e.g. from a previous husky install) silently overrides the repo's hook directory, so `npm install` installs the hook but git never runs it
- The pre-commit hook auto-formats staged .ts/.js files with prettier — prevents format-check CI failures

## Test plan
- [x] `npm run prepare` succeeds and installs hook
- [x] Commits from worktrees trigger the pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)