### PR TITLE
fix: variadic Math.max/min + 5 hardening test fixtures

### DIFF
--- a/src/codegen/stdlib/math.ts
+++ b/src/codegen/stdlib/math.ts
@@ -187,16 +187,17 @@ export class MathGenerator {
   }
 
   private generateMax(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 2) {
-      return this.ctx.emitError("Math.max() requires 2 arguments", expr.loc);
+    if (expr.args.length < 2) {
+      return this.ctx.emitError("Math.max() requires at least 2 arguments", expr.loc);
     }
-    const a = this.ctx.generateExpression(expr.args[0], params);
-    const b = this.ctx.generateExpression(expr.args[1], params);
-    const dblA = this.ctx.ensureDouble(a);
-    const dblB = this.ctx.ensureDouble(b);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.maximum.f64(double ${dblA}, double ${dblB})`);
-    return result;
+    let current = this.ctx.ensureDouble(this.ctx.generateExpression(expr.args[0], params));
+    for (let i = 1; i < expr.args.length; i++) {
+      const next = this.ctx.ensureDouble(this.ctx.generateExpression(expr.args[i], params));
+      const result = this.ctx.nextTemp();
+      this.ctx.emit(`${result} = call double @llvm.maximum.f64(double ${current}, double ${next})`);
+      current = result;
+    }
+    return current;
   }
 
   private generateTrunc(expr: MethodCallNode, params: string[]): string {
@@ -272,15 +273,16 @@ export class MathGenerator {
   }
 
   private generateMin(expr: MethodCallNode, params: string[]): string {
-    if (expr.args.length !== 2) {
-      return this.ctx.emitError("Math.min() requires 2 arguments", expr.loc);
+    if (expr.args.length < 2) {
+      return this.ctx.emitError("Math.min() requires at least 2 arguments", expr.loc);
     }
-    const a = this.ctx.generateExpression(expr.args[0], params);
-    const b = this.ctx.generateExpression(expr.args[1], params);
-    const dblA = this.ctx.ensureDouble(a);
-    const dblB = this.ctx.ensureDouble(b);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.minimum.f64(double ${dblA}, double ${dblB})`);
-    return result;
+    let current = this.ctx.ensureDouble(this.ctx.generateExpression(expr.args[0], params));
+    for (let i = 1; i < expr.args.length; i++) {
+      const next = this.ctx.ensureDouble(this.ctx.generateExpression(expr.args[i], params));
+      const result = this.ctx.nextTemp();
+      this.ctx.emit(`${result} = call double @llvm.minimum.f64(double ${current}, double ${next})`);
+      current = result;
+    }
+    return current;
   }
 }

--- a/tests/fixtures/edge-cases/class-inheritance-basic.ts
+++ b/tests/fixtures/edge-cases/class-inheritance-basic.ts
@@ -1,0 +1,54 @@
+class Animal {
+  name: string;
+  legs: number;
+
+  constructor(name: string, legs: number) {
+    this.name = name;
+    this.legs = legs;
+  }
+
+  describe(): string {
+    return this.name + " has " + this.legs.toString() + " legs";
+  }
+}
+
+class Dog extends Animal {
+  breed: string;
+
+  constructor(name: string, breed: string) {
+    super(name, 4);
+    this.breed = breed;
+  }
+
+  bark(): string {
+    return this.name + " says woof";
+  }
+}
+
+const d = new Dog("Rex", "Lab");
+if (d.name !== "Rex") {
+  process.exit(1);
+}
+if (d.legs !== 4) {
+  process.exit(1);
+}
+if (d.breed !== "Lab") {
+  process.exit(1);
+}
+
+const desc = d.describe();
+if (desc !== "Rex has 4 legs") {
+  process.exit(1);
+}
+
+const bk = d.bark();
+if (bk !== "Rex says woof") {
+  process.exit(1);
+}
+
+const a = new Animal("Cat", 4);
+if (a.describe() !== "Cat has 4 legs") {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/empty-collection-methods.ts
+++ b/tests/fixtures/edge-cases/empty-collection-methods.ts
@@ -1,0 +1,56 @@
+const empty: number[] = [];
+
+const filtered = empty.filter((n: number) => n > 0);
+if (filtered.length !== 0) {
+  process.exit(1);
+}
+
+const mapped = empty.map((n: number) => n * 2);
+if (mapped.length !== 0) {
+  process.exit(1);
+}
+
+const found = empty.find((n: number) => n > 0);
+
+const idx = empty.findIndex((n: number) => n > 0);
+if (idx !== -1) {
+  process.exit(1);
+}
+
+const has = empty.includes(5);
+if (has) {
+  process.exit(1);
+}
+
+const some = empty.some((n: number) => n > 0);
+if (some) {
+  process.exit(1);
+}
+
+const every = empty.every((n: number) => n > 0);
+if (!every) {
+  process.exit(1);
+}
+
+const joined = empty.join(",");
+if (joined !== "") {
+  process.exit(1);
+}
+
+const sliced = empty.slice(0, 5);
+if (sliced.length !== 0) {
+  process.exit(1);
+}
+
+const emptyStr: string[] = [];
+const strFiltered = emptyStr.filter((s: string) => s.length > 0);
+if (strFiltered.length !== 0) {
+  process.exit(1);
+}
+
+const strJoined = emptyStr.join("-");
+if (strJoined !== "") {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/large-array-ops.ts
+++ b/tests/fixtures/edge-cases/large-array-ops.ts
@@ -1,0 +1,51 @@
+const big: number[] = [];
+for (let i = 0; i < 10000; i++) {
+  big.push(i);
+}
+
+if (big.length !== 10000) {
+  process.exit(1);
+}
+
+if (big[0] !== 0) {
+  process.exit(1);
+}
+if (big[9999] !== 9999) {
+  process.exit(1);
+}
+
+const sum = big.reduce((acc: number, n: number) => acc + n, 0);
+if (sum !== 49995000) {
+  process.exit(1);
+}
+
+const evens = big.filter((n: number) => n % 2 === 0);
+if (evens.length !== 5000) {
+  process.exit(1);
+}
+
+const found = big.find((n: number) => n === 7777);
+if (found !== 7777) {
+  process.exit(1);
+}
+
+const idx = big.indexOf(5000);
+if (idx !== 5000) {
+  process.exit(1);
+}
+
+const sliced = big.slice(100, 110);
+if (sliced.length !== 10) {
+  process.exit(1);
+}
+if (sliced[0] !== 100) {
+  process.exit(1);
+}
+
+const rev = sliced.slice(0, sliced.length);
+rev.reverse();
+if (rev[0] !== 109) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/number-to-string-ops.ts
+++ b/tests/fixtures/edge-cases/number-to-string-ops.ts
@@ -1,0 +1,66 @@
+const n = 42;
+const s = n.toString();
+if (s !== "42") {
+  process.exit(1);
+}
+
+const pi = 3.14159;
+const ps = pi.toString();
+if (ps !== "3.14159") {
+  process.exit(1);
+}
+
+const neg = -100;
+const ns = neg.toString();
+if (ns !== "-100") {
+  process.exit(1);
+}
+
+const zero = 0;
+const zs = zero.toString();
+if (zs !== "0") {
+  process.exit(1);
+}
+
+const big = 1000000;
+const bs = big.toString();
+if (bs !== "1000000") {
+  process.exit(1);
+}
+
+const f = Math.floor(3.7);
+if (f !== 3) {
+  process.exit(1);
+}
+
+const c = Math.ceil(3.2);
+if (c !== 4) {
+  process.exit(1);
+}
+
+const r = Math.round(3.5);
+if (r !== 4) {
+  process.exit(1);
+}
+
+const a = Math.abs(-42);
+if (a !== 42) {
+  process.exit(1);
+}
+
+const mx = Math.max(1, 5, 3);
+if (mx !== 5) {
+  process.exit(1);
+}
+
+const mn = Math.min(1, 5, 3);
+if (mn !== 1) {
+  process.exit(1);
+}
+
+const sq = Math.sqrt(144);
+if (sq !== 12) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/string-boundary-ops.ts
+++ b/tests/fixtures/edge-cases/string-boundary-ops.ts
@@ -1,0 +1,80 @@
+const empty = "";
+if (empty.length !== 0) {
+  process.exit(1);
+}
+
+const trimmed = empty.trim();
+if (trimmed !== "") {
+  process.exit(1);
+}
+
+const upper = empty.toUpperCase();
+if (upper !== "") {
+  process.exit(1);
+}
+
+const lower = empty.toLowerCase();
+if (lower !== "") {
+  process.exit(1);
+}
+
+const idx = empty.indexOf("x");
+if (idx !== -1) {
+  process.exit(1);
+}
+
+const inc = empty.includes("x");
+if (inc) {
+  process.exit(1);
+}
+
+const rep = empty.replace("a", "b");
+if (rep !== "") {
+  process.exit(1);
+}
+
+const sub = empty.substring(0, 0);
+if (sub !== "") {
+  process.exit(1);
+}
+
+const sliced = empty.slice(0, 0);
+if (sliced !== "") {
+  process.exit(1);
+}
+
+const split = empty.split(",");
+if (split.length !== 1) {
+  process.exit(1);
+}
+if (split[0] !== "") {
+  process.exit(1);
+}
+
+const long = "abcdefghijklmnopqrstuvwxyz";
+const atEnd = long.charAt(25);
+if (atEnd !== "z") {
+  process.exit(1);
+}
+
+const pastEnd = long.charAt(100);
+if (pastEnd !== "") {
+  process.exit(1);
+}
+
+const negAt = long.at(-1);
+if (negAt !== "z") {
+  process.exit(1);
+}
+
+const starts = long.startsWith("abc");
+if (!starts) {
+  process.exit(1);
+}
+
+const ends = long.endsWith("xyz");
+if (!ends) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `Math.max()` and `Math.min()` now support any number of arguments (was limited to exactly 2)
- Chains `llvm.maximum.f64` / `llvm.minimum.f64` intrinsics for 3+ args
- 5 new test fixtures covering crash-prone patterns:
  - Empty collection operations (filter/map/find/some/every/join/slice on empty arrays)
  - String boundary operations (empty string methods, charAt past end, negative at())
  - Large array operations (10K elements with reduce/filter/find/indexOf/slice/reverse)
  - Class inheritance (extends, super(), inherited methods)
  - Number-to-string conversions and Math functions

## Test plan
- [x] All fixtures pass with both JS and native compilers
- [x] `npm run verify:quick` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)