### PR TITLE
fix: hoist allocas out of conditional branches in split and lastIndexOf

### DIFF
--- a/src/codegen/types/collections/string/search.ts
+++ b/src/codegen/types/collections/string/search.ts
@@ -258,6 +258,12 @@ export function generateLastIndexOfFrom(
   substring: string,
   fromIndex: string,
 ): string {
+  const lastPosPtr = ctx.nextAllocaReg("lastpos");
+  ctx.emit(`${lastPosPtr} = alloca i32`);
+
+  const curPtrStorage = ctx.nextAllocaReg("curptr");
+  ctx.emit(`${curPtrStorage} = alloca i8*`);
+
   const isNeg = ctx.emitIcmp("slt", "i32", fromIndex, "0");
 
   const negLabel = ctx.nextLabel("lastindexof_from_neg");
@@ -269,13 +275,7 @@ export function generateLastIndexOfFrom(
   ctx.emitBr(endAllLabel);
 
   ctx.emitLabel(searchLabel);
-
-  const lastPosPtr = ctx.nextAllocaReg("lastpos");
-  ctx.emit(`${lastPosPtr} = alloca i32`);
   ctx.emitStore("i32", "-1", lastPosPtr);
-
-  const curPtrStorage = ctx.nextAllocaReg("curptr");
-  ctx.emit(`${curPtrStorage} = alloca i8*`);
   ctx.emitStore("i8*", strPtr, curPtrStorage);
 
   const strPtrInt = ctx.nextTemp();

--- a/src/codegen/types/collections/string/split.ts
+++ b/src/codegen/types/collections/string/split.ts
@@ -17,6 +17,19 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   const delimLenI32 = ctx.nextTemp();
   ctx.emit(`${delimLenI32} = trunc i64 ${delimLen} to i32`);
 
+  const emptyCounterPtr = ctx.nextTemp();
+  ctx.emit(`${emptyCounterPtr} = alloca i32`);
+  const partCountPtr = ctx.nextTemp();
+  ctx.emit(`${partCountPtr} = alloca i32`);
+  const scanPosPtr = ctx.nextTemp();
+  ctx.emit(`${scanPosPtr} = alloca i32`);
+  const startPosPtr = ctx.nextTemp();
+  ctx.emit(`${startPosPtr} = alloca i32`);
+  const curPosPtr = ctx.nextTemp();
+  ctx.emit(`${curPosPtr} = alloca i32`);
+  const partIndexPtr = ctx.nextTemp();
+  ctx.emit(`${partIndexPtr} = alloca i32`);
+
   const isEmptyDelim = ctx.emitIcmp("eq", "i32", delimLenI32, "0");
 
   const emptyDelimLabel = ctx.nextLabel("split_empty_delim");
@@ -41,8 +54,6 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   const emptyLoopBodyLabel = ctx.nextLabel("split_empty_body");
   const emptyLoopEndLabel = ctx.nextLabel("split_empty_end");
 
-  const emptyCounterPtr = ctx.nextTemp();
-  ctx.emit(`${emptyCounterPtr} = alloca i32`);
   ctx.emitStore("i32", "0", emptyCounterPtr);
   ctx.emitBr(emptyLoopLabel);
 
@@ -109,12 +120,7 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   const countCheckLabel = ctx.nextLabel("split_count_check");
   const countEndLabel = ctx.nextLabel("split_count_end");
 
-  const partCountPtr = ctx.nextTemp();
-  ctx.emit(`${partCountPtr} = alloca i32`);
   ctx.emitStore("i32", "1", partCountPtr);
-
-  const scanPosPtr = ctx.nextTemp();
-  ctx.emit(`${scanPosPtr} = alloca i32`);
   ctx.emitStore("i32", "0", scanPosPtr);
 
   ctx.emitBr(countLabel);
@@ -174,16 +180,8 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   const extractNoMatchLabel = ctx.nextLabel("split_extract_nomatch");
   const extractEndLabel = ctx.nextLabel("split_extract_end");
 
-  const startPosPtr = ctx.nextTemp();
-  ctx.emit(`${startPosPtr} = alloca i32`);
   ctx.emitStore("i32", "0", startPosPtr);
-
-  const curPosPtr = ctx.nextTemp();
-  ctx.emit(`${curPosPtr} = alloca i32`);
   ctx.emitStore("i32", "0", curPosPtr);
-
-  const partIndexPtr = ctx.nextTemp();
-  ctx.emit(`${partIndexPtr} = alloca i32`);
   ctx.emitStore("i32", "0", partIndexPtr);
 
   ctx.emitBr(extractLabel);


### PR DESCRIPTION
## Summary
- Hoists 8 `alloca` instructions from inside conditional branches to the function entry block in `generateSplit` (6 allocas) and `generateLastIndexOfFrom` (2 allocas)
- Prevents undefined behavior where LLVM stack slots may not exist when accessed from other basic blocks
- Same class of bug as #298 (replaceAll)

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] All string split and lastIndexOf tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)