### PR TITLE
fix: child classes inherit parent constructor

### DIFF
--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -46,6 +46,19 @@ export class ClassGenerator {
     return null;
   }
 
+  private findInheritedConstructor(parentClassName: string): ClassMethod | null {
+    const parentNode = this.findClassNode(parentClassName);
+    if (!parentNode) return null;
+    for (let mi = 0; mi < parentNode.methods.length; mi++) {
+      const m = parentNode.methods[mi] as ClassMethod;
+      if (m && m.isConstructor) return m;
+    }
+    if (parentNode.extends) {
+      return this.findInheritedConstructor(parentNode.extends as string);
+    }
+    return null;
+  }
+
   private getAllFieldsIncludingInherited(classNode: ClassNode): ClassField[] {
     const allFields: ClassField[] = [];
     if (classNode.extends) {
@@ -418,14 +431,26 @@ export class ClassGenerator {
         console.log("WARNING: constructor for " + className + " returned falsy");
       }
     } else {
-      const defaultCtorIr = this.generateDefaultConstructorFromTypes(
-        className,
-        fieldLlvmTypes,
-        allFields,
-      );
-      if (defaultCtorIr) {
-        parts.push(defaultCtorIr);
-        parts.push("\n");
+      const inheritedCtor = classNode.extends
+        ? this.findInheritedConstructor(classNode.extends as string)
+        : null;
+      if (inheritedCtor) {
+        this.ctx.clearOutput();
+        const constructorIr = this.generateConstructor(className, inheritedCtor, allFields);
+        if (constructorIr) {
+          parts.push(constructorIr);
+          parts.push("\n");
+        }
+      } else {
+        const defaultCtorIr = this.generateDefaultConstructorFromTypes(
+          className,
+          fieldLlvmTypes,
+          allFields,
+        );
+        if (defaultCtorIr) {
+          parts.push(defaultCtorIr);
+          parts.push("\n");
+        }
       }
     }
 
@@ -1038,6 +1063,9 @@ export class ClassGenerator {
         constructorResult2 = m;
         break;
       }
+    }
+    if (!constructorResult2 && classNode.extends) {
+      constructorResult2 = this.findInheritedConstructor(classNode.extends as string);
     }
     const constructor2 = constructorResult2 as ClassMethod;
     const paramTypes = constructor2 ? constructor2.paramTypes || [] : [];

--- a/tests/fixtures/classes/class-inherited-constructor.ts
+++ b/tests/fixtures/classes/class-inherited-constructor.ts
@@ -1,0 +1,60 @@
+class Animal {
+  name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+  speak(): string {
+    return this.name + " makes a sound";
+  }
+}
+
+class Dog extends Animal {
+  speak(): string {
+    return this.name + " barks";
+  }
+}
+
+class Cat extends Animal {
+  speak(): string {
+    return this.name + " meows";
+  }
+}
+
+class Base {
+  value: number;
+  constructor(v: number) {
+    this.value = v;
+  }
+}
+
+class Child extends Base {
+  double(): number {
+    return this.value * 2;
+  }
+}
+
+const d: Dog = new Dog("Rex");
+const c: Cat = new Cat("Whiskers");
+const a: Animal = new Animal("Generic");
+const ch: Child = new Child(5);
+
+let pass: boolean = true;
+if (d.speak() !== "Rex barks") {
+  console.log("FAIL dog: " + d.speak());
+  pass = false;
+}
+if (c.speak() !== "Whiskers meows") {
+  console.log("FAIL cat: " + c.speak());
+  pass = false;
+}
+if (a.speak() !== "Generic makes a sound") {
+  console.log("FAIL animal: " + a.speak());
+  pass = false;
+}
+if (ch.double() !== 10) {
+  console.log("FAIL child: " + ch.double().toString());
+  pass = false;
+}
+if (pass) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Child classes that don't define their own constructor now correctly inherit the parent's constructor
- Previously, `new Child(5)` on a class extending `Base(v: number)` would ignore the argument — all fields initialized to 0/null
- Two fixes: (1) `generateClass` now uses parent's constructor as template for child, (2) `generateNewExpression` resolves inherited constructor params for correct call-site typing

## Test plan
- [x] New test: `class-inherited-constructor.ts` — Dog/Cat extending Animal with string params, Child extending Base with number params
- [x] `npm run verify:quick` passes (733 tests, self-hosting Stage 0+1)
- [x] Native compiler produces correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)