### PR TITLE
test: unskip 4 object-array callback tests now passing

### DIFF
--- a/tests/fixtures/arrays/object-array-filter.ts
+++ b/tests/fixtures/arrays/object-array-filter.ts
@@ -1,4 +1,4 @@
-// @test-skip
+
 interface Item {
   name: string;
   score: number;

--- a/tests/fixtures/arrays/object-array-find.ts
+++ b/tests/fixtures/arrays/object-array-find.ts
@@ -1,4 +1,4 @@
-// @test-skip
+
 interface Point {
   x: number;
   y: number;

--- a/tests/fixtures/arrays/object-array-reduce.ts
+++ b/tests/fixtures/arrays/object-array-reduce.ts
@@ -1,4 +1,4 @@
-// @test-skip
+
 interface Item {
   name: string;
   score: number;

--- a/tests/fixtures/edge-cases/interface-array-processing.ts
+++ b/tests/fixtures/edge-cases/interface-array-processing.ts
@@ -1,4 +1,4 @@
-// @test-skip
+
 interface User {
   name: string;
   age: number;


### PR DESCRIPTION
## Summary
- Unskips object-array-filter, object-array-find, object-array-reduce, and interface-array-processing tests
- These were skipped due to Stage 1 self-hosting failures that are now resolved (likely fixed by alloca hoisting in #354)
- Reduces skip count from 22 to 18

## Test plan
- [x] All 4 tests pass with both JS and native compiler
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)