### PR TITLE
fix: class array .map() with numeric return type no longer crashes

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -19,6 +19,7 @@ import {
   UnaryNode,
   MapNode,
   SetNode,
+  ArrowFunctionNode,
 } from "../../ast/types.js";
 import { SymbolTable, SymbolKind } from "./symbol-table.js";
 import type { TypeChecker } from "../../typescript/type-checker.js";
@@ -585,9 +586,26 @@ export class TypeInference {
       if (objResolved) return objResolved;
     }
 
+    if (method === "map") {
+      if (expr.args.length === 1) {
+        const cb = expr.args[0] as Expression;
+        const cbBase = cb as { type: string };
+        if (cbBase.type === "arrow_function") {
+          const arrow = cb as ArrowFunctionNode;
+          if (arrow.returnType === "number" || arrow.returnType === "boolean") {
+            return this.ctx.typeContext.getArrayType(arrow.returnType);
+          }
+          if (arrow.returnType === "string") {
+            return this.ctx.typeContext.getArrayType("string");
+          }
+        }
+      }
+      const objResolved = this.resolveExpressionType(expr.object);
+      if (objResolved && objResolved.arrayDepth > 0) return objResolved;
+    }
+
     if (
       method === "filter" ||
-      method === "map" ||
       method === "sort" ||
       method === "reverse" ||
       method === "flat" ||
@@ -1389,6 +1407,9 @@ export class TypeInference {
       return false;
     }
     if (e.type === "variable") {
+      const varName = (expr as VariableNode).name;
+      const kind = this.ctx.symbolTable.getKind(varName);
+      if (kind === SymbolKind.Array) return false;
       const resolved = this.resolveExpressionType(expr);
       if (resolved && resolved.arrayDepth > 0) {
         if (resolved.arrayDepth > 1) {

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -27,6 +27,7 @@ import {
   MapNode,
   SetNode,
   AwaitExpressionNode,
+  ArrowFunctionNode,
   SourceLocation,
 } from "../../ast/types.js";
 import {
@@ -858,6 +859,23 @@ export class VariableAllocator {
       if (genericReturn === "string") isString = true;
       else if (genericReturn === "string[]") isStringArray = true;
       else if (genericReturn && genericReturn.endsWith("[]")) isObjectArray = true;
+    }
+
+    if (
+      (isObjectArray || isStringArray) &&
+      nodeType === "method_call" &&
+      (stmtValue as MethodCallNode).method === "map" &&
+      (stmtValue as MethodCallNode).args.length === 1
+    ) {
+      const mapArg = (stmtValue as MethodCallNode).args[0];
+      if (mapArg.type === "arrow_function") {
+        const arrowRet = (mapArg as ArrowFunctionNode).returnType;
+        if (arrowRet === "number" || arrowRet === "boolean") {
+          isObjectArray = false;
+          isStringArray = false;
+          isArray = true;
+        }
+      }
     }
 
     const classification = this.classifyVariable(

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -815,16 +815,22 @@ export function generateArrayMap(
   const callbackArg = expr.args[0];
   const paramCount = getCallbackParamCount(callbackArg as ExprBase);
   let callbackFn: string;
+  let arrowReturnType = "";
   if (callbackArg.type === "variable") {
     callbackFn = gen.mangleUserName((callbackArg as VariableNode).name);
   } else if (callbackArg.type === "arrow_function") {
+    arrowReturnType = (callbackArg as ArrowFunctionNode).returnType || "";
     if (isStringArray || isObjectArray) {
       if (paramCount >= 2) {
         gen.setExpectedCallbackParamTypes([elementType || "string", "number"]);
       } else {
         gen.setExpectedCallbackParamType(elementType || "string");
       }
-      gen.setExpectedCallbackReturnType("string");
+      if (arrowReturnType === "number" || arrowReturnType === "boolean") {
+        gen.setExpectedCallbackReturnType("number");
+      } else {
+        gen.setExpectedCallbackReturnType("string");
+      }
     } else {
       if (paramCount >= 2) {
         gen.setExpectedCallbackParamTypes(["number", "number"]);
@@ -840,7 +846,10 @@ export function generateArrayMap(
   }
 
   let result: string;
-  if (isStringArray || isObjectArray) {
+  const callbackReturnsNumber = arrowReturnType === "number" || arrowReturnType === "boolean";
+  if (isObjectArray && callbackReturnsNumber) {
+    result = generateObjectArrayToNumericMap(gen, arrayPtr, callbackFn, paramCount);
+  } else if (isStringArray || isObjectArray) {
     result = generateStringArrayMapImpl(gen, arrayPtr, callbackFn, paramCount);
   } else {
     result = generateNumericArrayMap(gen, arrayPtr, callbackFn, paramCount);
@@ -954,6 +963,98 @@ function generateNumericArrayMap(
     "double",
     `@${callbackFn}`,
     buildIterCallArgsWithIndex(gen, `double ${elem}`, counter, paramCount),
+  );
+
+  const resultElemPtr = gen.nextTemp();
+  gen.emit(
+    `${resultElemPtr} = getelementptr inbounds double, double* ${resultDataPtr}, i32 ${counter}`,
+  );
+  gen.emitStore("double", result, resultElemPtr);
+
+  const nextCounter = gen.nextTemp();
+  gen.emit(`${nextCounter} = add i32 ${counter}, 1`);
+  gen.emitStore("i32", nextCounter, counterPtr);
+  gen.emitBr(checkLabel);
+
+  gen.emitLabel(endLabel);
+  gen.setVariableType(resultArrayPtr, "%Array*");
+  return resultArrayPtr;
+}
+
+function generateObjectArrayToNumericMap(
+  gen: IGeneratorContext,
+  arrayPtr: string,
+  callbackFn: string,
+  paramCount: number = 1,
+): string {
+  const lenPtr = gen.nextTemp();
+  gen.emit(
+    `${lenPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
+  );
+  const length = gen.emitLoad("i32", lenPtr);
+
+  const dataPtrField = gen.nextTemp();
+  gen.emit(
+    `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+  );
+  const dataPtr = gen.nextTemp();
+  gen.emit(`${dataPtr} = load i8*, i8** ${dataPtrField}`);
+  const dataPtrAsI8pp = gen.emitBitcast(dataPtr, "i8*", "i8**");
+
+  const resultArrayMem = gen.emitCall("i8*", "@GC_malloc", "i64 24");
+  const resultArrayPtr = gen.emitBitcast(resultArrayMem, "i8*", "%Array*");
+
+  const doubleSize = 8;
+  const lengthI64 = gen.nextTemp();
+  gen.emit(`${lengthI64} = zext i32 ${length} to i64`);
+  const resultSizeI64 = gen.nextTemp();
+  gen.emit(`${resultSizeI64} = mul i64 ${lengthI64}, ${doubleSize}`);
+  const resultMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${resultSizeI64}`);
+  const resultDataPtr = gen.emitBitcast(resultMem, "i8*", "double*");
+
+  const resultDataPtrField = gen.nextTemp();
+  gen.emit(
+    `${resultDataPtrField} = getelementptr inbounds %Array, %Array* ${resultArrayPtr}, i32 0, i32 0`,
+  );
+  gen.emit(`store double* ${resultDataPtr}, double** ${resultDataPtrField}`);
+
+  const resultLenField = gen.nextTemp();
+  gen.emit(
+    `${resultLenField} = getelementptr inbounds %Array, %Array* ${resultArrayPtr}, i32 0, i32 1`,
+  );
+  gen.emitStore("i32", length, resultLenField);
+
+  const resultCapField = gen.nextTemp();
+  gen.emit(
+    `${resultCapField} = getelementptr inbounds %Array, %Array* ${resultArrayPtr}, i32 0, i32 2`,
+  );
+  gen.emitStore("i32", length, resultCapField);
+
+  const counterPtr = gen.nextTemp();
+  gen.emit(`${counterPtr} = alloca i32`);
+  gen.emitStore("i32", "0", counterPtr);
+
+  const checkLabel = gen.nextLabel("objnummap_check");
+  const bodyLabel = gen.nextLabel("objnummap_body");
+  const endLabel = gen.nextLabel("objnummap_end");
+
+  gen.emitBr(checkLabel);
+
+  gen.emitLabel(checkLabel);
+  const counter = gen.emitLoad("i32", counterPtr);
+  const cond = gen.emitIcmp("slt", "i32", counter, length);
+  gen.emitBrCond(cond, bodyLabel, endLabel);
+
+  gen.emitLabel(bodyLabel);
+  const elemPtr = gen.nextTemp();
+  gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtrAsI8pp}, i32 ${counter}`);
+  const elem = gen.nextTemp();
+  gen.emit(`${elem} = load i8*, i8** ${elemPtr}`);
+
+  const result = gen.emitCall(
+    "double",
+    `@${callbackFn}`,
+    buildIterCallArgsWithIndex(gen, `i8* ${elem}`, counter, paramCount),
   );
 
   const resultElemPtr = gen.nextTemp();

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -1150,12 +1150,19 @@ function transformObjectExpression(node: TreeSitterNode): ObjectNode {
       const params = paramsNode ? extractFunctionParams(paramsNode) : [];
       const body = bodyNode ? transformStatementBlock(bodyNode) : createEmptyBlock();
 
+      const retTypeNode = getChildByFieldName(child, "return_type");
+      let retType: string | undefined = undefined;
+      if (retTypeNode) {
+        retType = extractTypeString(retTypeNode);
+      }
+
       const arrowFn: ArrowFunctionNode = {
         type: "arrow_function",
         params,
         body,
         async: undefined,
         captures: undefined,
+        returnType: retType,
       };
       properties.push({ key, value: arrowFn });
     }
@@ -1356,12 +1363,19 @@ function transformArrowFunction(node: TreeSitterNode): ArrowFunctionNode {
     }
   }
 
+  const returnTypeNode = getChildByFieldName(node, "return_type");
+  let returnType: string | undefined = undefined;
+  if (returnTypeNode) {
+    returnType = extractTypeString(returnTypeNode);
+  }
+
   return {
     type: "arrow_function",
     params,
     body,
     async: isAsync || undefined,
     captures: undefined,
+    returnType,
   };
 }
 
@@ -1383,12 +1397,19 @@ function transformFunctionExpression(node: TreeSitterNode): ArrowFunctionNode {
     }
   }
 
+  const returnTypeNode = getChildByFieldName(node, "return_type");
+  let returnType: string | undefined = undefined;
+  if (returnTypeNode) {
+    returnType = extractTypeString(returnTypeNode);
+  }
+
   return {
     type: "arrow_function",
     params,
     body,
     async: isAsync || undefined,
     captures: undefined,
+    returnType,
   };
 }
 

--- a/tests/fixtures/arrays/class-array-map-numeric.ts
+++ b/tests/fixtures/arrays/class-array-map-numeric.ts
@@ -1,0 +1,24 @@
+class Person {
+  name: string;
+  age: number;
+  constructor(name: string, age: number) {
+    this.name = name;
+    this.age = age;
+  }
+}
+
+const people: Person[] = [
+  new Person("alice", 30),
+  new Person("bob", 25),
+  new Person("charlie", 35),
+];
+const ages = people.map((p: Person): number => p.age);
+const names = people.map((p: Person): string => p.name);
+
+if (ages[0] === 30 && ages[1] === 25 && ages[2] === 35) {
+  if (names[0] === "alice" && names[1] === "bob" && names[2] === "charlie") {
+    if (ages.length === 3 && names.length === 3) {
+      console.log("TEST_PASSED");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `.map()` on class arrays (e.g. `people.map((p: Person): number => p.age)`) previously crashed LLVM opt with type mismatch — the result was stored as `%ObjectArray` but contained `double` values
- Fixed type inference to use callback return type annotation when resolving `.map()` result type
- Added `generateObjectArrayToNumericMap()` codegen that reads `i8*` elements from ObjectArray source but writes `double` results to a numeric `%Array`
- Fixed native parser to extract arrow function return type annotations (was missing from tree-sitter transformer)

## Test plan
- [x] New test: `class-array-map-numeric.ts` — maps class array to numbers and strings
- [x] 728 tests passing, 0 failures
- [x] Self-hosting passes (Stage 0 + Stage 1)
- [x] Existing map tests still pass (numeric, string, filter-map chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)