### PR TITLE
bump version to 0.2.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chadscript",
-  "version": "0.1.1-alpha",
+  "version": "0.2.0-beta",
   "description": "A JavaScript to native code compiler using LLVM",
   "type": "module",
   "main": "dist/chad-node.js",


### PR DESCRIPTION
## Summary
- Bumps ChadScript from 0.1.1-alpha to 0.2.0-beta
- All core language features work reliably, 621+ tests passing, self-hosting stable
- 15 skipped tests are all infrastructure (11 network, 3 import helpers, 1 x86-64-only) — only 1 effective compiler bug remaining (ternary x86-64 link failure)

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 0 + Stage 1)
- [ ] CI passes on x86-64 Linux