### PR TITLE
fix: clamp splice start index to array length (#297)

### DIFF
--- a/src/codegen/types/collections/array/splice.ts
+++ b/src/codegen/types/collections/array/splice.ts
@@ -76,8 +76,11 @@ function generateNumericArraySplice(
   const startClamped = gen.nextTemp();
   gen.emit(`${startClamped} = select i1 ${startNeg}, i32 ${startFromEnd}, i32 ${startRaw}`);
   const startTooLow = gen.emitIcmp("slt", "i32", startClamped, "0");
+  const startLow = gen.nextTemp();
+  gen.emit(`${startLow} = select i1 ${startTooLow}, i32 0, i32 ${startClamped}`);
+  const startTooHigh = gen.emitIcmp("sgt", "i32", startLow, length);
   const start = gen.nextTemp();
-  gen.emit(`${start} = select i1 ${startTooLow}, i32 0, i32 ${startClamped}`);
+  gen.emit(`${start} = select i1 ${startTooHigh}, i32 ${length}, i32 ${startLow}`);
 
   let deleteCount: string;
   if (expr.args.length >= 2) {
@@ -184,8 +187,11 @@ function generateStringArraySplice(
   const startClamped = gen.nextTemp();
   gen.emit(`${startClamped} = select i1 ${startNeg}, i32 ${startFromEnd}, i32 ${startRaw}`);
   const startTooLow = gen.emitIcmp("slt", "i32", startClamped, "0");
+  const startLow = gen.nextTemp();
+  gen.emit(`${startLow} = select i1 ${startTooLow}, i32 0, i32 ${startClamped}`);
+  const startTooHigh = gen.emitIcmp("sgt", "i32", startLow, length);
   const start = gen.nextTemp();
-  gen.emit(`${start} = select i1 ${startTooLow}, i32 0, i32 ${startClamped}`);
+  gen.emit(`${start} = select i1 ${startTooHigh}, i32 ${length}, i32 ${startLow}`);
 
   let deleteCount: string;
   if (expr.args.length >= 2) {

--- a/tests/fixtures/arrays/array-splice-past-end.ts
+++ b/tests/fixtures/arrays/array-splice-past-end.ts
@@ -1,0 +1,21 @@
+const a: number[] = [1, 2, 3];
+a.splice(100, 1);
+if (a.length !== 3) throw new Error("splice past end should be no-op, got length " + a.length);
+if (a[0] !== 1) throw new Error("a[0]");
+if (a[1] !== 2) throw new Error("a[1]");
+if (a[2] !== 3) throw new Error("a[2]");
+
+const b: string[] = ["x", "y", "z"];
+b.splice(50, 2);
+if (b.length !== 3)
+  throw new Error("string splice past end should be no-op, got length " + b.length);
+
+const c: number[] = [10, 20, 30];
+c.splice(3, 0);
+if (c.length !== 3) throw new Error("splice at exact end should be no-op");
+
+const d: number[] = [1, 2, 3];
+c.splice(-100, 1);
+if (c.length !== 2) throw new Error("splice with very negative start should remove from index 0");
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `array.splice(100, 1)` on a 3-element array no longer corrupts memory — start index is now clamped to `<= length` (was only clamped to `>= 0`)
- Without clamping, `remaining = length - start` goes negative, causing memcpy/memmove with huge unsigned sizes
- Fix applies to both numeric and string arrays
- Adds test fixture for splice with out-of-bounds start index

## Test plan
- [x] `npm run verify:quick` passes
- [x] New `array-splice-past-end.ts` test passes
- [x] Existing splice tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)