### PR TITLE
fix: let variable assigned from class instance now typed correctly

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1450,6 +1450,17 @@ export class VariableAllocator {
       className = this.getIndexAccessClassName(stmt.value) || "Unknown";
     } else if (valueBase.type === "member_access") {
       className = this.getMemberAccessClassName(stmt.value) || "Unknown";
+    } else if (valueBase.type === "variable") {
+      const srcName = (stmt.value as VariableNode).name;
+      const srcMeta = this.ctx.symbolTable.getClassMetadata(srcName);
+      className = srcMeta ? srcMeta.className : "Unknown";
+    } else if (valueBase.type === "ternary") {
+      const resolved = stmt.value ? this.ctx.resolveExpressionType(stmt.value) : null;
+      if (resolved && this.isKnownClass(resolved.base)) {
+        className = resolved.base;
+      } else {
+        className = "Unknown";
+      }
     } else if (stmt.declaredType) {
       className = stripNullable(stmt.declaredType);
     } else {
@@ -1471,9 +1482,14 @@ export class VariableAllocator {
 
     const instancePtr = this.ctx.generateExpression(stmt.value!, params);
     if (fields.length > 0) {
-      const typedPtr = this.ctx.nextTemp();
-      this.ctx.emit(`${typedPtr} = bitcast i8* ${instancePtr} to ${ptrType}`);
-      this.ctx.emit(`store ${ptrType} ${typedPtr}, ${ptrType}* ${allocaReg}`);
+      const valueType = this.ctx.getVariableType(instancePtr);
+      if (valueType === ptrType) {
+        this.ctx.emit(`store ${ptrType} ${instancePtr}, ${ptrType}* ${allocaReg}`);
+      } else {
+        const typedPtr = this.ctx.nextTemp();
+        this.ctx.emit(`${typedPtr} = bitcast i8* ${instancePtr} to ${ptrType}`);
+        this.ctx.emit(`store ${ptrType} ${typedPtr}, ${ptrType}* ${allocaReg}`);
+      }
     } else {
       this.ctx.emit(`store ${ptrType} ${instancePtr}, ${ptrType}* ${allocaReg}`);
     }

--- a/tests/fixtures/classes/class-let-variable-assign.ts
+++ b/tests/fixtures/classes/class-let-variable-assign.ts
@@ -1,0 +1,25 @@
+class Node {
+  value: number;
+  next: Node | null;
+  constructor(value: number) {
+    this.value = value;
+    this.next = null;
+  }
+}
+
+function main(): void {
+  const a = new Node(1);
+  a.next = new Node(2);
+  let current = a;
+  const n = current.next;
+  if (n === null) {
+    console.log("FAIL: n should not be null");
+    return;
+  }
+  console.log(n.value);
+  if (n.value === 2) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Variables assigned from another class instance (`let current = a` where `a` is a `Node`) were allocated as `i8*` instead of `%Node_struct*`, causing segfaults on field access
- Root cause: `allocateClassInstance` had no handler for `variable` expression type — fell through to `className = "Unknown"`, producing `i8*` alloca
- Also added `ternary` expression handler for class instances from conditional expressions
- Skip unnecessary bitcast when source value already has the correct struct pointer type

## Test plan
- [x] New test: `class-let-variable-assign.ts` — linked list traversal via `let` variable
- [x] All 708 tests pass
- [x] Self-hosting verification passes (Stage 0 + Stage 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)