### PR TITLE
fix: reject IIFE with compile error instead of segfault

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -433,6 +433,13 @@ export class MethodCallGenerator {
     const objBase = expr.object as { type: string };
     const method = expr.method;
 
+    if (method === "") {
+      return this.ctx.emitError(
+        "Immediately invoked function expressions (IIFE) are not supported.",
+        expr.loc,
+      );
+    }
+
     // Named-object dispatch: console, process, fs, path, crypto, sqlite, JSON, etc.
     const varName = this.getVariableName(expr.object);
     if (varName !== null) {


### PR DESCRIPTION
## Summary
- Immediately invoked function expressions (`(function(){ ... })()`) now produce a clear compile error instead of silently generating code that segfaults at runtime
- The node compiler already rejected these via the fallback "Method '' is not supported" error, but this adds an explicit check with a descriptive message

Note: The native compiler still crashes on IIFE input (tree-sitter parser issue), but this fix ensures the node compiler path gives a clear error. IIFE is not a supported pattern in ChadScript.

## Test plan
- [x] `node dist/chad-node.js build` on IIFE input → clear error message
- [x] All existing tests pass (731)
- [x] Self-hosting passes (verify:quick)