### PR TITLE
fix: string array sort with custom comparator

### DIFF
--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -35,6 +35,7 @@ interface ExpressionOrchestratorContext {
   setUsesPromises(value: boolean): void;
   getExpectedCallbackParamType(): string | null;
   getExpectedCallbackReturnType(): string | null;
+  getExpectedCallbackParamTypes(): string[] | null;
   setLastInlineLambdaEnvPtr(ptr: string | null): void;
   setLastTypeAssertionSourceVar(name: string | null): void;
   emitWarning(message: string, loc?: { line: number; column: number }, suggestion?: string): void;
@@ -209,19 +210,16 @@ export class ExpressionGenerator {
       interfaceTypes: string[];
     };
     let typeHints: { paramTypes?: string[]; returnType?: string } | undefined = undefined;
+    const cbParamTypes = this.ctx.getExpectedCallbackParamTypes();
     const cbParamType = this.ctx.getExpectedCallbackParamType();
     const cbReturnType = this.ctx.getExpectedCallbackReturnType();
-    if (cbParamType || cbReturnType) {
-      const hintParamTypes: string[] = cbParamType ? [cbParamType] : [];
-      if (cbParamType) {
-        for (let pi = 1; pi < expr.params.length; pi++) {
-          hintParamTypes.push(cbParamType);
-        }
-      }
-      typeHints = {
-        paramTypes: hintParamTypes.length > 0 ? hintParamTypes : undefined,
-        returnType: cbReturnType || undefined,
-      };
+    if (cbParamTypes || cbParamType || cbReturnType) {
+      const hintParamTypes: string[] | undefined = cbParamTypes
+        ? cbParamTypes
+        : cbParamType
+          ? [cbParamType]
+          : undefined;
+      typeHints = { paramTypes: hintParamTypes, returnType: cbReturnType || undefined };
     }
     if (!typeHints && expr.returnType) {
       typeHints = { returnType: expr.returnType };

--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -212,8 +212,16 @@ export class ExpressionGenerator {
     const cbParamType = this.ctx.getExpectedCallbackParamType();
     const cbReturnType = this.ctx.getExpectedCallbackReturnType();
     if (cbParamType || cbReturnType) {
-      const hintParamTypes: string[] | undefined = cbParamType ? [cbParamType] : undefined;
-      typeHints = { paramTypes: hintParamTypes, returnType: cbReturnType || undefined };
+      const hintParamTypes: string[] = cbParamType ? [cbParamType] : [];
+      if (cbParamType) {
+        for (let pi = 1; pi < expr.params.length; pi++) {
+          hintParamTypes.push(cbParamType);
+        }
+      }
+      typeHints = {
+        paramTypes: hintParamTypes.length > 0 ? hintParamTypes : undefined,
+        returnType: cbReturnType || undefined,
+      };
     }
     if (!typeHints && expr.returnType) {
       typeHints = { returnType: expr.returnType };

--- a/src/codegen/infrastructure/base-generator.ts
+++ b/src/codegen/infrastructure/base-generator.ts
@@ -39,8 +39,9 @@ export class BaseGenerator {
   public thisPointer: string | null = null; // Current 'this' pointer (i32*)
   public currentClassName: string | null = null; // Current class name (for super resolution)
   public expectedArrayElementType: "string" | "number" | "boolean" | "pointer" | null = null; // Expected array element type for context-aware generation
-  public expectedCallbackParamType: string | null = null; // Expected callback parameter type for lambda generation
-  public expectedCallbackReturnType: string | null = null; // Expected callback return type for lambda generation
+  public expectedCallbackParamType: string | null = null;
+  public expectedCallbackReturnType: string | null = null;
+  public expectedCallbackParamTypes: string[] | null = null;
   public currentFunctionReturnType: string = "double"; // Current function/method return type for return statements
 
   public debugInfoEnabled: boolean = false;

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -586,6 +586,10 @@ export interface IGeneratorContext {
   setExpectedCallbackReturnType(type: string | null): void;
   getExpectedCallbackReturnType(): string | null;
 
+  expectedCallbackParamTypes: string[] | null;
+  setExpectedCallbackParamTypes(types: string[] | null): void;
+  getExpectedCallbackParamTypes(): string[] | null;
+
   /**
    * Current 'this' pointer for class methods
    */
@@ -1012,6 +1016,7 @@ export class MockGeneratorContext implements IGeneratorContext {
   public currentDeclaredMapType: string | undefined = undefined;
   public expectedCallbackParamType: string | null = null;
   public expectedCallbackReturnType: string | null = null;
+  public expectedCallbackParamTypes: string[] | null = null;
   public thisPointer: string | null = null;
   public currentClassName: string | null = null;
   public ast?: AST;
@@ -1296,6 +1301,12 @@ export class MockGeneratorContext implements IGeneratorContext {
   }
   getExpectedCallbackReturnType(): string | null {
     return this.expectedCallbackReturnType;
+  }
+  setExpectedCallbackParamTypes(types: string[] | null): void {
+    this.expectedCallbackParamTypes = types;
+  }
+  getExpectedCallbackParamTypes(): string[] | null {
+    return this.expectedCallbackParamTypes;
   }
   getLastInlineLambdaEnvPtr(): string | null {
     return this.lastInlineLambdaEnvPtr;

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -956,6 +956,12 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public getExpectedCallbackReturnType(): string | null {
     return this.expectedCallbackReturnType;
   }
+  public setExpectedCallbackParamTypes(types: string[] | null): void {
+    this.expectedCallbackParamTypes = types;
+  }
+  public getExpectedCallbackParamTypes(): string[] | null {
+    return this.expectedCallbackParamTypes;
+  }
   public getLastInlineLambdaEnvPtr(): string | null {
     return this.lastInlineLambdaEnvPtr;
   }

--- a/src/codegen/types/collections/array/sort.ts
+++ b/src/codegen/types/collections/array/sort.ts
@@ -342,9 +342,7 @@ function generateStringSortWithFn(
   gen.emit(`${valB} = load i8*, i8** ${ptrB}`);
 
   const cmpResult = gen.nextTemp();
-  const cmpArgs = envPtr
-    ? `i8* ${envPtr}, i8* ${valA}, i8* ${valB}`
-    : `i8* ${valA}, i8* ${valB}`;
+  const cmpArgs = envPtr ? `i8* ${envPtr}, i8* ${valA}, i8* ${valB}` : `i8* ${valA}, i8* ${valB}`;
   gen.emit(`${cmpResult} = call double @${compareFn}(${cmpArgs})`);
   const shouldSwap = gen.nextTemp();
   gen.emit(`${shouldSwap} = fcmp ogt double ${cmpResult}, 0.0`);

--- a/src/codegen/types/collections/array/sort.ts
+++ b/src/codegen/types/collections/array/sort.ts
@@ -87,14 +87,20 @@ export function generateArraySort(
   if (predicateArg.type === "variable") {
     compareFn = gen.mangleUserName((predicateArg as VariableNode).name);
   } else if (predicateArg.type === "arrow_function") {
+    if (isStringArray) {
+      gen.setExpectedCallbackParamType("string");
+    }
     compareFn = gen.generateExpression(predicateArg, params);
+    gen.setExpectedCallbackParamType(null);
   } else {
     return gen.emitError("sort() comparator must be a function name or inline function", expr.loc);
   }
 
-  // Capture env ptr for inline lambda closures, then clear it
   const sortEnvPtr = gen.getLastInlineLambdaEnvPtr();
   gen.setLastInlineLambdaEnvPtr(null);
+  if (isStringArray) {
+    return generateStringSortWithFn(gen, arrayPtr, compareFn, sortEnvPtr);
+  }
   return generateNumericSortWithFn(gen, arrayPtr, compareFn, sortEnvPtr);
 }
 
@@ -255,5 +261,117 @@ function generateNumericSortWithFn(
   gen.emit(`${endLabel}:`);
 
   gen.setVariableType(arrayPtr, "%Array*");
+  return arrayPtr;
+}
+
+function generateStringSortWithFn(
+  gen: ArraySortContext,
+  arrayPtr: string,
+  compareFn: string,
+  envPtr?: string | null,
+): string {
+  const lenPtr = gen.nextTemp();
+  gen.emit(
+    `${lenPtr} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 1`,
+  );
+  const length = gen.nextTemp();
+  gen.emit(`${length} = load i32, i32* ${lenPtr}`);
+
+  const dataPtrField = gen.nextTemp();
+  gen.emit(
+    `${dataPtrField} = getelementptr inbounds %StringArray, %StringArray* ${arrayPtr}, i32 0, i32 0`,
+  );
+  const dataPtr = gen.nextTemp();
+  gen.emit(`${dataPtr} = load i8**, i8*** ${dataPtrField}`);
+
+  const checkLabel = gen.nextLabel("sort_check");
+  const outerBody = gen.nextLabel("sort_outer");
+  const innerCheck = gen.nextLabel("sort_inner_check");
+  const innerBody = gen.nextLabel("sort_inner_body");
+  const swapLabel = gen.nextLabel("sort_swap");
+  const noSwapLabel = gen.nextLabel("sort_noswap");
+  const innerNext = gen.nextLabel("sort_inner_next");
+  const outerNext = gen.nextLabel("sort_outer_next");
+  const endLabel = gen.nextLabel("sort_end");
+
+  const iPtr = gen.nextTemp();
+  gen.emit(`${iPtr} = alloca i32`);
+  gen.emit(`store i32 0, i32* ${iPtr}`);
+
+  const jPtr = gen.nextTemp();
+  gen.emit(`${jPtr} = alloca i32`);
+
+  const lenMinus1 = gen.nextTemp();
+  gen.emit(`${lenMinus1} = sub i32 ${length}, 1`);
+
+  gen.emit(`br label %${checkLabel}`);
+
+  gen.emit(`${checkLabel}:`);
+  const i = gen.nextTemp();
+  gen.emit(`${i} = load i32, i32* ${iPtr}`);
+  const outerCond = gen.nextTemp();
+  gen.emit(`${outerCond} = icmp slt i32 ${i}, ${lenMinus1}`);
+  gen.emit(`br i1 ${outerCond}, label %${outerBody}, label %${endLabel}`);
+
+  gen.emit(`${outerBody}:`);
+  gen.emit(`store i32 0, i32* ${jPtr}`);
+
+  const remaining = gen.nextTemp();
+  gen.emit(`${remaining} = sub i32 ${lenMinus1}, ${i}`);
+
+  gen.emit(`br label %${innerCheck}`);
+
+  gen.emit(`${innerCheck}:`);
+  const j = gen.nextTemp();
+  gen.emit(`${j} = load i32, i32* ${jPtr}`);
+  const innerCond = gen.nextTemp();
+  gen.emit(`${innerCond} = icmp slt i32 ${j}, ${remaining}`);
+  gen.emit(`br i1 ${innerCond}, label %${innerBody}, label %${outerNext}`);
+
+  gen.emit(`${innerBody}:`);
+  const ptrA = gen.nextTemp();
+  gen.emit(`${ptrA} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${j}`);
+  const valA = gen.nextTemp();
+  gen.emit(`${valA} = load i8*, i8** ${ptrA}`);
+
+  const jPlus1 = gen.nextTemp();
+  gen.emit(`${jPlus1} = add i32 ${j}, 1`);
+  const ptrB = gen.nextTemp();
+  gen.emit(`${ptrB} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${jPlus1}`);
+  const valB = gen.nextTemp();
+  gen.emit(`${valB} = load i8*, i8** ${ptrB}`);
+
+  const cmpResult = gen.nextTemp();
+  const cmpArgs = envPtr
+    ? `i8* ${envPtr}, i8* ${valA}, i8* ${valB}`
+    : `i8* ${valA}, i8* ${valB}`;
+  gen.emit(`${cmpResult} = call double @${compareFn}(${cmpArgs})`);
+  const shouldSwap = gen.nextTemp();
+  gen.emit(`${shouldSwap} = fcmp ogt double ${cmpResult}, 0.0`);
+  gen.emit(`br i1 ${shouldSwap}, label %${swapLabel}, label %${noSwapLabel}`);
+
+  gen.emit(`${swapLabel}:`);
+  gen.emit(`store i8* ${valB}, i8** ${ptrA}`);
+  gen.emit(`store i8* ${valA}, i8** ${ptrB}`);
+  gen.emit(`br label %${innerNext}`);
+
+  gen.emit(`${noSwapLabel}:`);
+  gen.emit(`br label %${innerNext}`);
+
+  gen.emit(`${innerNext}:`);
+  const nextJ = gen.nextTemp();
+  gen.emit(`${nextJ} = add i32 ${j}, 1`);
+  gen.emit(`store i32 ${nextJ}, i32* ${jPtr}`);
+  gen.emit(`br label %${innerCheck}`);
+
+  gen.emit(`${outerNext}:`);
+  const nextI = gen.nextTemp();
+  gen.emit(`${nextI} = add i32 ${i}, 1`);
+  gen.emit(`store i32 ${nextI}, i32* ${iPtr}`);
+  gen.emit(`br label %${checkLabel}`);
+
+  gen.emit(`${endLabel}:`);
+
+  gen.setVariableType(arrayPtr, "%StringArray*");
   return arrayPtr;
 }

--- a/src/codegen/types/collections/array/sort.ts
+++ b/src/codegen/types/collections/array/sort.ts
@@ -88,10 +88,10 @@ export function generateArraySort(
     compareFn = gen.mangleUserName((predicateArg as VariableNode).name);
   } else if (predicateArg.type === "arrow_function") {
     if (isStringArray) {
-      gen.setExpectedCallbackParamType("string");
+      gen.setExpectedCallbackParamTypes(["string", "string"]);
     }
     compareFn = gen.generateExpression(predicateArg, params);
-    gen.setExpectedCallbackParamType(null);
+    gen.setExpectedCallbackParamTypes(null);
   } else {
     return gen.emitError("sort() comparator must be a function name or inline function", expr.loc);
   }

--- a/tests/fixtures/arrays/string-sort-comparator.ts
+++ b/tests/fixtures/arrays/string-sort-comparator.ts
@@ -1,0 +1,27 @@
+let passed = true;
+
+const strs: string[] = ["cherry", "apple", "banana"];
+strs.sort((a: string, b: string): number => {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+});
+if (strs[0] !== "apple") passed = false;
+if (strs[1] !== "banana") passed = false;
+if (strs[2] !== "cherry") passed = false;
+
+const desc: string[] = ["a", "c", "b"];
+desc.sort((a: string, b: string): number => {
+  if (a > b) return -1;
+  if (a < b) return 1;
+  return 0;
+});
+if (desc[0] !== "c") passed = false;
+if (desc[1] !== "b") passed = false;
+if (desc[2] !== "a") passed = false;
+
+if (passed) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAILED");
+}


### PR DESCRIPTION
## Summary
- `["c","a","b"].sort((a, b) => ...)` was silently broken — comparator received raw pointer values as doubles instead of string args
- root cause: sort codegen always dispatched to numeric sort loop (loading doubles from `%Array`), and callback param type hint only filled first param
- added `generateStringSortWithFn` that uses `%StringArray` struct and passes `i8*` strings
- fixed orchestrator to fill callback param type hints for ALL arrow function params, not just the first

## Test plan
- [x] new fixture `arrays/string-sort-comparator.ts` — ascending and descending custom sort
- [x] `npm run verify:quick` passes (self-hosting + all tests)
- [x] works on both JS and native compiler