### PR TITLE
fix: use emitCallVoid for describe/test callbacks

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1073,7 +1073,10 @@ export class CallExpressionGenerator {
       );
     }
 
-    const callResult = this.ctx.emitCall("double", `@${callbackFn}`, "");
+    const envPtr = this.ctx.getLastInlineLambdaEnvPtr();
+    const callArgs = envPtr ? `i8* ${envPtr}` : "";
+    this.ctx.emitCallVoid(`@${callbackFn}`, callArgs);
+    if (envPtr) this.ctx.setLastInlineLambdaEnvPtr(null);
 
     const failed = this.ctx.emitLoad("i1", "@__test_current_failed");
 
@@ -1150,7 +1153,10 @@ export class CallExpressionGenerator {
       );
     }
 
-    const callResult = this.ctx.emitCall("double", `@${callbackFn}`, "");
+    const descEnvPtr = this.ctx.getLastInlineLambdaEnvPtr();
+    const descCallArgs = descEnvPtr ? `i8* ${descEnvPtr}` : "";
+    this.ctx.emitCallVoid(`@${callbackFn}`, descCallArgs);
+    if (descEnvPtr) this.ctx.setLastInlineLambdaEnvPtr(null);
 
     const restoredDepth = this.ctx.emitLoad("i32", "@__describe_depth");
     const decDepth = this.ctx.nextTemp();


### PR DESCRIPTION
## Summary
- describe() and test() callbacks were called with `emitCall("double", ...)` but the lambda functions return void
- this generated invalid LLVM IR (calling a void function and expecting a double return)
- switched to `emitCallVoid` and added closure environment pointer passing for callbacks with captures

the native compiler still crashes on nested describe+test (separate self-hosting bug with nested function calls inside lambda bodies), so describe.ts remains @test-skip. but the generated IR is now correct.

## Test plan
- [x] `npm run verify:quick` passes
- [x] JS compiler correctly builds and runs describe.ts