### PR TITLE
fix: hoist remaining allocas from conditional blocks

### DIFF
--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -371,6 +371,9 @@ export function handleStringArrayIndexOf(
   const notfoundLabel = ctx.nextLabel("indexof_notfound");
   const endLabel = ctx.nextLabel("indexof_end");
 
+  const counterPtr = ctx.nextTemp();
+  ctx.emit(`${counterPtr} = alloca i32`);
+
   const arrIsNull = ctx.emitIcmp("eq", "%StringArray*", arrayPtr, "null");
   ctx.emitBrCond(arrIsNull, notfoundLabel, `${checkLabel}_arrvalid`);
 
@@ -399,8 +402,6 @@ export function handleStringArrayIndexOf(
   const stillNeg = ctx.emitIcmp("slt", "i32", resolved, "0");
   const clampedFrom = ctx.nextTemp();
   ctx.emit(`${clampedFrom} = select i1 ${stillNeg}, i32 0, i32 ${resolved}`);
-  const counterPtr = ctx.nextTemp();
-  ctx.emit(`${counterPtr} = alloca i32`);
   ctx.emitStore("i32", clampedFrom, counterPtr);
 
   ctx.emitBr(checkLabel);

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -1603,6 +1603,13 @@ export class ControlFlowGenerator {
     const catchEntryLabel = this.nextLabel("catch_entry");
     const finallyLabel = this.nextLabel("finally_block");
 
+    const paramName = tryStmt.catchParam;
+    let paramAlloca = "";
+    if (paramName) {
+      paramAlloca = this.ctx.nextAllocaReg(paramName);
+      this.emit(`${paramAlloca} = alloca i8*`);
+    }
+
     this.ctx.emitBrCond(isException, catchEntryLabel, tryBodyLabel);
 
     this.ctx.emitLabel(tryBodyLabel);
@@ -1619,11 +1626,8 @@ export class ControlFlowGenerator {
     this.ctx.emitStore("i8*", prevFrame, "@__exception_stack");
 
     if (tryStmt.catchBody) {
-      const paramName = tryStmt.catchParam;
       if (paramName) {
         const excMsg = this.ctx.emitLoad("i8*", "@__exception_message");
-        const paramAlloca = this.ctx.nextAllocaReg(paramName);
-        this.emit(`${paramAlloca} = alloca i8*`);
         this.ctx.emitStore("i8*", excMsg, paramAlloca);
         this.ctx.defineVariable(paramName, paramAlloca, "i8*", SymbolKind.String, "local");
       }


### PR DESCRIPTION
## Summary
- Hoists 2 remaining `alloca` instructions out of conditional blocks into the entry block, eliminating LLVM undefined behavior
- `control-flow.ts`: catch parameter alloca moved before try/catch branch
- `string-methods.ts`: indexOf loop counter alloca moved before null-check branch

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)