### PR TITLE
fix: for...of on class arrays from member access (this.field, obj.field)

### DIFF
--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -1047,6 +1047,27 @@ export class ControlFlowGenerator {
         }
       }
     }
+    if (iterBase.type === "member_access") {
+      const ma = iterable as MemberAccessNode;
+      const objBase = ma.object as ExprBase;
+      let ownerClassName: string | null = null;
+      if (objBase.type === "this") {
+        ownerClassName = this.ctx.getCurrentClassName() || null;
+      } else if (objBase.type === "variable") {
+        const objName = (ma.object as VariableNode).name;
+        const cm = this.ctx.symbolTable.getClassMetadata(objName);
+        if (cm) ownerClassName = cm.className;
+      }
+      if (ownerClassName) {
+        const fieldTsType = this.ctx.classGenGetFieldTsType(ownerClassName, ma.property);
+        if (fieldTsType && fieldTsType.endsWith("[]")) {
+          const elemName = fieldTsType.slice(0, -2).trim();
+          if (this.ctx.classGenGetClassFields(elemName).length > 0) {
+            return elemName;
+          }
+        }
+      }
+    }
     if (iterBase.type === "method_call") {
       const mcNode = iterable as MethodCallNode;
       const objBase = mcNode.object as ExprBase;

--- a/tests/fixtures/classes/class-forof-this-field.ts
+++ b/tests/fixtures/classes/class-forof-this-field.ts
@@ -1,0 +1,34 @@
+class Point {
+  x: number;
+  y: number;
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+}
+
+class Shape {
+  points: Point[];
+  constructor() {
+    this.points = [];
+  }
+  addPoint(x: number, y: number): void {
+    this.points.push(new Point(x, y));
+  }
+  totalX(): number {
+    let sum = 0;
+    for (const p of this.points) {
+      sum = sum + p.x;
+    }
+    return sum;
+  }
+}
+
+const s = new Shape();
+s.addPoint(10, 20);
+s.addPoint(30, 40);
+s.addPoint(50, 60);
+
+if (s.totalX() === 90) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/classes/class-nested-field-access.ts
+++ b/tests/fixtures/classes/class-nested-field-access.ts
@@ -1,0 +1,20 @@
+class Inner {
+  value: number;
+  constructor(value: number) {
+    this.value = value;
+  }
+}
+
+class Outer {
+  inner: Inner;
+  name: string;
+  constructor(name: string, val: number) {
+    this.name = name;
+    this.inner = new Inner(val);
+  }
+}
+
+const obj = new Outer("test", 42);
+if (obj.inner.value === 42 && obj.name === "test") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `for (const p of this.points)` and `for (const p of obj.field)` now correctly access class fields when the array element type is a class
- Extends the `getIterableClassElementType()` helper to resolve class element types from member access expressions on `this` and on class instance variables
- Also adds test for nested class field access (`obj.inner.value`)

## Test plan
- [x] `class-forof-this-field.ts` — iterates `this.points` (Point[]) inside class method, accesses `.x`
- [x] `class-nested-field-access.ts` — accesses `obj.inner.value` (nested class field)
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)