### PR TITLE
fix: static factory methods return correct type

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -548,6 +548,13 @@ export class TypeInference {
         }
       }
 
+      if (this.getClass(varName)) {
+        const classMethod = this.getClassMethod(varName, method);
+        if (classMethod && classMethod.returnType) {
+          return this.ctx.typeContext.resolve(stripNullable(classMethod.returnType));
+        }
+      }
+
       const ifaceType = this.st.getInterfaceType(varName);
       if (ifaceType && ifaceType.length > 0) {
         const methodReturnType = this.getInterfaceMethodReturnType(ifaceType, method);

--- a/tests/fixtures/classes/class-static-factory.ts
+++ b/tests/fixtures/classes/class-static-factory.ts
@@ -1,0 +1,30 @@
+class Config {
+  host: string;
+  port: number;
+  constructor(host: string, port: number) {
+    this.host = host;
+    this.port = port;
+  }
+  static createDefault(): Config {
+    return new Config("localhost", 8080);
+  }
+  describe(): string {
+    return this.host + ":" + this.port.toString();
+  }
+}
+
+const cfg = Config.createDefault();
+let pass = true;
+if (cfg.host !== "localhost") {
+  console.log("FAIL host");
+  pass = false;
+}
+if (cfg.port !== 8080) {
+  console.log("FAIL port");
+  pass = false;
+}
+if (cfg.describe() !== "localhost:8080") {
+  console.log("FAIL describe: " + cfg.describe());
+  pass = false;
+}
+if (pass) console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `Config.createDefault()` and similar static factory methods now correctly track the return type as a class instance
- Previously, `const cfg = Config.createDefault()` allocated `cfg` as `double` instead of `i8*`, causing LLVM opt type mismatch errors
- Root cause: type inference only checked `st.isClass()` (symbol table lookup) for the class name — static calls use bare class names which aren't in the symbol table. Added fallback to check AST class definitions directly

## Test plan
- [x] New test: `tests/fixtures/classes/class-static-factory.ts` — static factory with field access and method calls on result
- [x] All existing tests pass
- [x] Self-hosting Stage 0+1 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)