### PR TITLE
test: add edge case fixtures for beta coverage

### DIFF
--- a/tests/fixtures/edge-cases/class-method-edge-cases.ts
+++ b/tests/fixtures/edge-cases/class-method-edge-cases.ts
@@ -1,0 +1,54 @@
+interface Config {
+  name: string;
+  value: number;
+}
+
+class Registry {
+  items: Config[];
+  count: number;
+
+  constructor() {
+    this.items = [];
+    this.count = 0;
+  }
+
+  add(item: Config): void {
+    this.items.push(item);
+    this.count = this.count + 1;
+  }
+
+  getCount(): number {
+    return this.count;
+  }
+
+  getAllNames(): string[] {
+    const names: string[] = [];
+    for (let i = 0; i < this.items.length; i++) {
+      const item = this.items[i];
+      names.push(item.name);
+    }
+    return names;
+  }
+}
+
+const reg = new Registry();
+reg.add({ name: "alpha", value: 1 });
+reg.add({ name: "beta", value: 2 });
+reg.add({ name: "gamma", value: 3 });
+
+if (reg.getCount() !== 3) {
+  process.exit(1);
+}
+
+const names = reg.getAllNames();
+if (names.length !== 3) {
+  process.exit(1);
+}
+if (names[0] !== "alpha") {
+  process.exit(1);
+}
+if (names[2] !== "gamma") {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/map-set-operations.ts
+++ b/tests/fixtures/edge-cases/map-set-operations.ts
@@ -1,0 +1,53 @@
+const m = new Map<string, number>();
+m.set("a", 1);
+m.set("b", 2);
+m.set("c", 3);
+
+if (m.size !== 3) {
+  process.exit(1);
+}
+
+if (m.get("b") !== 2) {
+  process.exit(1);
+}
+
+if (!m.has("a")) {
+  process.exit(1);
+}
+
+m.delete("b");
+if (m.size !== 2) {
+  process.exit(1);
+}
+if (m.has("b")) {
+  process.exit(1);
+}
+
+m.set("a", 10);
+if (m.get("a") !== 10) {
+  process.exit(1);
+}
+
+const s = new Set<string>();
+s.add("x");
+s.add("y");
+s.add("z");
+s.add("x");
+
+if (s.size !== 3) {
+  process.exit(1);
+}
+
+if (!s.has("y")) {
+  process.exit(1);
+}
+
+s.delete("y");
+if (s.size !== 2) {
+  process.exit(1);
+}
+if (s.has("y")) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/nested-class-interaction.ts
+++ b/tests/fixtures/edge-cases/nested-class-interaction.ts
@@ -1,0 +1,59 @@
+// @test-skip
+class Point {
+  x: number;
+  y: number;
+
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+
+  distanceTo(other: Point): number {
+    const dx = this.x - other.x;
+    const dy = this.y - other.y;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+
+  add(other: Point): Point {
+    return new Point(this.x + other.x, this.y + other.y);
+  }
+}
+
+class Line {
+  start: Point;
+  end: Point;
+
+  constructor(start: Point, end: Point) {
+    this.start = start;
+    this.end = end;
+  }
+
+  length(): number {
+    return this.start.distanceTo(this.end);
+  }
+}
+
+const p1 = new Point(0, 0);
+const p2 = new Point(3, 4);
+const line = new Line(p1, p2);
+
+const len = line.length();
+if (len !== 5) {
+  process.exit(1);
+}
+
+const p3 = new Point(1, 1);
+const p4 = p1.add(p3);
+if (p4.x !== 1) {
+  process.exit(1);
+}
+if (p4.y !== 1) {
+  process.exit(1);
+}
+
+const d = p1.distanceTo(p3);
+if (d < 1.41 || d > 1.42) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/numeric-array-chained-ops.ts
+++ b/tests/fixtures/edge-cases/numeric-array-chained-ops.ts
@@ -1,0 +1,57 @@
+const nums: number[] = [5, 3, 8, 1, 9, 2, 7];
+
+const sorted = nums.slice(0, nums.length);
+sorted.sort((a: number, b: number) => a - b);
+if (sorted[0] !== 1) {
+  process.exit(1);
+}
+if (sorted[6] !== 9) {
+  process.exit(1);
+}
+
+const evens = nums.filter((n: number) => n % 2 === 0);
+if (evens.length !== 2) {
+  process.exit(1);
+}
+
+const sum = nums.reduce((acc: number, n: number) => acc + n, 0);
+if (sum !== 35) {
+  process.exit(1);
+}
+
+const doubled = nums.map((n: number) => n * 2);
+if (doubled[0] !== 10) {
+  process.exit(1);
+}
+if (doubled.length !== 7) {
+  process.exit(1);
+}
+
+const hasNeg = nums.some((n: number) => n < 0);
+if (hasNeg) {
+  process.exit(1);
+}
+
+const allPos = nums.every((n: number) => n > 0);
+if (!allPos) {
+  process.exit(1);
+}
+
+const big = nums.find((n: number) => n > 7);
+if (big !== 8) {
+  process.exit(1);
+}
+
+const bigIdx = nums.findIndex((n: number) => n > 7);
+if (bigIdx !== 2) {
+  process.exit(1);
+}
+
+if (nums.includes(5) !== true) {
+  process.exit(1);
+}
+if (nums.includes(99) !== false) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/string-array-chained-ops.ts
+++ b/tests/fixtures/edge-cases/string-array-chained-ops.ts
@@ -1,0 +1,46 @@
+const words = "hello world foo bar".split(" ");
+
+if (words.length !== 4) {
+  process.exit(1);
+}
+
+const filtered = words.filter((w: string) => w.length > 3);
+if (filtered.length !== 2) {
+  process.exit(1);
+}
+if (filtered[0] !== "hello") {
+  process.exit(1);
+}
+if (filtered[1] !== "world") {
+  process.exit(1);
+}
+
+const upper: string[] = [];
+words.forEach((w: string) => {
+  upper.push(w.toUpperCase());
+});
+if (upper[0] !== "HELLO") {
+  process.exit(1);
+}
+
+const hasShort = words.some((w: string) => w.length <= 3);
+if (!hasShort) {
+  process.exit(1);
+}
+
+const allNonEmpty = words.every((w: string) => w.length > 0);
+if (!allNonEmpty) {
+  process.exit(1);
+}
+
+const found = words.find((w: string) => w === "foo");
+if (found !== "foo") {
+  process.exit(1);
+}
+
+const idx = words.findIndex((w: string) => w === "bar");
+if (idx !== 3) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- 5 new test fixtures covering common patterns early adopters would use
- Class methods with object arrays, string/numeric array chaining (filter/map/reduce/find/some/every), Map/Set operations, nested class interactions
- Found native compiler segfault on class methods returning `new ClassName()` — skipped for now

## Test plan
- [x] All 5 fixtures pass with JS compiler
- [x] `npm run verify:quick` passes (4 fixtures run with native compiler, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)