### PR TITLE
fix: string ordering operators use strcmp instead of broken single-char optimization

### DIFF
--- a/src/codegen/expressions/operators/binary.ts
+++ b/src/codegen/expressions/operators/binary.ts
@@ -734,6 +734,8 @@ export class BinaryExpressionGenerator {
     this.ctx.emit(`${isSingleChar} = and i1 ${byteMatch}, ${isNull}`);
 
     const isEq = op === "===" || op === "==";
+    const isNe = op === "!==" || op === "!=";
+    if (!isEq && !isNe) return "";
     let cmpBool: string;
     if (isEq) {
       cmpBool = isSingleChar;

--- a/tests/fixtures/strings/string-comparison-operators.ts
+++ b/tests/fixtures/strings/string-comparison-operators.ts
@@ -1,0 +1,60 @@
+const a = "apple";
+const b = "banana";
+const c = "cherry";
+
+if (a < b) {
+  console.log("a < b: true");
+} else {
+  console.log("a < b: false");
+}
+
+if (b > a) {
+  console.log("b > a: true");
+} else {
+  console.log("b > a: false");
+}
+
+if (a > b) {
+  console.log("FAIL: a > b should be false");
+} else {
+  console.log("a > b: false");
+}
+
+if (b >= b) {
+  console.log("b >= b: true");
+} else {
+  console.log("FAIL: b >= b should be true");
+}
+
+if (a <= a) {
+  console.log("a <= a: true");
+} else {
+  console.log("FAIL: a <= a should be true");
+}
+
+if (c > b) {
+  console.log("c > b: true");
+} else {
+  console.log("FAIL: c > b should be true");
+}
+
+const strs: string[] = ["apple", "banana", "cherry", "date"];
+const gtBanana = strs.filter((item: string): boolean => {
+  return item > "banana";
+});
+if (gtBanana.length === 2) {
+  console.log("filter > banana: 2 items");
+} else {
+  console.log("FAIL: filter > banana got " + gtBanana.length.toString());
+}
+
+const ltCherry = strs.filter((item: string): boolean => {
+  return item < "cherry";
+});
+if (ltCherry.length === 2) {
+  console.log("filter < cherry: 2 items");
+} else {
+  console.log("FAIL: filter < cherry got " + ltCherry.length.toString());
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- String comparison operators (`>`, `<`, `>=`, `<=`) were incorrectly handled by the single-char literal optimization path, which only implemented `==`/`!=` but returned wrong results for ordering operators (treating `>` as `!=`)
- Now ordering operators correctly fall through to `strcmp`-based comparison
- Fixes string comparisons both at top level and inside lambda/filter callbacks

## Test plan
- [x] New test fixture `strings/string-comparison-operators.ts` covers all ordering operators and filter lambdas
- [x] `npm run verify:quick` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)