### PR TITLE
fix: class-typed fields on class instances now work correctly

### DIFF
--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -15,6 +15,7 @@ import type { SymbolTable, ClassInfo, ObjectArrayMetadata } from "./symbol-table
 import type { InterfaceStructGenerator } from "../types/interface-struct-generator.js";
 
 import type { FieldInfo } from "./type-resolver/types.js";
+import { stripNullable } from "./type-system.js";
 
 interface ObjectInfo {
   ptr: string;
@@ -368,14 +369,24 @@ export class AssignmentGenerator {
       this.ctx.emit(`store %StringSet* ${value}, %StringSet** ${fieldPtr}`);
     } else if (hasTsType && fiTsType && fiTsType.startsWith("Set<")) {
       this.ctx.emit(`store %Set* ${value}, %Set** ${fieldPtr}`);
-    } else if (
-      hasTsType &&
-      fiTsType &&
-      fiTsType !== "number" &&
-      fiTsType !== "boolean" &&
-      !this.isEnumType(fiTsType)
-    ) {
-      this.ctx.emit(`store i8* ${value}, i8** ${fieldPtr}`);
+    } else if (hasTsType && fiTsType) {
+      const strippedTsType = stripNullable(fiTsType);
+      const classFields = this.ctx.classGenGetClassFields(strippedTsType);
+      if (classFields.length > 0) {
+        const structType = `%${strippedTsType}_struct*`;
+        const valueType = this.ctx.getVariableType(value);
+        if (valueType === structType) {
+          this.ctx.emit(`store ${structType} ${value}, ${structType}* ${fieldPtr}`);
+        } else {
+          const cast = this.ctx.nextTemp();
+          this.ctx.emit(`${cast} = bitcast i8* ${value} to ${structType}`);
+          this.ctx.emit(`store ${structType} ${cast}, ${structType}* ${fieldPtr}`);
+        }
+      } else if (fiTsType !== "number" && fiTsType !== "boolean" && !this.isEnumType(fiTsType)) {
+        this.ctx.emit(`store i8* ${value}, i8** ${fieldPtr}`);
+      } else {
+        this.ctx.emit(`store double ${this.ctx.ensureDouble(value)}, double* ${fieldPtr}`);
+      }
     } else {
       this.ctx.emit(`store double ${this.ctx.ensureDouble(value)}, double* ${fieldPtr}`);
     }

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2630,33 +2630,20 @@ export class VariableAllocator {
     if (!classMeta) return null;
     const className = classMeta.className;
     if (!className) return null;
-    const classFields = this.ctx.classGenGetClassFields(className);
-    for (let i = 0; i < classFields.length; i++) {
-      const cf = classFields[i]!;
-      if (cf.name === memberExpr.property) {
-        const fieldLlvmType = cf.fieldType;
-        if (fieldLlvmType.startsWith("%") && fieldLlvmType.endsWith("_struct*")) {
-          const candidateClass = fieldLlvmType.slice(1, -8);
-          if (this.isKnownClass(candidateClass)) return candidateClass;
-        }
-        if (fieldLlvmType === "i8*") {
-          const ast = this.ctx.getAst();
-          if (ast && ast.classes) {
-            for (let j = 0; j < ast.classes.length; j++) {
-              const cls = ast.classes[j];
-              if (!cls || !cls.fields) continue;
-              if (cls.name !== className) continue;
-              for (let k = 0; k < cls.fields.length; k++) {
-                const field = cls.fields[k] as { name: string; fieldType: string };
-                if (field.name === memberExpr.property) {
-                  const tsType = stripNullable(field.fieldType);
-                  if (this.isKnownClass(tsType)) return tsType;
-                }
-              }
-            }
+    const ast = this.ctx.getAst();
+    if (ast && ast.classes) {
+      for (let j = 0; j < ast.classes.length; j++) {
+        const cls = ast.classes[j];
+        if (!cls || !cls.fields) continue;
+        if (cls.name !== className) continue;
+        for (let k = 0; k < cls.fields.length; k++) {
+          const field = cls.fields[k] as { name: string; fieldType: string; tsType?: string };
+          if (field.name === memberExpr.property) {
+            const rawType = field.tsType || field.fieldType;
+            const tsType = stripNullable(rawType);
+            if (this.isKnownClass(tsType)) return tsType;
           }
         }
-        break;
       }
     }
     return null;

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -3796,9 +3796,10 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         if (!cls || !cls.fields) continue;
         if (cls.name !== className) continue;
         for (let k = 0; k < cls.fields.length; k++) {
-          const field = cls.fields[k] as { name: string; fieldType: string };
+          const field = cls.fields[k] as { name: string; fieldType: string; tsType?: string };
           if (field.name === memberExpr.property) {
-            const tsType = stripNullable(field.fieldType);
+            const rawType = field.tsType || field.fieldType;
+            const tsType = stripNullable(rawType);
             if (this.isKnownClass(tsType)) return tsType;
           }
         }

--- a/tests/fixtures/classes/class-field-class-instance.ts
+++ b/tests/fixtures/classes/class-field-class-instance.ts
@@ -1,4 +1,3 @@
-// @test-skip
 class Node {
   value: number;
   next: Node | null;


### PR DESCRIPTION
## Summary
- Class fields typed as other classes (e.g., `next: Node | null`) now store and load correctly
- Root cause: `getMemberAccessClassName` checked `getClassFields().fieldType` which returns primitive type names (`"double"`) for class-typed fields, missing the actual class type. Now checks `tsType` field from AST class definitions instead
- Also fixes store codegen in `assignment-generator.ts` to bitcast `i8*` values to the correct struct type when storing into class-typed fields
- Unskips `class-field-class-instance` test (was the only compiler-bug skip remaining)

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 0 + Stage 1)
- [x] `class-field-class-instance` test now prints `1 2 3 TEST_PASSED`
- [x] Existing class tests (`class-array-field-access`, `class-array-method-call`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)