### PR TITLE
fix: support chained member access assignment (a.next.next = value)

### DIFF
--- a/src/codegen/expressions/method-calls/class-dispatch.ts
+++ b/src/codegen/expressions/method-calls/class-dispatch.ts
@@ -699,6 +699,26 @@ export function handleClassMethods(
           }
         }
       }
+    } else if (baseExprBase.type === "variable") {
+      const varName = (baseExpr as VariableNode).name;
+      const rawType = ctx.symbolTable.getRawInterfaceType(varName);
+      if (rawType) {
+        const resolvedClass = findClassWithMethod(ctx, rawType, method);
+        if (resolvedClass) {
+          instancePtr = ctx.generateExpression(expr.object, params);
+          className = resolvedClass;
+        }
+      }
+      if (!className) {
+        const objArrayMeta = ctx.symbolTable.getObjectArrayMetadata(varName);
+        if (objArrayMeta && objArrayMeta.elementInterfaceName) {
+          const resolvedClass = findClassWithMethod(ctx, objArrayMeta.elementInterfaceName, method);
+          if (resolvedClass) {
+            instancePtr = ctx.generateExpression(expr.object, params);
+            className = resolvedClass;
+          }
+        }
+      }
     }
   } else if (exprObjBase.type === "super") {
     const thisPtr = ctx.getThisPointer();

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -145,9 +145,22 @@ export class AssignmentGenerator {
           className = classWithField.name;
         }
       }
-    } else if (objType === "member_access" && property === "length") {
-      this.handleArrayLengthAssignment(object as MemberAccessNode, memberAccessValue, params);
-      return;
+    } else if (objType === "member_access") {
+      if (property === "length") {
+        this.handleArrayLengthAssignment(object as MemberAccessNode, memberAccessValue, params);
+        return;
+      }
+      const resolvedClass = this.resolveClassFromMemberAccess(object as MemberAccessNode);
+      if (resolvedClass) {
+        this.handleChainedMemberAccessAssignment(
+          object as MemberAccessNode,
+          resolvedClass,
+          property,
+          memberAccessValue,
+          params,
+        );
+        return;
+      }
     } else if (objType === "index_access") {
       this.handleIndexAccessPropertyAssignment(
         object as IndexAccessNode,
@@ -308,6 +321,77 @@ export class AssignmentGenerator {
           ". Did you forget to declare it with a type annotation?",
       );
     }
+  }
+
+  private resolveClassFromMemberAccess(expr: MemberAccessNode): string | null {
+    const innerObj = expr.object as { type: string };
+    let ownerClass: string | null = null;
+
+    if (innerObj.type === "variable") {
+      const varName = (expr.object as VariableNode).name;
+      if (this.ctx.symbolTable.isClass(varName)) {
+        const classMeta = this.ctx.symbolTable.getClassInfo(varName)!;
+        ownerClass = classMeta.className;
+      }
+    } else if (innerObj.type === "this") {
+      ownerClass = this.ctx.getCurrentClassName();
+    } else if (innerObj.type === "member_access") {
+      ownerClass = this.resolveClassFromMemberAccess(expr.object as MemberAccessNode);
+    }
+
+    if (!ownerClass) return null;
+
+    const fieldInfo = this.ctx.classGenGetFieldInfo(ownerClass, expr.property);
+    if (!fieldInfo) return null;
+    const fi = fieldInfo as FieldInfo;
+    if (!fi.tsType) return null;
+
+    const strippedType = stripNullable(fi.tsType);
+    const classFields = this.ctx.classGenGetClassFields(strippedType);
+    if (classFields.length > 0) return strippedType;
+
+    return null;
+  }
+
+  private handleChainedMemberAccessAssignment(
+    object: MemberAccessNode,
+    targetClassName: string,
+    property: string,
+    memberAccessValue: MemberAccessAssignmentNode,
+    params: string[],
+  ): void {
+    const fieldInfoResult = this.ctx.classGenGetFieldInfo(targetClassName, property);
+    if (!fieldInfoResult) {
+      return this.ctx.emitError(`Field '${property}' not found in class ${targetClassName}`);
+    }
+    const fi = fieldInfoResult as FieldInfo;
+
+    if (fi.tsType && fi.tsType.startsWith("Map<string,")) {
+      this.ctx.setCurrentDeclaredMapType(fi.tsType);
+    }
+    if (fi.tsType && fi.tsType.startsWith("Set<")) {
+      this.ctx.setCurrentDeclaredSetType(fi.tsType);
+    }
+
+    const value = this.ctx.generateExpression(memberAccessValue.value, params);
+    this.ctx.setCurrentDeclaredMapType(undefined);
+    this.ctx.setCurrentDeclaredSetType(undefined);
+
+    const objPtr = this.ctx.generateExpression(object, params);
+    const structType = `%${targetClassName}_struct`;
+    const varType = this.ctx.getVariableType(objPtr);
+    let typedPtr: string;
+    if (varType === `${structType}*`) {
+      typedPtr = objPtr;
+    } else {
+      typedPtr = this.ctx.emitBitcast(objPtr, "i8*", `${structType}*`);
+    }
+
+    const fieldPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${fieldPtr} = getelementptr inbounds ${structType}, ${structType}* ${typedPtr}, i32 0, i32 ${fi.index}`,
+    );
+    this.storeFieldValueDirect(fi.type, fi.tsType || null, fieldPtr, value, memberAccessValue);
   }
 
   private storeFieldValueDirect(

--- a/tests/fixtures/classes/class-bst-insert.ts
+++ b/tests/fixtures/classes/class-bst-insert.ts
@@ -1,0 +1,53 @@
+class TreeNode {
+  value: number;
+  left: TreeNode | null;
+  right: TreeNode | null;
+  constructor(value: number) {
+    this.value = value;
+    this.left = null;
+    this.right = null;
+  }
+}
+
+function insert(root: TreeNode | null, value: number): TreeNode {
+  if (root === null) {
+    return new TreeNode(value);
+  }
+  if (value < root.value) {
+    root.left = insert(root.left, value);
+  } else {
+    root.right = insert(root.right, value);
+  }
+  return root;
+}
+
+function sumTree(node: TreeNode | null): number {
+  if (node === null) {
+    return 0;
+  }
+  return node.value + sumTree(node.left) + sumTree(node.right);
+}
+
+function countNodes(node: TreeNode | null): number {
+  if (node === null) {
+    return 0;
+  }
+  return 1 + countNodes(node.left) + countNodes(node.right);
+}
+
+function main(): void {
+  let root: TreeNode | null = null;
+  root = insert(root, 5);
+  root = insert(root, 3);
+  root = insert(root, 7);
+  root = insert(root, 1);
+  root = insert(root, 9);
+
+  const sum = sumTree(root);
+  const count = countNodes(root);
+  if (sum === 25 && count === 5) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();

--- a/tests/fixtures/classes/class-chained-member-assign.ts
+++ b/tests/fixtures/classes/class-chained-member-assign.ts
@@ -1,0 +1,28 @@
+class ListNode {
+  value: number;
+  next: ListNode | null;
+  constructor(value: number) {
+    this.value = value;
+    this.next = null;
+  }
+}
+
+function main(): void {
+  const a = new ListNode(1);
+  const b = new ListNode(2);
+  const c = new ListNode(3);
+  a.next = b;
+  a.next.next = c;
+
+  let sum = a.value;
+  let cur = a.next;
+  while (cur !== null) {
+    sum = sum + cur.value;
+    cur = cur.next;
+  }
+  if (sum === 6) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();

--- a/tests/fixtures/classes/class-chained-this-assign.ts
+++ b/tests/fixtures/classes/class-chained-this-assign.ts
@@ -1,0 +1,35 @@
+class Inner {
+  count: number;
+  label: string;
+  constructor(count: number, label: string) {
+    this.count = count;
+    this.label = label;
+  }
+}
+
+class Outer {
+  inner: Inner;
+  constructor(inner: Inner) {
+    this.inner = inner;
+  }
+
+  updateCount(n: number): void {
+    this.inner.count = n;
+  }
+
+  updateLabel(s: string): void {
+    this.inner.label = s;
+  }
+}
+
+function main(): void {
+  const inner = new Inner(0, "start");
+  const outer = new Outer(inner);
+  outer.updateCount(42);
+  outer.updateLabel("done");
+  if (outer.inner.count === 42 && outer.inner.label === "done") {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();

--- a/tests/fixtures/classes/class-index-method-call.ts
+++ b/tests/fixtures/classes/class-index-method-call.ts
@@ -1,0 +1,24 @@
+class Counter {
+  count: number;
+  constructor() {
+    this.count = 0;
+  }
+
+  increment(): void {
+    this.count = this.count + 1;
+  }
+}
+
+function main(): void {
+  const items: Counter[] = [];
+  items.push(new Counter());
+  items.push(new Counter());
+  items[0].increment();
+  items[0].increment();
+  items[1].increment();
+  if (items[0].count === 2 && items[1].count === 1) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- `a.next.next = value` and `this.inner.count = n` now work — previously produced a compile error ("unable to determine class for object of type 'member_access'")
- Resolves class type by walking the member access chain: variable → field tsType → strip nullable → check if known class
- Supports arbitrary depth chaining and works from both variable and `this` contexts

## Test plan
- [x] `class-chained-member-assign.ts` — linked list `a.next.next = c`, traverse and sum
- [x] `class-chained-this-assign.ts` — `this.inner.count = n` and `this.inner.label = s` from methods
- [x] All existing tests pass
- [x] Self-hosting Stage 1 passes