### PR TITLE
fix: class methods with string-method names dispatch correctly

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -584,8 +584,10 @@ export class MethodCallGenerator {
       }
     }
 
-    const stringResult = dispatchStringMethod(this.ctx, method, expr, params);
-    if (stringResult !== null) return stringResult;
+    if (!this.isClassInstanceExpression(expr.object)) {
+      const stringResult = dispatchStringMethod(this.ctx, method, expr, params);
+      if (stringResult !== null) return stringResult;
+    }
 
     if (
       method === "set" ||

--- a/tests/fixtures/classes/class-method-string-array.ts
+++ b/tests/fixtures/classes/class-method-string-array.ts
@@ -1,0 +1,29 @@
+class Tokenizer {
+  split(input: string): string[] {
+    const result: string[] = [];
+    let current: string = "";
+    for (let i: number = 0; i < input.length; i++) {
+      const ch: string = input[i];
+      if (ch === " ") {
+        if (current.length > 0) {
+          result.push(current);
+          current = "";
+        }
+      } else {
+        current = current + ch;
+      }
+    }
+    if (current.length > 0) {
+      result.push(current);
+    }
+    return result;
+  }
+}
+
+const t: Tokenizer = new Tokenizer();
+const tokens: string[] = t.split("hello world foo");
+if (tokens.length === 3 && tokens[0] === "hello" && tokens[1] === "world" && tokens[2] === "foo") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: got " + tokens.length.toString() + " tokens");
+}


### PR DESCRIPTION
## Summary
- Class methods named `split`, `trim`, `indexOf`, `toString`, etc. were intercepted by the string method dispatcher before reaching class method dispatch
- Added `isClassInstanceExpression` check to skip string dispatch when the object is a known class instance
- Adds test fixture: class with a `split` method that returns `string[]`

## Test plan
- [x] New test: `class-method-string-array.ts` — class `Tokenizer.split()` returns correct `string[]`
- [x] `npm run verify:quick` passes (732 tests, self-hosting Stage 0+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)