### PR TITLE
fix: method call on new expression resolves return type (#38)

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -557,6 +557,17 @@ export class TypeInference {
       }
     }
 
+    if (objBase.type === "new") {
+      const newExpr = expr.object as NewNode;
+      const className = newExpr.className;
+      if (className) {
+        const classMethod = this.getClassMethod(className, method);
+        if (classMethod && classMethod.returnType) {
+          return this.ctx.typeContext.resolve(stripNullable(classMethod.returnType));
+        }
+      }
+    }
+
     if (objBase.type === "this") {
       const className = this.ctx.getCurrentClassName();
       if (className) {

--- a/tests/fixtures/classes/class-method-return-this.ts
+++ b/tests/fixtures/classes/class-method-return-this.ts
@@ -1,0 +1,23 @@
+class Builder {
+  name: string;
+  value: number;
+  constructor() {
+    this.name = "";
+    this.value = 0;
+  }
+  setName(n: string): Builder {
+    this.name = n;
+    return this;
+  }
+  setValue(v: number): Builder {
+    this.value = v;
+    return this;
+  }
+}
+
+const b = new Builder().setName("test");
+const c = b.setValue(42);
+
+if (b.name === "test" && c.value === 42) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `new ClassName().method()` now correctly resolves the method's return type instead of defaulting to string
- Previously, `const b = new Builder().setName("test"); b.name` would crash with a type mismatch or produce garbage because the variable was typed as `double` instead of a class pointer

Root cause: `resolveMethodCallByObjectType` in type-inference.ts handled `variable`, `this`, and `member_access` object types but not `new` expressions. When the method call target was `new X()`, the return type resolution fell through to null, causing the variable allocator to default to string/double.

731 tests passing (was 730).

## Test plan
- [x] `tests/fixtures/classes/class-method-return-this.ts` — `new Builder().setName()` returns class with correct fields
- [x] All existing tests pass
- [x] Self-hosting passes (verify:quick)