### PR TITLE
fix: split detectArrayType to avoid native destructuring miscompilation

### DIFF
--- a/src/codegen/types/collections/array/context.ts
+++ b/src/codegen/types/collections/array/context.ts
@@ -26,32 +26,65 @@ export function loadArrayMeta(
   return { length, dataPtr };
 }
 
+export function isStringArrayType(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  arrayPtr: string,
+): boolean {
+  const exprObjBase = expr.object as ExprBase;
+  if (exprObjBase.type === "variable") {
+    const varName = (expr.object as VariableNode).name;
+    const varType = gen.getVariableType(varName);
+    if (varType === "%StringArray*" || varType === "%StringArray") return true;
+    const ptrType = gen.getVariableType(arrayPtr);
+    if (ptrType === "%StringArray*") return true;
+    return false;
+  } else if (exprObjBase.type === "member_access") {
+    const ptrType = gen.getVariableType(arrayPtr);
+    return ptrType === "%StringArray*";
+  } else {
+    const ptrType = gen.getVariableType(arrayPtr);
+    if (ptrType === "%StringArray*") return true;
+    return false;
+  }
+}
+
+export function isObjectArrayType(
+  gen: IGeneratorContext,
+  expr: MethodCallNode,
+  arrayPtr: string,
+): boolean {
+  const exprObjBase = expr.object as ExprBase;
+  if (exprObjBase.type === "variable") {
+    const varName = (expr.object as VariableNode).name;
+    const varType = gen.getVariableType(varName);
+    if (varType === "%ObjectArray*" || varType === "%ObjectArray") return true;
+    const ptrType = gen.getVariableType(arrayPtr);
+    if (ptrType === "%ObjectArray*") return true;
+    return false;
+  } else if (exprObjBase.type === "member_access") {
+    const ptrType = gen.getVariableType(arrayPtr);
+    if (ptrType === "%StringArray*") return false;
+    if (ptrType && ptrType.indexOf("*") !== -1 && ptrType !== "%Array*") return true;
+    return false;
+  } else {
+    const ptrType = gen.getVariableType(arrayPtr);
+    if (ptrType === "%ObjectArray*") return true;
+    return false;
+  }
+}
+
 /**
- * Detects whether the array expression is a string or object array.
- * Shared by find/some/every/filter/forEach/reduce/map.
+ * @deprecated Use isStringArrayType and isObjectArrayType instead.
+ * Object destructuring of return values is miscompiled by the native compiler:
+ * it calls the function twice and reads field 0 both times, ignoring field 1.
  */
 export function detectArrayType(
   gen: IGeneratorContext,
   expr: MethodCallNode,
   arrayPtr: string,
 ): { isStringArray: boolean; isObjectArray: boolean } {
-  let isStringArray = false;
-  let isObjectArray = false;
-  const exprObjBase = expr.object as ExprBase;
-  if (exprObjBase.type === "variable") {
-    const varName = (expr.object as VariableNode).name;
-    const varType = gen.getVariableType(varName);
-    isStringArray = varType === "%StringArray*" || varType === "%StringArray";
-    isObjectArray = varType === "%ObjectArray*" || varType === "%ObjectArray";
-  } else if (exprObjBase.type === "member_access") {
-    const ptrType = gen.getVariableType(arrayPtr);
-    isStringArray = ptrType === "%StringArray*";
-    if (!isStringArray && ptrType && ptrType.indexOf("*") !== -1 && ptrType !== "%Array*") {
-      isObjectArray = true;
-    }
-  } else {
-    const ptrType = gen.getVariableType(arrayPtr);
-    isStringArray = ptrType === "%StringArray*";
-  }
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
   return { isStringArray, isObjectArray };
 }

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -2,7 +2,12 @@
 // Exported functions accept (gen, expr, params) and handle callback resolution internally.
 
 import { MethodCallNode, VariableNode, ArrowFunctionNode } from "../../../../ast/types.js";
-import { IGeneratorContext, loadArrayMeta, isStringArrayType, isObjectArrayType } from "./context.js";
+import {
+  IGeneratorContext,
+  loadArrayMeta,
+  isStringArrayType,
+  isObjectArrayType,
+} from "./context.js";
 
 interface ExprBase {
   type: string;

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -2,7 +2,7 @@
 // Exported functions accept (gen, expr, params) and handle callback resolution internally.
 
 import { MethodCallNode, VariableNode, ArrowFunctionNode } from "../../../../ast/types.js";
-import { IGeneratorContext, loadArrayMeta, detectArrayType } from "./context.js";
+import { IGeneratorContext, loadArrayMeta, isStringArrayType, isObjectArrayType } from "./context.js";
 
 interface ExprBase {
   type: string;
@@ -57,7 +57,8 @@ export function generateArrayFilter(
   }
 
   const arrayPtr = gen.generateExpression(expr.object, params);
-  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
 
   let elementType = "";
   if (isObjectArray) {
@@ -319,7 +320,8 @@ export function generateArrayForEach(
   }
 
   const arrayPtr = gen.generateExpression(expr.object, params);
-  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
 
   let elementType = "";
   if (isObjectArray) {
@@ -479,7 +481,8 @@ export function generateArrayReduce(
   }
 
   const arrayPtr = gen.generateExpression(expr.object, params);
-  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
 
   let elementType = "";
   if (isObjectArray) {
@@ -792,7 +795,8 @@ export function generateArrayMap(
   }
 
   const arrayPtr = gen.generateExpression(expr.object, params);
-  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
 
   let elementType = "";
   if (isObjectArray) {
@@ -1069,7 +1073,8 @@ export function generateArrayReduceRight(
   }
 
   const arrayPtr = gen.generateExpression(expr.object, params);
-  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
 
   const callbackArg = expr.args[0];
   let callbackFn: string;

--- a/src/codegen/types/collections/array/search-predicate.ts
+++ b/src/codegen/types/collections/array/search-predicate.ts
@@ -2,7 +2,7 @@
 // Exported functions accept (gen, expr, params) and handle predicate resolution internally.
 
 import { MethodCallNode, VariableNode } from "../../../../ast/types.js";
-import { IGeneratorContext, loadArrayMeta, detectArrayType } from "./context.js";
+import { IGeneratorContext, loadArrayMeta, isStringArrayType, isObjectArrayType } from "./context.js";
 
 interface ExprBase {
   type: string;
@@ -32,7 +32,8 @@ export function generateArrayFind(
   }
 
   const arrayPtr = gen.generateExpression(expr.object, params);
-  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
 
   let elementType = "";
   if (isObjectArray) {
@@ -214,7 +215,8 @@ export function generateArraySome(
   }
 
   const arrayPtr = gen.generateExpression(expr.object, params);
-  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
 
   let elementType = "";
   if (isObjectArray) {
@@ -399,7 +401,8 @@ export function generateArrayEvery(
   }
 
   const arrayPtr = gen.generateExpression(expr.object, params);
-  const { isStringArray, isObjectArray } = detectArrayType(gen, expr, arrayPtr);
+  const isStringArray = isStringArrayType(gen, expr, arrayPtr);
+  const isObjectArray = isObjectArrayType(gen, expr, arrayPtr);
 
   let elementType = "";
   if (isObjectArray) {

--- a/src/codegen/types/collections/array/search-predicate.ts
+++ b/src/codegen/types/collections/array/search-predicate.ts
@@ -2,7 +2,12 @@
 // Exported functions accept (gen, expr, params) and handle predicate resolution internally.
 
 import { MethodCallNode, VariableNode } from "../../../../ast/types.js";
-import { IGeneratorContext, loadArrayMeta, isStringArrayType, isObjectArrayType } from "./context.js";
+import {
+  IGeneratorContext,
+  loadArrayMeta,
+  isStringArrayType,
+  isObjectArrayType,
+} from "./context.js";
 
 interface ExprBase {
   type: string;

--- a/tests/self-hosting.test.ts
+++ b/tests/self-hosting.test.ts
@@ -33,12 +33,7 @@ const NATIVE_ENV: NodeJS.ProcessEnv = {
 
 const STAGE0_TODO = new Set<string>([]);
 
-const STAGE1_TODO = new Set<string>([
-  "arrays/object-array-filter",
-  "arrays/object-array-find",
-  "arrays/object-array-reduce",
-  "edge-cases/interface-array-processing",
-]);
+const STAGE1_TODO = new Set<string>([]);
 
 function isCrashSignal(signal: string | null): boolean {
   return signal === "SIGSEGV" || signal === "SIGABRT" || signal === "SIGBUS";


### PR DESCRIPTION
## Summary
- Split `detectArrayType()` (which returned `{ isStringArray, isObjectArray }`) into two separate boolean-returning functions: `isStringArrayType()` and `isObjectArrayType()`
- The native compiler miscompiles object destructuring of function return values — it calls the function twice and reads field 0 both times, ignoring field 1. This caused Stage 1 to misidentify object arrays as number arrays, breaking filter/find/reduce on object arrays.
- All 4 previously-skipped Stage 1 tests now pass: object-array-filter, object-array-find, object-array-reduce, interface-array-processing
- STAGE1_TODO cleared to empty

## Root cause
Native compiler's `desugarDestructuring` in the parser doesn't create temp variables for non-variable RHS expressions. `const { a, b } = fn()` compiles as two separate `fn()` calls, each reading field 0 of a `{ i8* }*` struct instead of one call reading fields 0 and 1 of `{ i8*, i8* }*`.

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] All 4 previously-TODO'd Stage 1 tests now pass
- [x] No other callers of deprecated `detectArrayType` remain in src/

🤖 Generated with [Claude Code](https://claude.com/claude-code)