### PR TITLE
fix: sort() on class/object arrays now works correctly

### DIFF
--- a/src/codegen/types/collections/array/sort.ts
+++ b/src/codegen/types/collections/array/sort.ts
@@ -64,15 +64,18 @@ export function generateArraySort(
   gen.setUsesArraySort(true);
 
   let isStringArray = false;
+  let isObjectArray = false;
   const exprObjBase = expr.object as ExprBase;
   if (exprObjBase.type === "variable") {
     const varName = (expr.object as VariableNode).name;
     const varType = gen.getVariableType(varName);
     isStringArray = varType === "%StringArray*" || varType === "%StringArray";
+    isObjectArray = varType === "%ObjectArray*" || varType === "%ObjectArray";
   }
-  if (!isStringArray) {
+  if (!isStringArray && !isObjectArray) {
     const ptrType = gen.getVariableType(arrayPtr);
     if (ptrType === "%StringArray*" || ptrType === "%StringArray") isStringArray = true;
+    if (ptrType === "%ObjectArray*" || ptrType === "%ObjectArray") isObjectArray = true;
   }
 
   if (expr.args.length === 0) {
@@ -82,6 +85,15 @@ export function generateArraySort(
     return generateDefaultNumericSort(gen, arrayPtr);
   }
 
+  let elementType = "";
+  if (isObjectArray) {
+    const exprObjBase2 = expr.object as ExprBase;
+    if (exprObjBase2.type === "variable") {
+      const varName = (expr.object as VariableNode).name;
+      elementType = gen.symbolTable.getObjectArrayElementType(varName) || "";
+    }
+  }
+
   const predicateArg = expr.args[0];
   let compareFn: string;
   if (predicateArg.type === "variable") {
@@ -89,6 +101,8 @@ export function generateArraySort(
   } else if (predicateArg.type === "arrow_function") {
     if (isStringArray) {
       gen.setExpectedCallbackParamTypes(["string", "string"]);
+    } else if (isObjectArray) {
+      gen.setExpectedCallbackParamTypes([elementType || "i8*", elementType || "i8*"]);
     }
     compareFn = gen.generateExpression(predicateArg, params);
     gen.setExpectedCallbackParamTypes(null);
@@ -100,6 +114,9 @@ export function generateArraySort(
   gen.setLastInlineLambdaEnvPtr(null);
   if (isStringArray) {
     return generateStringSortWithFn(gen, arrayPtr, compareFn, sortEnvPtr);
+  }
+  if (isObjectArray) {
+    return generateObjectSortWithFn(gen, arrayPtr, compareFn, sortEnvPtr);
   }
   return generateNumericSortWithFn(gen, arrayPtr, compareFn, sortEnvPtr);
 }
@@ -371,5 +388,115 @@ function generateStringSortWithFn(
   gen.emit(`${endLabel}:`);
 
   gen.setVariableType(arrayPtr, "%StringArray*");
+  return arrayPtr;
+}
+
+function generateObjectSortWithFn(
+  gen: ArraySortContext,
+  arrayPtr: string,
+  compareFn: string,
+  envPtr?: string | null,
+): string {
+  const lenPtr = gen.nextTemp();
+  gen.emit(
+    `${lenPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
+  );
+  const length = gen.nextTemp();
+  gen.emit(`${length} = load i32, i32* ${lenPtr}`);
+
+  const dataPtrField = gen.nextTemp();
+  gen.emit(
+    `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+  );
+  const rawDataPtr = gen.nextTemp();
+  gen.emit(`${rawDataPtr} = load i8*, i8** ${dataPtrField}`);
+  const dataPtr = gen.nextTemp();
+  gen.emit(`${dataPtr} = bitcast i8* ${rawDataPtr} to i8**`);
+
+  const checkLabel = gen.nextLabel("sort_check");
+  const outerBody = gen.nextLabel("sort_outer");
+  const innerCheck = gen.nextLabel("sort_inner_check");
+  const innerBody = gen.nextLabel("sort_inner_body");
+  const swapLabel = gen.nextLabel("sort_swap");
+  const noSwapLabel = gen.nextLabel("sort_noswap");
+  const innerNext = gen.nextLabel("sort_inner_next");
+  const outerNext = gen.nextLabel("sort_outer_next");
+  const endLabel = gen.nextLabel("sort_end");
+
+  const iAlloc = gen.nextTemp();
+  gen.emit(`${iAlloc} = alloca i32`);
+  gen.emit(`store i32 0, i32* ${iAlloc}`);
+
+  const jAlloc = gen.nextTemp();
+  gen.emit(`${jAlloc} = alloca i32`);
+
+  const lenMinus1 = gen.nextTemp();
+  gen.emit(`${lenMinus1} = sub i32 ${length}, 1`);
+
+  gen.emit(`br label %${checkLabel}`);
+
+  gen.emit(`${checkLabel}:`);
+  const i = gen.nextTemp();
+  gen.emit(`${i} = load i32, i32* ${iAlloc}`);
+  const outerCond = gen.nextTemp();
+  gen.emit(`${outerCond} = icmp slt i32 ${i}, ${lenMinus1}`);
+  gen.emit(`br i1 ${outerCond}, label %${outerBody}, label %${endLabel}`);
+
+  gen.emit(`${outerBody}:`);
+  gen.emit(`store i32 0, i32* ${jAlloc}`);
+  const remaining = gen.nextTemp();
+  gen.emit(`${remaining} = sub i32 ${lenMinus1}, ${i}`);
+  gen.emit(`br label %${innerCheck}`);
+
+  gen.emit(`${innerCheck}:`);
+  const j = gen.nextTemp();
+  gen.emit(`${j} = load i32, i32* ${jAlloc}`);
+  const innerCond = gen.nextTemp();
+  gen.emit(`${innerCond} = icmp slt i32 ${j}, ${remaining}`);
+  gen.emit(`br i1 ${innerCond}, label %${innerBody}, label %${outerNext}`);
+
+  gen.emit(`${innerBody}:`);
+  const ptrA = gen.nextTemp();
+  gen.emit(`${ptrA} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${j}`);
+  const valA = gen.nextTemp();
+  gen.emit(`${valA} = load i8*, i8** ${ptrA}`);
+
+  const jPlus1 = gen.nextTemp();
+  gen.emit(`${jPlus1} = add i32 ${j}, 1`);
+  const ptrB = gen.nextTemp();
+  gen.emit(`${ptrB} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${jPlus1}`);
+  const valB = gen.nextTemp();
+  gen.emit(`${valB} = load i8*, i8** ${ptrB}`);
+
+  const cmpResult = gen.nextTemp();
+  const cmpArgs = envPtr ? `i8* ${envPtr}, i8* ${valA}, i8* ${valB}` : `i8* ${valA}, i8* ${valB}`;
+  gen.emit(`${cmpResult} = call double @${compareFn}(${cmpArgs})`);
+  const shouldSwap = gen.nextTemp();
+  gen.emit(`${shouldSwap} = fcmp ogt double ${cmpResult}, 0.0`);
+  gen.emit(`br i1 ${shouldSwap}, label %${swapLabel}, label %${noSwapLabel}`);
+
+  gen.emit(`${swapLabel}:`);
+  gen.emit(`store i8* ${valB}, i8** ${ptrA}`);
+  gen.emit(`store i8* ${valA}, i8** ${ptrB}`);
+  gen.emit(`br label %${innerNext}`);
+
+  gen.emit(`${noSwapLabel}:`);
+  gen.emit(`br label %${innerNext}`);
+
+  gen.emit(`${innerNext}:`);
+  const nextJ = gen.nextTemp();
+  gen.emit(`${nextJ} = add i32 ${j}, 1`);
+  gen.emit(`store i32 ${nextJ}, i32* ${jAlloc}`);
+  gen.emit(`br label %${innerCheck}`);
+
+  gen.emit(`${outerNext}:`);
+  const nextI = gen.nextTemp();
+  gen.emit(`${nextI} = add i32 ${i}, 1`);
+  gen.emit(`store i32 ${nextI}, i32* ${iAlloc}`);
+  gen.emit(`br label %${checkLabel}`);
+
+  gen.emit(`${endLabel}:`);
+
+  gen.setVariableType(arrayPtr, "%ObjectArray*");
   return arrayPtr;
 }

--- a/tests/fixtures/arrays/class-array-sort.ts
+++ b/tests/fixtures/arrays/class-array-sort.ts
@@ -1,0 +1,44 @@
+class Student {
+  name: string;
+  score: number;
+  constructor(name: string, score: number) {
+    this.name = name;
+    this.score = score;
+  }
+}
+
+const students: Student[] = [];
+students.push(new Student("Alice", 85));
+students.push(new Student("Bob", 92));
+students.push(new Student("Charlie", 78));
+
+students.sort((a: Student, b: Student): number => a.score - b.score);
+
+let pass: boolean = true;
+if (students[0].name !== "Charlie") {
+  console.log("FAIL first: " + students[0].name);
+  pass = false;
+}
+if (students[1].name !== "Alice") {
+  console.log("FAIL second: " + students[1].name);
+  pass = false;
+}
+if (students[2].name !== "Bob") {
+  console.log("FAIL third: " + students[2].name);
+  pass = false;
+}
+
+students.sort((a: Student, b: Student): number => b.score - a.score);
+
+if (students[0].name !== "Bob") {
+  console.log("FAIL desc first: " + students[0].name);
+  pass = false;
+}
+if (students[2].name !== "Charlie") {
+  console.log("FAIL desc last: " + students[2].name);
+  pass = false;
+}
+
+if (pass) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Sorting arrays of class instances with a comparator (e.g., `students.sort((a, b) => a.score - b.score)`) previously segfaulted or produced wrong results
- Two root causes: (1) sort used numeric array (`%Array`) data layout instead of object array (`%ObjectArray`), (2) comparator callback params defaulted to `double` instead of `i8*` for class instances
- Added `generateObjectSortWithFn` that uses `i8**` data pointers and `i8*` element swaps
- Set `expectedCallbackParamTypes` for object array sort so the comparator lambda receives the correct class element type

## Test plan
- [x] New test: `class-array-sort.ts` — ascending and descending sort by field on multi-field class
- [x] `npm run verify:quick` passes (735 tests, self-hosting Stage 0+1)
- [x] Native compiler produces correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)