### PR TITLE
fix: emit clear error for Map<number, string> instead of crashing

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1825,6 +1825,13 @@ export class VariableAllocator {
       }
     }
 
+    if (!mapTypeInfoResult && stmt.value && stmt.value.type === "new") {
+      const newNode = stmt.value as NewNode;
+      if (newNode.className === "Map" && newNode.typeArgs && newNode.typeArgs.length === 2) {
+        mapTypeInfoResult = { keyType: newNode.typeArgs[0], valueType: newNode.typeArgs[1] };
+      }
+    }
+
     if (
       !mapTypeInfoResult &&
       stmt.value &&
@@ -1845,6 +1852,16 @@ export class VariableAllocator {
       }
       if (mapTypeInfo.keyType !== "number") {
         this.allocatePointerMap(stmt, params, mapTypeInfo);
+        return;
+      }
+      if (
+        mapTypeInfo.valueType !== "number" &&
+        mapTypeInfo.valueType !== "boolean"
+      ) {
+        this.ctx.emitError(
+          `Map<number, ${mapTypeInfo.valueType}> is not supported. Use Map<string, ${mapTypeInfo.valueType}> instead`,
+          stmt.loc,
+        );
         return;
       }
     }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2366,6 +2366,22 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             );
             continue;
           }
+          let numMapValueType = "number";
+          if (stmt.declaredType) {
+            const parsed = parseMapTypeString(stmt.declaredType);
+            if (parsed) numMapValueType = parsed.valueType;
+          }
+          if (numMapValueType === "number" && stmt.value && stmt.value.type === "new") {
+            const newNode = stmt.value as NewNode;
+            if (newNode.className === "Map" && newNode.typeArgs && newNode.typeArgs.length === 2) {
+              numMapValueType = newNode.typeArgs[1];
+            }
+          }
+          if (numMapValueType !== "number" && numMapValueType !== "boolean") {
+            this.emitError(
+              `Map<number, ${numMapValueType}> is not supported. Use Map<string, ${numMapValueType}> instead`,
+            );
+          }
           llvmType = "%Map*";
           kind = SymbolKind.Map;
           defaultValue = "null";

--- a/tests/fixtures/edge-cases/map-number-string-error.ts
+++ b/tests/fixtures/edge-cases/map-number-string-error.ts
@@ -1,0 +1,7 @@
+// @test-description: Map<number, string> should give a clear error instead of crashing
+// @test-compile-error: Map<number, string> is not supported
+function test(): void {
+  const m = new Map<number, string>();
+  m.set(1, "hello");
+}
+test();


### PR DESCRIPTION
## Summary
- `Map<number, string>` (and other numeric-key maps with non-numeric values) previously generated invalid LLVM IR that crashed during optimization
- Now emits a clear compile-time error: `Map<number, string> is not supported. Use Map<string, string> instead`
- Detects the unsupported type combination from both explicit type annotations and `new Map<K,V>()` typeArgs
- Covers function-scope declarations; global-scope detection is a follow-up

## Test plan
- [x] New test: `map-number-string-error.ts` verifies compile error
- [x] Existing `Map<number, number>` and `Map<string, *>` tests still pass
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 1)