### PR TITLE
fix: add missing type inference for process.cwd, Date.now, fs.existsSync

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -451,6 +451,7 @@ export class TypeInference {
       const varName = (expr.object as VariableNode).name;
 
       if (varName === "fs" && method === "readFileSync") return this.ctx.typeContext.stringType;
+      if (varName === "fs" && method === "existsSync") return this.ctx.typeContext.booleanType;
       if (varName === "fs" && method === "readdirSync")
         return this.ctx.typeContext.getArrayType("string");
 
@@ -509,6 +510,15 @@ export class TypeInference {
           method === "uptime"
         )
           return this.ctx.typeContext.numberType;
+      }
+
+      if (varName === "process") {
+        if (method === "cwd") return this.ctx.typeContext.stringType;
+        if (method === "uptime") return this.ctx.typeContext.numberType;
+      }
+
+      if (varName === "Date") {
+        if (method === "now") return this.ctx.typeContext.numberType;
       }
 
       if (varName === "Array" && method === "from")

--- a/tests/fixtures/builtins/process-cwd-type.ts
+++ b/tests/fixtures/builtins/process-cwd-type.ts
@@ -1,0 +1,11 @@
+const cwd = process.cwd();
+if (cwd === "") {
+  process.exit(1);
+}
+
+const now = Date.now();
+if (now <= 0) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `process.cwd()` at global scope was incorrectly allocated as `double` — now properly returns `string`
- `process.uptime()` now returns `number` in type inference
- `Date.now()` now returns `number` in type inference
- `fs.existsSync()` now returns `boolean` in type inference
- These were causing compilation failures when storing results in global variables (type mismatch: `i8*` stored as `double`)

## Test plan
- [x] New test fixture `builtins/process-cwd-type.ts`
- [x] `npm run verify:quick` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)