### PR TITLE
fix: splice() return type now correctly tracked as array

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -622,7 +622,7 @@ export class TypeInference {
     method: string,
     objBase: ExprBase,
   ): ResolvedType | null {
-    if (method === "slice" || method === "concat") {
+    if (method === "slice" || method === "splice" || method === "concat") {
       const objResolved = this.resolveExpressionType(expr.object);
       if (objResolved) return objResolved;
     }
@@ -1329,7 +1329,11 @@ export class TypeInference {
           return true;
         }
       }
-      if (methodExpr.method === "slice" || methodExpr.method === "concat") {
+      if (
+        methodExpr.method === "slice" ||
+        methodExpr.method === "splice" ||
+        methodExpr.method === "concat"
+      ) {
         const objBase = methodExpr.object as ExprBase;
         if (objBase.type === "array") {
           return true;
@@ -1532,6 +1536,7 @@ export class TypeInference {
       }
       if (
         methodExpr.method === "slice" ||
+        methodExpr.method === "splice" ||
         methodExpr.method === "concat" ||
         methodExpr.method === "filter"
       ) {
@@ -2447,6 +2452,7 @@ export class TypeInference {
       if (
         methodExpr.method === "map" ||
         methodExpr.method === "filter" ||
+        methodExpr.method === "splice" ||
         methodExpr.method === "slice" ||
         methodExpr.method === "concat"
       ) {

--- a/tests/fixtures/arrays/splice-return-type.ts
+++ b/tests/fixtures/arrays/splice-return-type.ts
@@ -1,0 +1,20 @@
+const nums = [1, 2, 3, 4, 5];
+const removedNums = nums.splice(1, 2);
+
+const strs = ["a", "b", "c", "d"];
+const removedStrs = strs.splice(1, 2);
+
+if (
+  removedNums.length === 2 &&
+  removedNums[0] === 2 &&
+  removedNums[1] === 3 &&
+  nums.length === 3 &&
+  removedStrs.length === 2 &&
+  removedStrs[0] === "b" &&
+  removedStrs[1] === "c" &&
+  strs.length === 2
+) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL");
+}


### PR DESCRIPTION
## Summary
- `arr.splice(start, count)` return value can now be used as an array (`.length`, indexing, etc.)
- Previously, the type inference didn't recognize `splice` as returning the same array type as its source, causing `removed.length` to fail with ".length is not available on type 'number'"
- Added `splice` alongside `slice`/`concat` in all 4 type inference paths: expression type resolution, number array detection, string array detection, and object array detection

## Test plan
- [x] New fixture `splice-return-type.ts` tests both number and string array splice return values
- [x] All tests pass (739 total)
- [x] Self-hosting Stage 0 + Stage 1 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)