### PR TITLE
fix: unskip ternary-nested test, now passes on native compiler (#35)

### DIFF
--- a/tests/fixtures/control-flow/ternary-nested.ts
+++ b/tests/fixtures/control-flow/ternary-nested.ts
@@ -1,4 +1,3 @@
-// @test-skip
 let passed = true;
 
 const x = 5;


### PR DESCRIPTION
## Summary
- Nested ternary expressions now work correctly on the native compiler — unskipping `ternary-nested.ts` test
- Reduces @test-skip count from 16 to 15 (11 network infra, 3 import helpers, 1 describe segfault)

## Test plan
- [x] `npm run verify:quick` passes with ternary-nested unskipped
- [x] Manual verification: `.build/chad build` + run produces `TEST_PASSED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)