### PR TITLE
implement string.search() for regex pattern matching

### DIFF
--- a/src/codegen/expressions/method-calls/string-dispatch.ts
+++ b/src/codegen/expressions/method-calls/string-dispatch.ts
@@ -29,6 +29,7 @@ import {
   handleToUpperCase,
   handleToLowerCase,
   handleMatch,
+  handleSearch,
 } from "./string-methods.js";
 
 function rejectNonString(
@@ -234,6 +235,10 @@ export function dispatchStringMethod(
   if (method === "toFixed") return handleNumberToFixed(ctx, expr, params);
   if (method === "match") {
     if (ctx.isStringExpression(expr.object)) return handleMatch(ctx, expr, params);
+    return null;
+  }
+  if (method === "search") {
+    if (ctx.isStringExpression(expr.object)) return handleSearch(ctx, expr, params);
     return null;
   }
   return null;

--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -804,3 +804,29 @@ export function handleMatch(
   const regexPtr = ctx.generateExpression(regexArg, params);
   return ctx.regexGen.generateRegexMatch(regexPtr, strPtr, 9);
 }
+
+export function handleSearch(
+  ctx: MethodCallGeneratorContext,
+  expr: MethodCallNode,
+  params: string[],
+): string {
+  const strPtr = ctx.generateExpression(expr.object, params);
+
+  if (expr.args.length !== 1) {
+    return ctx.emitError(
+      "search() expects 1 argument (a regex), got " + expr.args.length,
+      expr.loc,
+    );
+  }
+
+  const regexArg = expr.args[0];
+
+  if (regexArg.type === "regex") {
+    const regexNode = regexArg as RegexNode;
+    const regexPtr = ctx.regexGen.generateRegexCompile(regexNode.pattern, regexNode.flags || "");
+    return ctx.regexGen.generateRegexSearch(regexPtr, strPtr);
+  }
+
+  const regexPtr = ctx.generateExpression(regexArg, params);
+  return ctx.regexGen.generateRegexSearch(regexPtr, strPtr);
+}

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -126,6 +126,7 @@ export interface IRegexGenerator {
   generateRegexMatch(regexPtr: string, testStr: string, numGroups: number): string;
   generateRegexCompileRuntime(patternPtr: string, cflags: number): string;
   generateRegexExecDyn(regexPtr: string, testStr: string): string;
+  generateRegexSearch(regexPtr: string, testStr: string): string;
 }
 
 export interface IControlFlowGenerator {
@@ -1893,6 +1894,7 @@ export class MockGeneratorContext implements IGeneratorContext {
     generateRegexCompileRuntime: (_patternPtr: string, _cflags: number): string =>
       "%mock_regex_compile_runtime",
     generateRegexExecDyn: (_regexPtr: string, _testStr: string): string => "%mock_regex_exec_dyn",
+    generateRegexSearch: (_regexPtr: string, _testStr: string): string => "%mock_regex_search",
   };
   controlFlowGen: IControlFlowGenerator = {
     generateLogicalOp: (

--- a/src/codegen/types/objects/regex.ts
+++ b/src/codegen/types/objects/regex.ts
@@ -198,6 +198,36 @@ export class RegexGenerator {
     this.ctx.emitCallVoid("@cs_regex_free", `i8* ${regexPtr}`);
   }
 
+  generateRegexSearch(regexPtr: string, testStr: string): string {
+    this.ctx.setUsesRegex(true);
+    const pmatchPtr = this.ctx.emitCall("i8*", "@cs_pmatch_alloc", "i32 1");
+    const execResult = this.ctx.emitCall(
+      "i32",
+      "@cs_regex_exec",
+      `i8* ${regexPtr}, i8* ${testStr}, i32 1, i8* ${pmatchPtr}, i32 0`,
+    );
+    const isNoMatch = this.ctx.emitIcmp("ne", "i32", execResult, "0");
+    const noMatchLabel = this.nextLabel("search_nomatch");
+    const matchLabel = this.nextLabel("search_found");
+    const endLabel = this.nextLabel("search_end");
+    this.ctx.emitBrCond(isNoMatch, noMatchLabel, matchLabel);
+
+    this.ctx.emitLabel(noMatchLabel);
+    this.ctx.emitBr(endLabel);
+
+    this.ctx.emitLabel(matchLabel);
+    const matchIdx = this.ctx.emitCall("i64", "@cs_pmatch_start", `i8* ${pmatchPtr}, i32 0`);
+    const matchDbl = this.nextTemp();
+    this.emit(`${matchDbl} = sitofp i64 ${matchIdx} to double`);
+    this.ctx.emitBr(endLabel);
+
+    this.ctx.emitLabel(endLabel);
+    const result = this.nextTemp();
+    this.emit(`${result} = phi double [ -1.0, %${noMatchLabel} ], [ ${matchDbl}, %${matchLabel} ]`);
+    this.ctx.setVariableType(result, "double");
+    return result;
+  }
+
   generateRegexMatch(regexPtr: string, testStr: string, numGroups: number): string {
     this.ctx.setUsesRegex(true);
     const MAX_GROUPS = numGroups + 1;

--- a/tests/fixtures/strings/string-search.ts
+++ b/tests/fixtures/strings/string-search.ts
@@ -1,0 +1,32 @@
+function testSearch(): void {
+  const str = "hello world";
+
+  const idx = str.search(/world/);
+  if (idx !== 6) {
+    console.log("FAIL: expected 6 got " + idx);
+    process.exit(1);
+  }
+
+  const noMatch = str.search(/xyz/);
+  if (noMatch !== -1) {
+    console.log("FAIL: expected -1 got " + noMatch);
+    process.exit(1);
+  }
+
+  const caseInsensitive = str.search(/HELLO/i);
+  if (caseInsensitive !== 0) {
+    console.log("FAIL: case insensitive expected 0 got " + caseInsensitive);
+    process.exit(1);
+  }
+
+  const digitStr = "abc123def";
+  const digitIdx = digitStr.search(/[0-9]+/);
+  if (digitIdx !== 3) {
+    console.log("FAIL: digit expected 3 got " + digitIdx);
+    process.exit(1);
+  }
+
+  console.log("TEST_PASSED");
+}
+
+testSearch();


### PR DESCRIPTION
## Summary
- Adds `string.search(regex)` returning the index of the first match, or -1 if no match
- Supports regex literals with flags (e.g., `/pattern/i`)
- Uses existing regex C bridge infrastructure

## Test plan
- [x] `tests/fixtures/strings/string-search.ts` — basic match, no match, case-insensitive, character class
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)