### PR TITLE
fix: Set/Map params read garbage, add 5 hardening fixtures

### DIFF
--- a/src/codegen/expressions/variables.ts
+++ b/src/codegen/expressions/variables.ts
@@ -93,7 +93,7 @@ export class VariableExpressionGenerator {
       let allocaReg = this.ctx.getVariableAlloca(name)!;
       const mapMeta = this.ctx.symbolTable.getMapMetadata(name);
       const mapType = mapMeta && mapMeta.keyType !== "number" ? "%StringMap*" : "%Map*";
-      if (allocaReg.startsWith("@")) {
+      if (allocaReg.startsWith("@") || this.ctx.symbolTable.isPointerAlloca(name)) {
         const loaded = this.ctx.nextTemp();
         this.ctx.emit(`${loaded} = load ${mapType}, ${mapType}* ${allocaReg}`);
         this.ctx.setVariableType(loaded, mapType);
@@ -108,7 +108,7 @@ export class VariableExpressionGenerator {
       let allocaReg = this.ctx.getVariableAlloca(name)!;
       const setValueType = this.ctx.symbolTable.getSetValueType(name);
       const setType = setValueType === "string" ? "%StringSet*" : "%Set*";
-      if (allocaReg.startsWith("@")) {
+      if (allocaReg.startsWith("@") || this.ctx.symbolTable.isPointerAlloca(name)) {
         const loaded = this.ctx.nextTemp();
         this.ctx.emit(`${loaded} = load ${setType}, ${setType}* ${allocaReg}`);
         this.ctx.setVariableType(loaded, setType);

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -494,6 +494,21 @@ export class FunctionGenerator {
         } else {
           this.ctx.emit(`store %ObjectArray* %arg${i}, %ObjectArray** ${allocaReg}`);
         }
+      } else if (llvmType === "%Set*") {
+        this.ctx.defineVariableWithMetadata(
+          paramName,
+          allocaReg,
+          "%Set*",
+          SymbolKind.Set,
+          "local",
+          createPointerAllocaMetadata(),
+        );
+        this.ctx.emit(`${allocaReg} = alloca %Set*`);
+        if (isOptional && hasOptionalParams) {
+          this.generateOptionalParamInit(i, allocaReg, llvmType, paramInfo!, funcParams);
+        } else {
+          this.ctx.emit(`store %Set* %arg${i}, %Set** ${allocaReg}`);
+        }
       } else if (llvmType === "%StringSet*") {
         this.ctx.defineVariableWithMetadata(
           paramName,
@@ -510,18 +525,20 @@ export class FunctionGenerator {
           this.ctx.emit(`store %StringSet* %arg${i}, %StringSet** ${allocaReg}`);
         }
       } else if (llvmType === "%StringMap*") {
+        const mapMeta = createMapMetadataSymbol({
+          keyType: "string",
+          valueType: "string",
+          llvmKeyType: "i8*",
+          llvmValueType: "i8*",
+        });
+        mapMeta.isPointerAlloca = true;
         this.ctx.defineVariableWithMetadata(
           paramName,
           allocaReg,
           "%StringMap*",
           SymbolKind.Map,
           "local",
-          createMapMetadataSymbol({
-            keyType: "string",
-            valueType: "string",
-            llvmKeyType: "i8*",
-            llvmValueType: "i8*",
-          }),
+          mapMeta,
         );
         this.ctx.emit(`${allocaReg} = alloca %StringMap*`);
         if (isOptional && hasOptionalParams) {

--- a/src/codegen/infrastructure/type-context.ts
+++ b/src/codegen/infrastructure/type-context.ts
@@ -81,7 +81,8 @@ export class TypeContext {
 
   getSetType(valueType: string): ResolvedType {
     const base = "Set<" + valueType + ">";
-    return this.intern(base, "%StringSet*");
+    const llvmType = valueType === "string" ? "%StringSet*" : "%Set*";
+    return this.intern(base, llvmType);
   }
 
   getInterfaceType(name: string): ResolvedType {

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -338,6 +338,7 @@ export class TypeInference {
 
   private resolveFromVarTypeExtended(varType: string): ResolvedType | null {
     if (varType === "%StringSet*") return this.ctx.typeContext.getSetType("string");
+    if (varType === "%Set*") return this.ctx.typeContext.getSetType("number");
     if (varType === "%Promise*") return this.ctx.typeContext.resolve("Promise");
     if (varType === "%__FetchResponse*") return this.ctx.typeContext.resolve("Response");
     if (varType === "double") return this.ctx.typeContext.numberType;

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -141,7 +141,8 @@ function resolvedSpecialToLlvm(rt: ResolvedType): string | null {
   if (rt.base === "void") return "void";
   if (rt.base === "null" || rt.base === "undefined") return "i8*";
   if (rt.base.startsWith("Map")) return "%StringMap*";
-  if (rt.base.startsWith("Set")) return "%StringSet*";
+  if (rt.base === "Set<string>") return "%StringSet*";
+  if (rt.base.startsWith("Set")) return "%Set*";
   return null;
 }
 
@@ -196,7 +197,8 @@ function collectionTypeToLlvm(tsType: string): string | null {
   if (tsType === "number[]" || tsType === "boolean[]") return "%Array*";
   if (tsType === "Uint8Array") return "%Uint8Array*";
   if (tsType.endsWith("[]")) return "%ObjectArray*";
-  if (tsType.startsWith("Set<")) return "%StringSet*";
+  if (tsType === "Set<string>") return "%StringSet*";
+  if (tsType.startsWith("Set<")) return "%Set*";
   return null;
 }
 

--- a/tests/fixtures/arrays/array-triple-chain.ts
+++ b/tests/fixtures/arrays/array-triple-chain.ts
@@ -1,0 +1,26 @@
+// @test-description: three-level chained array method calls
+
+const nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+const result = nums
+  .filter((n: number) => n % 2 === 0)
+  .map((n: number) => n * 10)
+  .join(",");
+
+if (result !== "20,40,60,80,100") {
+  console.log("FAIL: got " + result);
+  process.exit(1);
+}
+
+const words = ["hello", "world", "foo", "bar", "baz"];
+const upper = words
+  .filter((w: string) => w.length > 3)
+  .map((w: string) => w.toUpperCase())
+  .join(" ");
+
+if (upper !== "HELLO WORLD") {
+  console.log("FAIL: upper = " + upper);
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/control-flow/switch-fallthrough.ts
+++ b/tests/fixtures/control-flow/switch-fallthrough.ts
@@ -1,0 +1,54 @@
+// @test-description: switch fall-through between cases
+
+function classify(x: number): string {
+  let result = "";
+  switch (x) {
+    case 1:
+    case 2:
+    case 3:
+      result = "small";
+      break;
+    case 4:
+      result = "medium";
+      break;
+    case 5:
+    case 6:
+      result = "large";
+      break;
+    default:
+      result = "unknown";
+      break;
+  }
+  return result;
+}
+
+if (classify(1) !== "small") {
+  console.log("FAIL: 1 should be small, got " + classify(1));
+  process.exit(1);
+}
+if (classify(2) !== "small") {
+  console.log("FAIL: 2 should be small, got " + classify(2));
+  process.exit(1);
+}
+if (classify(3) !== "small") {
+  console.log("FAIL: 3 should be small, got " + classify(3));
+  process.exit(1);
+}
+if (classify(4) !== "medium") {
+  console.log("FAIL: 4 should be medium, got " + classify(4));
+  process.exit(1);
+}
+if (classify(5) !== "large") {
+  console.log("FAIL: 5 should be large, got " + classify(5));
+  process.exit(1);
+}
+if (classify(6) !== "large") {
+  console.log("FAIL: 6 should be large, got " + classify(6));
+  process.exit(1);
+}
+if (classify(99) !== "unknown") {
+  console.log("FAIL: 99 should be unknown, got " + classify(99));
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/deeply-nested-calls.ts
+++ b/tests/fixtures/edge-cases/deeply-nested-calls.ts
@@ -1,0 +1,39 @@
+// @test-description: deeply nested function calls (3+ levels)
+
+function double(n: number): number {
+  return n * 2;
+}
+
+function add1(n: number): number {
+  return n + 1;
+}
+
+function negate(n: number): number {
+  return 0 - n;
+}
+
+const result = double(add1(double(3)));
+if (result !== 14) {
+  console.log("FAIL: double(add1(double(3))) should be 14, got " + String(result));
+  process.exit(1);
+}
+
+const result2 = add1(add1(add1(add1(0))));
+if (result2 !== 4) {
+  console.log("FAIL: 4x add1(0) should be 4, got " + String(result2));
+  process.exit(1);
+}
+
+const result3 = negate(double(add1(5)));
+if (result3 !== -12) {
+  console.log("FAIL: negate(double(add1(5))) should be -12, got " + String(result3));
+  process.exit(1);
+}
+
+const maxResult = Math.max(Math.min(10, 20), Math.abs(-5));
+if (maxResult !== 10) {
+  console.log("FAIL: Math.max(Math.min(10,20), Math.abs(-5)) should be 10, got " + String(maxResult));
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/empty-collections-as-args.ts
+++ b/tests/fixtures/edge-cases/empty-collections-as-args.ts
@@ -1,0 +1,60 @@
+// @test-description: empty arrays maps and sets passed as function arguments
+
+function sumArray(arr: number[]): number {
+  let total = 0;
+  for (let i = 0; i < arr.length; i++) {
+    total = total + arr[i];
+  }
+  return total;
+}
+
+function countStrings(arr: string[]): number {
+  return arr.length;
+}
+
+function countSet(s: Set<number>): number {
+  return s.size;
+}
+
+if (sumArray([]) !== 0) {
+  console.log("FAIL: sum of empty should be 0");
+  process.exit(1);
+}
+if (countStrings([]) !== 0) {
+  console.log("FAIL: count of empty strings should be 0");
+  process.exit(1);
+}
+
+const emptyNums: number[] = [];
+if (sumArray(emptyNums) !== 0) {
+  console.log("FAIL: sum of empty var should be 0");
+  process.exit(1);
+}
+
+const emptySet = new Set<number>();
+if (countSet(emptySet) !== 0) {
+  console.log("FAIL: empty set size should be 0");
+  process.exit(1);
+}
+
+if (sumArray([10, 20, 30]) !== 60) {
+  console.log("FAIL: sum should be 60");
+  process.exit(1);
+}
+
+function mapSize(m: Map<string, string>): number {
+  return m.size;
+}
+
+const m = new Map<string, string>();
+if (mapSize(m) !== 0) {
+  console.log("FAIL: empty map size should be 0");
+  process.exit(1);
+}
+m.set("key", "val");
+if (mapSize(m) !== 1) {
+  console.log("FAIL: map size should be 1");
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/strings/template-literal-expressions.ts
+++ b/tests/fixtures/strings/template-literal-expressions.ts
@@ -1,0 +1,30 @@
+// @test-description: template literals with method calls and arithmetic
+
+function greet(name: string): string {
+  return `hello ${name}`;
+}
+
+const arr = [1, 2, 3];
+const nums = `sum: ${1 + 2 + 3}`;
+const method = `joined: ${arr.join(",")}`;
+const nested = `greeting: ${greet("world")}`;
+const multi = `${arr.length} items: ${arr.join(" ")}`;
+
+if (nums !== "sum: 6") {
+  console.log("FAIL: nums = " + nums);
+  process.exit(1);
+}
+if (method !== "joined: 1,2,3") {
+  console.log("FAIL: method = " + method);
+  process.exit(1);
+}
+if (nested !== "greeting: hello world") {
+  console.log("FAIL: nested = " + nested);
+  process.exit(1);
+}
+if (multi !== "3 items: 1 2 3") {
+  console.log("FAIL: multi = " + multi);
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- **Set<number> and Map<string,string> passed as function arguments returned garbage** — `.size` read random memory instead of the actual size field. Root cause: variable loading code didn't emit `load` for pointer-alloca params (params store a pointer to the struct, so need an extra load vs local allocas which ARE the struct).
- Also fixed `Set<number>` type mapping — was incorrectly mapped to `%StringSet*` instead of `%Set*` in 3 places (collectionTypeToLlvm, resolvedSpecialToLlvm, getSetType).
- Added 5 new test fixtures covering previously untested patterns: switch fall-through, template literals with method calls, 3-level chained array methods, empty collections as function args, deeply nested function calls.

## Test plan
- [x] All 691 tests pass (5 new)
- [x] `npm run verify:quick` passes (Stage 1 self-hosting)
- [x] Set<number> and Map<string,string> params now return correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)