### PR TITLE
implement array.reduceRight() for numeric and string arrays

### DIFF
--- a/src/codegen/expressions/method-calls/string-dispatch.ts
+++ b/src/codegen/expressions/method-calls/string-dispatch.ts
@@ -279,6 +279,7 @@ function dispatchArrayTransforms(
 ): string | null {
   if (method === "forEach") return ctx.arrayGen.generateArrayForEach(expr, params);
   if (method === "reduce") return ctx.arrayGen.generateArrayReduce(expr, params);
+  if (method === "reduceRight") return ctx.arrayGen.generateArrayReduceRight(expr, params);
   if (method === "reverse") return ctx.arrayGen.generateArrayReverse(expr, params);
   if (method === "shift") return ctx.arrayGen.generateArrayShift(expr, params);
   return null;

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -318,6 +318,7 @@ export interface IArrayGenerator {
   generateArrayFilter(expr: MethodCallNode, params: string[]): string;
   generateArrayForEach(expr: MethodCallNode, params: string[]): string;
   generateArrayReduce(expr: MethodCallNode, params: string[]): string;
+  generateArrayReduceRight(expr: MethodCallNode, params: string[]): string;
   generateArraySlice(expr: MethodCallNode, params: string[]): string;
   generateArrayConcat(expr: MethodCallNode, params: string[]): string;
   generateArrayReverse(expr: MethodCallNode, params: string[]): string;
@@ -2080,6 +2081,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     generateArrayForEach: (_expr: MethodCallNode, _params: string[]): string =>
       "%mock_array_foreach",
     generateArrayReduce: (_expr: MethodCallNode, _params: string[]): string => "%mock_array_reduce",
+    generateArrayReduceRight: (_expr: MethodCallNode, _params: string[]): string =>
+      "%mock_array_reduceright",
     generateArraySlice: (_expr: MethodCallNode, _params: string[]): string => "%mock_array_slice",
     generateArrayConcat: (_expr: MethodCallNode, _params: string[]): string => "%mock_array_concat",
     generateArrayReverse: (_expr: MethodCallNode, _params: string[]): string =>

--- a/src/codegen/types/collections/array.ts
+++ b/src/codegen/types/collections/array.ts
@@ -29,6 +29,7 @@ import {
   generateArrayFilter,
   generateArrayForEach,
   generateArrayReduce,
+  generateArrayReduceRight,
   generateArrayMap,
   generateStringArrayMap,
 } from "./array/iteration.js";
@@ -86,6 +87,10 @@ export class ArrayGenerator {
 
   generateArrayReduce(expr: MethodCallNode, params: string[]): string {
     return generateArrayReduce(this.ctx, expr, params);
+  }
+
+  generateArrayReduceRight(expr: MethodCallNode, params: string[]): string {
+    return generateArrayReduceRight(this.ctx, expr, params);
   }
 
   generateArrayMap(expr: MethodCallNode, params: string[]): string {

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -859,3 +859,249 @@ function generateStringArrayMapImpl(
   gen.setVariableType(resultArrayPtr, "%StringArray*");
   return resultArrayPtr;
 }
+
+// ============================================
+// reduceRight
+// ============================================
+
+export function generateArrayReduceRight(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+): string {
+  if (expr.args.length < 1 || expr.args.length > 2) {
+    return gen.emitError(
+      "reduceRight() requires 1-2 arguments (callback, optional initialValue)",
+      expr.loc,
+    );
+  }
+
+  const arrayPtr = gen.generateExpression(expr.object, params);
+
+  let isStringArray = false;
+  const exprObjBase = expr.object as ExprBase;
+  if (exprObjBase.type === "variable") {
+    const varName = (expr.object as VariableNode).name;
+    const varType = gen.getVariableType(varName);
+    isStringArray = varType === "%StringArray*" || varType === "%StringArray";
+  } else {
+    const ptrType = gen.getVariableType(arrayPtr);
+    isStringArray = ptrType === "%StringArray*";
+  }
+
+  const callbackArg = expr.args[0];
+  let callbackFn: string;
+  if (callbackArg.type === "variable") {
+    callbackFn = gen.mangleUserName((callbackArg as VariableNode).name);
+  } else if (callbackArg.type === "arrow_function") {
+    if (isStringArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
+    callbackFn = gen.generateExpression(callbackArg, params);
+    gen.setExpectedCallbackParamType(null);
+  } else {
+    return gen.emitError(
+      "reduceRight() argument must be a function name or inline function",
+      expr.loc,
+    );
+  }
+
+  let initialValue: string | null = null;
+  if (expr.args.length === 2) {
+    initialValue = gen.generateExpression(expr.args[1], params);
+  }
+
+  let result: string;
+  if (isStringArray) {
+    result = generateStringArrayReduceRight(gen, arrayPtr, callbackFn, initialValue);
+  } else {
+    result = generateNumericArrayReduceRight(gen, arrayPtr, callbackFn, initialValue);
+  }
+  gen.setLastInlineLambdaEnvPtr(null);
+  return result;
+}
+
+function generateNumericArrayReduceRight(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  callbackFn: string,
+  initialValue: string | null,
+): string {
+  const arrayMeta = loadArrayMeta(gen, arrayPtr);
+  const length = arrayMeta.length;
+  const dataPtr = arrayMeta.dataPtr;
+
+  const checkLabel = gen.nextLabel("reduceright_check");
+  const bodyLabel = gen.nextLabel("reduceright_body");
+  const endLabel = gen.nextLabel("reduceright_end");
+
+  const accPtr = gen.nextTemp();
+  gen.emit(`${accPtr} = alloca double`);
+
+  const counterPtr = gen.nextTemp();
+  gen.emit(`${counterPtr} = alloca i32`);
+
+  if (initialValue !== null) {
+    const dblInit = gen.ensureDouble(initialValue);
+    gen.emitStore("double", dblInit, accPtr);
+    const lastIdx = gen.nextTemp();
+    gen.emit(`${lastIdx} = sub i32 ${length}, 1`);
+    gen.emitStore("i32", lastIdx, counterPtr);
+  } else {
+    const isEmpty = gen.emitIcmp("eq", "i32", length, "0");
+    const emptyLabel = gen.nextLabel("reduceright_empty");
+    const okLabel = gen.nextLabel("reduceright_has_elems");
+    gen.emitBrCond(isEmpty, emptyLabel, okLabel);
+    gen.emitLabel(emptyLabel);
+    const stderrPtr = gen.nextTemp();
+    gen.emit(`${stderrPtr} = load i8*, i8** @stderr`);
+    const fmtStr = gen.createStringConstant(
+      "Error: reduceRight of empty array with no initial value\n",
+    );
+    const fprintfResult = gen.nextTemp();
+    gen.emit(
+      `${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* ${fmtStr})`,
+    );
+    gen.emit("call void @exit(i32 1)");
+    gen.emit("unreachable");
+    gen.emitLabel(okLabel);
+    const lastIdx = gen.nextTemp();
+    gen.emit(`${lastIdx} = sub i32 ${length}, 1`);
+    const lastElemPtr = gen.nextTemp();
+    gen.emit(`${lastElemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${lastIdx}`);
+    const lastElem = gen.emitLoad("double", lastElemPtr);
+    gen.emitStore("double", lastElem, accPtr);
+    const startIdx = gen.nextTemp();
+    gen.emit(`${startIdx} = sub i32 ${length}, 2`);
+    gen.emitStore("i32", startIdx, counterPtr);
+  }
+
+  gen.emitBr(checkLabel);
+
+  gen.emitLabel(checkLabel);
+  const counter = gen.emitLoad("i32", counterPtr);
+  const cond = gen.emitIcmp("sge", "i32", counter, "0");
+  gen.emitBrCond(cond, bodyLabel, endLabel);
+
+  gen.emitLabel(bodyLabel);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds double, double* ${dataPtr}, i32 ${counter}`);
+  const elem = gen.emitLoad("double", elemPtr);
+
+  const acc = gen.emitLoad("double", accPtr);
+
+  const newAcc = gen.emitCall(
+    "double",
+    `@${callbackFn}`,
+    buildIterCallArgs(gen, `double ${acc}, double ${elem}`),
+  );
+  gen.emitStore("double", newAcc, accPtr);
+
+  const nextCounter = gen.nextTemp();
+  gen.emit(`${nextCounter} = sub i32 ${counter}, 1`);
+  gen.emitStore("i32", nextCounter, counterPtr);
+  gen.emitBr(checkLabel);
+
+  gen.emitLabel(endLabel);
+  const finalAcc = gen.emitLoad("double", accPtr);
+  gen.setVariableType(finalAcc, "double");
+  return finalAcc;
+}
+
+function generateStringArrayReduceRight(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  callbackFn: string,
+  initialValue: string | null,
+): string {
+  const lenPtr = gen.nextTemp();
+  gen.emit(
+    `${lenPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
+  );
+  const length = gen.emitLoad("i32", lenPtr);
+
+  const dataPtrField = gen.nextTemp();
+  gen.emit(
+    `${dataPtrField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
+  );
+  const dataPtr = gen.nextTemp();
+  gen.emit(`${dataPtr} = load i8**, i8*** ${dataPtrField}`);
+
+  const checkLabel = gen.nextLabel("reduceright_check");
+  const bodyLabel = gen.nextLabel("reduceright_body");
+  const endLabel = gen.nextLabel("reduceright_end");
+
+  const accPtr = gen.nextTemp();
+  gen.emit(`${accPtr} = alloca i8*`);
+
+  const counterPtr = gen.nextTemp();
+  gen.emit(`${counterPtr} = alloca i32`);
+
+  if (initialValue !== null) {
+    gen.emit(`store i8* ${initialValue}, i8** ${accPtr}`);
+    const lastIdx = gen.nextTemp();
+    gen.emit(`${lastIdx} = sub i32 ${length}, 1`);
+    gen.emitStore("i32", lastIdx, counterPtr);
+  } else {
+    const isEmpty = gen.emitIcmp("eq", "i32", length, "0");
+    const emptyLabel = gen.nextLabel("reduceright_empty");
+    const okLabel = gen.nextLabel("reduceright_has_elems");
+    gen.emitBrCond(isEmpty, emptyLabel, okLabel);
+    gen.emitLabel(emptyLabel);
+    const stderrPtr = gen.nextTemp();
+    gen.emit(`${stderrPtr} = load i8*, i8** @stderr`);
+    const fmtStr = gen.createStringConstant(
+      "Error: reduceRight of empty array with no initial value\n",
+    );
+    const fprintfResult = gen.nextTemp();
+    gen.emit(
+      `${fprintfResult} = call i32 (i8*, i8*, ...) @fprintf(i8* ${stderrPtr}, i8* ${fmtStr})`,
+    );
+    gen.emit("call void @exit(i32 1)");
+    gen.emit("unreachable");
+    gen.emitLabel(okLabel);
+    const lastIdx = gen.nextTemp();
+    gen.emit(`${lastIdx} = sub i32 ${length}, 1`);
+    const lastElemPtr = gen.nextTemp();
+    gen.emit(`${lastElemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${lastIdx}`);
+    const lastElem = gen.nextTemp();
+    gen.emit(`${lastElem} = load i8*, i8** ${lastElemPtr}`);
+    gen.emit(`store i8* ${lastElem}, i8** ${accPtr}`);
+    const startIdx = gen.nextTemp();
+    gen.emit(`${startIdx} = sub i32 ${length}, 2`);
+    gen.emitStore("i32", startIdx, counterPtr);
+  }
+
+  gen.emitBr(checkLabel);
+
+  gen.emitLabel(checkLabel);
+  const counter = gen.emitLoad("i32", counterPtr);
+  const cond = gen.emitIcmp("sge", "i32", counter, "0");
+  gen.emitBrCond(cond, bodyLabel, endLabel);
+
+  gen.emitLabel(bodyLabel);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${counter}`);
+  const elem = gen.nextTemp();
+  gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
+
+  const acc = gen.nextTemp();
+  gen.emit(`${acc} = load i8*, i8** ${accPtr}`);
+
+  const newAcc = gen.emitCall(
+    "i8*",
+    `@${callbackFn}`,
+    buildIterCallArgs(gen, `i8* ${acc}, i8* ${elem}`),
+  );
+  gen.emit(`store i8* ${newAcc}, i8** ${accPtr}`);
+
+  const nextCounter = gen.nextTemp();
+  gen.emit(`${nextCounter} = sub i32 ${counter}, 1`);
+  gen.emitStore("i32", nextCounter, counterPtr);
+  gen.emitBr(checkLabel);
+
+  gen.emitLabel(endLabel);
+  const finalAcc = gen.emitLoad("i8*", accPtr);
+  gen.setVariableType(finalAcc, "i8*");
+  return finalAcc;
+}

--- a/tests/fixtures/arrays/array-reduce-right.ts
+++ b/tests/fixtures/arrays/array-reduce-right.ts
@@ -1,0 +1,59 @@
+function add(acc: number, val: number): number {
+  return acc + val;
+}
+
+function sub(acc: number, val: number): number {
+  return acc - val;
+}
+
+function concat(acc: string, val: string): string {
+  return acc + val;
+}
+
+function testReduceRight(): void {
+  const nums: number[] = [1, 2, 3, 4, 5];
+
+  const sum = nums.reduceRight(add, 0);
+  if (sum !== 15) {
+    console.log("FAIL: sum expected 15 got " + sum);
+    process.exit(1);
+  }
+
+  const noInit = nums.reduceRight(add);
+  if (noInit !== 15) {
+    console.log("FAIL: noInit expected 15 got " + noInit);
+    process.exit(1);
+  }
+
+  const nums2: number[] = [1, 2, 3, 4];
+  const rightFold = nums2.reduceRight(sub);
+  if (rightFold !== -2) {
+    console.log("FAIL: rightFold expected -2 got " + rightFold);
+    process.exit(1);
+  }
+
+  const strs: string[] = ["a", "b", "c"];
+
+  const joined = strs.reduceRight(concat, "");
+  if (joined !== "cba") {
+    console.log("FAIL: joined expected 'cba' got '" + joined + "'");
+    process.exit(1);
+  }
+
+  const strNoInit = strs.reduceRight(concat);
+  if (strNoInit !== "cba") {
+    console.log("FAIL: strNoInit expected 'cba' got '" + strNoInit + "'");
+    process.exit(1);
+  }
+
+  const single: number[] = [42];
+  const singleResult = single.reduceRight(add);
+  if (singleResult !== 42) {
+    console.log("FAIL: singleResult expected 42 got " + singleResult);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testReduceRight();


### PR DESCRIPTION
## Summary
- Adds `array.reduceRight()` support for both `number[]` and `string[]` arrays
- Iterates from last element to first, with optional initial value
- Runtime error on empty array with no initial value (matches reduce behavior)

## Test plan
- [x] `tests/fixtures/arrays/array-reduce-right.ts` — numeric sum, no-init, right-fold subtraction, string concat, single-element edge case
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)