### PR TITLE
fix: String(true) now returns 'true' instead of '1'

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -15,6 +15,7 @@ import {
   mapParamTypeToLLVM,
   mapReturnTypeToLLVM,
 } from "../infrastructure/type-system.js";
+import { createStringConstant } from "../types/collections/string/constants.js";
 
 /**
  * CallExpressionGenerator
@@ -520,8 +521,32 @@ export class CallExpressionGenerator {
     if (this.ctx.isStringExpression(arg)) {
       return this.ctx.generateExpression(arg, params);
     }
-    const numValue = this.ctx.generateExpression(arg, params);
-    return this.ctx.stringGen.doConvertNumberToString(numValue);
+    let isBool = arg.type === "boolean";
+    if (!isBool && arg.type === "variable") {
+      const varName = (arg as VariableNode).name;
+      isBool = this.ctx.symbolTable.isBoolean(varName);
+    }
+    const value = this.ctx.generateExpression(arg, params);
+    const varType = this.ctx.getVariableType(value);
+    if (isBool || varType === "i1") {
+      const trueStr = createStringConstant(this.ctx, "true");
+      const falseStr = createStringConstant(this.ctx, "false");
+      let boolI1: string;
+      if (varType === "i1") {
+        boolI1 = value;
+      } else if (varType === "i64") {
+        boolI1 = this.ctx.nextTemp();
+        this.ctx.emit(`${boolI1} = icmp ne i64 ${value}, 0`);
+      } else {
+        boolI1 = this.ctx.nextTemp();
+        this.ctx.emit(`${boolI1} = fcmp one double ${value}, 0.0`);
+      }
+      const result = this.ctx.nextTemp();
+      this.ctx.emit(`${result} = select i1 ${boolI1}, i8* ${trueStr}, i8* ${falseStr}`);
+      this.ctx.setVariableType(result, "i8*");
+      return result;
+    }
+    return this.ctx.stringGen.doConvertNumberToString(value);
   }
 
   private generateIsNaN(expr: CallNode, params: string[]): string {

--- a/tests/fixtures/builtins/string-boolean-conversion.ts
+++ b/tests/fixtures/builtins/string-boolean-conversion.ts
@@ -1,0 +1,33 @@
+const t = String(true);
+if (t !== "true") {
+  process.exit(1);
+}
+
+const f = String(false);
+if (f !== "false") {
+  process.exit(1);
+}
+
+const x = true;
+const xs = String(x);
+if (xs !== "true") {
+  process.exit(1);
+}
+
+const y = false;
+const ys = String(y);
+if (ys !== "false") {
+  process.exit(1);
+}
+
+const n = String(42);
+if (n !== "42") {
+  process.exit(1);
+}
+
+const s = String("hello");
+if (s !== "hello") {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `String(true)` was returning `"1"` instead of `"true"`, `String(false)` returned `"0"` instead of `"false"`
- Root cause: `generateString()` in calls.ts treated all non-string args as numbers, calling `doConvertNumberToString` which converts boolean 1/0 to string "1"/"0"
- Fix: detect boolean args (literals via `arg.type === "boolean"`, variables via `symbolTable.isBoolean()`) and emit `select i1` to pick `"true"`/`"false"` string constants
- Handles all boolean storage types: `i1` (direct select), `i64` (icmp ne 0), `double` (fcmp one 0.0)

## Test plan
- [x] New test: `string-boolean-conversion.ts` — String(true), String(false), String(boolVar), String(42), String("hello")
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 1)