### PR TITLE
fix: prefer actual interface defs over hardcoded ast type builtins

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -1956,19 +1956,19 @@ export class MemberAccessGenerator {
   private getInterfaceInfo(
     interfaceName: string,
   ): { keys: string[]; types: string[]; tsTypes: string[] } | null {
+    const ifaceProps = this.ctx.getInterfaceProperties(interfaceName);
+    if (ifaceProps) {
+      return {
+        keys: ifaceProps.keys,
+        types: ifaceProps.types,
+        tsTypes: ifaceProps.tsTypes,
+      };
+    }
     const builtinFields = this.getBuiltinAstTypeFields(interfaceName);
     if (builtinFields) {
       return builtinFields;
     }
-    const ifaceProps = this.ctx.getInterfaceProperties(interfaceName);
-    if (!ifaceProps) {
-      return null;
-    }
-    return {
-      keys: ifaceProps.keys,
-      types: ifaceProps.types,
-      tsTypes: ifaceProps.tsTypes,
-    };
+    return null;
   }
 
   private getTypeAliasInfo(

--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -392,6 +392,17 @@ export class TypeResolver {
     if (!name) {
       return null;
     }
+    const interfacesLen = this.ctx.getAstInterfacesLength();
+    for (let i = 0; i < interfacesLen; i++) {
+      const ifaceName = this.ctx.getAstInterfaceNameAt(i);
+      if (!ifaceName) {
+        continue;
+      }
+      if (ifaceName === name) {
+        const iface = this.ctx.getAstInterfaceAt(i);
+        return iface;
+      }
+    }
     const builtinType = getBuiltinAstTypeByName(name);
     if (builtinType) {
       const fields: InterfaceField[] = [];
@@ -406,38 +417,10 @@ export class TypeResolver {
       };
       return ifaceDecl;
     }
-    const interfacesLen = this.ctx.getAstInterfacesLength();
-    if (interfacesLen === 0) {
-      return null;
-    }
-    for (let i = 0; i < interfacesLen; i++) {
-      const ifaceName = this.ctx.getAstInterfaceNameAt(i);
-      if (!ifaceName) {
-        continue;
-      }
-      if (ifaceName === name) {
-        const iface = this.ctx.getAstInterfaceAt(i);
-        return iface;
-      }
-    }
     return null;
   }
 
   getInterfaceMetadata(name: string): ObjectMetadata | null {
-    const builtinType = getBuiltinAstTypeByName(name);
-    if (builtinType) {
-      const keys: string[] = [];
-      const types: string[] = [];
-      const tsTypes: string[] = [];
-      for (let i = 0; i < builtinType.fields.length; i++) {
-        const f = builtinType.fields[i];
-        keys.push(stripOptional(f.name));
-        types.push(canonicalTypeToLlvm(f.type, "default", this.isEnumType(f.type), false, ""));
-        tsTypes.push(f.type);
-      }
-      return { keys, types, tsTypes };
-    }
-
     const iface = this.getInterface(name);
     if (!iface) return null;
     const keys: string[] = [];


### PR DESCRIPTION
## Summary
- Fixes native compiler crash when user-defined interfaces share names with built-in AST types (IfStatement, BlockStatement, etc.)
- Root cause: `getInterfaceInfo` and `getInterface` checked hardcoded built-in types BEFORE actual interface definitions, using wrong field layouts
- Fix: check actual interface definitions first, fall back to built-in only when no definition exists

Previously, `const o: IfStatement = {...}; o.elseBlock = ...` would SIGSEGV because the codegen used a hardcoded 4-field layout while the actual interface had 5 fields. This also caused GEP mismatches for BlockStatement and other AST type names.

## Test plan
- [x] Field mutation on IfStatement-named interface no longer crashes
- [x] Field mutation on BlockStatement-named interface no longer crashes
- [x] All tests pass (`npm run verify:quick`)
- [x] Stage 1 self-hosting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)