### PR TITLE
enable 3 network integration tests, fix formatting

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -76,6 +76,9 @@ const testFiles = [
   "tests/unit/type-system.test.ts",
   "tests/network.test.ts",
   "tests/http-routes.test.ts",
+  "tests/http-headers.test.ts",
+  "tests/http-query-string.test.ts",
+  "tests/multipart.test.ts",
 ];
 
 const env =

--- a/tests/fixtures/edge-cases/deeply-nested-calls.ts
+++ b/tests/fixtures/edge-cases/deeply-nested-calls.ts
@@ -32,7 +32,9 @@ if (result3 !== -12) {
 
 const maxResult = Math.max(Math.min(10, 20), Math.abs(-5));
 if (maxResult !== 10) {
-  console.log("FAIL: Math.max(Math.min(10,20), Math.abs(-5)) should be 10, got " + String(maxResult));
+  console.log(
+    "FAIL: Math.max(Math.min(10,20), Math.abs(-5)) should be 10, got " + String(maxResult),
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- Wire up 3 existing but unused integration test files (`http-headers.test.ts`, `http-query-string.test.ts`, `multipart.test.ts`) into the test runner. These were fully written but never added to `scripts/test.js`, so they never ran in CI.
- Fix prettier formatting in `deeply-nested-calls.ts` from PR #366.
- Test count: 691 → 701 (10 new integration tests covering HTTP headers, query strings, and multipart parsing).

## Test plan
- [x] All 701 tests pass locally (both node and native compiler)
- [x] `npm run verify:quick` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)