### PR TITLE
feat: implement array.fill(value, start?, end?)

### DIFF
--- a/src/codegen/expressions/method-calls/string-dispatch.ts
+++ b/src/codegen/expressions/method-calls/string-dispatch.ts
@@ -294,6 +294,7 @@ function dispatchArrayReorder(
   if (method === "findIndex") return ctx.arrayGen.generateArrayFindIndex(expr, params);
   if (method === "sort") return ctx.arrayGen.generateArraySort(expr, params);
   if (method === "splice") return ctx.arrayGen.generateArraySplice(expr, params);
+  if (method === "fill") return ctx.arrayGen.generateArrayFill(expr, params);
   return null;
 }
 

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -329,6 +329,7 @@ export interface IArrayGenerator {
   generateArrayFindIndex(expr: MethodCallNode, params: string[]): string;
   generateArraySort(expr: MethodCallNode, params: string[]): string;
   generateArraySplice(expr: MethodCallNode, params: string[]): string;
+  generateArrayFill(expr: MethodCallNode, params: string[]): string;
 }
 
 /**
@@ -2095,6 +2096,7 @@ export class MockGeneratorContext implements IGeneratorContext {
       "%mock_array_findindex",
     generateArraySort: (_expr: MethodCallNode, _params: string[]): string => "%mock_array_sort",
     generateArraySplice: (_expr: MethodCallNode, _params: string[]): string => "%mock_array_splice",
+    generateArrayFill: (_expr: MethodCallNode, _params: string[]): string => "%mock_array_fill",
   };
 
   resolveImportAlias(localName: string): string {

--- a/src/codegen/types/collections/array.ts
+++ b/src/codegen/types/collections/array.ts
@@ -9,7 +9,7 @@ import { IGeneratorContext } from "../../infrastructure/generator-context.js";
 // Array sub-modules
 // No alias — ChadScript doesn't resolve import aliases in self-hosting
 import { generateArrayLiteral } from "./array/literal.js";
-import { generateArrayPush, generateArrayPop } from "./array/mutators.js";
+import { generateArrayPush, generateArrayPop, generateArrayFill } from "./array/mutators.js";
 import { generateArrayReverse, generateArrayShift, generateArrayUnshift } from "./array/reorder.js";
 import {
   generateArrayIndexOf,
@@ -146,5 +146,9 @@ export class ArrayGenerator {
 
   generateArraySplice(expr: MethodCallNode, params: string[]): string {
     return generateArraySplice(this.ctx, expr, params);
+  }
+
+  generateArrayFill(expr: MethodCallNode, params: string[]): string {
+    return generateArrayFill(this.ctx, expr, params);
   }
 }

--- a/src/codegen/types/collections/array/mutators.ts
+++ b/src/codegen/types/collections/array/mutators.ts
@@ -684,3 +684,156 @@ function generateObjectArrayPush(
   gen.setVariableType(newLenDouble, "double");
   return newLenDouble;
 }
+
+export function generateArrayFill(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+): string {
+  if (expr.args.length < 1 || expr.args.length > 3) {
+    return gen.emitError("fill() requires 1-3 arguments", expr.loc);
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+  const fillValue = gen.generateExpression(expr.args[0], params);
+
+  let isStringArray = false;
+  const exprObjBase = expr.object as ExprBase;
+  if (exprObjBase.type === "variable") {
+    const varName = (expr.object as VariableNode).name;
+    const varType = gen.getVariableType(varName);
+    isStringArray = varType === "%StringArray*" || varType === "%StringArray";
+  }
+  if (!isStringArray) {
+    const ptrType = gen.getVariableType(arrayPtr);
+    if (ptrType === "%StringArray*" || ptrType === "%StringArray") isStringArray = true;
+  }
+
+  if (isStringArray) {
+    return generateStringArrayFillImpl(gen, expr, params, arrayPtr, fillValue);
+  }
+  return generateNumericArrayFillImpl(gen, expr, params, arrayPtr, fillValue);
+}
+
+function clampFillIndex(gen: IGeneratorContext, rawDouble: string, length: string): string {
+  const dbl = gen.ensureDouble(rawDouble);
+  const i32Val = gen.nextTemp();
+  gen.emit(`${i32Val} = fptosi double ${dbl} to i32`);
+  const isNeg = gen.emitIcmp("slt", "i32", i32Val, "0");
+  const clamped = gen.nextTemp();
+  gen.emit(`${clamped} = select i1 ${isNeg}, i32 0, i32 ${i32Val}`);
+  const tooHigh = gen.emitIcmp("sgt", "i32", clamped, length);
+  const result = gen.nextTemp();
+  gen.emit(`${result} = select i1 ${tooHigh}, i32 ${length}, i32 ${clamped}`);
+  return result;
+}
+
+function generateNumericArrayFillImpl(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+  arrayPtr: string,
+  fillValue: string,
+): string {
+  const dblValue = gen.ensureDouble(fillValue);
+
+  const lenPtr = gen.nextTemp();
+  gen.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
+  const length = gen.emitLoad("i32", lenPtr);
+
+  const dataPtrField = gen.nextTemp();
+  gen.emit(`${dataPtrField} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
+  const dataPtr = gen.emitLoad("double*", dataPtrField);
+
+  const startVal =
+    expr.args.length >= 2
+      ? clampFillIndex(gen, gen.generateExpression(expr.args[1], params), length)
+      : "0";
+  const endVal =
+    expr.args.length >= 3
+      ? clampFillIndex(gen, gen.generateExpression(expr.args[2], params), length)
+      : length;
+
+  const counterPtr = gen.nextTemp();
+  gen.emit(`${counterPtr} = alloca i32`);
+  gen.emitStore("i32", startVal, counterPtr);
+
+  const loopLabel = gen.nextLabel("fill_loop");
+  const bodyLabel = gen.nextLabel("fill_body");
+  const endLabel = gen.nextLabel("fill_end");
+
+  gen.emitBr(loopLabel);
+  gen.emitLabel(loopLabel);
+  const counter = gen.emitLoad("i32", counterPtr);
+  const cond = gen.emitIcmp("slt", "i32", counter, endVal);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
+
+  gen.emitLabel(bodyLabel);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
+  gen.emitStore("double", dblValue, elemPtr);
+  const next = gen.nextTemp();
+  gen.emit(`${next} = add i32 ${counter}, 1`);
+  gen.emitStore("i32", next, counterPtr);
+  gen.emitBr(loopLabel);
+
+  gen.emitLabel(endLabel);
+  gen.setVariableType(arrayPtr, "%Array*");
+  return arrayPtr;
+}
+
+function generateStringArrayFillImpl(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+  arrayPtr: string,
+  fillValue: string,
+): string {
+  const lenPtr = gen.nextTemp();
+  gen.emit(
+    `${lenPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
+  );
+  const length = gen.emitLoad("i32", lenPtr);
+
+  const dataPtrField = gen.nextTemp();
+  gen.emit(
+    `${dataPtrField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
+  );
+  const dataPtr = gen.emitLoad("i8**", dataPtrField);
+
+  const startVal =
+    expr.args.length >= 2
+      ? clampFillIndex(gen, gen.generateExpression(expr.args[1], params), length)
+      : "0";
+  const endVal =
+    expr.args.length >= 3
+      ? clampFillIndex(gen, gen.generateExpression(expr.args[2], params), length)
+      : length;
+
+  const counterPtr = gen.nextTemp();
+  gen.emit(`${counterPtr} = alloca i32`);
+  gen.emitStore("i32", startVal, counterPtr);
+
+  const loopLabel = gen.nextLabel("fill_loop");
+  const bodyLabel = gen.nextLabel("fill_body");
+  const endLabel = gen.nextLabel("fill_end");
+
+  gen.emitBr(loopLabel);
+  gen.emitLabel(loopLabel);
+  const counter = gen.emitLoad("i32", counterPtr);
+  const cond = gen.emitIcmp("slt", "i32", counter, endVal);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
+
+  gen.emitLabel(bodyLabel);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${counter}`);
+  gen.emitStore("i8*", fillValue, elemPtr);
+  const next = gen.nextTemp();
+  gen.emit(`${next} = add i32 ${counter}, 1`);
+  gen.emitStore("i32", next, counterPtr);
+  gen.emitBr(loopLabel);
+
+  gen.emitLabel(endLabel);
+  gen.setVariableType(arrayPtr, "%StringArray*");
+  return arrayPtr;
+}

--- a/tests/fixtures/arrays/array-fill.ts
+++ b/tests/fixtures/arrays/array-fill.ts
@@ -1,0 +1,40 @@
+function testArrayFill(): void {
+  const nums: number[] = [1, 2, 3, 4, 5];
+  nums.fill(0);
+  if (nums[0] !== 0 || nums[4] !== 0) {
+    console.log("FAIL: fill all with 0");
+    process.exit(1);
+  }
+
+  const nums2: number[] = [1, 2, 3, 4, 5];
+  nums2.fill(9, 2);
+  if (nums2[0] !== 1 || nums2[1] !== 2 || nums2[2] !== 9 || nums2[3] !== 9 || nums2[4] !== 9) {
+    console.log("FAIL: fill from index 2");
+    process.exit(1);
+  }
+
+  const nums3: number[] = [1, 2, 3, 4, 5];
+  nums3.fill(7, 1, 3);
+  if (nums3[0] !== 1 || nums3[1] !== 7 || nums3[2] !== 7 || nums3[3] !== 4 || nums3[4] !== 5) {
+    console.log("FAIL: fill range 1-3");
+    process.exit(1);
+  }
+
+  const strs: string[] = ["a", "b", "c"];
+  strs.fill("x");
+  if (strs[0] !== "x" || strs[1] !== "x" || strs[2] !== "x") {
+    console.log("FAIL: fill strings");
+    process.exit(1);
+  }
+
+  const strs2: string[] = ["a", "b", "c", "d"];
+  strs2.fill("z", 1, 3);
+  if (strs2[0] !== "a" || strs2[1] !== "z" || strs2[2] !== "z" || strs2[3] !== "d") {
+    console.log("FAIL: fill strings with range");
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testArrayFill();


### PR DESCRIPTION
## Summary
- Adds `array.fill(value, start?, end?)` for both `number[]` and `string[]` arrays
- Supports all 3 call signatures: `fill(val)`, `fill(val, start)`, `fill(val, start, end)`
- Start/end indices clamped to valid range (negative → 0, > length → length)
- Returns the array (matches JS spec for chaining)

## Test plan
- [x] New test fixture `arrays/array-fill.ts` covering: fill all, fill from index, fill range, string fill, string fill range
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)