### PR TITLE
fix: .length on chained method call results returns correct value

### DIFF
--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -365,6 +365,31 @@ export function handleLengthProperty(
     return ctx.emitError(`.length is not available on type 'number'`, expr.loc);
   }
 
+  if (exprObjType === "method_call" || exprObjType === "call") {
+    const resultPtr = ctx.generateExpression(expr.object, params);
+    const resultType = ctx.getVariableType(resultPtr);
+    if (resultType === "%StringArray*") {
+      return getStringArrayLengthFromPtr(ctx, resultPtr);
+    }
+    if (resultType === "%Array*") {
+      return getArrayLengthFromPtr(ctx, resultPtr, "%Array");
+    }
+    if (resultType === "%ObjectArray*") {
+      return getArrayLengthFromPtr(ctx, resultPtr, "%ObjectArray");
+    }
+    if (resultType === "%Uint8Array*") {
+      return getArrayLengthFromPtr(ctx, resultPtr, "%Uint8Array");
+    }
+    const lenI64 = ctx.nextTemp();
+    ctx.emit(`${lenI64} = call i64 @strlen(i8* ${resultPtr})`);
+    const lenI32 = ctx.nextTemp();
+    ctx.emit(`${lenI32} = trunc i64 ${lenI64} to i32`);
+    const len = ctx.nextTemp();
+    ctx.emit(`${len} = sitofp i32 ${lenI32} to double`);
+    ctx.setVariableType(len, "double");
+    return len;
+  }
+
   return getStringLength(ctx, expr.object, params);
 }
 

--- a/tests/fixtures/arrays/filter-chain-length.ts
+++ b/tests/fixtures/arrays/filter-chain-length.ts
@@ -1,0 +1,15 @@
+const n = [1, 2, 3, 4, 5].filter((x: number): boolean => x > 3).length;
+let passed = true;
+
+if (n !== 2) {
+  passed = false;
+}
+
+const words = ["hello", "world", "hi"].filter((s: string): boolean => s.length > 2).length;
+if (words !== 2) {
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `[1,2,3,4,5].filter(x => x > 3).length` was returning `5` (original array length) instead of `2`
- Root cause: `handleLengthProperty` had no handler for `method_call`/`call` expression types — fell through to `getStringLength` which treated the array pointer as a string
- Added type-aware dispatch for method call results: checks `getVariableType` on the generated result and routes to the correct array/string length getter

## Test plan
- [x] New fixture `arrays/filter-chain-length.ts` — filter().length on both number[] and string[]
- [x] All tests pass (619 total)
- [x] Self-hosting verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)