### PR TITLE
fix: compile error for non-destructured map entries instead of segfault

### DIFF
--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -439,6 +439,16 @@ export class ControlFlowGenerator {
       return this.generateMapEntriesForOf(stmt, params);
     }
 
+    const isNonDestructuredEntries =
+      !forOfStmt.destructuredNames && this.isMapEntriesCall(forOfStmt.iterable);
+    if (isNonDestructuredEntries) {
+      return this.ctx.emitError(
+        "Map entries() requires destructured iteration: for (const [key, value] of map.entries())",
+        stmt.loc,
+        "Use destructuring: for (const [key, value] of map.entries()) { ... }",
+      );
+    }
+
     const isStringIterable = this.ctx.isStringExpression(forOfStmt.iterable);
     if (isStringIterable) {
       return this.generateStringForOf(stmt as ForOfStatement, params);

--- a/tests/fixtures/collections/map-entries-destructured.ts
+++ b/tests/fixtures/collections/map-entries-destructured.ts
@@ -1,0 +1,32 @@
+// @test-description: map entries iteration with destructuring
+
+const m = new Map<string, string>();
+m.set("a", "1");
+m.set("b", "2");
+m.set("c", "3");
+
+let count = 0;
+const keys: string[] = [];
+const values: string[] = [];
+for (const [key, value] of m.entries()) {
+  keys.push(key);
+  values.push(value);
+  count = count + 1;
+}
+
+if (count !== 3) {
+  console.log("FAIL count: " + String(count));
+  process.exit(1);
+}
+
+if (keys.join(",") !== "a,b,c") {
+  console.log("FAIL keys: " + keys.join(","));
+  process.exit(1);
+}
+
+if (values.join(",") !== "1,2,3") {
+  console.log("FAIL values: " + values.join(","));
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");

--- a/tests/fixtures/errors/map-entries-no-destructure.ts
+++ b/tests/fixtures/errors/map-entries-no-destructure.ts
@@ -1,0 +1,9 @@
+// @test-description: map entries without destructuring emits compile error
+// @test-compile-error: Map entries() requires destructured iteration
+
+const m = new Map<string, string>();
+m.set("a", "1");
+
+for (const entry of m.entries()) {
+  console.log(entry);
+}


### PR DESCRIPTION
## Summary
- `for (const entry of map.entries()) { entry[0] }` previously segfaulted at runtime — the entry pointer was treated as a string and `strlen` was called on it. Now emits a clear compile-time error with suggestion to use destructuring syntax.
- Adds test for correct destructured pattern: `for (const [key, value] of map.entries())` — already worked, now has explicit test coverage.

## Test plan
- [x] All 703 tests pass (2 new: destructured entries + compile error test)
- [x] `npm run verify:quick` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)