### PR TITLE
fix: for...of on class arrays from function/method returns

### DIFF
--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -487,10 +487,10 @@ export class ControlFlowGenerator {
             elementKind = SymbolKind.Array;
           }
         }
-        const rawElemType = this.ctx.symbolTable.getRawInterfaceType(varName);
-        if (rawElemType && this.ctx.classGenGetClassFields(rawElemType).length > 0) {
-          elementKind = SymbolKind.Class;
-        }
+      }
+      const classElemType = this.getIterableClassElementType(forOfStmt.iterable);
+      if (classElemType) {
+        elementKind = SymbolKind.Class;
       }
     } else {
       arrayType = "%Array";
@@ -516,11 +516,7 @@ export class ControlFlowGenerator {
     } else if (elementKind === SymbolKind.Array && isObjectArray) {
       actualElementType = "%Array*";
     } else if (elementKind === SymbolKind.Class && isObjectArray) {
-      const iterBase = forOfStmt.iterable as ExprBase;
-      if (iterBase.type === "variable") {
-        const vn = (forOfStmt.iterable as VariableNode).name;
-        forOfClassName = this.ctx.symbolTable.getRawInterfaceType(vn) || "";
-      }
+      forOfClassName = this.getIterableClassElementType(forOfStmt.iterable) || "";
       if (forOfClassName) {
         actualElementType = `%${forOfClassName}_struct*`;
       }
@@ -1022,6 +1018,64 @@ export class ControlFlowGenerator {
       }
     }
 
+    return null;
+  }
+
+  private getIterableClassElementType(iterable: Expression): string | null {
+    const iterBase = iterable as ExprBase;
+    if (iterBase.type === "variable") {
+      const varName = (iterable as VariableNode).name;
+      const rawElemType = this.ctx.symbolTable.getRawInterfaceType(varName);
+      if (rawElemType && this.ctx.classGenGetClassFields(rawElemType).length > 0) {
+        return rawElemType;
+      }
+    }
+    if (iterBase.type === "call") {
+      const callNode = iterable as CallNode;
+      const ast = this.ctx.getAst();
+      if (ast && ast.functions) {
+        for (let i = 0; i < ast.functions.length; i++) {
+          const func = ast.functions[i];
+          if (!func || func.name !== callNode.name) continue;
+          const retType = func.returnType;
+          if (retType && retType.endsWith("[]")) {
+            const elemName = retType.slice(0, -2).trim();
+            if (this.ctx.classGenGetClassFields(elemName).length > 0) {
+              return elemName;
+            }
+          }
+        }
+      }
+    }
+    if (iterBase.type === "method_call") {
+      const mcNode = iterable as MethodCallNode;
+      const objBase = mcNode.object as ExprBase;
+      if (objBase.type === "variable") {
+        const objName = (mcNode.object as VariableNode).name;
+        const classMeta = this.ctx.symbolTable.getClassMetadata(objName);
+        if (classMeta) {
+          const className = classMeta.className;
+          const ast = this.ctx.getAst();
+          if (ast && ast.classes) {
+            for (let i = 0; i < ast.classes.length; i++) {
+              const cls = ast.classes[i];
+              if (!cls || cls.name !== className) continue;
+              for (let j = 0; j < cls.methods.length; j++) {
+                const method = cls.methods[j];
+                if (!method || method.name !== mcNode.method) continue;
+                const retType = method.returnType;
+                if (retType && retType.endsWith("[]")) {
+                  const elemName = retType.slice(0, -2).trim();
+                  if (this.ctx.classGenGetClassFields(elemName).length > 0) {
+                    return elemName;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     return null;
   }
 

--- a/tests/fixtures/classes/class-forof-method-call.ts
+++ b/tests/fixtures/classes/class-forof-method-call.ts
@@ -1,0 +1,37 @@
+class Entry {
+  key: string;
+  val: number;
+  constructor(key: string, val: number) {
+    this.key = key;
+    this.val = val;
+  }
+}
+
+class Store {
+  entries: Entry[];
+  constructor() {
+    this.entries = [];
+  }
+  add(key: string, val: number): void {
+    this.entries.push(new Entry(key, val));
+  }
+  getAll(): Entry[] {
+    return this.entries;
+  }
+}
+
+const store = new Store();
+store.add("a", 1);
+store.add("b", 2);
+store.add("c", 3);
+
+let sum = 0;
+let keys = "";
+for (const e of store.getAll()) {
+  sum = sum + e.val;
+  keys = keys + e.key;
+}
+
+if (sum === 6 && keys === "abc") {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/classes/class-forof-method-return.ts
+++ b/tests/fixtures/classes/class-forof-method-return.ts
@@ -1,0 +1,27 @@
+class Task {
+  name: string;
+  priority: number;
+  constructor(name: string, priority: number) {
+    this.name = name;
+    this.priority = priority;
+  }
+}
+
+function getTasks(): Task[] {
+  const tasks: Task[] = [];
+  tasks.push(new Task("build", 1));
+  tasks.push(new Task("test", 2));
+  tasks.push(new Task("deploy", 3));
+  return tasks;
+}
+
+let total = 0;
+let names = "";
+for (const task of getTasks()) {
+  total = total + task.priority;
+  names = names + task.name;
+}
+
+if (total === 6 && names === "buildtestdeploy") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Extends the for...of class array fix (#375) to handle class arrays returned by functions and class methods
- `for (const item of getItems())` and `for (const e of store.getAll())` now correctly access class fields
- Extracts a reusable `getIterableClassElementType()` helper that resolves class element types from variables, function calls, and method calls

## Test plan
- [x] `class-forof-method-return.ts` — iterates `Task[]` from standalone function return
- [x] `class-forof-method-call.ts` — iterates `Entry[]` from class method return
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)