### PR TITLE
fix: .map()/.filter() on class arrays without type annotation

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -173,6 +173,22 @@ export class TypeInference {
       }
       if (this.isStringExpression(elements[0])) return this.ctx.typeContext.getArrayType("string");
       if (firstElem.type === "object") return this.ctx.typeContext.getArrayType("object");
+      if (firstElem.type === "new") {
+        const newExpr = elements[0] as NewNode;
+        const resolvedClassName = this.resolveClassAlias(newExpr.className);
+        const cls = this.getClass(resolvedClassName);
+        if (cls) return this.ctx.typeContext.getArrayType(resolvedClassName);
+      }
+      const elemResolved = this.resolveExpressionType(elements[0]);
+      if (
+        elemResolved &&
+        elemResolved.arrayDepth === 0 &&
+        elemResolved.base !== "number" &&
+        elemResolved.base !== "boolean" &&
+        elemResolved.base !== "string"
+      ) {
+        return this.ctx.typeContext.getArrayType(elemResolved.base);
+      }
       return this.ctx.typeContext.getArrayType("number");
     }
     if (e.type === "unary") {

--- a/tests/fixtures/arrays/class-array-map-filter.ts
+++ b/tests/fixtures/arrays/class-array-map-filter.ts
@@ -1,0 +1,18 @@
+class Item {
+  name: string;
+  value: number;
+  constructor(n: string, v: number) {
+    this.name = n;
+    this.value = v;
+  }
+}
+
+const items = [new Item("alpha", 10), new Item("beta", 20), new Item("gamma", 30)];
+
+const names = items.map((item: Item): string => item.name);
+console.log(names.join(","));
+
+const big = items.filter((item: Item): boolean => item.value > 15);
+console.log(big.length);
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
- `[new Item("a"), new Item("b")]` without an explicit `Item[]` type annotation was misclassified as a number array (`%Array*`) instead of an object array (`%ObjectArray*`)
- This caused `.map()` and `.filter()` callbacks to receive class instance pointers as `double` values, producing wrong results (empty strings, wrong counts)
- Now the type inferrer checks array literal elements for `new` expressions that resolve to known classes, and falls back to recursive element type resolution for other non-primitive types

## Test plan
- [x] New test fixture `arrays/class-array-map-filter.ts` — `.map()` extracts field, `.filter()` filters by field value
- [x] All existing tests pass
- [x] Self-hosting Stage 1 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)