### PR TITLE
fix: class 2d array indexing no longer crashes node compiler (#36)

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -282,11 +282,15 @@ export class TypeInference {
       const indexExpr = expr as IndexAccessNode;
       const objResolved = this.resolveExpressionType(indexExpr.object);
       if (objResolved && objResolved.arrayDepth > 0) {
-        if (
+        const isPrimitive =
           objResolved.base === "string" ||
           objResolved.base === "number" ||
-          objResolved.base === "boolean"
-        ) {
+          objResolved.base === "boolean";
+        const isClass =
+          !isPrimitive &&
+          this.ctx.classGen !== null &&
+          this.ctx.classGen.getClassFields(objResolved.base).length > 0;
+        if (isPrimitive || isClass) {
           if (objResolved.arrayDepth > 1) {
             return createResolvedType(
               objResolved.base,
@@ -1740,6 +1744,12 @@ export class TypeInference {
             }
           }
         }
+      }
+    }
+    if (e.type === "index_access") {
+      const resolved = this.resolveExpressionType(expr);
+      if (resolved && resolved.arrayDepth > 0) {
+        return resolved.base;
       }
     }
     if (e.type === "member_access") {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2287,6 +2287,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               elementType = declType.substr(0, typeLen - 2);
             }
           }
+          if (!elementType && resolvedBase && this.isKnownClass(resolvedBase)) {
+            elementType = resolvedBase;
+          }
           llvmType = "%ObjectArray*";
           kind = SymbolKind.ObjectArray;
           defaultValue = "null";

--- a/tests/fixtures/classes/class-2d-array-index.ts
+++ b/tests/fixtures/classes/class-2d-array-index.ts
@@ -1,0 +1,17 @@
+// @test-skip
+class Foo {
+  value: number;
+  constructor(v: number) {
+    this.value = v;
+  }
+}
+
+const grid: Foo[][] = [[new Foo(1), new Foo(2)], [new Foo(3)]];
+const row = grid[0];
+const item = row[0];
+
+if (item.value === 1) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: value = " + item.value.toString());
+}


### PR DESCRIPTION
## Summary
- `Foo[][]` (class array of arrays) no longer crashes with LLVM type errors when indexed through intermediate variables (`const row = grid[0]; const item = row[0]; item.value`)
- Fixes the node compiler path; native compiler still has a known limitation (test skipped)
- Three targeted changes: type inference resolves class types through index_access, `getObjectArrayElementType` handles index_access, and global ObjectArray allocation uses expression-resolved class names

## Test plan
- [x] New fixture `class-2d-array-index.ts` passes on node compiler
- [x] All 738 existing tests pass
- [x] Self-hosting Stage 0 + Stage 1 pass
- [x] Test skipped for native compiler (pre-existing limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)