### PR TITLE
fix: native parser switch default case no longer always executes

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -2187,6 +2187,7 @@ function transformSwitchStatement(node: TreeSitterNode): BlockStatement {
   const statements: Statement[] = [];
   let pendingConditions: Expression[] = [];
   let defaultStatements: Statement[] | null = null;
+  const allConditions: Expression[] = [];
 
   if (bodyNode) {
     const bn = bodyNode as NodeBase;
@@ -2246,6 +2247,7 @@ function transformSwitchStatement(node: TreeSitterNode): BlockStatement {
               elseBlock: null,
             };
             statements.push(ifStmt);
+            allConditions.push(finalCondition);
           }
         }
       } else if (cl.type === "switch_default") {
@@ -2270,7 +2272,20 @@ function transformSwitchStatement(node: TreeSitterNode): BlockStatement {
     }
   }
 
-  if (defaultStatements) {
+  if (defaultStatements && allConditions.length > 0) {
+    let combined: Expression = allConditions[0];
+    for (let ac = 1; ac < allConditions.length; ac++) {
+      combined = { type: "binary", op: "||", left: combined, right: allConditions[ac] };
+    }
+    const negated: Expression = { type: "unary", op: "!", operand: combined };
+    const defaultIf: IfStatement = {
+      type: "if",
+      condition: negated,
+      thenBlock: { type: "block", statements: defaultStatements },
+      elseBlock: null,
+    };
+    statements.push(defaultIf);
+  } else if (defaultStatements) {
     for (let ds = 0; ds < defaultStatements.length; ds++) {
       statements.push(defaultStatements[ds]);
     }

--- a/tests/fixtures/control-flow/switch-basic.ts
+++ b/tests/fixtures/control-flow/switch-basic.ts
@@ -1,4 +1,3 @@
-// @test-skip
 function testSwitch(): void {
   const x: number = 2;
   let result: string = "";

--- a/tests/fixtures/control-flow/switch-string.ts
+++ b/tests/fixtures/control-flow/switch-string.ts
@@ -1,4 +1,3 @@
-// @test-skip
 function testSwitchString(): void {
   const color: string = "green";
   let code: number = 0;


### PR DESCRIPTION
## Summary
- Switch statements compiled by the native parser now work correctly — default case only runs when no case matches
- Unskips `switch-basic.ts` and `switch-string.ts` (both were @test-skip since PR #220)
- Root cause: native parser generated independent if-statements for each case + appended default unconditionally
- Fix: wrap default in `if (!(case1 || case2 || ...))` guard — minimal change that avoids struct layout disruption that caused previous fix attempts to SIGSEGV on Stage 1

## Why previous fixes failed
All prior attempts (#32) tried to chain if-else statements (matching the TS parser algorithm). This changed IfStatement struct allocation patterns, which the native compiler tracks by creation site. Any change to how IfStatement.elseBlock is set post-creation breaks Stage 1 self-hosting with SIGSEGV. This fix keeps the flat if-list structure intact and only adds a guard condition around default.

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] `switch-basic.ts` passes: numeric switch with default
- [x] `switch-string.ts` passes: string switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)