### PR TITLE
fix: global scope interface field assignment from function returns

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -1699,6 +1699,16 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         }
         const iface = this.getInterfaceDeclByName(rt);
         if (iface) {
+          const keys: string[] = [];
+          const tsTypes: string[] = [];
+          const types: string[] = [];
+          const allFields = this.getAllInterfaceFields(iface);
+          for (let i = 0; i < allFields.length; i++) {
+            const field = allFields[i] as { name: string; type: string };
+            keys.push(stripOptional(field.name));
+            tsTypes.push(field.type);
+            types.push(this.tsTypeToLlvmJsonWithEnums(field.type));
+          }
           this.globalVariables.set(name, {
             llvmType: "i8*",
             kind: SymbolKind.Object,
@@ -1710,7 +1720,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             "i8*",
             SymbolKind.Object,
             "global",
-            createInterfaceMetadata(rt),
+            createObjectMetadataWithInterface({ keys, types, tsTypes }, rt),
           );
           return `@${name} = global i8* null\n`;
         }

--- a/tests/fixtures/objects/global-interface-field-assign.ts
+++ b/tests/fixtures/objects/global-interface-field-assign.ts
@@ -1,0 +1,24 @@
+interface Counter {
+  count: number;
+  label: string;
+}
+
+function makeCounter(): Counter {
+  return { count: 0, label: "default" };
+}
+
+const c = makeCounter();
+c.count = 5;
+c.label = "updated";
+let passed = true;
+
+if (c.count !== 5) {
+  passed = false;
+}
+if (c.label !== "updated") {
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `const c = makeCounter(); c.count = 5;` at global scope was silently dropping the field assignment when `makeCounter()` returns an interface type
- Root cause: `tryHandleGlobalCallReturn` registered interface-returning functions with `createInterfaceMetadata` which sets `objectMetadata: undefined`. The assignment handler requires `objectMetadata` (with keys/types) to generate the GEP store — without it, `getObjectInfo` returned undefined and the assignment was silently skipped
- Fix: build proper `objectMetadata` from the interface's field definitions using `getAllInterfaceFields`, same pattern as the JSON.parse interface handler

## Test plan
- [x] New fixture `objects/global-interface-field-assign.ts` — mutate number and string fields on interface returned from function at global scope
- [x] All 620 tests pass
- [x] Self-hosting verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)