### PR TITLE
fix: this.classArray[i].field and variable[i].method() now work correctly

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -1863,6 +1863,40 @@ export class MemberAccessGenerator {
           return elemType;
         }
       }
+    } else if (arrayExpr.type === "member_access") {
+      const memberAccess = arrayExpr as MemberAccessNode;
+      const memberObjBase = memberAccess.object as { type: string };
+      let ownerClassName: string | null = null;
+      if (memberObjBase.type === "this") {
+        ownerClassName = this.ctx.getCurrentClassName();
+      } else if (memberObjBase.type === "variable") {
+        const vn = (memberAccess.object as VariableNode).name;
+        if (this.ctx.symbolTable.isClass(vn)) {
+          const cm = this.ctx.symbolTable.getClassInfo(vn);
+          if (cm) ownerClassName = cm.className;
+        }
+      }
+      if (ownerClassName) {
+        const fieldInfo = this.ctx.classGenGetFieldInfo(ownerClassName, memberAccess.property);
+        if (fieldInfo) {
+          const fi = fieldInfo as FieldInfo;
+          if (fi.tsType) {
+            let tsType = fi.tsType;
+            if (tsType.indexOf(" | ") !== -1) {
+              tsType = tsType
+                .replace(/ \| undefined/g, "")
+                .replace(/ \| null/g, "")
+                .trim();
+            }
+            if (tsType.endsWith("[]")) {
+              const elemType = tsType.substring(0, tsType.length - 2);
+              if (this.ctx.classGenGetClassFields(elemType).length > 0) {
+                return elemType;
+              }
+            }
+          }
+        }
+      }
     }
     return null;
   }

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -2688,6 +2688,35 @@ export class VariableAllocator {
       ) {
         return objArrayMeta.elementInterfaceName;
       }
+    } else if (objBase.type === "member_access") {
+      const memberAccess = indexExpr.object as MemberAccessNode;
+      const memberObjBase = memberAccess.object as ExprBase;
+      let ownerClassName: string | null = null;
+      if (memberObjBase.type === "this") {
+        ownerClassName = this.ctx.getCurrentClassName();
+      } else if (memberObjBase.type === "variable") {
+        const vn = (memberAccess.object as VariableNode).name;
+        if (this.ctx.symbolTable.isClass(vn)) {
+          const cm = this.ctx.symbolTable.getClassInfo(vn);
+          if (cm) ownerClassName = cm.className;
+        }
+      }
+      if (ownerClassName) {
+        const fieldInfo = this.ctx.classGenGetFieldInfo(ownerClassName, memberAccess.property);
+        if (fieldInfo && fieldInfo.tsType) {
+          let tsType = fieldInfo.tsType;
+          if (tsType.indexOf(" | ") !== -1) {
+            tsType = tsType
+              .replace(/ \| undefined/g, "")
+              .replace(/ \| null/g, "")
+              .trim();
+          }
+          if (tsType.endsWith("[]")) {
+            const elemType = tsType.substring(0, tsType.length - 2);
+            if (this.isKnownClass(elemType)) return elemType;
+          }
+        }
+      }
     }
     return null;
   }

--- a/tests/fixtures/classes/class-this-array-index.ts
+++ b/tests/fixtures/classes/class-this-array-index.ts
@@ -1,0 +1,50 @@
+class Item {
+  name: string;
+  value: number;
+  constructor(name: string, value: number) {
+    this.name = name;
+    this.value = value;
+  }
+}
+
+class Container {
+  items: Item[];
+  constructor() {
+    this.items = [];
+  }
+
+  add(name: string, value: number): void {
+    this.items.push(new Item(name, value));
+  }
+
+  lookup(target: string): Item | null {
+    for (let i = 0; i < this.items.length; i++) {
+      const e = this.items[i];
+      if (e.name === target) {
+        return e;
+      }
+    }
+    return null;
+  }
+
+  total(): number {
+    let sum = 0;
+    for (let i = 0; i < this.items.length; i++) {
+      sum = sum + this.items[i].value;
+    }
+    return sum;
+  }
+}
+
+function main(): void {
+  const c = new Container();
+  c.add("x", 10);
+  c.add("y", 20);
+  c.add("z", 30);
+  const found = c.lookup("y");
+  if (found !== null && found.value === 20 && c.total() === 60) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- `this.items[i].value` inside class methods now correctly resolves the element as a class instance instead of raw `i8*` — previously returned garbage memory
- `variable[i].method()` on class arrays now dispatches to the correct class method — previously errored with "Method not supported"
- Both variable-allocator and member-access expression codegen now handle `member_access` base expressions in index access patterns

## Test plan
- [x] `class-this-array-index.ts` — Container with Item[] field, lookup and total methods accessing this.items[i]
- [x] All existing tests pass
- [x] Self-hosting Stage 1 passes