### PR TITLE
fix: native parser destructuring creates temp vars (root cause fix)

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -51,6 +51,8 @@ import {
   TypeAssertionNode,
 } from "../ast/types.js";
 
+let destructureCounter = 0;
+
 interface ExprBase {
   type: string;
 }
@@ -1764,6 +1766,20 @@ function desugarDestructuring(
 
   const results: VariableDeclaration[] = [];
 
+  let objectRef: Expression = rhsExpr;
+  const rhsBase = rhsExpr as ExprBase;
+  if (rhsBase.type !== "variable") {
+    const tempName = "__destructure_" + String(destructureCounter);
+    destructureCounter = destructureCounter + 1;
+    results.push({
+      type: "variable_declaration",
+      kind: "const",
+      name: tempName,
+      value: rhsExpr,
+    });
+    objectRef = { type: "variable", name: tempName } as Expression;
+  }
+
   if (nn.type === "object_pattern") {
     for (let i = 0; i < nameNode.namedChildCount; i++) {
       const prop = getNamedChild(nameNode, i);
@@ -1776,7 +1792,7 @@ function desugarDestructuring(
           type: "variable_declaration",
           kind,
           name: propName,
-          value: { type: "member_access", object: rhsExpr, property: propName } as Expression,
+          value: { type: "member_access", object: objectRef, property: propName } as Expression,
         });
       } else if (p.type === "pair_pattern") {
         const keyNode = getNamedChild(prop, 0);
@@ -1788,7 +1804,7 @@ function desugarDestructuring(
             type: "variable_declaration",
             kind,
             name: aliasName,
-            value: { type: "member_access", object: rhsExpr, property: keyName } as Expression,
+            value: { type: "member_access", object: objectRef, property: keyName } as Expression,
           });
         }
       }
@@ -1809,7 +1825,7 @@ function desugarDestructuring(
           name: e.text,
           value: {
             type: "index_access",
-            object: rhsExpr,
+            object: objectRef,
             index: { type: "number", value: idx },
           } as Expression,
         });


### PR DESCRIPTION
## Summary
- Native parser's `desugarDestructuring` now creates temp variables for non-variable RHS expressions, matching the TS parser's behavior
- Previously, `const { a, b } = fn()` was desugared as `const a = fn().a; const b = fn().b;` — calling `fn()` twice and always reading field 0
- Now correctly desugars to `const __destructure_N = fn(); const a = __destructure_N.a; const b = __destructure_N.b;`

## Root cause
This was the actual root cause of the Stage 1 object array test failures (fixed by workaround in #362). The native compiler's parser reused the RHS expression directly for each destructured property, causing functions to be called N times instead of once, with only field 0 ever being read.

## Impact
- Fixes ALL object destructuring of function return values in native-compiled code
- The `detectArrayType` split in #362 is now technically unnecessary (the destructuring works correctly), but is still good practice to avoid depending on correct destructuring
- Any user code using `const { x, y } = someFunction()` will now work correctly when compiled by the native compiler

## Test plan
- [x] `npm run verify:quick` passes (683 tests + Stage 1 self-hosting)
- [x] Existing destructuring fixtures pass (object-destructure, array-destructure, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)