### PR TITLE
unskip try-catch-throw test — now passes on both compilers

### DIFF
--- a/tests/fixtures/error-handling/try-catch-throw-string.ts
+++ b/tests/fixtures/error-handling/try-catch-throw-string.ts
@@ -1,4 +1,3 @@
-// @test-skip
 let passed = true;
 
 let caught = false;


### PR DESCRIPTION
## Summary
- `throw "string"` + try-catch now works correctly on both JS and native compilers
- Renamed `try-catch-throw.ts` → `try-catch-throw-string.ts` to avoid output binary collision with existing `try-catch-throw.js` at concurrency 32
- Removes `@test-skip` — this was skipped since the feature was added

## Test plan
- [x] `npm run verify:quick` passes (tests + self-hosting)
- [x] Both JS and native compilers produce correct TEST_PASSED output

🤖 Generated with [Claude Code](https://claude.com/claude-code)