### PR TITLE
fix: map entries and find() on class arrays (#36)

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -396,6 +396,18 @@ export class TypeInference {
 
     if (method === "at" || method === "find") {
       if (this.isArrayExpression(expr.object)) return this.ctx.typeContext.numberType;
+      const objResolved = this.resolveExpressionType(expr.object);
+      if (
+        objResolved &&
+        objResolved.arrayDepth > 0 &&
+        objResolved.base !== "string" &&
+        objResolved.base !== "number" &&
+        objResolved.base !== "boolean" &&
+        this.ctx.classGen !== null &&
+        this.ctx.classGen.getClassFields(objResolved.base).length > 0
+      ) {
+        return this.ctx.typeContext.resolve(objResolved.base);
+      }
       return this.ctx.typeContext.stringType;
     }
 

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2232,26 +2232,43 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
                   this.symbolTable.getObjectArrayElementType(arrName) ||
                   this.symbolTable.getRawInterfaceType(arrName);
                 if (elemType) {
-                  kind = SymbolKind.Object;
-                  ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
-                  this.globalVariables.set(name, { llvmType, kind, initialized: false });
-                  const props = this.getInterfaceProperties(elemType);
-                  if (props) {
+                  const classFields = this.classGen
+                    ? this.classGen.getClassFields(elemType) || []
+                    : [];
+                  if (classFields.length > 0) {
+                    kind = SymbolKind.Class;
+                    ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
+                    this.globalVariables.set(name, { llvmType, kind, initialized: false });
                     this.defineVariableWithMetadata(
                       name,
                       `@${name}`,
                       llvmType,
                       kind,
                       "global",
-                      createObjectMetadataWithInterface(
-                        { keys: props.keys, types: props.types },
-                        elemType,
-                      ),
+                      createClassMetadata({ className: elemType }),
                     );
                   } else {
-                    this.defineVariable(name, `@${name}`, llvmType, kind, "global");
+                    kind = SymbolKind.Object;
+                    ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
+                    this.globalVariables.set(name, { llvmType, kind, initialized: false });
+                    const props = this.getInterfaceProperties(elemType);
+                    if (props) {
+                      this.defineVariableWithMetadata(
+                        name,
+                        `@${name}`,
+                        llvmType,
+                        kind,
+                        "global",
+                        createObjectMetadataWithInterface(
+                          { keys: props.keys, types: props.types },
+                          elemType,
+                        ),
+                      );
+                    } else {
+                      this.defineVariable(name, `@${name}`, llvmType, kind, "global");
+                    }
+                    this.symbolTable.setRawInterfaceType(name, elemType);
                   }
-                  this.symbolTable.setRawInterfaceType(name, elemType);
                   continue;
                 }
               }

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -2373,7 +2373,9 @@ export class ControlFlowGenerator {
     }
 
     const lenPtr = this.nextTemp();
-    this.emit(`${lenPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${iterableValue}, i32 0, i32 1`);
+    this.emit(
+      `${lenPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${iterableValue}, i32 0, i32 1`,
+    );
     const lengthI32 = this.ctx.emitLoad("i32", lenPtr);
 
     const indexAlloca = this.ctx.nextAllocaReg("__forof_idx");

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -2373,7 +2373,7 @@ export class ControlFlowGenerator {
     }
 
     const lenPtr = this.nextTemp();
-    this.emit(`${lenPtr} = getelementptr inbounds %Array, %Array* ${iterableValue}, i32 0, i32 0`);
+    this.emit(`${lenPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${iterableValue}, i32 0, i32 1`);
     const lengthI32 = this.ctx.emitLoad("i32", lenPtr);
 
     const indexAlloca = this.ctx.nextAllocaReg("__forof_idx");
@@ -2401,6 +2401,20 @@ export class ControlFlowGenerator {
           "local",
           createObjectMetadata(vti.objectMetadata),
         );
+      } else if (
+        vti.valueType &&
+        vti.valueType !== "string" &&
+        vti.valueType !== "number" &&
+        this.ctx.classGenGetClassFields(vti.valueType).length > 0
+      ) {
+        this.ctx.defineVariableWithMetadata(
+          valueName,
+          valueAlloca,
+          "i8*",
+          SymbolKind.Class,
+          "local",
+          createClassMetadata({ className: vti.valueType }),
+        );
       } else {
         this.ctx.defineVariable(valueName, valueAlloca, "i8*", SymbolKind.String, "local");
       }
@@ -2423,14 +2437,12 @@ export class ControlFlowGenerator {
     this.ctx.emitLabel(bodyLabel);
     this.ctx.setCurrentLabel(bodyLabel);
 
-    // inbounds GEP loads stay raw
     const dataFieldPtr = this.nextTemp();
     this.emit(
-      `${dataFieldPtr} = getelementptr inbounds %Array, %Array* ${iterableValue}, i32 0, i32 2`,
+      `${dataFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${iterableValue}, i32 0, i32 0`,
     );
-    const dataPtr = this.nextTemp();
-    this.emit(`${dataPtr} = load double*, double** ${dataFieldPtr}`);
-    const dataCast = this.ctx.emitBitcast(dataPtr, "double*", "i8**");
+    const dataRaw = this.ctx.emitLoad("i8*", dataFieldPtr);
+    const dataCast = this.ctx.emitBitcast(dataRaw, "i8*", "i8**");
 
     const indexI64 = this.nextTemp();
     this.emit(`${indexI64} = sext i32 ${currentIndex} to i64`);

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -1234,14 +1234,20 @@ export class StringMapGenerator {
     const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
 
     const dataFieldPtr = this.nextTemp();
-    this.emit(`${dataFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`);
+    this.emit(
+      `${dataFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+    );
     const dataCast = this.ctx.emitBitcast(dataPtr, "i8**", "i8*");
     this.ctx.emitStore("i8*", dataCast, dataFieldPtr);
     const lenFieldPtr = this.nextTemp();
-    this.emit(`${lenFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`);
+    this.emit(
+      `${lenFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
+    );
     this.ctx.emitStore("i32", mapSize, lenFieldPtr);
     const capFieldPtr = this.nextTemp();
-    this.emit(`${capFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 2`);
+    this.emit(
+      `${capFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 2`,
+    );
     this.ctx.emitStore("i32", mapSize, capFieldPtr);
 
     const loopLabel = this.nextLabel("strmap_entries_loop");

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -1224,7 +1224,7 @@ export class StringMapGenerator {
     const mapCapacity = this.ctx.emitLoad("i32", capacityFieldPtr);
 
     const arrayMem = this.ctx.emitCall("i8*", "@GC_malloc", "i64 24");
-    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%Array*");
+    const arrayPtr = this.ctx.emitBitcast(arrayMem, "i8*", "%ObjectArray*");
 
     const mapSizeI64 = this.nextTemp();
     this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
@@ -1233,16 +1233,16 @@ export class StringMapGenerator {
     const dataMem = this.ctx.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
     const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "i8**");
 
+    const dataFieldPtr = this.nextTemp();
+    this.emit(`${dataFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`);
+    const dataCast = this.ctx.emitBitcast(dataPtr, "i8**", "i8*");
+    this.ctx.emitStore("i8*", dataCast, dataFieldPtr);
     const lenFieldPtr = this.nextTemp();
-    this.emit(`${lenFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 0`);
+    this.emit(`${lenFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`);
     this.ctx.emitStore("i32", mapSize, lenFieldPtr);
     const capFieldPtr = this.nextTemp();
-    this.emit(`${capFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 1`);
+    this.emit(`${capFieldPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 2`);
     this.ctx.emitStore("i32", mapSize, capFieldPtr);
-    const dataFieldPtr = this.nextTemp();
-    this.emit(`${dataFieldPtr} = getelementptr inbounds %Array, %Array* ${arrayPtr}, i32 0, i32 2`);
-    const dataCast = this.ctx.emitBitcast(dataPtr, "i8**", "double*");
-    this.ctx.emitStore("double*", dataCast, dataFieldPtr);
 
     const loopLabel = this.nextLabel("strmap_entries_loop");
     const bodyLabel = this.nextLabel("strmap_entries_body");

--- a/tests/fixtures/arrays/class-array-find.ts
+++ b/tests/fixtures/arrays/class-array-find.ts
@@ -1,0 +1,15 @@
+class User {
+  name: string;
+  active: boolean;
+  constructor(name: string, active: boolean) {
+    this.name = name;
+    this.active = active;
+  }
+}
+
+const users: User[] = [new User("alice", true), new User("bob", false), new User("charlie", true)];
+const found = users.find((u: User): boolean => u.name === "bob");
+
+if (found.name === "bob" && found.active === false) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/maps/map-entries-class-values.ts
+++ b/tests/fixtures/maps/map-entries-class-values.ts
@@ -1,0 +1,21 @@
+class Person {
+  name: string;
+  age: number;
+  constructor(name: string, age: number) {
+    this.name = name;
+    this.age = age;
+  }
+}
+
+const m = new Map<string, Person>();
+m.set("alice", new Person("Alice", 30));
+m.set("bob", new Person("Bob", 25));
+
+let nameSum = "";
+for (const [k, v] of m.entries()) {
+  nameSum = nameSum + v.name + ",";
+}
+
+if (nameSum === "Alice,Bob,") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Map entries iteration with class-typed values no longer produces garbage data
- `find()` on class arrays now returns a properly typed class instance instead of a raw string pointer

Previously, `for (const [k, v] of map.entries())` where `v` is a class instance would produce garbled field access. Root cause: `generateStringMapEntries` used `%Array` struct (wrong field order) instead of `%ObjectArray`.

Similarly, `classArray.find(predicate)` would return an `i8*` typed as string, causing field access like `found.name` to print the raw pointer. Root cause: type inference always returned `stringType` for non-numeric `find()`, and the global variable handler used `SymbolKind.Object` instead of `SymbolKind.Class`.

730 tests passing (was 729).

## Test plan
- [x] `tests/fixtures/maps/map-entries-class-values.ts` — Map<string, Person> entries iteration
- [x] `tests/fixtures/arrays/class-array-find.ts` — find() on User[] returns correct class instance
- [x] Existing `object-array-find` and `interface-array-processing` tests still pass (no regression)
- [x] Self-hosting passes (verify:quick)