### PR TITLE
fix: static field initializers now compile to correct values (#38)

### DIFF
--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -8,6 +8,8 @@ import {
   InterfaceDeclaration,
   CommonField,
   TypeAliasDeclaration,
+  UnaryNode,
+  NumberNode,
 } from "../../../ast/types.js";
 import { IGeneratorContext } from "../../infrastructure/generator-context.js";
 import {
@@ -76,6 +78,66 @@ export class ClassGenerator {
       allFields.push(classNode.fields[i]);
     }
     return allFields;
+  }
+
+  private formatLlvmDouble(v: number): string {
+    const s = v.toString();
+    if (s.indexOf(".") === -1 && s.indexOf("e") === -1) return s + ".0";
+    return s;
+  }
+
+  private resolveStaticInitializer(
+    field: ClassField,
+    llvmType: string,
+    parts: string[],
+  ): string | null {
+    const init = field.initializer;
+    if (!init) return null;
+
+    if (init.type === "number" && llvmType === "double") {
+      const numNode = init as NumberNode;
+      return this.formatLlvmDouble(numNode.value);
+    }
+
+    if (init.type === "boolean" && llvmType === "double") {
+      const boolNode = init as { type: "boolean"; value: boolean; loc?: object };
+      return boolNode.value ? "1.000000e+00" : "0.000000e+00";
+    }
+
+    if (init.type === "unary") {
+      const unary = init as UnaryNode;
+      if (unary.op === "-" && unary.operand.type === "number") {
+        const innerNum = unary.operand as NumberNode;
+        return this.formatLlvmDouble(-innerNum.value);
+      }
+    }
+
+    if (init.type === "string" && llvmType === "i8*") {
+      const strNode = init as { type: "string"; value: string; loc?: object };
+      const strVal = strNode.value;
+      const strId = this.ctx.nextString();
+      let escaped = "";
+      let byteCount = 0;
+      for (let i = 0; i < strVal.length; i++) {
+        const ch = strVal[i];
+        const code = strVal.charCodeAt(i);
+        if (code < 32 || code > 126 || ch === '"' || ch === "\\") {
+          const hex = code.toString(16).padStart(2, "0").toUpperCase();
+          escaped += "\\" + hex;
+          byteCount += 1;
+        } else {
+          escaped += ch;
+          byteCount += 1;
+        }
+      }
+      const len = byteCount + 1;
+      parts.push(
+        `${strId} = private unnamed_addr constant [${len} x i8] c"${escaped}\\00", align 1\n`,
+      );
+      return `getelementptr inbounds ([${len} x i8], [${len} x i8]* ${strId}, i32 0, i32 0)`;
+    }
+
+    return null;
   }
 
   private fieldToLlvmType(f: ClassField): string {
@@ -464,6 +526,8 @@ export class ClassGenerator {
       if (llvmType === "i8*") defaultVal = "null";
       else if (llvmType === "i1") defaultVal = "0";
       else if (llvmType.endsWith("*")) defaultVal = "null";
+      const initVal = this.resolveStaticInitializer(field, llvmType, parts);
+      if (initVal !== null) defaultVal = initVal;
       parts.push(`${globalName} = global ${llvmType} ${defaultVal}\n`);
     }
 

--- a/tests/fixtures/classes/class-static-init.ts
+++ b/tests/fixtures/classes/class-static-init.ts
@@ -1,0 +1,34 @@
+// @test-skip
+// native compiler's tree-sitter parser doesn't populate field initializers yet
+class Config {
+  static version: string = "1.0.0";
+  static maxRetries: number = 5;
+  static debug: boolean = true;
+  static negative: number = -42;
+}
+
+let passed = true;
+
+if (Config.version !== "1.0.0") {
+  console.log("FAIL: version = " + Config.version);
+  passed = false;
+}
+
+if (Config.maxRetries !== 5) {
+  console.log("FAIL: maxRetries = " + Config.maxRetries.toString());
+  passed = false;
+}
+
+if (Config.debug !== true) {
+  console.log("FAIL: debug is not true");
+  passed = false;
+}
+
+if (Config.negative !== -42) {
+  console.log("FAIL: negative = " + Config.negative.toString());
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `static count: number = 42` now correctly initializes to `42.0` instead of `0.0` in the LLVM global
- Handles number, string, boolean literals and unary negation (`-42`)
- String initializers emit proper LLVM constant expressions with `getelementptr`

**Limitation**: Only works when compiled via node compiler (parser-ts). The native compiler's tree-sitter parser doesn't populate `field.initializer` — this is a pre-existing parser bug that affects both static and non-static field initializers.

## Test plan
- [x] New test fixture `class-static-init.ts` (skipped in auto-discovery since native compiler can't parse field initializers yet)
- [x] Manual verification with node compiler: all 4 field types pass
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 0/1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)