### PR TITLE
fix: switch default case only executes when no case matches

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -2184,9 +2184,9 @@ function transformSwitchStatement(node: TreeSitterNode): BlockStatement {
     ? transformExpression(exprNode)
     : { type: "variable" as const, name: "undefined" };
 
-  const statements: Statement[] = [];
   let pendingConditions: Expression[] = [];
   let defaultStatements: Statement[] | null = null;
+  const caseIfNodes: object[] = [];
 
   if (bodyNode) {
     const bn = bodyNode as NodeBase;
@@ -2245,7 +2245,7 @@ function transformSwitchStatement(node: TreeSitterNode): BlockStatement {
               thenBlock: thenBlock,
               elseBlock: null,
             };
-            statements.push(ifStmt);
+            caseIfNodes.push(ifStmt);
           }
         }
       } else if (cl.type === "switch_default") {
@@ -2270,12 +2270,38 @@ function transformSwitchStatement(node: TreeSitterNode): BlockStatement {
     }
   }
 
-  if (defaultStatements) {
-    for (let ds = 0; ds < defaultStatements.length; ds++) {
-      statements.push(defaultStatements[ds]);
+  if (caseIfNodes.length === 0) {
+    const statements: Statement[] = [];
+    if (defaultStatements) {
+      for (let ds = 0; ds < defaultStatements.length; ds++) {
+        statements.push(defaultStatements[ds]);
+      }
     }
+    return { type: "block", statements: statements };
   }
 
+  let chainedIf = caseIfNodes[caseIfNodes.length - 1] as IfStatement;
+  if (defaultStatements) {
+    chainedIf = {
+      type: "if",
+      condition: chainedIf.condition,
+      thenBlock: chainedIf.thenBlock,
+      elseBlock: { type: "block", statements: defaultStatements },
+    };
+  }
+  for (let ci = caseIfNodes.length - 2; ci >= 0; ci--) {
+    const prev = caseIfNodes[ci] as IfStatement;
+    const elseWrapper: BlockStatement = { type: "block", statements: [chainedIf] };
+    chainedIf = {
+      type: "if",
+      condition: prev.condition,
+      thenBlock: prev.thenBlock,
+      elseBlock: elseWrapper,
+    };
+  }
+
+  const statements: Statement[] = [];
+  statements.push(chainedIf);
   return { type: "block", statements: statements };
 }
 

--- a/tests/fixtures/control-flow/switch-basic.ts
+++ b/tests/fixtures/control-flow/switch-basic.ts
@@ -1,4 +1,3 @@
-// @test-skip
 function testSwitch(): void {
   const x: number = 2;
   let result: string = "";

--- a/tests/fixtures/control-flow/switch-string.ts
+++ b/tests/fixtures/control-flow/switch-string.ts
@@ -1,4 +1,3 @@
-// @test-skip
 function testSwitchString(): void {
   const color: string = "green";
   let code: number = 0;


### PR DESCRIPTION
## Summary
- Switch statements with `default` cases now work correctly — default only runs when no case matches
- Previously default ALWAYS executed, making switch unusable (#32)
- Unskips `switch-basic.ts` and `switch-string.ts` (skip count 18 → 16)

The fix builds an if-else-if chain bottom-up instead of independent if-statements. Uses object creation (not mutation) to avoid a native compiler codegen bug with interface field assignment.

## Test plan
- [x] `switch-basic.ts` passes (both compilers)
- [x] `switch-string.ts` passes (both compilers)
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] Stage 1 binary correctly compiles and runs switch tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)