### PR TITLE
fix: this.field class-typed field detection for tree traversal

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2624,11 +2624,15 @@ export class VariableAllocator {
     if (e.type !== "member_access") return null;
     const memberExpr = expr as MemberAccessNode;
     const objBase = memberExpr.object as ExprBase;
-    if (objBase.type !== "variable") return null;
-    const varName = (memberExpr.object as VariableNode).name;
-    const classMeta = this.ctx.symbolTable.getClassMetadata(varName);
-    if (!classMeta) return null;
-    const className = classMeta.className;
+    let className: string | null = null;
+    if (objBase.type === "variable") {
+      const varName = (memberExpr.object as VariableNode).name;
+      const classMeta = this.ctx.symbolTable.getClassMetadata(varName);
+      if (!classMeta) return null;
+      className = classMeta.className;
+    } else if (objBase.type === "this") {
+      className = this.ctx.getCurrentClassName();
+    }
     if (!className) return null;
     const ast = this.ctx.getAst();
     if (ast && ast.classes) {

--- a/tests/fixtures/classes/class-recursive-tree.ts
+++ b/tests/fixtures/classes/class-recursive-tree.ts
@@ -1,0 +1,39 @@
+class TreeNode {
+  value: number;
+  left: TreeNode | null;
+  right: TreeNode | null;
+  constructor(value: number) {
+    this.value = value;
+    this.left = null;
+    this.right = null;
+  }
+  sum(): number {
+    let total = this.value;
+    if (this.left !== null) {
+      const l = this.left;
+      total = total + l.sum();
+    }
+    if (this.right !== null) {
+      const r = this.right;
+      total = total + r.sum();
+    }
+    return total;
+  }
+}
+
+function main(): void {
+  const root = new TreeNode(1);
+  root.left = new TreeNode(2);
+  root.right = new TreeNode(3);
+  const leftNode = root.left;
+  leftNode.left = new TreeNode(4);
+  leftNode.right = new TreeNode(5);
+
+  const total = root.sum();
+  console.log(total);
+  if (total === 15) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- `getMemberAccessClassName` now handles `this.field` expressions (previously only handled `variable.field`)
- Enables recursive data structures: `const l = this.left` where `left: TreeNode | null` now correctly tracks `l` as a `TreeNode` instance
- Tree traversal with recursive `sum()` method now works correctly

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 0 + Stage 1)
- [x] New `class-recursive-tree` test: binary tree with depth 3, recursive sum = 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)