### PR TITLE
fix: split().join() chaining produces correct string output

### DIFF
--- a/src/codegen/types/collections/string/split.ts
+++ b/src/codegen/types/collections/string/split.ts
@@ -282,6 +282,7 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   ctx.emit(
     `${result} = phi %StringArray* [ ${emptyArrPtr}, %${emptyLoopEndLabel} ], [ ${arrayPtr}, %${extractEndLabel} ]`,
   );
+  ctx.setVariableType(result, "%StringArray*");
 
   return result;
 }

--- a/tests/fixtures/strings/string-split-chain.ts
+++ b/tests/fixtures/strings/string-split-chain.ts
@@ -1,0 +1,15 @@
+const x = "hello world".split(" ").join("-");
+let passed = true;
+
+if (x !== "hello-world") {
+  passed = false;
+}
+
+const y = "a,b,c".split(",").join(" | ");
+if (y !== "a | b | c") {
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `"hello world".split(" ").join("-")` was producing garbage numeric output instead of `"hello-world"`
- Root cause: `generateSplit` never called `setVariableType` on its result temp, so downstream `join()` couldn't detect it was a `%StringArray*` and defaulted to numeric array join
- One-line fix: add `ctx.setVariableType(result, "%StringArray*")` after the phi node in split.ts

## Test plan
- [x] New fixture `strings/string-split-chain.ts` — chained split+join on string literals
- [x] All 618 tests pass
- [x] Self-hosting verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)