### PR TITLE
unskip nested ternary test — now passes on both compilers

### DIFF
--- a/tests/fixtures/control-flow/ternary-nested.ts
+++ b/tests/fixtures/control-flow/ternary-nested.ts
@@ -1,4 +1,3 @@
-// @test-skip
 let passed = true;
 
 const x = 5;


### PR DESCRIPTION
## Summary
- Nested ternary expressions (`x > 10 ? 100 : x > 3 ? 50 : 0`) now work correctly on both JS and native compilers
- Removes `@test-skip` from `ternary-nested.ts` — this was skipped since PR #281 due to native compiler link failures
- Recent alloca-hoisting fixes (PRs #298-300) likely resolved the underlying issue

## Test plan
- [x] `npm run verify:quick` passes (tests + self-hosting)
- [x] Manual native compile + run of the fixture passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)