### PR TITLE
fix: detect captured variable mutation inside closures

### DIFF
--- a/src/semantic/closure-mutation-checker.ts
+++ b/src/semantic/closure-mutation-checker.ts
@@ -226,10 +226,14 @@ class ClosureMutationChecker {
           capturedNames.push(capName);
         }
       }
-      // Recurse into the arrow body as a new function scope.
+      const capturedInClosure: string[] = [];
+      for (let i = 0; i < info.captures.length; i++) {
+        const cap = info.captures[i] as { name: string; llvmType: string };
+        capturedInClosure.push(cap.name);
+      }
       const arrowBodyTyped = arrow.body as { type: string };
       if (arrowBodyTyped.type === "block") {
-        this.walkBlock(arrow.body as BlockStatement, arrow.params.slice(), []);
+        this.walkBlock(arrow.body as BlockStatement, arrow.params.slice(), capturedInClosure);
       }
     } else if (etype === "binary") {
       // BinaryNode: { type, op, left, right } — must include op to get correct GEP index for left/right

--- a/tests/fixtures/closures/closure-inner-mutation.ts
+++ b/tests/fixtures/closures/closure-inner-mutation.ts
@@ -1,0 +1,8 @@
+// @test-compile-error: variable 'sum' is captured by a closure but reassigned after capture
+// @test-description: mutating a captured variable inside a closure is a compile error
+let sum = 0;
+const arr: number[] = [1, 2, 3];
+arr.forEach((x: number): void => {
+  sum = sum + x;
+});
+console.log(String(sum));


### PR DESCRIPTION
## Summary
- `arr.forEach((x) => { sum = sum + x; })` where `sum` is an outer variable was silently producing wrong output (sum stayed 0) because ChadScript captures by value
- The closure-mutation-checker only detected mutations AFTER capture (`x = 2` after `const f = () => x`), not mutations INSIDE the closure body
- Fix: pass captured variable names into the arrow body walk so assignments to captured vars inside the closure are flagged as compile errors
- Users now get a clear error message instead of silently wrong behavior

## Test plan
- [x] New fixture `closures/closure-inner-mutation.ts` — forEach with captured var mutation triggers compile error
- [x] All 621 tests pass
- [x] Self-hosting verification passes (compiler itself doesn't use this pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)