### PR TITLE
fix: for...of on class arrays now accesses fields correctly

### DIFF
--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -33,6 +33,7 @@ import {
   ObjectMetadata,
   createObjectMetadata,
   createObjectMetadataWithInterface,
+  createClassMetadata,
 } from "../infrastructure/symbol-table.js";
 import type { UnionCommonFields } from "../infrastructure/type-resolver/index.js";
 import type { FieldInfo } from "../infrastructure/type-resolver/types.js";
@@ -486,6 +487,10 @@ export class ControlFlowGenerator {
             elementKind = SymbolKind.Array;
           }
         }
+        const rawElemType = this.ctx.symbolTable.getRawInterfaceType(varName);
+        if (rawElemType && this.ctx.classGenGetClassFields(rawElemType).length > 0) {
+          elementKind = SymbolKind.Class;
+        }
       }
     } else {
       arrayType = "%Array";
@@ -505,22 +510,43 @@ export class ControlFlowGenerator {
     this.ctx.emitStore("i32", "0", indexAlloca);
 
     let actualElementType = elementType;
+    let forOfClassName = "";
     if (elementKind === SymbolKind.StringArray) {
       actualElementType = "%StringArray*";
     } else if (elementKind === SymbolKind.Array && isObjectArray) {
       actualElementType = "%Array*";
+    } else if (elementKind === SymbolKind.Class && isObjectArray) {
+      const iterBase = forOfStmt.iterable as ExprBase;
+      if (iterBase.type === "variable") {
+        const vn = (forOfStmt.iterable as VariableNode).name;
+        forOfClassName = this.ctx.symbolTable.getRawInterfaceType(vn) || "";
+      }
+      if (forOfClassName) {
+        actualElementType = `%${forOfClassName}_struct*`;
+      }
     }
 
     const elemAlloca = this.ctx.nextAllocaReg(forOfStmt.variableName);
     this.emit(`${elemAlloca} = alloca ${actualElementType}`);
 
-    this.ctx.defineVariable(
-      forOfStmt.variableName,
-      elemAlloca,
-      actualElementType,
-      elementKind,
-      "local",
-    );
+    if (elementKind === SymbolKind.Class && forOfClassName) {
+      this.ctx.defineVariableWithMetadata(
+        forOfStmt.variableName,
+        elemAlloca,
+        actualElementType,
+        SymbolKind.Class,
+        "local",
+        createClassMetadata({ className: forOfClassName }),
+      );
+    } else {
+      this.ctx.defineVariable(
+        forOfStmt.variableName,
+        elemAlloca,
+        actualElementType,
+        elementKind,
+        "local",
+      );
+    }
 
     if (elementKind === SymbolKind.StringArray) {
       this.ctx.symbolTable.setResolvedType(

--- a/tests/fixtures/classes/class-forof-array.ts
+++ b/tests/fixtures/classes/class-forof-array.ts
@@ -1,0 +1,24 @@
+class Item {
+  name: string;
+  value: number;
+  constructor(name: string, value: number) {
+    this.name = name;
+    this.value = value;
+  }
+}
+
+const items: Item[] = [];
+items.push(new Item("a", 10));
+items.push(new Item("b", 20));
+items.push(new Item("c", 30));
+
+let total = 0;
+let names = "";
+for (const item of items) {
+  total = total + item.value;
+  names = names + item.name;
+}
+
+if (total === 60 && names === "abc") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `for (const item of classArray)` now correctly accesses class fields like `item.value` and `item.name`
- Previously, the loop variable was allocated as an opaque `i8*` pointer, so field access would convert the pointer address to a number instead of doing a struct GEP
- The fix detects class element types from the iterable's metadata and registers the loop variable as a `SymbolKind.Class` with the correct `%ClassName_struct*` type

## Test plan
- [x] New test fixture `classes/class-forof-array.ts` — iterates `Item[]`, sums `.value` and concatenates `.name`
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)