### PR TITLE
fix: nullable class/interface params now correctly access fields

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -309,12 +309,20 @@ export class FunctionGenerator {
           this.ctx.defineVariable(paramName, allocaReg, "i8*", SymbolKind.Pointer, "local");
         } else {
           const ast = this.ctx.getAst();
+          let strippedParamType = paramTypes[i];
+          if (strippedParamType.indexOf(" | ") !== -1) {
+            strippedParamType = strippedParamType
+              .split(" | ")
+              .filter((p: string) => p.trim() !== "null" && p.trim() !== "undefined")
+              .join(" | ")
+              .trim();
+          }
           let classDefName: string = "";
           const classes = ast ? ast.classes || [] : [];
           for (let jc = 0; jc < classes.length; jc++) {
             const cls = classes[jc] as ClassNode;
             if (!cls || !cls.name) continue;
-            if (cls.name === paramTypes[i]) {
+            if (cls.name === strippedParamType) {
               classDefName = cls.name;
               break;
             }
@@ -326,7 +334,7 @@ export class FunctionGenerator {
           for (let ji = 0; ji < interfaces.length; ji++) {
             const iface = interfaces[ji] as InterfaceDeclaration;
             if (!iface || !iface.name) continue;
-            if (iface.name === paramTypes[i]) {
+            if (iface.name === strippedParamType) {
               interfaceDefName = iface.name;
               interfaceDefFields = this.ctx.getAllInterfaceFields(iface);
               break;

--- a/tests/fixtures/classes/class-nullable-param.ts
+++ b/tests/fixtures/classes/class-nullable-param.ts
@@ -1,0 +1,30 @@
+class Node {
+  value: number;
+  next: Node | null;
+  constructor(value: number) {
+    this.value = value;
+    this.next = null;
+  }
+}
+
+function sumList(node: Node | null): number {
+  if (node === null) {
+    return 0;
+  }
+  return node.value + sumList(node.next);
+}
+
+function main(): void {
+  const c = new Node(30);
+  const b = new Node(20);
+  b.next = c;
+  const a = new Node(10);
+  a.next = b;
+
+  const result = sumList(a);
+  if (result === 60) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- `function sumList(node: Node | null)` no longer segfaults — `node.value` after a null guard now works correctly
- Root cause: function parameter type `"Node | null"` didn't match class name `"Node"` in the parameter setup loop, so the param was registered as a generic `i8*` object instead of a class instance with struct metadata
- Fix: strip `| null` and `| undefined` from parameter types before looking up class/interface definitions
- Also fixes the same issue for interface-typed nullable params

## Test plan
- [x] `class-nullable-param.ts` — recursive linked list sum with `Node | null` param
- [x] Verified interface nullable params also work
- [x] `npm run verify:quick` passes (all tests + Stage 1 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)