### PR TITLE
test: add 5 edge case fixtures for map/set/array/string

### DIFF
--- a/tests/fixtures/edge-cases/array-slice-edge-cases.ts
+++ b/tests/fixtures/edge-cases/array-slice-edge-cases.ts
@@ -1,0 +1,24 @@
+const arr = [1, 2, 3, 4, 5];
+
+const empty = arr.slice(5);
+if (empty.length !== 0) process.exit(1);
+
+const full = arr.slice(0);
+if (full.length !== 5) process.exit(2);
+
+const negSlice = arr.slice(-2);
+if (negSlice.length !== 2) process.exit(3);
+if (negSlice[0] !== 4) process.exit(4);
+
+const midSlice = arr.slice(1, 3);
+if (midSlice.length !== 2) process.exit(5);
+if (midSlice[0] !== 2) process.exit(6);
+if (midSlice[1] !== 3) process.exit(7);
+
+const beyondEnd = arr.slice(0, 100);
+if (beyondEnd.length !== 5) process.exit(8);
+
+const negBoth = arr.slice(-3, -1);
+if (negBoth.length !== 2) process.exit(9);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/map-operations-chain.ts
+++ b/tests/fixtures/edge-cases/map-operations-chain.ts
@@ -1,0 +1,25 @@
+const m = new Map<string, string>();
+
+m.set("a", "1");
+m.set("b", "2");
+m.set("c", "3");
+
+if (m.size !== 3) process.exit(1);
+if (m.has("a") !== true) process.exit(2);
+if (m.get("a") !== "1") process.exit(3);
+
+m.delete("b");
+if (m.size !== 2) process.exit(4);
+if (m.has("b") !== false) process.exit(5);
+
+m.set("d", "4");
+m.set("e", "5");
+if (m.size !== 4) process.exit(6);
+
+m.clear();
+if (m.size !== 0) process.exit(7);
+
+m.set("x", "y");
+if (m.get("x") !== "y") process.exit(8);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/numeric-map-operations.ts
+++ b/tests/fixtures/edge-cases/numeric-map-operations.ts
@@ -1,0 +1,20 @@
+const m = new Map<number, number>();
+
+m.set(0, 100);
+m.set(1, 200);
+m.set(-1, 300);
+
+if (m.size !== 3) process.exit(1);
+if (m.get(0) !== 100) process.exit(2);
+if (m.get(-1) !== 300) process.exit(3);
+if (m.has(1) !== true) process.exit(4);
+
+m.delete(0);
+if (m.size !== 2) process.exit(5);
+if (m.has(0) !== false) process.exit(6);
+
+m.set(5, 500);
+if (m.get(5) !== 500) process.exit(7);
+if (m.size !== 3) process.exit(8);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/set-string-operations.ts
+++ b/tests/fixtures/edge-cases/set-string-operations.ts
@@ -1,0 +1,27 @@
+const s = new Set<string>();
+
+s.add("hello");
+s.add("world");
+s.add("hello");
+
+if (s.size !== 2) process.exit(1);
+if (s.has("hello") !== true) process.exit(2);
+if (s.has("missing") !== false) process.exit(3);
+
+s.delete("hello");
+if (s.size !== 1) process.exit(4);
+if (s.has("hello") !== false) process.exit(5);
+
+s.add("a");
+s.add("b");
+s.add("c");
+if (s.size !== 4) process.exit(6);
+
+s.add("d");
+if (s.size !== 5) process.exit(7);
+
+s.delete("a");
+s.delete("b");
+if (s.size !== 3) process.exit(8);
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/string-methods-empty.ts
+++ b/tests/fixtures/edge-cases/string-methods-empty.ts
@@ -1,0 +1,22 @@
+const empty = "";
+
+if (empty.length !== 0) process.exit(1);
+if (empty.trim() !== "") process.exit(2);
+if (empty.toUpperCase() !== "") process.exit(3);
+if (empty.toLowerCase() !== "") process.exit(4);
+if (empty.indexOf("x") !== -1) process.exit(5);
+if (empty.includes("x") !== false) process.exit(6);
+if (empty.startsWith("") !== true) process.exit(7);
+if (empty.endsWith("") !== true) process.exit(8);
+
+const parts = empty.split(",");
+if (parts.length !== 1) process.exit(9);
+if (parts[0] !== "") process.exit(10);
+
+const repeated = empty.repeat(100);
+if (repeated !== "") process.exit(11);
+
+const replaced = empty.replace("a", "b");
+if (replaced !== "") process.exit(12);
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- Adds 5 new test fixtures covering edge cases in collections and string methods
- Map operations chain: set/get/has/delete/clear/re-set sequence
- Array slice edge cases: empty slice, negative indices, beyond-end, negative both
- String methods on empty string: trim, case, indexOf, includes, split, repeat, replace
- Numeric map operations: zero key, negative key, delete, re-add
- String set operations: dedup, has, delete, multiple adds

## Test plan
- [x] All 5 fixtures pass with JS compiler
- [x] All 679 tests pass
- [x] verify:quick passes (Stage 0 + Stage 1 self-hosting)