### PR TITLE
test: add linked list traversal test (Class|null variable bug)

### DIFF
--- a/tests/fixtures/classes/class-inheritance-speak.ts
+++ b/tests/fixtures/classes/class-inheritance-speak.ts
@@ -1,0 +1,33 @@
+class Animal {
+  name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+  speak(): string {
+    return this.name + " makes a sound";
+  }
+}
+
+class Dog extends Animal {
+  breed: string;
+  constructor(name: string, breed: string) {
+    super(name);
+    this.breed = breed;
+  }
+  speak(): string {
+    return this.name + " barks";
+  }
+  info(): string {
+    return this.name + " is a " + this.breed;
+  }
+}
+
+const d = new Dog("Rex", "Shepherd");
+if (d.speak() !== "Rex barks") process.exit(1);
+if (d.info() !== "Rex is a Shepherd") process.exit(1);
+if (d.name !== "Rex") process.exit(1);
+
+const a = new Animal("Cat");
+if (a.speak() !== "Cat makes a sound") process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/classes/class-linked-list.ts
+++ b/tests/fixtures/classes/class-linked-list.ts
@@ -1,0 +1,27 @@
+// @test-skip
+class ListNode {
+  value: number;
+  next: ListNode | null;
+  constructor(value: number) {
+    this.value = value;
+    this.next = null;
+  }
+}
+
+const a = new ListNode(1);
+const b = new ListNode(2);
+const c = new ListNode(3);
+a.next = b;
+b.next = c;
+
+let current: ListNode | null = a;
+let sum = 0;
+while (current !== null) {
+  sum = sum + current.value;
+  current = current.next;
+}
+
+if (sum !== 6) {
+  process.exit(1);
+}
+console.log("TEST_PASSED");

--- a/tests/fixtures/classes/class-multiple-methods.ts
+++ b/tests/fixtures/classes/class-multiple-methods.ts
@@ -1,0 +1,34 @@
+class Circle {
+  radius: number;
+  constructor(radius: number) {
+    this.radius = radius;
+  }
+  area(): number {
+    return 3.14159 * this.radius * this.radius;
+  }
+}
+
+class Rectangle {
+  width: number;
+  height: number;
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+  }
+  area(): number {
+    return this.width * this.height;
+  }
+}
+
+const c = new Circle(5);
+const r = new Rectangle(4, 6);
+const ca = c.area();
+const ra = r.area();
+
+if (ca < 78.5 || ca > 78.6) process.exit(1);
+if (ra !== 24) process.exit(1);
+
+const total = ca + ra;
+if (total < 102.5 || total > 102.6) process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/classes/class-stack-array.ts
+++ b/tests/fixtures/classes/class-stack-array.ts
@@ -1,0 +1,34 @@
+class Stack {
+  items: number[];
+  constructor() {
+    this.items = [];
+  }
+  push(item: number): void {
+    this.items.push(item);
+  }
+  pop(): number {
+    return this.items.pop();
+  }
+  peek(): number {
+    return this.items[this.items.length - 1];
+  }
+  isEmpty(): boolean {
+    return this.items.length === 0;
+  }
+  size(): number {
+    return this.items.length;
+  }
+}
+
+const s = new Stack();
+if (!s.isEmpty()) process.exit(1);
+s.push(10);
+s.push(20);
+s.push(30);
+if (s.size() !== 3) process.exit(1);
+if (s.peek() !== 30) process.exit(1);
+const v = s.pop();
+if (v !== 30) process.exit(1);
+if (s.size() !== 2) process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/fibonacci-palindrome.ts
+++ b/tests/fixtures/edge-cases/fibonacci-palindrome.ts
@@ -1,0 +1,31 @@
+function fibonacci(n: number): number {
+  if (n <= 1) return n;
+  let a = 0;
+  let b = 1;
+  for (let i = 2; i <= n; i++) {
+    const temp = a + b;
+    a = b;
+    b = temp;
+  }
+  return b;
+}
+
+if (fibonacci(0) !== 0) process.exit(1);
+if (fibonacci(1) !== 1) process.exit(1);
+if (fibonacci(10) !== 55) process.exit(1);
+if (fibonacci(20) !== 6765) process.exit(1);
+
+function isPalindrome(s: string): boolean {
+  const len = s.length;
+  for (let i = 0; i < len / 2; i++) {
+    if (s.charAt(i) !== s.charAt(len - 1 - i)) return false;
+  }
+  return true;
+}
+
+if (!isPalindrome("racecar")) process.exit(1);
+if (!isPalindrome("a")) process.exit(1);
+if (!isPalindrome("")) process.exit(1);
+if (isPalindrome("hello")) process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/large-array-operations.ts
+++ b/tests/fixtures/edge-cases/large-array-operations.ts
@@ -1,0 +1,18 @@
+const arr: number[] = [];
+for (let i = 0; i < 100; i++) {
+  arr.push(i);
+}
+if (arr.length !== 100) process.exit(1);
+
+const reversed = arr.reverse();
+if (reversed[0] !== 99) process.exit(1);
+if (reversed[99] !== 0) process.exit(1);
+
+const sliced = arr.slice(90, 100);
+if (sliced.length !== 10) process.exit(1);
+if (sliced[0] !== 9) process.exit(1);
+
+arr.splice(0, 50);
+if (arr.length !== 50) process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/large-string-operations.ts
+++ b/tests/fixtures/edge-cases/large-string-operations.ts
@@ -1,0 +1,16 @@
+let result = "";
+for (let i = 0; i < 1000; i++) {
+  result = result + "a";
+}
+if (result.length !== 1000) process.exit(1);
+
+const big = "x".repeat(10000);
+if (big.length !== 10000) process.exit(1);
+
+const idx = big.indexOf("x");
+if (idx !== 0) process.exit(1);
+
+const sub = big.substring(5000, 5010);
+if (sub.length !== 10) process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/map-delete-has-size.ts
+++ b/tests/fixtures/edge-cases/map-delete-has-size.ts
@@ -1,0 +1,13 @@
+const m = new Map<string, number>();
+m.set("a", 1);
+m.set("b", 2);
+m.set("c", 3);
+
+if (!m.has("b")) process.exit(1);
+const val = m.get("b");
+if (val !== 2) process.exit(1);
+m.delete("b");
+if (m.has("b")) process.exit(1);
+if (m.size !== 2) process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/null-string-ternary.ts
+++ b/tests/fixtures/edge-cases/null-string-ternary.ts
@@ -1,0 +1,20 @@
+function divide(a: number, b: number): string {
+  if (b === 0) return "error: division by zero";
+  return (a / b).toString();
+}
+
+if (divide(10, 2) !== "5") process.exit(1);
+if (divide(10, 0) !== "error: division by zero") process.exit(1);
+const r = divide(7, 3);
+if (!r.startsWith("2.333333")) process.exit(1);
+
+const x: string | null = null;
+const y: string | null = "hello";
+if (x !== null) process.exit(1);
+if (y === null) process.exit(1);
+if (y !== "hello") process.exit(1);
+
+const z = y === null ? "null" : y;
+if (z !== "hello") process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/set-string-number-ops.ts
+++ b/tests/fixtures/edge-cases/set-string-number-ops.ts
@@ -1,0 +1,22 @@
+const s = new Set<string>();
+s.add("hello");
+s.add("world");
+s.add("hello");
+
+if (s.size !== 2) process.exit(1);
+if (!s.has("hello")) process.exit(1);
+if (!s.has("world")) process.exit(1);
+if (s.has("foo")) process.exit(1);
+
+s.delete("hello");
+if (s.has("hello")) process.exit(1);
+if (s.size !== 1) process.exit(1);
+
+const ns = new Set<number>();
+ns.add(1);
+ns.add(2);
+ns.add(3);
+ns.add(2);
+if (ns.size !== 3) process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/switch-true-pattern.ts
+++ b/tests/fixtures/edge-cases/switch-true-pattern.ts
@@ -1,0 +1,22 @@
+function classify(n: number): string {
+  switch (true) {
+    case n < 0:
+      return "negative";
+    case n === 0:
+      return "zero";
+    case n < 10:
+      return "small";
+    case n < 100:
+      return "medium";
+    default:
+      return "large";
+  }
+}
+
+if (classify(-5) !== "negative") process.exit(1);
+if (classify(0) !== "zero") process.exit(1);
+if (classify(5) !== "small") process.exit(1);
+if (classify(50) !== "medium") process.exit(1);
+if (classify(500) !== "large") process.exit(1);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/strings/string-array-chain-ops.ts
+++ b/tests/fixtures/strings/string-array-chain-ops.ts
@@ -1,0 +1,19 @@
+const words = "hello world foo bar baz";
+const parts = words.split(" ");
+if (parts.length !== 5) process.exit(1);
+
+const sorted = parts.sort();
+if (sorted[0] !== "bar") process.exit(1);
+if (sorted[1] !== "baz") process.exit(1);
+if (sorted[4] !== "world") process.exit(1);
+
+const filtered = parts.filter((w: string) => w.length > 3);
+if (filtered.length !== 2) process.exit(1);
+
+const mapped = parts.map((w: string) => w.toUpperCase());
+if (mapped[0] !== "BAR") process.exit(1);
+
+const joined = parts.join(", ");
+if (joined !== "bar, baz, foo, hello, world") process.exit(1);
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- Adds test for linked list traversal using `let current: ListNode | null = a` with a while loop
- Currently `@test-skip` because the native compiler miscompiles `ClassName | null` typed variables — treats them as `i32*` instead of `%ClassName_struct*`, so member access (`.next`) doesn't generate a GEP and creates an infinite loop
- JS compiler handles this correctly

## Root cause
The native-compiled variable allocator's `isKnownClass(strippedDeclType)` check fails for `ListNode | null` → stripped to `ListNode`. The class lookup in the native compiler doesn't find the class, so the variable is allocated as a generic pointer instead of a class instance.

## Test plan
- [x] JS compiler: TEST_PASSED
- [x] Native compiler: hangs (infinite loop) — correctly skipped
- [x] `npm test` passes (649/649)

🤖 Generated with [Claude Code](https://claude.com/claude-code)