### PR TITLE
fix: hoist alloca out of conditional branch in generateReplaceAll

### DIFF
--- a/src/codegen/types/collections/string/manipulation.ts
+++ b/src/codegen/types/collections/string/manipulation.ts
@@ -813,6 +813,9 @@ export function generateReplaceAll(
   searchPtr: string,
   replacePtr: string,
 ): string {
+  const resultPtr = ctx.nextTemp();
+  ctx.emit(`${resultPtr} = alloca i8*`);
+
   const searchLen = ctx.emitCall("i64", "@strlen", `i8* ${searchPtr}`);
   const isEmpty = ctx.emitIcmp("eq", "i64", searchLen, "0");
   const emptyLabel = ctx.nextLabel("replaceall_empty");
@@ -825,8 +828,6 @@ export function generateReplaceAll(
   ctx.emitBr(doneLabel);
 
   ctx.emitLabel(doReplaceLabel);
-  const resultPtr = ctx.nextTemp();
-  ctx.emit(`${resultPtr} = alloca i8*`);
   ctx.emitStore("i8*", strPtr, resultPtr);
 
   const loopLabel = ctx.nextLabel("replaceall_loop");


### PR DESCRIPTION
## Summary
- Hoists `alloca i8*` in `generateReplaceAll` from inside the `replaceall_do` conditional block to before the branch, fixing a CLAUDE.md Rule #1 violation
- `alloca` inside conditional branches produces undefined behavior in LLVM IR — the stack slot may not exist when accessed from other blocks

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] `string-replaceall-empty` test continues to pass
- [x] No new test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)