### PR TITLE
fix: map entries() type inference for global scope

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -1422,6 +1422,12 @@ export class TypeInference {
           }
         }
       }
+      if (methodExpr.method === "entries") {
+        if (methodObjBase.type === "variable") {
+          const varName = (methodExpr.object as VariableNode).name;
+          if (this.ctx.symbolTable.isMap(varName)) return true;
+        }
+      }
       if (
         methodExpr.method === "slice" ||
         methodExpr.method === "concat" ||

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2136,6 +2136,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         ) {
           isObjectArray = true;
         }
+        if (!isObjectArray && stmt.value && this.typeInference.isObjectArrayExpression(stmt.value)) {
+          isObjectArray = true;
+        }
         // Detect Uint8Array from declared type or expression analysis.
         // Must clear isString since readFileSync resolves to "string" by default,
         // but the declared type takes precedence.

--- a/tests/fixtures/edge-cases/map-entries-iteration.ts
+++ b/tests/fixtures/edge-cases/map-entries-iteration.ts
@@ -1,0 +1,9 @@
+const m = new Map<string, string>();
+m.set("a", "1");
+m.set("b", "2");
+m.set("c", "3");
+const entries = m.entries();
+if (entries.length !== 3) {
+  process.exit(1);
+}
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `Map.entries()` called at global scope was mistyped as `double` instead of `%ObjectArray*`, causing LLVM type errors
- Added Map entries() detection to `isObjectArrayByDispatch` in type-inference.ts
- Added `isObjectArrayExpression` fallback in global variable declarations in llvm-generator.ts
- New test: `map-entries-iteration.ts` validates entries().length works correctly

## Test plan
- [x] New test fixture passes with JS compiler
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)