### PR TITLE
fix: class methods now support default parameter values

### DIFF
--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -426,6 +426,7 @@ export interface ClassMethod {
   body: BlockStatement;
   isConstructor: boolean;
   isStatic?: boolean;
+  parameters?: FunctionParameter[];
 }
 
 export interface ClassField {

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -3,6 +3,7 @@ import {
   ClassNode,
   ClassMethod,
   ClassField,
+  FunctionParameter,
   VariableNode,
   InterfaceDeclaration,
   CommonField,
@@ -770,6 +771,18 @@ export class ClassGenerator {
     }
 
     const thisType = `%${className}_struct*`;
+
+    let hasOptionalParams = false;
+    if (method.parameters) {
+      for (let pi = 0; pi < method.parameters.length; pi++) {
+        const p = method.parameters[pi] as FunctionParameter;
+        if (p.optional || p.defaultValue) {
+          hasOptionalParams = true;
+          break;
+        }
+      }
+    }
+
     let ir = `define ${returnLLVMType} @${this.ctx.mangleUserName(className)}_${method.name}(${thisType} %this`;
 
     const paramLLVMTypes: string[] = [];
@@ -782,13 +795,15 @@ export class ClassGenerator {
       }
     }
 
-    if (method.params.length > 0) {
-      ir += ", ";
-      const paramParts: string[] = [];
-      for (let pidx = 0; pidx < paramLLVMTypes.length; pidx++) {
-        paramParts.push(paramLLVMTypes[pidx] + " %arg" + pidx);
-      }
-      ir += paramParts.join(", ");
+    const paramParts: string[] = [];
+    if (hasOptionalParams) {
+      paramParts.push("i32 %__argc");
+    }
+    for (let pidx = 0; pidx < paramLLVMTypes.length; pidx++) {
+      paramParts.push(paramLLVMTypes[pidx] + " %arg" + pidx);
+    }
+    if (paramParts.length > 0) {
+      ir += ", " + paramParts.join(", ");
     }
     ir += ") {\n";
     ir += "entry:\n";
@@ -815,6 +830,14 @@ export class ClassGenerator {
 
       this.defineParameterWithType(paramName, allocaReg, llvmType, tsType);
       this.emit(`${allocaReg} = alloca ${llvmType}`);
+
+      if (hasOptionalParams && method.parameters && method.parameters[i]) {
+        const paramInfo = method.parameters[i] as FunctionParameter;
+        if (paramInfo.optional || paramInfo.defaultValue) {
+          this.generateOptionalParamInit(i, allocaReg, llvmType, paramInfo, method.params);
+          continue;
+        }
+      }
       this.ctx.emitStore(llvmType, `%arg${i}`, allocaReg);
     }
 
@@ -1080,7 +1103,21 @@ export class ClassGenerator {
       paramLLVMTypes.push(this.tsTypeToLlvm(pType));
     }
 
+    let methodHasOptionalParams = false;
+    if (method.parameters) {
+      for (let pi = 0; pi < method.parameters.length; pi++) {
+        const p = method.parameters[pi] as FunctionParameter;
+        if (p.optional || p.defaultValue) {
+          methodHasOptionalParams = true;
+          break;
+        }
+      }
+    }
+
     const argParts: string[] = [];
+    if (methodHasOptionalParams) {
+      argParts.push(`i32 ${args.length}`);
+    }
     const loopLimit = method.params.length > args.length ? method.params.length : args.length;
     for (let ai = 0; ai < loopLimit; ai++) {
       if (ai < args.length) {
@@ -1381,6 +1418,43 @@ export class ClassGenerator {
       }
     }
     return "i8*";
+  }
+
+  private optionalParamCounter = 0;
+
+  private generateOptionalParamInit(
+    paramIndex: number,
+    allocaReg: string,
+    llvmType: string,
+    paramInfo: FunctionParameter,
+    params: string[],
+  ): void {
+    const labelId = this.optionalParamCounter++;
+    const hasArgLabel = `has_arg_${labelId}`;
+    const noArgLabel = `no_arg_${labelId}`;
+    const doneLabel = `done_arg_${labelId}`;
+
+    const cmpReg = this.nextTemp();
+    this.emit(`${cmpReg} = icmp sgt i32 %__argc, ${paramIndex}`);
+    this.emit(`br i1 ${cmpReg}, label %${hasArgLabel}, label %${noArgLabel}`);
+
+    this.emit(`${hasArgLabel}:`);
+    const ptrType = llvmType === "double" ? "double*" : llvmType + "*";
+    this.emit(`store ${llvmType} %arg${paramIndex}, ${ptrType} ${allocaReg}`);
+    this.emit(`br label %${doneLabel}`);
+
+    this.emit(`${noArgLabel}:`);
+    if (paramInfo.defaultValue) {
+      const defaultReg = this.ctx.generateExpression(paramInfo.defaultValue, params);
+      const coerced = llvmType === "double" ? this.ctx.ensureDouble(defaultReg) : defaultReg;
+      this.emit(`store ${llvmType} ${coerced}, ${ptrType} ${allocaReg}`);
+    } else {
+      const defaultVal = llvmType === "double" ? "0.0" : "null";
+      this.emit(`store ${llvmType} ${defaultVal}, ${ptrType} ${allocaReg}`);
+    }
+    this.emit(`br label %${doneLabel}`);
+
+    this.emit(`${doneLabel}:`);
   }
 
   private defineParameterWithType(

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -2901,6 +2901,17 @@ function transformClassMethod(node: TreeSitterNode): ClassMethod | null {
   const parameterProperties =
     isConstructor && paramsNode ? extractParameterProperties(paramsNode) : undefined;
 
+  let methodParameters: FunctionParameter[] | undefined;
+  if (paramsNode) {
+    const fpList = extractFunctionParameters(paramsNode);
+    const hasOptional = fpList.some(
+      (fp: FunctionParameter) => fp.optional === true || fp.defaultValue !== undefined,
+    );
+    if (hasOptional) {
+      methodParameters = fpList;
+    }
+  }
+
   const result: ClassMethod = {
     type: "method",
     name,
@@ -2912,6 +2923,7 @@ function transformClassMethod(node: TreeSitterNode): ClassMethod | null {
     isConstructor,
   };
   if (isStatic) result.isStatic = true;
+  if (methodParameters) result.parameters = methodParameters;
   return result;
 }
 

--- a/src/parser-ts/handlers/declarations.ts
+++ b/src/parser-ts/handlers/declarations.ts
@@ -227,6 +227,20 @@ function transformMethodDeclaration(
     : { type: "block", statements: [] };
 
   const isStatic = node.modifiers?.some((m) => m.kind === ts.SyntaxKind.StaticKeyword) ?? false;
+
+  const parameters: FunctionParameter[] = node.parameters.map((p) => {
+    const paramName = ts.isIdentifier(p.name) ? p.name.text : "";
+    const paramType = p.type ? extractTypeString(p.type) : undefined;
+    const optional = !!p.questionToken;
+    let defaultValue = undefined;
+    if (p.initializer) {
+      defaultValue = transformExpression(p.initializer, checker);
+    }
+    return { name: paramName, type: paramType, optional, defaultValue };
+  });
+
+  const hasOptionalParams = parameters.some((p) => p.optional || p.defaultValue);
+
   const result: ClassMethod = {
     type: "method",
     name,
@@ -239,6 +253,9 @@ function transformMethodDeclaration(
   };
   if (isStatic) {
     result.isStatic = true;
+  }
+  if (hasOptionalParams) {
+    result.parameters = parameters;
   }
   return result;
 }

--- a/tests/fixtures/classes/class-method-default-params.ts
+++ b/tests/fixtures/classes/class-method-default-params.ts
@@ -22,14 +22,37 @@ const c: Calculator = new Calculator();
 
 let pass: boolean = true;
 
-if (g.greet() !== "hi world") { console.log("FAIL greet()"); pass = false; }
-if (g.greet("chad") !== "hi chad") { console.log("FAIL greet(chad)"); pass = false; }
+if (g.greet() !== "hi world") {
+  console.log("FAIL greet()");
+  pass = false;
+}
+if (g.greet("chad") !== "hi chad") {
+  console.log("FAIL greet(chad)");
+  pass = false;
+}
 
-if (f.format("x") !== "[x]") { console.log("FAIL format(x)"); pass = false; }
-if (f.format("x", "<") !== "<x]") { console.log("FAIL format(x, <)"); pass = false; }
-if (f.format("x", "<", ">") !== "<x>") { console.log("FAIL format(x, <, >)"); pass = false; }
+if (f.format("x") !== "[x]") {
+  console.log("FAIL format(x)");
+  pass = false;
+}
+if (f.format("x", "<") !== "<x]") {
+  console.log("FAIL format(x, <)");
+  pass = false;
+}
+if (f.format("x", "<", ">") !== "<x>") {
+  console.log("FAIL format(x, <, >)");
+  pass = false;
+}
 
-if (c.add(5) !== 15) { console.log("FAIL add(5)"); pass = false; }
-if (c.add(5, 20) !== 25) { console.log("FAIL add(5, 20)"); pass = false; }
+if (c.add(5) !== 15) {
+  console.log("FAIL add(5)");
+  pass = false;
+}
+if (c.add(5, 20) !== 25) {
+  console.log("FAIL add(5, 20)");
+  pass = false;
+}
 
-if (pass) { console.log("TEST_PASSED"); }
+if (pass) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/classes/class-method-default-params.ts
+++ b/tests/fixtures/classes/class-method-default-params.ts
@@ -1,0 +1,35 @@
+class Greeter {
+  greet(name: string = "world"): string {
+    return "hi " + name;
+  }
+}
+
+class Formatter {
+  format(text: string, prefix: string = "[", suffix: string = "]"): string {
+    return prefix + text + suffix;
+  }
+}
+
+class Calculator {
+  add(a: number, b: number = 10): number {
+    return a + b;
+  }
+}
+
+const g: Greeter = new Greeter();
+const f: Formatter = new Formatter();
+const c: Calculator = new Calculator();
+
+let pass: boolean = true;
+
+if (g.greet() !== "hi world") { console.log("FAIL greet()"); pass = false; }
+if (g.greet("chad") !== "hi chad") { console.log("FAIL greet(chad)"); pass = false; }
+
+if (f.format("x") !== "[x]") { console.log("FAIL format(x)"); pass = false; }
+if (f.format("x", "<") !== "<x]") { console.log("FAIL format(x, <)"); pass = false; }
+if (f.format("x", "<", ">") !== "<x>") { console.log("FAIL format(x, <, >)"); pass = false; }
+
+if (c.add(5) !== 15) { console.log("FAIL add(5)"); pass = false; }
+if (c.add(5, 20) !== 25) { console.log("FAIL add(5, 20)"); pass = false; }
+
+if (pass) { console.log("TEST_PASSED"); }


### PR DESCRIPTION
## Summary
- Class methods with default parameter values (e.g., `greet(name: string = "world")`) now work correctly
- Previously, calling a class method with fewer arguments than parameters would pass `null` instead of the default value
- Implements the same `__argc` mechanism that standalone functions use: method definition checks argument count and evaluates default expressions when args are missing
- Both TS and native parsers now extract `parameters` with `defaultValue` for class methods

## Test plan
- [x] New test: `class-method-default-params.ts` — string defaults, number defaults, multiple optional params
- [x] `npm run verify:quick` passes (732 tests, self-hosting Stage 0+1)
- [x] Native compiler produces correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)