### PR TITLE
fix: console.log boolean variables print true/false instead of 1/0

### DIFF
--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -7,6 +7,7 @@ import {
   UnaryNode,
 } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
+import { SymbolKind } from "../../infrastructure/symbol-table.js";
 
 function emitPrint(
   ctx: MethodCallGeneratorContext,
@@ -503,6 +504,12 @@ function emitSingleArg(
 
   if (arg.type === "variable") {
     const varName = (arg as VariableNode).name;
+    const varKind = ctx.symbolTable.getKind(varName);
+    if (varKind === SymbolKind.Boolean) {
+      const argValue = ctx.generateExpression(arg, params);
+      emitBooleanPrint(ctx, useStderr, argValue);
+      return;
+    }
     const ifaceType =
       ctx.symbolTable.getInterfaceType(varName) || ctx.symbolTable.getRawInterfaceType(varName);
     if (ifaceType) {

--- a/tests/fixtures/builtins/console-log-boolean-var.ts
+++ b/tests/fixtures/builtins/console-log-boolean-var.ts
@@ -1,0 +1,13 @@
+const a = true;
+const b = false;
+const c = [1, 2, 3].includes(2);
+const d = [1, 2, 3].some((n: number) => n > 2);
+const e = "hello".startsWith("h");
+const f = "hello".includes("ell");
+let output = "";
+output = output + a + "," + b + "," + c + "," + d + "," + e + "," + f;
+if (a === true && b === false && c === true && d === true && e === true && f === true) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: " + output);
+}


### PR DESCRIPTION
## Summary
- `const r = arr.includes(2); console.log(r)` now prints `true` instead of `1`
- Affects all boolean-returning methods stored in variables: `includes`, `startsWith`, `endsWith`, `some`, `every`, `has`, `delete`
- Root cause: console.log checked `isBooleanExpression(arg)` on the AST node, which only matches method calls and binary ops — not variable references. Added SymbolKind.Boolean check for variable args.

## Test plan
- [x] New test `console-log-boolean-var.ts` passes
- [x] All 623 tests pass
- [x] Self-hosting Stage 1 passes