### PR TITLE
fix: global scope map variables from function returns get correct type

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2252,6 +2252,13 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               mapValueType = mapNode.valueType || "string";
             }
           }
+          if (!isStringMap && resolved && resolved.base.startsWith("Map<")) {
+            const parsed = parseMapTypeString(resolved.base);
+            if (parsed && parsed.keyType === "string") {
+              isStringMap = true;
+              mapValueType = parsed.valueType;
+            }
+          }
           if (isStringMap) {
             llvmType = "%StringMap*";
             kind = SymbolKind.Map;
@@ -2279,6 +2286,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           let pointerMapValueType = "string";
           if (stmt.declaredType) {
             const parsed = parseMapTypeString(stmt.declaredType);
+            if (parsed && parsed.keyType !== "string" && parsed.keyType !== "number") {
+              isPointerMap = true;
+              pointerMapKeyType = parsed.keyType;
+              pointerMapValueType = parsed.valueType;
+            }
+          }
+          if (!isPointerMap && resolved && resolved.base.startsWith("Map<")) {
+            const parsed = parseMapTypeString(resolved.base);
             if (parsed && parsed.keyType !== "string" && parsed.keyType !== "number") {
               isPointerMap = true;
               pointerMapKeyType = parsed.keyType;

--- a/tests/fixtures/maps/global-map-return.ts
+++ b/tests/fixtures/maps/global-map-return.ts
@@ -1,0 +1,23 @@
+function makeMap(): Map<string, string> {
+  const m = new Map<string, string>();
+  m.set("a", "1");
+  m.set("b", "2");
+  return m;
+}
+
+const m = makeMap();
+let passed = true;
+
+if (m.size !== 2) {
+  passed = false;
+}
+if (m.get("a") !== "1") {
+  passed = false;
+}
+if (m.get("b") !== "2") {
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `const m = makeMap()` at global scope where `makeMap()` returns `Map<string, string>` was incorrectly typed as `%Map*` (numeric map) instead of `%StringMap*`, causing invalid LLVM IR
- Root cause: the map sub-type detection only checked `stmt.declaredType` and `MapNode.keyType`, but when the value is a function call, neither is set. Now also extracts key/value types from the resolved expression type
- Same fix applied for pointer maps (non-string key types)

## Test plan
- [x] New fixture `maps/global-map-return.ts` — function returning `Map<string, string>` used at global scope
- [x] All 616 tests pass
- [x] Self-hosting verification passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)