### PR TITLE
add choices validation to argparse with string[] type

### DIFF
--- a/src/argparse.ts
+++ b/src/argparse.ts
@@ -10,6 +10,7 @@ interface ArgDef {
   defaultValue: string;
   isPositional: boolean;
   subcommands: string;
+  choices: string[];
 }
 
 interface SubcommandDef {
@@ -82,6 +83,7 @@ export class ArgumentParser {
       defaultValue: "",
       isPositional: false,
       subcommands: "",
+      choices: [],
     });
   }
 
@@ -95,10 +97,10 @@ export class ArgumentParser {
       defaultValue: "",
       isPositional: false,
       subcommands: subcommands,
+      choices: [],
     });
   }
 
-  // Add an option that takes a value (e.g., -o file.txt, --output file.txt)
   addOption(name: string, shortFlag: string, help: string, defaultVal: string): void {
     this.args.push({
       name: name,
@@ -109,6 +111,7 @@ export class ArgumentParser {
       defaultValue: defaultVal,
       isPositional: false,
       subcommands: "",
+      choices: [],
     });
   }
 
@@ -128,10 +131,31 @@ export class ArgumentParser {
       defaultValue: defaultVal,
       isPositional: false,
       subcommands: subcommands,
+      choices: [],
     });
   }
 
-  // Add a positional argument (e.g., filename)
+  addScopedOptionWithChoices(
+    name: string,
+    shortFlag: string,
+    help: string,
+    defaultVal: string,
+    subcommands: string,
+    choices: string[],
+  ): void {
+    this.args.push({
+      name: name,
+      shortFlag: shortFlag,
+      longFlag: name,
+      help: help,
+      isFlag: false,
+      defaultValue: defaultVal,
+      isPositional: false,
+      subcommands: subcommands,
+      choices: choices,
+    });
+  }
+
   addPositional(name: string, help: string): void {
     this.args.push({
       name: name,
@@ -142,6 +166,7 @@ export class ArgumentParser {
       defaultValue: "",
       isPositional: true,
       subcommands: "",
+      choices: [],
     });
   }
 
@@ -226,7 +251,37 @@ export class ArgumentParser {
     }
   }
 
+  isValidChoice(argIndex: number, value: string): boolean {
+    const choices = this.args[argIndex].choices;
+    if (choices.length === 0) return true;
+    let i = 0;
+    while (i < choices.length) {
+      if (choices[i] === value) return true;
+      i = i + 1;
+    }
+    return false;
+  }
+
   setOptionValue(argIndex: number, value: string): void {
+    if (!this.isValidChoice(argIndex, value)) {
+      const choices = this.args[argIndex].choices;
+      let choiceList = "";
+      let ci = 0;
+      while (ci < choices.length) {
+        if (ci > 0) choiceList = choiceList + ", ";
+        choiceList = choiceList + choices[ci];
+        ci = ci + 1;
+      }
+      console.error(
+        "Error: invalid value '" +
+          value +
+          "' for --" +
+          this.args[argIndex].name +
+          ". Valid values: " +
+          choiceList,
+      );
+      process.exit(1);
+    }
     let optIdx = 0;
     while (optIdx < this.parsedOptions.length) {
       if (

--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -79,7 +79,14 @@ parser.addScopedOption("output", "o", "Specify output file", "", "build,run,ir")
 parser.addScopedFlag("verbose", "v", "Show compilation steps", "build,run,ir");
 parser.addScopedFlag("debug-info", "g", "Emit DWARF debug info (skips stripping)", "build,run");
 parser.addScopedFlag("skip-semantic-analysis", "", "Skip semantic analysis", "build,run,ir");
-parser.addScopedOption("diagnostics", "", "Diagnostic output format (json)", "", "build,run,ir");
+parser.addScopedOptionWithChoices(
+  "diagnostics",
+  "",
+  "Diagnostic output format",
+  "",
+  "build,run,ir",
+  ["json", "text"],
+);
 parser.addScopedOption(
   "target",
   "",

--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -50,7 +50,14 @@ parser.addScopedFlag("debug", "", "Show internal debugging information", "build,
 parser.addScopedFlag("trace", "", "Show everything (AST, IR, variable tracking)", "build,run,ir");
 parser.addScopedFlag("skip-semantic-analysis", "", "Skip semantic analysis", "build,run,ir");
 parser.addScopedFlag("keep-temps", "", "Keep intermediate files (.ll, .o)", "build,run,ir");
-parser.addScopedOption("diagnostics", "", "Diagnostic output format (json)", "", "build,run,ir");
+parser.addScopedOptionWithChoices(
+  "diagnostics",
+  "",
+  "Diagnostic output format",
+  "",
+  "build,run,ir",
+  ["json", "text"],
+);
 parser.addScopedFlag("sanitize-address", "", "Build with AddressSanitizer", "build,run");
 parser.addScopedFlag("debug-info", "g", "Emit DWARF debug info", "build,run");
 parser.addScopedOption(


### PR DESCRIPTION
## Summary
- Invalid values for options with choices (like `--diagnostics FOO`) now get a clear error message instead of silently passing through
- `choices` field on ArgDef uses `string[]` instead of comma-separated string
- Applied to `--diagnostics` option (valid: json, text) in both chad-node.ts and chad-native.ts

## Test plan
- [x] `npm run verify:quick` passes
- [x] Type-checks cleanly with `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)