### PR TITLE
fix: resolve map.keys() and map.values() return types

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -596,6 +596,21 @@ export class TypeInference {
       if (objResolved && objResolved.arrayDepth > 0) return objResolved;
     }
 
+    if (method === "keys" || method === "values") {
+      if (objBase.type === "variable") {
+        const varName = (expr.object as VariableNode).name;
+        if (this.ctx.symbolTable.isMap(varName)) {
+          const mapMeta = this.ctx.symbolTable.getMapMetadata(varName);
+          if (mapMeta) {
+            if (method === "keys" && mapMeta.keyType === "string") {
+              return this.ctx.typeContext.getArrayType("string");
+            }
+            return this.ctx.typeContext.getArrayType("number");
+          }
+        }
+      }
+    }
+
     if (method === "values" || method === "entries") {
       if (objBase.type === "variable" && (expr.object as VariableNode).name === "Object") {
         return null;
@@ -2302,6 +2317,15 @@ export class TypeInference {
         const objBase = methodExpr.object as ExprBase;
         if (objBase.type === "variable" && (methodExpr.object as VariableNode).name === "Object") {
           return true;
+        }
+        if (objBase.type === "variable") {
+          const varName = (methodExpr.object as VariableNode).name;
+          if (this.ctx.symbolTable.isMap(varName)) {
+            const mapMeta = this.ctx.symbolTable.getMapMetadata(varName);
+            if (mapMeta && mapMeta.keyType === "string") {
+              return true;
+            }
+          }
         }
       }
       if (methodExpr.method === "values" || methodExpr.method === "entries") {

--- a/tests/fixtures/data-structures/map-keys-values.ts
+++ b/tests/fixtures/data-structures/map-keys-values.ts
@@ -1,0 +1,16 @@
+const m = new Map<string, string>();
+m.set("name", "Chad");
+m.set("lang", "TypeScript");
+
+const keys = m.keys();
+const values = m.values();
+
+if (keys.length !== 2) {
+  process.exit(1);
+}
+
+if (values.length !== 2) {
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- Map.keys() and Map.values() at global scope were misclassified as `number` (double) because `resolveMethodCallByMethod` had no handler for these methods on Map variables
- Now correctly resolves string map keys as `string[]` (%StringArray*) and map values as `number[]` (%Array*) to match codegen output
- Also added map.keys() detection to `isStringArrayExpression` for string-keyed maps

## Test plan
- [x] New fixture `map-keys-values.ts` — creates Map<string,string>, calls .keys()/.values(), checks .length
- [x] All 674 tests pass
- [x] verify:quick passes (Stage 0 + Stage 1 self-hosting)