### PR TITLE
unskip describe test — nested callbacks work in native compiler

### DIFF
--- a/tests/fixtures/test-runner/describe.ts
+++ b/tests/fixtures/test-runner/describe.ts
@@ -1,4 +1,3 @@
-// @test-skip
 describe("math", () => {
   test("addition", () => {
     assert.strictEqual(1 + 1, 2);


### PR DESCRIPTION
## Summary
- The `describe.ts` test fixture now passes on both JS and native compilers
- Nested callbacks (describe → test → assert) were previously crashing the native compiler, but recent fixes resolved the underlying issue
- Reduces skip count from 16 → 15

## Test plan
- [x] Both JS and native compiler produce correct output
- [x] All 617 tests pass (616 + 1 unskipped)
- [x] Self-hosting verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)