### PR TITLE
fix: Array.from(string) returns string[] without type annotation

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -319,6 +319,14 @@ export class MethodCallGenerator {
         if (method === "from") {
           if (expr.args.length === 0)
             return this.ctx.emitError("Array.from() requires at least 1 argument", expr.loc);
+          if (this.ctx.isStringExpression(expr.args[0])) {
+            const strPtr = this.ctx.generateExpression(expr.args[0], params);
+            const emptyDelim = this.ctx.nextTemp();
+            this.ctx.emit(
+              `${emptyDelim} = getelementptr inbounds [1 x i8], [1 x i8]* @.str.empty_str, i64 0, i64 0`,
+            );
+            return this.ctx.stringGen.doGenerateSplit(strPtr, emptyDelim);
+          }
           return this.ctx.generateExpression(expr.args[0], params);
         }
         if (method === "isArray") {

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -149,6 +149,7 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += '@.str.strfmt_no_nl = private unnamed_addr constant [3 x i8] c"%s\\00", align 1\n';
   ir += '@.str.numfmt_no_nl = private unnamed_addr constant [6 x i8] c"%.15g\\00", align 1\n';
   ir += '@.str.space = private unnamed_addr constant [2 x i8] c" \\00", align 1\n';
+  ir += '@.str.empty_str = private unnamed_addr constant [1 x i8] c"\\00", align 1\n';
   ir += '@.str.hello = private unnamed_addr constant [7 x i8] c"Hello\\0A\\00", align 1\n';
   ir += '@.str.throw_fmt = private constant [11 x i8] c"Error: %s\\0A\\00"\n';
   ir += '@.str.popen_mode = private unnamed_addr constant [2 x i8] c"r\\00", align 1\n';

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -546,8 +546,9 @@ export class TypeInference {
         if (method === "now") return this.ctx.typeContext.numberType;
       }
 
-      if (varName === "Array" && method === "from")
-        return this.ctx.typeContext.getArrayType("number");
+      if (varName === "Array" && method === "from") {
+        return null;
+      }
 
       if (this.st.isClass(varName)) {
         const className = this.st.getClassName(varName);
@@ -622,6 +623,16 @@ export class TypeInference {
     method: string,
     objBase: ExprBase,
   ): ResolvedType | null {
+    if (method === "from" && objBase.type === "variable") {
+      const objName = (expr.object as VariableNode).name;
+      if (objName === "Array") {
+        if (expr.args.length > 0 && this.isStringExpression(expr.args[0])) {
+          return this.ctx.typeContext.getArrayType("string");
+        }
+        return this.ctx.typeContext.getArrayType("number");
+      }
+    }
+
     if (method === "slice" || method === "splice" || method === "concat") {
       const objResolved = this.resolveExpressionType(expr.object);
       if (objResolved) return objResolved;
@@ -2390,6 +2401,17 @@ export class TypeInference {
       const methodExpr = expr as MethodCallNode;
       if (methodExpr.method === "split") {
         return true;
+      }
+      if (methodExpr.method === "from") {
+        const objBase = methodExpr.object as ExprBase;
+        if (
+          objBase.type === "variable" &&
+          (methodExpr.object as VariableNode).name === "Array" &&
+          methodExpr.args.length > 0 &&
+          this.isStringExpression(methodExpr.args[0])
+        ) {
+          return true;
+        }
       }
       if (methodExpr.method === "all") {
         const objBase = methodExpr.object as ExprBase;

--- a/tests/fixtures/arrays/array-from-string.ts
+++ b/tests/fixtures/arrays/array-from-string.ts
@@ -1,0 +1,6 @@
+const chars = Array.from("hello");
+if (chars.length === 5 && chars[0] === "h" && chars[4] === "o") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: length=" + chars.length.toString());
+}


### PR DESCRIPTION
## Summary
- `Array.from("hello")` now correctly produces a `string[]` without needing an explicit type annotation
- Previously, the variable allocator classified the result as `i8*` (string) instead of `%StringArray*`, causing garbage values on index access
- Root cause: `resolveMethodCallByObjectType` returned `number[]` for all `Array.from()` calls before the string-aware handler could run

## Test plan
- [x] New test fixture `arrays/array-from-string.ts`
- [x] All existing tests pass
- [x] Self-hosting (Stage 0 + Stage 1) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)