### PR TITLE
fix: unskip 3 object-array tests now passing on native compiler

### DIFF
--- a/tests/fixtures/arrays/object-array-filter.ts
+++ b/tests/fixtures/arrays/object-array-filter.ts
@@ -1,4 +1,3 @@
-// @test-skip
 interface Item {
   name: string;
   score: number;

--- a/tests/fixtures/arrays/object-array-find.ts
+++ b/tests/fixtures/arrays/object-array-find.ts
@@ -1,4 +1,3 @@
-// @test-skip
 interface Point {
   x: number;
   y: number;

--- a/tests/fixtures/arrays/object-array-reduce.ts
+++ b/tests/fixtures/arrays/object-array-reduce.ts
@@ -1,4 +1,3 @@
-// @test-skip
 interface Item {
   name: string;
   score: number;


### PR DESCRIPTION
## Summary
- Unskips `object-array-filter`, `object-array-find`, and `object-array-reduce` tests
- These were skipped because the native compiler couldn't compile them, but recent PRs (#329, #330, #332) fixed the underlying codegen issues
- Reduces skipped test count from 20 to 17

## Test plan
- [x] All 3 tests pass with native compiler (`.build/chad run`)
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 1)