### PR TITLE
test: 5 hardening fixtures for array/map edge cases

### DIFF
--- a/tests/fixtures/arrays/drain-and-refill.ts
+++ b/tests/fixtures/arrays/drain-and-refill.ts
@@ -1,0 +1,20 @@
+function testDrainAndRefill(): void {
+  const arr: number[] = [10, 20, 30];
+  const a = arr.pop();
+  if (a !== 30) process.exit(1);
+  const b = arr.pop();
+  if (b !== 20) process.exit(1);
+  const c = arr.pop();
+  if (c !== 10) process.exit(1);
+  if (arr.length !== 0) process.exit(1);
+  const d = arr.pop();
+  if (d !== 0) process.exit(1);
+  if (arr.length !== 0) process.exit(1);
+  arr.push(100);
+  arr.push(200);
+  if (arr.length !== 2) process.exit(1);
+  if (arr[0] !== 100) process.exit(1);
+  if (arr[1] !== 200) process.exit(1);
+  console.log("TEST_PASSED");
+}
+testDrainAndRefill();

--- a/tests/fixtures/arrays/filter-result-indexof.ts
+++ b/tests/fixtures/arrays/filter-result-indexof.ts
@@ -1,0 +1,16 @@
+function testFilterResultOps(): void {
+  const nums: number[] = [1, 2, 3, 4, 5, 6, 7, 8];
+  const evens = nums.filter((n: number): boolean => n % 2 === 0);
+  if (evens.length !== 4) process.exit(1);
+  if (evens[0] !== 2) process.exit(1);
+  if (evens[3] !== 8) process.exit(1);
+  const idx = evens.indexOf(6);
+  if (idx !== 2) process.exit(1);
+  const mapped = nums.map((n: number): number => n * 10);
+  if (mapped.length !== 8) process.exit(1);
+  if (mapped[0] !== 10) process.exit(1);
+  const mappedIdx = mapped.indexOf(50);
+  if (mappedIdx !== 4) process.exit(1);
+  console.log("TEST_PASSED");
+}
+testFilterResultOps();

--- a/tests/fixtures/arrays/push-return-value.ts
+++ b/tests/fixtures/arrays/push-return-value.ts
@@ -1,0 +1,16 @@
+function testPushReturnValue(): void {
+  const nums: number[] = [];
+  const len1 = nums.push(10);
+  const len2 = nums.push(20);
+  const len3 = nums.push(30);
+  if (len1 !== 1) process.exit(1);
+  if (len2 !== 2) process.exit(1);
+  if (len3 !== 3) process.exit(1);
+  const total = len1 + len2 + len3;
+  if (total !== 6) process.exit(1);
+  const strs: string[] = [];
+  const slen = strs.push("hello");
+  if (slen !== 1) process.exit(1);
+  console.log("TEST_PASSED");
+}
+testPushReturnValue();

--- a/tests/fixtures/edge-cases/empty-array-ops-function.ts
+++ b/tests/fixtures/edge-cases/empty-array-ops-function.ts
@@ -1,0 +1,15 @@
+function testEmptyArrayOps(): void {
+  const nums: number[] = [];
+  const popped = nums.pop();
+  if (popped !== 0) process.exit(1);
+  if (nums.length !== 0) process.exit(1);
+  const idx = nums.indexOf(42);
+  if (idx !== -1) process.exit(1);
+  const spliced = nums.splice(0, 0);
+  if (spliced.length !== 0) process.exit(1);
+  if (nums.length !== 0) process.exit(1);
+  const inc = nums.includes(1);
+  if (inc) process.exit(1);
+  console.log("TEST_PASSED");
+}
+testEmptyArrayOps();

--- a/tests/fixtures/edge-cases/map-delete-reinsert.ts
+++ b/tests/fixtures/edge-cases/map-delete-reinsert.ts
@@ -1,0 +1,19 @@
+function testMapDeleteReinsert(): void {
+  const m = new Map<number, number>();
+  m.set(1, 100);
+  m.set(2, 200);
+  m.set(3, 300);
+  if (m.size !== 3) process.exit(1);
+  m.delete(2);
+  if (m.size !== 2) process.exit(1);
+  if (!m.has(1)) process.exit(1);
+  if (!m.has(3)) process.exit(1);
+  const v3 = m.get(3);
+  if (v3 !== 300) process.exit(1);
+  m.set(2, 999);
+  if (m.size !== 3) process.exit(1);
+  const v2new = m.get(2);
+  if (v2new !== 999) process.exit(1);
+  console.log("TEST_PASSED");
+}
+testMapDeleteReinsert();


### PR DESCRIPTION
## Summary
- 5 new test fixtures exercising edge cases that could cause crashes:
  - push-return-value: use push() return value in arithmetic
  - map-delete-reinsert: delete then re-add entries to numeric map
  - empty-array-ops-function: pop, indexOf, splice, includes on empty arrays in function scope
  - filter-result-indexof: indexOf on filter/map results (type tracking through lambdas)
  - drain-and-refill: pop array to empty then push new elements (length/capacity interaction)

## Test plan
- [x] All 5 pass with JS compiler
- [x] `npm run verify:quick` passes