### PR TITLE
fix: prevent native compiler SIGSEGV on global method calls returning class instances

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2085,6 +2085,12 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         }
 
         const resolved = this.typeInference.resolveExpressionType(stmt.value);
+        let resolvedBase = "";
+        let resolvedDepth = 0;
+        if (resolved) {
+          resolvedBase = resolved.base;
+          resolvedDepth = resolved.arrayDepth;
+        }
         let isString = false;
         let isStringArray = false;
         let isObjectArray = false;
@@ -2098,8 +2104,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         let isBoolean = false;
         let isNumber = false;
         if (resolved) {
-          const base = resolved.base;
-          const depth = resolved.arrayDepth;
+          const base = resolvedBase;
+          const depth = resolvedDepth;
           isString = base === "string" && depth === 0;
           isStringArray = base === "string" && depth > 0;
           isObjectArray = depth > 0 && base !== "string" && base !== "number" && base !== "boolean";
@@ -2308,8 +2314,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               mapValueType = mapNode.valueType || "string";
             }
           }
-          if (!isStringMap && resolved && resolved.base.startsWith("Map<")) {
-            const parsed = parseMapTypeString(resolved.base);
+          if (!isStringMap && resolvedBase.startsWith("Map<")) {
+            const parsed = parseMapTypeString(resolvedBase);
             if (parsed && parsed.keyType === "string") {
               isStringMap = true;
               mapValueType = parsed.valueType;
@@ -2348,8 +2354,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               pointerMapValueType = parsed.valueType;
             }
           }
-          if (!isPointerMap && resolved && resolved.base.startsWith("Map<")) {
-            const parsed = parseMapTypeString(resolved.base);
+          if (!isPointerMap && resolvedBase.startsWith("Map<")) {
+            const parsed = parseMapTypeString(resolvedBase);
             if (parsed && parsed.keyType !== "string" && parsed.keyType !== "number") {
               isPointerMap = true;
               pointerMapKeyType = parsed.keyType;
@@ -2455,9 +2461,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               : null;
             className = func
               ? this.resolveImportAlias(stripNullable(func.returnType!))
-              : resolved!.base;
+              : resolvedBase;
           } else {
-            className = resolved!.base;
+            className = resolvedBase;
           }
           const fields = this.classGen ? this.classGen.getClassFields(className) || [] : [];
           llvmType = fields.length > 0 ? `%${className}_struct*` : "i32*";

--- a/tests/fixtures/classes/class-linked-list.ts
+++ b/tests/fixtures/classes/class-linked-list.ts
@@ -1,4 +1,3 @@
-// @test-skip
 class ListNode {
   value: number;
   next: ListNode | null;

--- a/tests/fixtures/edge-cases/class-return-new-instance.ts
+++ b/tests/fixtures/edge-cases/class-return-new-instance.ts
@@ -1,4 +1,3 @@
-// @test-skip
 class Vec {
   x: number;
   y: number;

--- a/tests/fixtures/edge-cases/nested-class-interaction.ts
+++ b/tests/fixtures/edge-cases/nested-class-interaction.ts
@@ -1,4 +1,3 @@
-// @test-skip
 class Point {
   x: number;
   y: number;


### PR DESCRIPTION
## Summary
- Fixed SIGSEGV crash when the native compiler processes global-scope method calls that return class instances (e.g., `const c = a.add(b)` where `add()` returns `Vec`)
- Root cause: the native compiler lost track of the `resolved` pointer through a long chain of boolean evaluations in `generateGlobalVariableDeclarations()`. Later access via `resolved.base` dereferenced a corrupted pointer.
- Fix: extract `resolved.base` and `resolved.arrayDepth` into local variables immediately after the type inference call, before the boolean evaluation chain
- Unskipped 3 test fixtures: class-return-new-instance, nested-class-interaction, class-linked-list

## Impact
- Class methods that return `new ClassName(...)` now work at global scope
- Self-referential class fields (`next: ListNode | null`) now compile correctly
- Classes that store other class instances as fields work correctly

## Test plan
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)
- [x] All 3 previously-skipped fixtures pass with native compiler
- [x] 0 test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)