### PR TITLE
remove enum support, reject with compile error

### DIFF
--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -17,7 +17,13 @@ import {
   addLinkLib,
   addLinkPath,
 } from "./compiler.js";
-import { LogLevel, logger } from "./utils/logger.js";
+import {
+  LogLevel_Normal,
+  LogLevel_Verbose,
+  LogLevel_Debug,
+  LogLevel_Trace,
+  logger,
+} from "./utils/logger.js";
 import { runInit } from "./codegen/stdlib/init-templates.js";
 import { ArgumentParser } from "./argparse.js";
 import { parseWithTSAPI } from "./parser-ts/index.js";
@@ -291,10 +297,10 @@ if (
 }
 
 // Configure compiler options from parsed flags
-let logLevel = LogLevel.Normal;
-if (parser.getFlag("verbose")) logLevel = LogLevel.Verbose;
-if (parser.getFlag("debug")) logLevel = LogLevel.Debug;
-if (parser.getFlag("trace")) logLevel = LogLevel.Trace;
+let logLevel = LogLevel_Normal;
+if (parser.getFlag("verbose")) logLevel = LogLevel_Verbose;
+if (parser.getFlag("debug")) logLevel = LogLevel_Debug;
+if (parser.getFlag("trace")) logLevel = LogLevel_Trace;
 
 if (parser.getFlag("skip-semantic-analysis")) setSkipSemanticAnalysis(true);
 if (parser.getFlag("keep-temps")) setKeepTemps(true);

--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -7,7 +7,7 @@ import {
   UnaryNode,
 } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
-import { SymbolKind } from "../../infrastructure/symbol-table.js";
+import { SymbolKind, SymbolKind_Boolean } from "../../infrastructure/symbol-table.js";
 
 function emitPrint(
   ctx: MethodCallGeneratorContext,
@@ -505,7 +505,7 @@ function emitSingleArg(
   if (arg.type === "variable") {
     const varName = (arg as VariableNode).name;
     const varKind = ctx.symbolTable.getKind(varName);
-    if (varKind === SymbolKind.Boolean) {
+    if (varKind === SymbolKind_Boolean) {
       const argValue = ctx.generateExpression(arg, params);
       emitBooleanPrint(ctx, useStderr, argValue);
       return;

--- a/src/codegen/infrastructure/base-generator.ts
+++ b/src/codegen/infrastructure/base-generator.ts
@@ -1,9 +1,53 @@
 import { Expression } from "../../ast/types.js";
-import { SymbolTable, SymbolKind, SymbolMetadata } from "./symbol-table.js";
+import {
+  SymbolTable,
+  SymbolKind,
+  SymbolMetadata,
+  SymbolKind_Number,
+  SymbolKind_String,
+  SymbolKind_Boolean,
+  SymbolKind_Array,
+  SymbolKind_StringArray,
+  SymbolKind_BooleanArray,
+  SymbolKind_ObjectArray,
+  SymbolKind_Object,
+  SymbolKind_Map,
+  SymbolKind_Set,
+  SymbolKind_Class,
+  SymbolKind_Regex,
+  SymbolKind_JSON,
+  SymbolKind_ProcessArgv,
+  SymbolKind_Closure,
+  SymbolKind_Pointer,
+  SymbolKind_Uint8Array,
+  SymbolKind_Url,
+  SymbolKind_UrlSearchParams,
+} from "./symbol-table.js";
 import type { ResolvedType } from "./type-system.js";
 
-// Re-export for convenience
-export { SymbolTable, SymbolKind };
+export {
+  SymbolTable,
+  SymbolKind,
+  SymbolKind_Number,
+  SymbolKind_String,
+  SymbolKind_Boolean,
+  SymbolKind_Array,
+  SymbolKind_StringArray,
+  SymbolKind_BooleanArray,
+  SymbolKind_ObjectArray,
+  SymbolKind_Object,
+  SymbolKind_Map,
+  SymbolKind_Set,
+  SymbolKind_Class,
+  SymbolKind_Regex,
+  SymbolKind_JSON,
+  SymbolKind_ProcessArgv,
+  SymbolKind_Closure,
+  SymbolKind_Pointer,
+  SymbolKind_Uint8Array,
+  SymbolKind_Url,
+  SymbolKind_UrlSearchParams,
+};
 
 // ============================================
 // BASE GENERATOR - Shared state and utilities

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -20,6 +20,17 @@ import {
 } from "../../ast/types.js";
 import {
   SymbolKind,
+  SymbolKind_Number,
+  SymbolKind_String,
+  SymbolKind_Boolean,
+  SymbolKind_Array,
+  SymbolKind_StringArray,
+  SymbolKind_ObjectArray,
+  SymbolKind_Object,
+  SymbolKind_Map,
+  SymbolKind_Set,
+  SymbolKind_Class,
+  SymbolKind_Pointer,
   SymbolTable,
   createPointerAllocaMetadata,
   createInterfacePointerAllocaMetadata,
@@ -304,9 +315,9 @@ export class FunctionGenerator {
 
       if (llvmType === "i8*") {
         if (paramTypes[i] === "string") {
-          this.ctx.defineVariable(paramName, allocaReg, "i8*", SymbolKind.String, "local");
+          this.ctx.defineVariable(paramName, allocaReg, "i8*", SymbolKind_String, "local");
         } else if (paramName === "nodePtr" || paramName === "treePtr") {
-          this.ctx.defineVariable(paramName, allocaReg, "i8*", SymbolKind.Pointer, "local");
+          this.ctx.defineVariable(paramName, allocaReg, "i8*", SymbolKind_Pointer, "local");
         } else {
           const ast = this.ctx.getAst();
           let strippedParamType = paramTypes[i];
@@ -371,7 +382,7 @@ export class FunctionGenerator {
                 paramName,
                 allocaReg,
                 "i8*",
-                SymbolKind.Object,
+                SymbolKind_Object,
                 "local",
                 createObjectMetadataWithInterface({ keys: biKeys, types: biTypes }, ptype),
               );
@@ -392,7 +403,7 @@ export class FunctionGenerator {
               paramName,
               allocaReg,
               "i8*",
-              SymbolKind.Class,
+              SymbolKind_Class,
               "local",
               createClassMetadata({ className: classDefName }),
             );
@@ -418,7 +429,7 @@ export class FunctionGenerator {
               paramName,
               allocaReg,
               "i8*",
-              SymbolKind.Object,
+              SymbolKind_Object,
               "local",
               createObjectMetadataWithInterface({ keys, types }, paramTypes[i]),
             );
@@ -427,12 +438,12 @@ export class FunctionGenerator {
               paramName,
               allocaReg,
               "i8*",
-              SymbolKind.Object,
+              SymbolKind_Object,
               "local",
               createObjectMetadataWithInterface(typeAliasCommonProps, paramTypes[i]),
             );
           } else {
-            this.ctx.defineVariable(paramName, allocaReg, "i8*", SymbolKind.Object, "local");
+            this.ctx.defineVariable(paramName, allocaReg, "i8*", SymbolKind_Object, "local");
           }
         }
         this.ctx.emit(`${allocaReg} = alloca i8*`);
@@ -446,7 +457,7 @@ export class FunctionGenerator {
           paramName,
           allocaReg,
           "%StringArray*",
-          SymbolKind.StringArray,
+          SymbolKind_StringArray,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -461,7 +472,7 @@ export class FunctionGenerator {
           paramName,
           allocaReg,
           "%Array*",
-          SymbolKind.Array,
+          SymbolKind_Array,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -482,7 +493,7 @@ export class FunctionGenerator {
             paramName,
             allocaReg,
             "%ObjectArray*",
-            SymbolKind.ObjectArray,
+            SymbolKind_ObjectArray,
             "local",
             createInterfacePointerAllocaMetadata(elementType),
           );
@@ -491,7 +502,7 @@ export class FunctionGenerator {
             paramName,
             allocaReg,
             "%ObjectArray*",
-            SymbolKind.ObjectArray,
+            SymbolKind_ObjectArray,
             "local",
             createPointerAllocaMetadata(),
           );
@@ -507,7 +518,7 @@ export class FunctionGenerator {
           paramName,
           allocaReg,
           "%Set*",
-          SymbolKind.Set,
+          SymbolKind_Set,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -522,7 +533,7 @@ export class FunctionGenerator {
           paramName,
           allocaReg,
           "%StringSet*",
-          SymbolKind.Set,
+          SymbolKind_Set,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -544,7 +555,7 @@ export class FunctionGenerator {
           paramName,
           allocaReg,
           "%StringMap*",
-          SymbolKind.Map,
+          SymbolKind_Map,
           "local",
           mapMeta,
         );
@@ -564,7 +575,7 @@ export class FunctionGenerator {
           paramName,
           allocaReg,
           llvmType,
-          SymbolKind.Object,
+          SymbolKind_Object,
           "local",
           createInterfacePointerAllocaMetadata(interfaceName),
         );
@@ -575,7 +586,7 @@ export class FunctionGenerator {
           this.ctx.emit(`store ${llvmType} %arg${i}, ${llvmType}* ${allocaReg}`);
         }
       } else {
-        this.ctx.defineVariable(paramName, allocaReg, "double", SymbolKind.Number, "local");
+        this.ctx.defineVariable(paramName, allocaReg, "double", SymbolKind_Number, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);
         if (isOptional && hasOptionalParams) {
           this.generateOptionalParamInit(i, allocaReg, llvmType, paramInfo!, funcParams);
@@ -814,18 +825,18 @@ export class FunctionGenerator {
   }
 
   private llvmTypeToSymbolKindPrimitive(llvmType: string): number | null {
-    if (llvmType === "double") return SymbolKind.Number;
-    if (llvmType === "i8*") return SymbolKind.String;
-    if (llvmType === "%Array*") return SymbolKind.Array;
-    if (llvmType === "%ObjectArray*") return SymbolKind.ObjectArray;
+    if (llvmType === "double") return SymbolKind_Number;
+    if (llvmType === "i8*") return SymbolKind_String;
+    if (llvmType === "%Array*") return SymbolKind_Array;
+    if (llvmType === "%ObjectArray*") return SymbolKind_ObjectArray;
     return null;
   }
 
   private llvmTypeToSymbolKindCollection(llvmType: string): number | null {
-    if (llvmType === "%StringArray*") return SymbolKind.StringArray;
-    if (llvmType === "%Map*") return SymbolKind.Map;
-    if (llvmType === "%StringMap*") return SymbolKind.Map;
-    if (llvmType === "%Set*") return SymbolKind.Set;
+    if (llvmType === "%StringArray*") return SymbolKind_StringArray;
+    if (llvmType === "%Map*") return SymbolKind_Map;
+    if (llvmType === "%StringMap*") return SymbolKind_Map;
+    if (llvmType === "%Set*") return SymbolKind_Set;
     return null;
   }
 
@@ -834,8 +845,8 @@ export class FunctionGenerator {
     if (prim !== null) return prim;
     const coll = this.llvmTypeToSymbolKindCollection(llvmType);
     if (coll !== null) return coll;
-    if (llvmType === "%StringSet*") return SymbolKind.Set;
-    return SymbolKind.Object;
+    if (llvmType === "%StringSet*") return SymbolKind_Set;
+    return SymbolKind_Object;
   }
 
   private getUnionCommonFields(memberNames: string[]): { keys: string[]; types: string[] } {

--- a/src/codegen/infrastructure/interface-allocator.ts
+++ b/src/codegen/infrastructure/interface-allocator.ts
@@ -12,6 +12,7 @@ import {
 } from "../../ast/types.js";
 import {
   SymbolKind,
+  SymbolKind_Object,
   SymbolTable,
   ObjectMetadata,
   SymbolMetadata,
@@ -194,7 +195,7 @@ export class InterfaceAllocator {
       stmt.name,
       allocaReg,
       "i8*",
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       createObjectMetadataWithInterface({ keys, types, tsTypes }, interfaceName),
     );
@@ -252,7 +253,7 @@ export class InterfaceAllocator {
               stmt.name,
               allocaReg,
               "i8*",
-              SymbolKind.Object,
+              SymbolKind_Object,
               "local",
               createObjectMetadataWithInterface(
                 { keys: reorderedKeys, types: reorderedTypes, tsTypes: reorderedTsTypes },
@@ -289,7 +290,7 @@ export class InterfaceAllocator {
       stmt.name,
       allocaReg,
       "i8*",
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       createObjectMetadataWithInterface({ keys, types, tsTypes }, interfaceName),
     );

--- a/src/codegen/infrastructure/symbol-table.ts
+++ b/src/codegen/infrastructure/symbol-table.ts
@@ -17,27 +17,26 @@ import type { TypeContext } from "./type-context.js";
 /**
  * Symbol kind for different variable types
  */
-export enum SymbolKind {
-  Number,
-  String,
-  Boolean,
-  Array,
-  StringArray,
-  BooleanArray,
-  ObjectArray,
-  Object,
-  Map,
-  Set,
-  Class,
-  Regex,
-  JSON,
-  ProcessArgv,
-  Closure,
-  Pointer,
-  Uint8Array,
-  Url,
-  UrlSearchParams,
-}
+export const SymbolKind_Number = 0;
+export const SymbolKind_String = 1;
+export const SymbolKind_Boolean = 2;
+export const SymbolKind_Array = 3;
+export const SymbolKind_StringArray = 4;
+export const SymbolKind_BooleanArray = 5;
+export const SymbolKind_ObjectArray = 6;
+export const SymbolKind_Object = 7;
+export const SymbolKind_Map = 8;
+export const SymbolKind_Set = 9;
+export const SymbolKind_Class = 10;
+export const SymbolKind_Regex = 11;
+export const SymbolKind_JSON = 12;
+export const SymbolKind_ProcessArgv = 13;
+export const SymbolKind_Closure = 14;
+export const SymbolKind_Pointer = 15;
+export const SymbolKind_Uint8Array = 16;
+export const SymbolKind_Url = 17;
+export const SymbolKind_UrlSearchParams = 18;
+export type SymbolKind = number;
 
 /**
  * Object-specific metadata
@@ -411,13 +410,13 @@ export interface Symbol {
  * const symbolTable = new SymbolTable();
  *
  * // Define a number variable
- * symbolTable.define('x', SymbolKind.Number, 'double', '%1', 'local');
+ * symbolTable.define('x', SymbolKind_Number, 'double', '%1', 'local');
  *
  * // Define a string variable
- * symbolTable.define('name', SymbolKind.String, 'i8*', '%2', 'local');
+ * symbolTable.define('name', SymbolKind_String, 'i8*', '%2', 'local');
  *
  * // Define an object with metadata
- * symbolTable.define('user', SymbolKind.Object, '%User*', '%3', 'local', {
+ * symbolTable.define('user', SymbolKind_Object, '%User*', '%3', 'local', {
  *   objectMetadata: {
  *     keys: ['name', 'age'],
  *     types: ['i8*', 'double']
@@ -530,7 +529,7 @@ export class SymbolTable {
     stack.push(symbol.objectMetadata || { keys: [], types: [] });
 
     symbol.objectMetadata = narrowedMetadata;
-    symbol.kind = SymbolKind.Object;
+    symbol.kind = SymbolKind_Object;
   }
 
   /**
@@ -729,10 +728,10 @@ export class SymbolTable {
     if (symbol) {
       const k = symbol.kind;
       if (
-        k === SymbolKind.Array ||
-        k === SymbolKind.StringArray ||
-        k === SymbolKind.BooleanArray ||
-        k === SymbolKind.ObjectArray
+        k === SymbolKind_Array ||
+        k === SymbolKind_StringArray ||
+        k === SymbolKind_BooleanArray ||
+        k === SymbolKind_ObjectArray
       ) {
         return undefined;
       }
@@ -743,7 +742,7 @@ export class SymbolTable {
   getObjectArrayElementType(name: string): string | undefined {
     if (!name) return undefined;
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.ObjectArray) {
+    if (symbol && symbol.kind === SymbolKind_ObjectArray) {
       return this.interfaceTypes.get(name);
     }
     return undefined;
@@ -954,7 +953,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Number;
+    const m = SymbolKind_Number;
     if (k === m) {
       return true;
     }
@@ -967,7 +966,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.String;
+    const m = SymbolKind_String;
     if (k === m) {
       return true;
     }
@@ -980,7 +979,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Boolean;
+    const m = SymbolKind_Boolean;
     if (k === m) {
       return true;
     }
@@ -993,13 +992,13 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    if (k === SymbolKind.Array) {
+    if (k === SymbolKind_Array) {
       return true;
     }
-    if (k === SymbolKind.StringArray) {
+    if (k === SymbolKind_StringArray) {
       return true;
     }
-    if (k === SymbolKind.BooleanArray) {
+    if (k === SymbolKind_BooleanArray) {
       return true;
     }
     return false;
@@ -1011,7 +1010,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Array;
+    const m = SymbolKind_Array;
     if (k === m) {
       return true;
     }
@@ -1024,7 +1023,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.StringArray;
+    const m = SymbolKind_StringArray;
     if (k === m) {
       return true;
     }
@@ -1037,7 +1036,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.BooleanArray;
+    const m = SymbolKind_BooleanArray;
     if (k === m) {
       return true;
     }
@@ -1050,7 +1049,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Object;
+    const m = SymbolKind_Object;
     if (k === m) {
       return true;
     }
@@ -1063,7 +1062,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Map;
+    const m = SymbolKind_Map;
     if (k === m) {
       return true;
     }
@@ -1076,7 +1075,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Set;
+    const m = SymbolKind_Set;
     if (k === m) {
       return true;
     }
@@ -1089,7 +1088,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Class;
+    const m = SymbolKind_Class;
     if (k === m) {
       return true;
     }
@@ -1102,7 +1101,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Regex;
+    const m = SymbolKind_Regex;
     if (k === m) {
       return true;
     }
@@ -1115,7 +1114,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.JSON;
+    const m = SymbolKind_JSON;
     if (k === m) {
       return true;
     }
@@ -1128,7 +1127,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.ProcessArgv;
+    const m = SymbolKind_ProcessArgv;
     if (k === m) {
       return true;
     }
@@ -1141,7 +1140,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Closure;
+    const m = SymbolKind_Closure;
     if (k === m) {
       return true;
     }
@@ -1154,7 +1153,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.ObjectArray;
+    const m = SymbolKind_ObjectArray;
     if (k === m) {
       return true;
     }
@@ -1167,7 +1166,7 @@ export class SymbolTable {
       return false;
     }
     const k = symbol.kind;
-    const m = SymbolKind.Uint8Array;
+    const m = SymbolKind_Uint8Array;
     if (k === m) {
       return true;
     }
@@ -1176,18 +1175,18 @@ export class SymbolTable {
 
   isUrl(name: string): boolean {
     const symbol = this.symbols.get(name);
-    return !!(symbol && symbol.kind === SymbolKind.Url);
+    return !!(symbol && symbol.kind === SymbolKind_Url);
   }
 
   isUrlSearchParams(name: string): boolean {
     const symbol = this.symbols.get(name);
-    return !!(symbol && symbol.kind === SymbolKind.UrlSearchParams);
+    return !!(symbol && symbol.kind === SymbolKind_UrlSearchParams);
   }
 
   defineUrl(name: string, allocaRegister: string, scope: string): void {
     const symbol: Symbol = {
       name,
-      kind: SymbolKind.Url,
+      kind: SymbolKind_Url,
       llvmType: "i8*",
       allocaRegister,
       scope,
@@ -1217,7 +1216,7 @@ export class SymbolTable {
   defineUrlSearchParams(name: string, allocaRegister: string, scope: string): void {
     const symbol: Symbol = {
       name,
-      kind: SymbolKind.UrlSearchParams,
+      kind: SymbolKind_UrlSearchParams,
       llvmType: "i8*",
       allocaRegister,
       scope,
@@ -1253,7 +1252,7 @@ export class SymbolTable {
    */
   getClosureMetadata(name: string): ClosureMetadata | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.Closure) {
+    if (symbol && symbol.kind === SymbolKind_Closure) {
       return symbol.closureMetadata;
     }
     return undefined;
@@ -1264,7 +1263,7 @@ export class SymbolTable {
    */
   getObjectMetadata(name: string): ObjectMetadata | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.Object) {
+    if (symbol && symbol.kind === SymbolKind_Object) {
       return symbol.objectMetadata;
     }
     return undefined;
@@ -1275,7 +1274,7 @@ export class SymbolTable {
    */
   getClassMetadata(name: string): ClassMetadata | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.Class) {
+    if (symbol && symbol.kind === SymbolKind_Class) {
       return symbol.classMetadata;
     }
     return undefined;
@@ -1297,7 +1296,7 @@ export class SymbolTable {
    */
   getMapMetadata(name: string): MapMetadata | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.Map) {
+    if (symbol && symbol.kind === SymbolKind_Map) {
       return symbol.mapMetadata;
     }
     return undefined;
@@ -1308,7 +1307,7 @@ export class SymbolTable {
    */
   getSetMetadata(name: string): SetMetadata | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.Set) {
+    if (symbol && symbol.kind === SymbolKind_Set) {
       return symbol.setMetadata;
     }
     return undefined;
@@ -1316,7 +1315,7 @@ export class SymbolTable {
 
   getSetValueType(name: string): string | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.Set && symbol.setMetadata) {
+    if (symbol && symbol.kind === SymbolKind_Set && symbol.setMetadata) {
       return symbol.setMetadata.valueType;
     }
     return undefined;
@@ -1324,7 +1323,7 @@ export class SymbolTable {
 
   getObjectArrayMetadata(name: string): ObjectArrayMetadata | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.ObjectArray) {
+    if (symbol && symbol.kind === SymbolKind_ObjectArray) {
       return symbol.objectArrayMetadata;
     }
     return undefined;
@@ -1334,7 +1333,7 @@ export class SymbolTable {
     const symbol = this.symbols.get(name);
     if (symbol) {
       symbol.objectArrayMetadata = metadata;
-      symbol.kind = SymbolKind.ObjectArray;
+      symbol.kind = SymbolKind_ObjectArray;
     }
   }
 
@@ -1347,7 +1346,7 @@ export class SymbolTable {
    */
   getStringAlloca(name: string): string | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.String) {
+    if (symbol && symbol.kind === SymbolKind_String) {
       return symbol.allocaRegister;
     }
     return undefined;
@@ -1373,7 +1372,7 @@ export class SymbolTable {
     const symbol = this.symbols.get(name);
     if (
       symbol &&
-      (symbol.kind === SymbolKind.Object || symbol.kind === SymbolKind.JSON) &&
+      (symbol.kind === SymbolKind_Object || symbol.kind === SymbolKind_JSON) &&
       symbol.objectMetadata
     ) {
       const objMeta = symbol.objectMetadata;
@@ -1437,7 +1436,7 @@ export class SymbolTable {
     const symbol = this.symbols.get(varName);
     if (
       symbol &&
-      (symbol.kind === SymbolKind.Object || symbol.kind === SymbolKind.JSON) &&
+      (symbol.kind === SymbolKind_Object || symbol.kind === SymbolKind_JSON) &&
       symbol.objectMetadata
     ) {
       const objMeta = symbol.objectMetadata;
@@ -1455,7 +1454,7 @@ export class SymbolTable {
    */
   getClassInfo(name: string): ClassInfo | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.Class && symbol.classMetadata) {
+    if (symbol && symbol.kind === SymbolKind_Class && symbol.classMetadata) {
       const classMeta = symbol.classMetadata;
       return {
         ptr: symbol.allocaRegister,
@@ -1470,7 +1469,7 @@ export class SymbolTable {
    */
   getClassName(name: string): string | undefined {
     const symbol = this.symbols.get(name);
-    if (symbol && symbol.kind === SymbolKind.Class && symbol.classMetadata) {
+    if (symbol && symbol.kind === SymbolKind_Class && symbol.classMetadata) {
       const classMeta = symbol.classMetadata;
       return classMeta.className;
     }

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -21,7 +21,7 @@ import {
   SetNode,
   ArrowFunctionNode,
 } from "../../ast/types.js";
-import { SymbolTable, SymbolKind } from "./symbol-table.js";
+import { SymbolTable, SymbolKind, SymbolKind_Array } from "./symbol-table.js";
 import type { TypeChecker } from "../../typescript/type-checker.js";
 import type { ClassGenerator } from "../types/objects/class.js";
 import type { TypeResolver } from "./type-resolver/index.js";
@@ -1485,7 +1485,7 @@ export class TypeInference {
     if (e.type === "variable") {
       const varName = (expr as VariableNode).name;
       const kind = this.ctx.symbolTable.getKind(varName);
-      if (kind === SymbolKind.Array) return false;
+      if (kind === SymbolKind_Array) return false;
       const resolved = this.resolveExpressionType(expr);
       if (resolved && resolved.arrayDepth > 0) {
         if (resolved.arrayDepth > 1) {

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -32,6 +32,23 @@ import {
 } from "../../ast/types.js";
 import {
   SymbolKind,
+  SymbolKind_Number,
+  SymbolKind_String,
+  SymbolKind_Boolean,
+  SymbolKind_Array,
+  SymbolKind_StringArray,
+  SymbolKind_ObjectArray,
+  SymbolKind_Object,
+  SymbolKind_Map,
+  SymbolKind_Set,
+  SymbolKind_Class,
+  SymbolKind_Regex,
+  SymbolKind_JSON,
+  SymbolKind_Closure,
+  SymbolKind_Pointer,
+  SymbolKind_Uint8Array,
+  SymbolKind_Url,
+  SymbolKind_UrlSearchParams,
   SymbolTable,
   ObjectMetadata,
   MapMetadata,
@@ -73,38 +90,36 @@ interface ExprBase {
   type: string;
 }
 
-export enum VarKind {
-  DeclaredInterface,
-  StringArray,
-  MapGetInterface,
-  FunctionInterfaceReturn,
-  MethodInterfaceReturn,
-  MethodArrayReturn,
-  MemberAccessInterface,
-  Await,
-  Promise,
-  Uint8Array,
-  ClassInstance,
-  TypedJsonInterface,
-  Response,
-  JSONObject,
-  Object,
-  Map,
-  Set,
-  ObjectArray,
-  Array,
-  Regex,
-  String,
-  ArrowFunction,
-  IndexedObjectArray,
-  ArrayMethodReturn,
-  Pointer,
-  Null,
-  Numeric,
-}
+const VarKind_DeclaredInterface = 0;
+const VarKind_StringArray = 1;
+const VarKind_MapGetInterface = 2;
+const VarKind_FunctionInterfaceReturn = 3;
+const VarKind_MethodInterfaceReturn = 4;
+const VarKind_MethodArrayReturn = 5;
+const VarKind_MemberAccessInterface = 6;
+const VarKind_Await = 7;
+const VarKind_Promise = 8;
+const VarKind_Uint8Array = 9;
+const VarKind_ClassInstance = 10;
+const VarKind_TypedJsonInterface = 11;
+const VarKind_Response = 12;
+const VarKind_JSONObject = 13;
+const VarKind_Object = 14;
+const VarKind_Map = 15;
+const VarKind_Set = 16;
+const VarKind_ObjectArray = 17;
+const VarKind_Array = 18;
+const VarKind_Regex = 19;
+const VarKind_String = 20;
+const VarKind_ArrowFunction = 21;
+const VarKind_IndexedObjectArray = 22;
+const VarKind_ArrayMethodReturn = 23;
+const VarKind_Pointer = 24;
+const VarKind_Null = 25;
+const VarKind_Numeric = 26;
 
 export interface VarClassification {
-  kind: VarKind;
+  kind: number;
   declaredInterfaceType: string | null;
   mapGetInterfaceType: string | null;
   functionInterfaceReturn: string | null;
@@ -446,62 +461,62 @@ export class VariableAllocator {
     indexedObjectType: { keys: string[]; types: string[]; tsTypes: string[] } | null,
     arrayMethodReturnType: { keys: string[]; types: string[]; tsTypes: string[] } | null,
   ): VarClassification {
-    let kind: VarKind;
+    let kind: number;
 
     if (declaredInterfaceType) {
-      kind = VarKind.DeclaredInterface;
+      kind = VarKind_DeclaredInterface;
     } else if (isStringArray) {
-      kind = VarKind.StringArray;
+      kind = VarKind_StringArray;
     } else if (mapGetInterfaceType) {
-      kind = VarKind.MapGetInterface;
+      kind = VarKind_MapGetInterface;
     } else if (functionInterfaceReturn) {
-      kind = VarKind.FunctionInterfaceReturn;
+      kind = VarKind_FunctionInterfaceReturn;
     } else if (methodInterfaceReturn) {
-      kind = VarKind.MethodInterfaceReturn;
+      kind = VarKind_MethodInterfaceReturn;
     } else if (methodArrayReturn) {
-      kind = VarKind.MethodArrayReturn;
+      kind = VarKind_MethodArrayReturn;
     } else if (memberAccessInterfaceType) {
-      kind = VarKind.MemberAccessInterface;
+      kind = VarKind_MemberAccessInterface;
     } else if (isAwait) {
-      kind = VarKind.Await;
+      kind = VarKind_Await;
     } else if (isPromise) {
-      kind = VarKind.Promise;
+      kind = VarKind_Promise;
     } else if (isUint8Array) {
-      kind = VarKind.Uint8Array;
+      kind = VarKind_Uint8Array;
     } else if (isClassInstance) {
-      kind = VarKind.ClassInstance;
+      kind = VarKind_ClassInstance;
     } else if (typedJsonInterface) {
-      kind = VarKind.TypedJsonInterface;
+      kind = VarKind_TypedJsonInterface;
     } else if (isResponse) {
-      kind = VarKind.Response;
+      kind = VarKind_Response;
     } else if (isJSONObject) {
-      kind = VarKind.JSONObject;
+      kind = VarKind_JSONObject;
     } else if (isObject) {
-      kind = VarKind.Object;
+      kind = VarKind_Object;
     } else if (isMap) {
-      kind = VarKind.Map;
+      kind = VarKind_Map;
     } else if (isSet) {
-      kind = VarKind.Set;
+      kind = VarKind_Set;
     } else if (isObjectArray) {
-      kind = VarKind.ObjectArray;
+      kind = VarKind_ObjectArray;
     } else if (isArray) {
-      kind = VarKind.Array;
+      kind = VarKind_Array;
     } else if (isRegex) {
-      kind = VarKind.Regex;
+      kind = VarKind_Regex;
     } else if (isString) {
-      kind = VarKind.String;
+      kind = VarKind_String;
     } else if (isArrowFunction) {
-      kind = VarKind.ArrowFunction;
+      kind = VarKind_ArrowFunction;
     } else if (indexedObjectType) {
-      kind = VarKind.IndexedObjectArray;
+      kind = VarKind_IndexedObjectArray;
     } else if (arrayMethodReturnType) {
-      kind = VarKind.ArrayMethodReturn;
+      kind = VarKind_ArrayMethodReturn;
     } else if (isPointer) {
-      kind = VarKind.Pointer;
+      kind = VarKind_Pointer;
     } else if (isNull) {
-      kind = VarKind.Null;
+      kind = VarKind_Null;
     } else {
-      kind = VarKind.Numeric;
+      kind = VarKind_Numeric;
     }
 
     return {
@@ -524,7 +539,7 @@ export class VariableAllocator {
       // For global Uint8Array vars, set wantsBinaryReturn so readFileSync etc.
       // dispatch to their binary variants (same as allocateUint8Array does for locals)
       const sym = this.ctx.symbolTable.lookup(stmt.name);
-      const isGlobalUint8Array = !!sym && sym.kind === SymbolKind.Uint8Array;
+      const isGlobalUint8Array = !!sym && sym.kind === SymbolKind_Uint8Array;
       if (isGlobalUint8Array) {
         this.ctx.setWantsBinaryReturn(true);
       }
@@ -564,15 +579,15 @@ export class VariableAllocator {
       const allocaReg = this.ctx.nextAllocaReg(stmt.name);
       const baseType = stmt.declaredType ? stripNullable(stmt.declaredType) : "";
       if (baseType === "string" || baseType === "i8_ptr" || baseType === "ptr") {
-        this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.String, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_String, "local");
         this.ctx.emit(`${allocaReg} = alloca i8*`);
         this.ctx.emit(`store i8* null, i8** ${allocaReg}`);
       } else if (baseType === "boolean") {
-        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Boolean, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind_Boolean, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);
         this.ctx.emit(`store double 0.0, double* ${allocaReg}`);
       } else if (baseType === "number") {
-        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Number, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind_Number, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);
         this.ctx.emit(`store double 0.0, double* ${allocaReg}`);
       } else if (baseType === "string[]") {
@@ -580,7 +595,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%StringArray*",
-          SymbolKind.StringArray,
+          SymbolKind_StringArray,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -591,7 +606,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%Array*",
-          SymbolKind.Array,
+          SymbolKind_Array,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -602,7 +617,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%ObjectArray*",
-          SymbolKind.ObjectArray,
+          SymbolKind_ObjectArray,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -635,7 +650,7 @@ export class VariableAllocator {
                 stmt.name,
                 allocaReg,
                 "i8*",
-                SymbolKind.Object,
+                SymbolKind_Object,
                 "local",
                 createObjectMetadata({ keys, types, tsTypes }),
               );
@@ -665,7 +680,7 @@ export class VariableAllocator {
                 stmt.name,
                 allocaReg,
                 "i8*",
-                SymbolKind.Object,
+                SymbolKind_Object,
                 "local",
                 createObjectMetadataWithInterface({ keys, types, tsTypes }, baseType),
               );
@@ -674,25 +689,25 @@ export class VariableAllocator {
               return;
             }
           }
-          this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.Object, "local");
+          this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_Object, "local");
           this.ctx.emit(`${allocaReg} = alloca i8*`);
           this.ctx.emit(`store i8* null, i8** ${allocaReg}`);
         } else if (this.isUnionOfInterfaceTypes(baseType)) {
-          this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.Object, "local");
+          this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_Object, "local");
           this.ctx.emit(`${allocaReg} = alloca i8*`);
           this.ctx.emit(`store i8* null, i8** ${allocaReg}`);
         } else if (this.isStringLiteralUnion(baseType)) {
-          this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.String, "local");
+          this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_String, "local");
           this.ctx.emit(`${allocaReg} = alloca i8*`);
           this.ctx.emit(`store i8* null, i8** ${allocaReg}`);
         } else if (this.isEnumType(baseType)) {
           // Enum types are stored as double (numeric constants)
-          this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Number, "local");
+          this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind_Number, "local");
           this.ctx.emit(`${allocaReg} = alloca double`);
           this.ctx.emit(`store double 0.0, double* ${allocaReg}`);
         } else if (baseType === "object" || baseType === "any" || baseType === "unknown") {
           // Generic object/any/unknown types are opaque pointers
-          this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.Object, "local");
+          this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_Object, "local");
           this.ctx.emit(`${allocaReg} = alloca i8*`);
           this.ctx.emit(`store i8* null, i8** ${allocaReg}`);
         } else {
@@ -913,87 +928,87 @@ export class VariableAllocator {
     const declKey = stmt.name + ":" + declLine + ":" + declCol;
     this.ctx.setCurrentVarDeclKey(declKey);
     switch (classification.kind) {
-      case VarKind.DeclaredInterface:
+      case VarKind_DeclaredInterface:
         this.allocateDeclaredInterface(stmt, params, classification.declaredInterfaceType!);
         break;
-      case VarKind.StringArray:
+      case VarKind_StringArray:
         this.allocateStringArray(stmt, params);
         break;
-      case VarKind.MapGetInterface:
+      case VarKind_MapGetInterface:
         this.allocateMapGetInterface(stmt, params, classification.mapGetInterfaceType!);
         break;
-      case VarKind.FunctionInterfaceReturn:
+      case VarKind_FunctionInterfaceReturn:
         this.allocateFunctionInterfaceReturn(stmt, params, classification.functionInterfaceReturn!);
         break;
-      case VarKind.MethodInterfaceReturn:
+      case VarKind_MethodInterfaceReturn:
         this.allocateMethodInterfaceReturn(stmt, params, classification.methodInterfaceReturn!);
         break;
-      case VarKind.MethodArrayReturn:
+      case VarKind_MethodArrayReturn:
         this.allocateMethodArrayReturn(stmt, params, classification.methodArrayReturn!);
         break;
-      case VarKind.MemberAccessInterface:
+      case VarKind_MemberAccessInterface:
         this.allocateMemberAccessInterface(stmt, params, classification.memberAccessInterfaceType!);
         break;
-      case VarKind.Await:
+      case VarKind_Await:
         this.allocateAwaitResult(stmt, params);
         break;
-      case VarKind.Promise:
+      case VarKind_Promise:
         this.allocatePromise(stmt, params);
         break;
-      case VarKind.Uint8Array:
+      case VarKind_Uint8Array:
         this.allocateUint8Array(stmt, params);
         break;
-      case VarKind.ClassInstance:
+      case VarKind_ClassInstance:
         this.allocateClassInstance(stmt, params);
         break;
-      case VarKind.TypedJsonInterface:
+      case VarKind_TypedJsonInterface:
         this.allocateTypedJsonInterface(stmt, params, classification.typedJsonInterface!);
         break;
-      case VarKind.Response:
+      case VarKind_Response:
         this.allocateResponse(stmt, params);
         break;
-      case VarKind.JSONObject:
+      case VarKind_JSONObject:
         this.allocateJSONObject(stmt, params);
         break;
-      case VarKind.Object:
+      case VarKind_Object:
         this.allocateObject(stmt, params);
         break;
-      case VarKind.Map:
+      case VarKind_Map:
         this.allocateMap(stmt, params);
         break;
-      case VarKind.Set:
+      case VarKind_Set:
         this.allocateSet(stmt, params);
         break;
-      case VarKind.ObjectArray:
+      case VarKind_ObjectArray:
         this.allocateObjectArray(stmt, params);
         break;
-      case VarKind.Array:
+      case VarKind_Array:
         this.allocateArray(stmt, params);
         break;
-      case VarKind.Regex:
+      case VarKind_Regex:
         this.allocateRegex(stmt, params);
         break;
-      case VarKind.String:
+      case VarKind_String:
         this.allocateString(stmt, params);
         break;
-      case VarKind.ArrowFunction:
+      case VarKind_ArrowFunction:
         this.allocateArrowFunction(stmt, params);
         break;
-      case VarKind.IndexedObjectArray:
+      case VarKind_IndexedObjectArray:
         this.allocateIndexedObjectArray(stmt, params, classification.indexedObjectType!);
         break;
-      case VarKind.ArrayMethodReturn:
+      case VarKind_ArrayMethodReturn:
         this.allocateArrayMethodReturn(stmt, params, classification.arrayMethodReturnType!);
         break;
-      case VarKind.Pointer:
+      case VarKind_Pointer:
         this.allocatePointer(stmt, params);
         break;
-      case VarKind.Null:
+      case VarKind_Null:
         this.allocateNullPointer(stmt);
         break;
-      case VarKind.Numeric:
+      case VarKind_Numeric:
         // Warn when a non-trivially-numeric expression falls through to Numeric.
-        // VarKind.Numeric is correct for number/boolean literals and arithmetic,
+        // VarKind_Numeric is correct for number/boolean literals and arithmetic,
         // but suspicious for calls/method calls that might return non-numeric types.
         if (nodeType === "call" || nodeType === "method_call") {
           if (!stmt.declaredType) {
@@ -1063,7 +1078,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "i8*",
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       createObjectMetadataWithInterface({ keys, types, tsTypes }, interfaceName),
     );
@@ -1164,7 +1179,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "i8*",
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       createObjectMetadataWithInterface({ keys, types, tsTypes }, interfaceName),
     );
@@ -1207,7 +1222,7 @@ export class VariableAllocator {
       }
     }
 
-    this.ctx.defineVariable(stmt.name, allocaReg, "%ObjectArray*", SymbolKind.ObjectArray, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "%ObjectArray*", SymbolKind_ObjectArray, "local");
     this.ctx.symbolTable.setRawInterfaceType(
       stmt.name,
       elementType.startsWith("{") ? "inline" : elementType,
@@ -1326,7 +1341,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       llvmType,
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       createObjectMetadataWithInterface({ keys, types, tsTypes }, interfaceName),
     );
@@ -1345,9 +1360,9 @@ export class VariableAllocator {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
     const elementType = arrayType.slice(0, -2);
     if (elementType === "string") {
-      this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.StringArray, "local");
+      this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_StringArray, "local");
     } else if (elementType === "number" || elementType === "boolean") {
-      this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.Array, "local");
+      this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_Array, "local");
     } else {
       const typeInfo = this.getTypeInfoForElementType(elementType);
       if (typeInfo) {
@@ -1355,7 +1370,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "i8*",
-          SymbolKind.ObjectArray,
+          SymbolKind_ObjectArray,
           "local",
           createObjectMetadataWithInterface(
             { keys: typeInfo.keys, types: typeInfo.types, tsTypes: typeInfo.tsTypes },
@@ -1367,7 +1382,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "i8*",
-          SymbolKind.ObjectArray,
+          SymbolKind_ObjectArray,
           "local",
           createInterfacePointerAllocaMetadata(elementType),
         );
@@ -1493,7 +1508,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       ptrType,
-      SymbolKind.Class,
+      SymbolKind_Class,
       "local",
       createClassMetadata({ className }),
     );
@@ -1610,7 +1625,7 @@ export class VariableAllocator {
 
   private allocatePromise(stmt: VariableDeclaration, params: string[]): void {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    this.ctx.defineVariable(stmt.name, allocaReg, "%Promise*", SymbolKind.Object, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "%Promise*", SymbolKind_Object, "local");
     this.ctx.emit(`${allocaReg} = alloca %Promise*`);
 
     const promisePtr = this.ctx.generateExpression(stmt.value!, params);
@@ -1634,7 +1649,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%ObjectArray*",
-          SymbolKind.ObjectArray,
+          SymbolKind_ObjectArray,
           "local",
         );
         this.ctx.emit(`${allocaReg} = alloca %ObjectArray*`);
@@ -1654,7 +1669,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%StringArray*",
-          SymbolKind.StringArray,
+          SymbolKind_StringArray,
           "local",
         );
         this.ctx.emit(`${allocaReg} = alloca %StringArray*`);
@@ -1670,7 +1685,7 @@ export class VariableAllocator {
         methodCall.method === "stat"
       ) {
         const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-        this.ctx.defineVariable(stmt.name, allocaReg, "%StatResult*", SymbolKind.Object, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "%StatResult*", SymbolKind_Object, "local");
         this.ctx.emit(`${allocaReg} = alloca %StatResult*`);
         const value = this.ctx.generateExpression(stmt.value!, params);
         const castReg = this.ctx.nextTemp();
@@ -1686,7 +1701,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%SpawnSyncResult*",
-          SymbolKind.Object,
+          SymbolKind_Object,
           "local",
         );
         this.ctx.emit(`${allocaReg} = alloca %SpawnSyncResult*`);
@@ -1706,7 +1721,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%__FetchResponse*",
-          SymbolKind.Object,
+          SymbolKind_Object,
           "local",
         );
         this.ctx.emit(`${allocaReg} = alloca %__FetchResponse*`);
@@ -1722,7 +1737,7 @@ export class VariableAllocator {
         stmt.name,
         allocaReg,
         "%__FetchResponse*",
-        SymbolKind.Object,
+        SymbolKind_Object,
         "local",
       );
       this.ctx.emit(`${allocaReg} = alloca %__FetchResponse*`);
@@ -1732,7 +1747,7 @@ export class VariableAllocator {
     }
 
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.String, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_String, "local");
     this.ctx.emit(`${allocaReg} = alloca i8*`);
 
     const value = this.ctx.generateExpression(stmt.value!, params);
@@ -1746,7 +1761,7 @@ export class VariableAllocator {
   ): void {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
     const structType = `%${interfaceName}*`;
-    this.ctx.defineVariable(stmt.name, allocaReg, structType, SymbolKind.Object, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, structType, SymbolKind_Object, "local");
     this.ctx.symbolTable.setRawInterfaceType(stmt.name, interfaceName);
     this.ctx.emit(`${allocaReg} = alloca ${structType}`);
 
@@ -1756,7 +1771,7 @@ export class VariableAllocator {
 
   private allocateResponse(stmt: VariableDeclaration, params: string[]): void {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    this.ctx.defineVariable(stmt.name, allocaReg, "%__FetchResponse*", SymbolKind.Object, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "%__FetchResponse*", SymbolKind_Object, "local");
     this.ctx.emit(`${allocaReg} = alloca %__FetchResponse*`);
 
     const responsePtr = this.ctx.generateExpression(stmt.value!, params);
@@ -1767,7 +1782,7 @@ export class VariableAllocator {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
     const interfaceName = this.ctx.getJSONParseInterface(stmt.value!);
     if (!interfaceName) {
-      this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.JSON, "local");
+      this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_JSON, "local");
       this.ctx.emit(`${allocaReg} = alloca i8*`);
       const jsonPtr = this.ctx.generateExpression(stmt.value!, params);
       this.ctx.emit(`store i8* ${jsonPtr}, i8** ${allocaReg}`);
@@ -1775,7 +1790,7 @@ export class VariableAllocator {
     }
 
     if (interfaceName === "number[]") {
-      this.ctx.defineVariable(stmt.name, allocaReg, "%Array*", SymbolKind.Array, "local");
+      this.ctx.defineVariable(stmt.name, allocaReg, "%Array*", SymbolKind_Array, "local");
       this.ctx.emit(`${allocaReg} = alloca %Array*`);
       const arrPtr = this.ctx.generateExpression(stmt.value!, params);
       this.ctx.emit(`store %Array* ${arrPtr}, %Array** ${allocaReg}`);
@@ -1785,7 +1800,7 @@ export class VariableAllocator {
     const interfaceDefResult = this.getInterface(interfaceName);
 
     if (!interfaceDefResult) {
-      this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.JSON, "local");
+      this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_JSON, "local");
       this.ctx.emit(`${allocaReg} = alloca i8*`);
       const jsonPtr = this.ctx.generateExpression(stmt.value!, params);
       this.ctx.emit(`store i8* ${jsonPtr}, i8** ${allocaReg}`);
@@ -1806,7 +1821,7 @@ export class VariableAllocator {
         stmt.name,
         allocaReg,
         "i8*",
-        SymbolKind.JSON,
+        SymbolKind_JSON,
         "local",
         createObjectMetadataWithInterface({ keys, types, tsTypes }, interfaceName),
       );
@@ -1852,7 +1867,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "i8*",
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       varMetadata,
     );
@@ -1914,7 +1929,7 @@ export class VariableAllocator {
       }
     }
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    this.ctx.defineVariable(stmt.name, allocaReg, "%Map*", SymbolKind.Map, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "%Map*", SymbolKind_Map, "local");
     const mapSizePtr = this.ctx.nextTemp();
     this.ctx.emit(`${mapSizePtr} = getelementptr %Map, %Map* null, i32 1`);
     const mapSizeI64 = this.ctx.nextTemp();
@@ -1941,7 +1956,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "%StringMap*",
-      SymbolKind.Map,
+      SymbolKind_Map,
       "local",
       createMapMetadataSymbol({
         keyType: "string",
@@ -1980,7 +1995,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "%StringMap*",
-      SymbolKind.Map,
+      SymbolKind_Map,
       "local",
       createMapMetadataSymbol({
         keyType: mapTypeInfo.keyType,
@@ -2074,7 +2089,7 @@ export class VariableAllocator {
       }
     }
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    this.ctx.defineVariable(stmt.name, allocaReg, "%Set*", SymbolKind.Set, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "%Set*", SymbolKind_Set, "local");
     const setSizePtr = this.ctx.nextTemp();
     this.ctx.emit(`${setSizePtr} = getelementptr %Set, %Set* null, i32 1`);
     const setSizeI64 = this.ctx.nextTemp();
@@ -2101,7 +2116,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "%StringSet*",
-      SymbolKind.Set,
+      SymbolKind_Set,
       "local",
       createSetMetadataSymbol({
         valueType: "string",
@@ -2131,7 +2146,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "%StringArray*",
-      SymbolKind.StringArray,
+      SymbolKind_StringArray,
       "local",
       createPointerAllocaMetadata(),
     );
@@ -2158,7 +2173,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "%Array*",
-      SymbolKind.Array,
+      SymbolKind_Array,
       "local",
       createPointerAllocaMetadata(),
     );
@@ -2177,7 +2192,7 @@ export class VariableAllocator {
 
   private allocateUint8Array(stmt: VariableDeclaration, params: string[]): void {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    this.ctx.defineVariable(stmt.name, allocaReg, "%Uint8Array*", SymbolKind.Uint8Array, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "%Uint8Array*", SymbolKind_Uint8Array, "local");
     this.ctx.emit(`${allocaReg} = alloca %Uint8Array*`);
 
     // Signal to readFileSync/etc. that we want binary return (%Uint8Array*)
@@ -2202,7 +2217,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%ObjectArray*",
-          SymbolKind.ObjectArray,
+          SymbolKind_ObjectArray,
           "local",
           createObjectMetadataWithInterface(
             {
@@ -2230,7 +2245,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%ObjectArray*",
-          SymbolKind.ObjectArray,
+          SymbolKind_ObjectArray,
           "local",
         );
         this.ctx.symbolTable.setRawInterfaceType(stmt.name, elementType);
@@ -2247,7 +2262,7 @@ export class VariableAllocator {
         stmt.name,
         allocaReg,
         "%ObjectArray*",
-        SymbolKind.ObjectArray,
+        SymbolKind_ObjectArray,
         "local",
       );
       this.ctx.symbolTable.setRawInterfaceType(stmt.name, "object");
@@ -2263,7 +2278,7 @@ export class VariableAllocator {
       return;
     }
 
-    this.ctx.defineVariable(stmt.name, allocaReg, "%ObjectArray*", SymbolKind.ObjectArray, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "%ObjectArray*", SymbolKind_ObjectArray, "local");
     this.ctx.emit(`${allocaReg} = alloca %ObjectArray*`);
     const value = this.ctx.generateExpression(stmt.value!, params);
     this.ctx.emit(`store %ObjectArray* ${value}, %ObjectArray** ${allocaReg}`);
@@ -2301,7 +2316,7 @@ export class VariableAllocator {
 
   private allocateRegex(stmt: VariableDeclaration, params: string[]): void {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.Regex, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_Regex, "local");
     this.ctx.emit(`${allocaReg} = alloca i8*`);
 
     const value = this.ctx.generateExpression(stmt.value!, params);
@@ -2326,7 +2341,7 @@ export class VariableAllocator {
 
   private allocateString(stmt: VariableDeclaration, params: string[]): void {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.String, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_String, "local");
     this.ctx.emit(`${allocaReg} = alloca i8*`);
 
     const value = this.ctx.generateExpression(stmt.value!, params);
@@ -2362,7 +2377,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "i8*",
-          SymbolKind.ObjectArray,
+          SymbolKind_ObjectArray,
           "local",
           createObjectMetadataWithInterface(
             { keys: typeInfo.keys, types: typeInfo.types, tsTypes: typeInfo.tsTypes },
@@ -2376,7 +2391,7 @@ export class VariableAllocator {
       }
     }
 
-    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.JSON, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_JSON, "local");
     this.ctx.emit(`${allocaReg} = alloca i8*`);
     const value = this.ctx.generateExpression(stmt.value!, params);
     this.ctx.emit(`store i8* ${value}, i8** ${allocaReg}`);
@@ -2413,19 +2428,19 @@ export class VariableAllocator {
     if (stmt.declaredType) {
       const baseType = stripNullable(stmt.declaredType);
       if (baseType === "number") {
-        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Number, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind_Number, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);
         this.ctx.emit(`store double 0.0, double* ${allocaReg}`);
         return;
       }
       if (baseType === "boolean") {
-        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind.Boolean, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "double", SymbolKind_Boolean, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);
         this.ctx.emit(`store double 0.0, double* ${allocaReg}`);
         return;
       }
       if (baseType === "string") {
-        this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.String, "local");
+        this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_String, "local");
         this.ctx.emit(`${allocaReg} = alloca i8*`);
         this.ctx.emit(`store i8* null, i8** ${allocaReg}`);
         return;
@@ -2435,7 +2450,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%StringArray*",
-          SymbolKind.StringArray,
+          SymbolKind_StringArray,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -2448,7 +2463,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "%Array*",
-          SymbolKind.Array,
+          SymbolKind_Array,
           "local",
           createPointerAllocaMetadata(),
         );
@@ -2472,7 +2487,7 @@ export class VariableAllocator {
             stmt.name,
             allocaReg,
             "i8*",
-            SymbolKind.Object,
+            SymbolKind_Object,
             "local",
             createObjectMetadata({ keys, types, tsTypes }),
           );
@@ -2498,7 +2513,7 @@ export class VariableAllocator {
           stmt.name,
           allocaReg,
           "i8*",
-          SymbolKind.Object,
+          SymbolKind_Object,
           "local",
           createObjectMetadataWithInterface({ keys, types, tsTypes }, baseType),
         );
@@ -2508,7 +2523,7 @@ export class VariableAllocator {
       }
     }
 
-    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind.String, "local");
+    this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_String, "local");
     this.ctx.emit(`${allocaReg} = alloca i8*`);
     this.ctx.emit(`store i8* null, i8** ${allocaReg}`);
   }
@@ -2524,12 +2539,12 @@ export class VariableAllocator {
       valueType === "%TSLanguage*";
     if (isTreeSitterType) {
       const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-      this.ctx.defineVariable(stmt.name, allocaReg, valueType, SymbolKind.Object, "local");
+      this.ctx.defineVariable(stmt.name, allocaReg, valueType, SymbolKind_Object, "local");
       this.ctx.emit(`${allocaReg} = alloca double`);
       this.ctx.emit(`store double ${value}, double* ${allocaReg}`);
     } else if (valueType && valueType !== "double" && valueType.indexOf("*") !== -1) {
       const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-      this.ctx.defineVariable(stmt.name, allocaReg, valueType, SymbolKind.Object, "local");
+      this.ctx.defineVariable(stmt.name, allocaReg, valueType, SymbolKind_Object, "local");
       this.ctx.emit(`${allocaReg} = alloca ${valueType}`);
       this.ctx.emit(`store ${valueType} ${value}, ${valueType}* ${allocaReg}`);
     } else {
@@ -2537,7 +2552,7 @@ export class VariableAllocator {
       const isBoolVal =
         stmt.value!.type === "boolean" ||
         (stmt.declaredType && stripNullable(stmt.declaredType) === "boolean");
-      const symKind = isBoolVal ? SymbolKind.Boolean : SymbolKind.Number;
+      const symKind = isBoolVal ? SymbolKind_Boolean : SymbolKind_Number;
       if (valueType === "i64" && this.isI64Eligible(stmt.name)) {
         this.ctx.defineVariable(stmt.name, allocaReg, "i64", symKind, "local");
         this.ctx.emit(`${allocaReg} = alloca i64`);
@@ -2624,7 +2639,7 @@ export class VariableAllocator {
         stmt.name,
         envTypedReg,
         "i8*",
-        SymbolKind.Closure,
+        SymbolKind_Closure,
         "local",
         createClosureMetadataSymbol({
           lambdaName,
@@ -2640,7 +2655,7 @@ export class VariableAllocator {
         stmt.name,
         allocaReg,
         "i8*",
-        SymbolKind.Closure,
+        SymbolKind_Closure,
         "local",
         createClosureMetadataSymbol({
           lambdaName,
@@ -3108,7 +3123,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "i8*",
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       createObjectMetadata({
         keys: typeInfo.keys,
@@ -3150,7 +3165,7 @@ export class VariableAllocator {
       stmt.name,
       allocaReg,
       "i8*",
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       createObjectMetadata({
         keys: typeInfo.keys,

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -39,7 +39,28 @@ import {
   MemberAccessNode,
   EnumDeclaration,
 } from "../ast/types.js";
-import { BaseGenerator, SymbolKind, SymbolTable } from "./infrastructure/base-generator.js";
+import {
+  BaseGenerator,
+  SymbolKind,
+  SymbolKind_Number,
+  SymbolKind_String,
+  SymbolKind_Boolean,
+  SymbolKind_Array,
+  SymbolKind_StringArray,
+  SymbolKind_ObjectArray,
+  SymbolKind_Object,
+  SymbolKind_Map,
+  SymbolKind_Set,
+  SymbolKind_Class,
+  SymbolKind_Regex,
+  SymbolKind_JSON,
+  SymbolKind_Closure,
+  SymbolKind_Pointer,
+  SymbolKind_Uint8Array,
+  SymbolKind_Url,
+  SymbolKind_UrlSearchParams,
+  SymbolTable,
+} from "./infrastructure/base-generator.js";
 import {
   MapMetadata,
   SymbolMetadata,
@@ -135,6 +156,7 @@ import { checkTypeAssertions } from "../semantic/type-assertion-checker.js";
 import { checkUninitializedFields } from "../semantic/uninitialized-field-checker.js";
 import { analyzeEscapes } from "../semantic/escape-analysis.js";
 import { checkBinaryTypes } from "../semantic/binary-type-checker.js";
+import { checkEnumDeclarations } from "../semantic/enum-checker.js";
 import { DebugMetadataBuilder } from "./infrastructure/debug-metadata.js";
 
 export interface SemaSymbolData {
@@ -1526,25 +1548,25 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       let llvmType = "";
 
       if (stype === "number") {
-        kind = SymbolKind.Number;
+        kind = SymbolKind_Number;
         llvmType = "double";
       } else if (stype === "string") {
-        kind = SymbolKind.String;
+        kind = SymbolKind_String;
         llvmType = "i8*";
       } else if (stype === "boolean") {
-        kind = SymbolKind.Boolean;
+        kind = SymbolKind_Boolean;
         llvmType = "double";
       } else if (stype === "array<number>") {
-        kind = SymbolKind.Array;
+        kind = SymbolKind_Array;
         llvmType = "%Array*";
       } else if (stype === "array<string>") {
-        kind = SymbolKind.StringArray;
+        kind = SymbolKind_StringArray;
         llvmType = "%StringArray*";
       } else if (stype === "object") {
-        kind = SymbolKind.Object;
+        kind = SymbolKind_Object;
         llvmType = "i8*";
       } else if (stype === "class") {
-        kind = SymbolKind.Class;
+        kind = SymbolKind_Class;
         llvmType = "i8*";
       }
 
@@ -1695,10 +1717,10 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         if (rt === "string" || rt === "i8_ptr" || rt === "ptr") {
           this.globalVariables.set(name, {
             llvmType: "i8*",
-            kind: SymbolKind.String,
+            kind: SymbolKind_String,
             initialized: false,
           });
-          this.defineVariable(name, `@${name}`, "i8*", SymbolKind.String, "global");
+          this.defineVariable(name, `@${name}`, "i8*", SymbolKind_String, "global");
           return `@${name} = global i8* null\n`;
         }
         const iface = this.getInterfaceDeclByName(rt);
@@ -1715,14 +1737,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
           this.globalVariables.set(name, {
             llvmType: "i8*",
-            kind: SymbolKind.Object,
+            kind: SymbolKind_Object,
             initialized: false,
           });
           this.defineVariableWithMetadata(
             name,
             `@${name}`,
             "i8*",
-            SymbolKind.Object,
+            SymbolKind_Object,
             "global",
             createObjectMetadataWithInterface({ keys, types, tsTypes }, rt),
           );
@@ -1734,14 +1756,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           const llvmType = fields.length > 0 ? `%${resolvedClassName}_struct*` : "i32*";
           this.globalVariables.set(name, {
             llvmType,
-            kind: SymbolKind.Class,
+            kind: SymbolKind_Class,
             initialized: false,
           });
           this.defineVariableWithMetadata(
             name,
             `@${name}`,
             llvmType,
-            SymbolKind.Class,
+            SymbolKind_Class,
             "global",
             createClassMetadata({ className: resolvedClassName }),
           );
@@ -1752,14 +1774,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           if (elementType === "string") {
             this.globalVariables.set(name, {
               llvmType: "%StringArray*",
-              kind: SymbolKind.StringArray,
+              kind: SymbolKind_StringArray,
               initialized: false,
             });
             this.defineVariable(
               name,
               `@${name}`,
               "%StringArray*",
-              SymbolKind.StringArray,
+              SymbolKind_StringArray,
               "global",
             );
             return `@${name} = global %StringArray* null\n`;
@@ -1767,22 +1789,22 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           if (elementType === "number" || elementType === "boolean") {
             this.globalVariables.set(name, {
               llvmType: "%Array*",
-              kind: SymbolKind.Array,
+              kind: SymbolKind_Array,
               initialized: false,
             });
-            this.defineVariable(name, `@${name}`, "%Array*", SymbolKind.Array, "global");
+            this.defineVariable(name, `@${name}`, "%Array*", SymbolKind_Array, "global");
             return `@${name} = global %Array* null\n`;
           }
           this.globalVariables.set(name, {
             llvmType: "%ObjectArray*",
-            kind: SymbolKind.ObjectArray,
+            kind: SymbolKind_ObjectArray,
             initialized: false,
           });
           this.defineVariableWithMetadata(
             name,
             `@${name}`,
             "%ObjectArray*",
-            SymbolKind.ObjectArray,
+            SymbolKind_ObjectArray,
             "global",
             createInterfaceMetadata(elementType),
           );
@@ -1794,14 +1816,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           if (commonProps) {
             this.globalVariables.set(name, {
               llvmType: "i8*",
-              kind: SymbolKind.Object,
+              kind: SymbolKind_Object,
               initialized: false,
             });
             this.defineVariableWithMetadata(
               name,
               `@${name}`,
               "i8*",
-              SymbolKind.Object,
+              SymbolKind_Object,
               "global",
               createObjectMetadataWithInterface(commonProps, rt),
             );
@@ -1818,7 +1840,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     const interfaceName = this.typeInference.getJSONParseInterface(methodCall);
     if (interfaceName === "number[]") {
       const llvmType = "%Array*";
-      const kind = SymbolKind.Array;
+      const kind = SymbolKind_Array;
       this.globalVariables.set(name, { llvmType, kind, initialized: false });
       this.defineVariableWithMetadata(
         name,
@@ -1843,7 +1865,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       }
       if (interfaceDef) {
         const llvmType = `%${interfaceName}*`;
-        const kind = SymbolKind.JSON;
+        const kind = SymbolKind_JSON;
         const keys: string[] = [];
         const tsTypes: string[] = [];
         const types: string[] = [];
@@ -1886,14 +1908,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     if (foundInterface) {
       this.globalVariables.set(name, {
         llvmType: "i8*",
-        kind: SymbolKind.Object,
+        kind: SymbolKind_Object,
         initialized: false,
       });
       this.defineVariableWithMetadata(
         name,
         `@${name}`,
         "i8*",
-        SymbolKind.Object,
+        SymbolKind_Object,
         "global",
         createInterfaceMetadata(strippedDeclaredType),
       );
@@ -1904,14 +1926,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       const llvmType = fields.length > 0 ? `%${strippedDeclaredType}_struct*` : "i8*";
       this.globalVariables.set(name, {
         llvmType,
-        kind: SymbolKind.Class,
+        kind: SymbolKind_Class,
         initialized: false,
       });
       this.defineVariableWithMetadata(
         name,
         `@${name}`,
         llvmType,
-        SymbolKind.Class,
+        SymbolKind_Class,
         "global",
         createClassMetadata({ className: strippedDeclaredType }),
       );
@@ -1926,7 +1948,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         if (members && members.length > 0) {
           aliasLlvm = tsTypeToLlvm(members[0].trim());
         }
-        const kind = aliasLlvm === "double" ? SymbolKind.Number : SymbolKind.Object;
+        const kind = aliasLlvm === "double" ? SymbolKind_Number : SymbolKind_Object;
         const defaultValue = aliasLlvm === "double" ? "0.0" : "null";
         this.globalVariables.set(name, {
           llvmType: aliasLlvm,
@@ -1946,14 +1968,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     if (funcReturnInterface) {
       this.globalVariables.set(name, {
         llvmType: "i8*",
-        kind: SymbolKind.Object,
+        kind: SymbolKind_Object,
         initialized: false,
       });
       this.defineVariableWithMetadata(
         name,
         `@${name}`,
         "i8*",
-        SymbolKind.Object,
+        SymbolKind_Object,
         "global",
         createInterfaceMetadata(funcReturnInterface),
       );
@@ -1963,14 +1985,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     if (indexAccessInterface) {
       this.globalVariables.set(name, {
         llvmType: "i8*",
-        kind: SymbolKind.Object,
+        kind: SymbolKind_Object,
         initialized: false,
       });
       this.defineVariableWithMetadata(
         name,
         `@${name}`,
         "i8*",
-        SymbolKind.Object,
+        SymbolKind_Object,
         "global",
         createInterfaceMetadata(indexAccessInterface),
       );
@@ -1982,17 +2004,17 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         const idxObjVar = idxNode.object as VariableNode;
         if (idxObjVar.name) {
           const arrSym = this.symbolTable.lookup(idxObjVar.name);
-          if (arrSym && arrSym.kind === SymbolKind.ObjectArray && arrSym.interfaceType) {
+          if (arrSym && arrSym.kind === SymbolKind_ObjectArray && arrSym.interfaceType) {
             this.globalVariables.set(name, {
               llvmType: "i8*",
-              kind: SymbolKind.Object,
+              kind: SymbolKind_Object,
               initialized: false,
             });
             this.defineVariableWithMetadata(
               name,
               `@${name}`,
               "i8*",
-              SymbolKind.Object,
+              SymbolKind_Object,
               "global",
               createInterfaceMetadata(arrSym.interfaceType),
             );
@@ -2032,10 +2054,10 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       const resolved = value ? this.typeInference.resolveExpressionType(value) : null;
       if (resolved) {
         if (resolved.base === "string") {
-          return { llvmType: "i8*", kind: SymbolKind.String, defaultValue: "null" };
+          return { llvmType: "i8*", kind: SymbolKind_String, defaultValue: "null" };
         }
         if (resolved.base === "boolean") {
-          return { llvmType: "i1", kind: SymbolKind.Boolean, defaultValue: "0" };
+          return { llvmType: "i1", kind: SymbolKind_Boolean, defaultValue: "0" };
         }
       }
       let isI64 = false;
@@ -2046,9 +2068,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         }
       }
       if (isI64) {
-        return { llvmType: "i64", kind: SymbolKind.Number, defaultValue: "0" };
+        return { llvmType: "i64", kind: SymbolKind_Number, defaultValue: "0" };
       }
-      return { llvmType: "double", kind: SymbolKind.Number, defaultValue: "0.0" };
+      return { llvmType: "double", kind: SymbolKind_Number, defaultValue: "0.0" };
     }
     return null;
   }
@@ -2190,7 +2212,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         const isJSONParse = this.typeInference.isJSONParseExpression(stmt.value);
 
         let llvmType: string = "";
-        let kind: number = SymbolKind.Number;
+        let kind: number = SymbolKind_Number;
         let defaultValue: string = "0.0";
 
         const stmtValueBase = stmt.value as { type: string };
@@ -2200,7 +2222,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             ir += `@${name} = global i8* null` + "\n";
             this.globalVariables.set(name, {
               llvmType: "i8*",
-              kind: SymbolKind.Url,
+              kind: SymbolKind_Url,
               initialized: false,
             });
             this.symbolTable.defineUrl(name, `@${name}`, "global");
@@ -2210,7 +2232,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             ir += `@${name} = global i8* null` + "\n";
             this.globalVariables.set(name, {
               llvmType: "i8*",
-              kind: SymbolKind.UrlSearchParams,
+              kind: SymbolKind_UrlSearchParams,
               initialized: false,
             });
             this.symbolTable.defineUrlSearchParams(name, `@${name}`, "global");
@@ -2220,7 +2242,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
         if (isString) {
           llvmType = "i8*";
-          kind = SymbolKind.String;
+          kind = SymbolKind_String;
           defaultValue = "null";
           if (stmtValueBase.type === "method_call") {
             const mc = stmt.value as MethodCallNode;
@@ -2236,7 +2258,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
                     ? this.classGen.getClassFields(elemType) || []
                     : [];
                   if (classFields.length > 0) {
-                    kind = SymbolKind.Class;
+                    kind = SymbolKind_Class;
                     ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
                     this.globalVariables.set(name, { llvmType, kind, initialized: false });
                     this.defineVariableWithMetadata(
@@ -2248,7 +2270,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
                       createClassMetadata({ className: elemType }),
                     );
                   } else {
-                    kind = SymbolKind.Object;
+                    kind = SymbolKind_Object;
                     ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
                     this.globalVariables.set(name, { llvmType, kind, initialized: false });
                     const props = this.getInterfaceProperties(elemType);
@@ -2276,7 +2298,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
         } else if (isStringArray) {
           llvmType = "%StringArray*";
-          kind = SymbolKind.StringArray;
+          kind = SymbolKind_StringArray;
           defaultValue = "null";
         } else if (isObjectArray) {
           let elementType = "";
@@ -2295,7 +2317,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             if (objArrElemType) elementType = objArrElemType;
           }
           llvmType = "%ObjectArray*";
-          kind = SymbolKind.ObjectArray;
+          kind = SymbolKind_ObjectArray;
           defaultValue = "null";
           ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
           this.globalVariables.set(name, { llvmType, kind, initialized: false });
@@ -2318,11 +2340,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           continue;
         } else if (isArray) {
           llvmType = "%Array*";
-          kind = SymbolKind.Array;
+          kind = SymbolKind_Array;
           defaultValue = "null";
         } else if (isObject) {
           llvmType = "i8*";
-          kind = SymbolKind.Object;
+          kind = SymbolKind_Object;
           defaultValue = "null";
           const objMeta = this.getObjectMetadata(stmt.value as ObjectNode);
           if (objMeta && objMeta.keys.length > 0) {
@@ -2369,7 +2391,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
           if (isStringMap) {
             llvmType = "%StringMap*";
-            kind = SymbolKind.Map;
+            kind = SymbolKind_Map;
             defaultValue = "null";
             const llvmValueType = mapValueType === "number" ? "double" : "i8*";
             ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
@@ -2410,7 +2432,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
           if (isPointerMap) {
             llvmType = "%StringMap*";
-            kind = SymbolKind.Map;
+            kind = SymbolKind_Map;
             defaultValue = "null";
             ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
             this.globalVariables.set(name, { llvmType, kind, initialized: false });
@@ -2446,7 +2468,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             );
           }
           llvmType = "%Map*";
-          kind = SymbolKind.Map;
+          kind = SymbolKind_Map;
           defaultValue = "null";
         } else if (isSet) {
           let isStringSet = false;
@@ -2463,7 +2485,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
           if (isStringSet) {
             llvmType = "%StringSet*";
-            kind = SymbolKind.Set;
+            kind = SymbolKind_Set;
             defaultValue = "null";
             ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
             this.globalVariables.set(name, { llvmType, kind, initialized: false });
@@ -2481,15 +2503,15 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             continue;
           }
           llvmType = "%Set*";
-          kind = SymbolKind.Set;
+          kind = SymbolKind_Set;
           defaultValue = "null";
         } else if (isRegex) {
           llvmType = "i8*";
-          kind = SymbolKind.Regex;
+          kind = SymbolKind_Regex;
           defaultValue = "null";
         } else if (isUint8Array) {
           llvmType = "%Uint8Array*";
-          kind = SymbolKind.Uint8Array;
+          kind = SymbolKind_Uint8Array;
           defaultValue = "null";
           ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
           this.globalVariables.set(name, { llvmType, kind, initialized: false });
@@ -2513,7 +2535,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
           const fields = this.classGen ? this.classGen.getClassFields(className) || [] : [];
           llvmType = fields.length > 0 ? `%${className}_struct*` : "i32*";
-          kind = SymbolKind.Class;
+          kind = SymbolKind_Class;
           defaultValue = "null";
           ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
           this.globalVariables.set(name, { llvmType, kind, initialized: false });
@@ -2528,11 +2550,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           continue;
         } else if (isBoolean) {
           llvmType = "double";
-          kind = SymbolKind.Boolean;
+          kind = SymbolKind_Boolean;
           defaultValue = "0.0";
         } else if (isNumber) {
           llvmType = "double";
-          kind = SymbolKind.Number;
+          kind = SymbolKind_Number;
           defaultValue = "0.0";
         } else if (isJSONParse) {
           const jsonIr = this.tryHandleGlobalJSONParse(name, stmt.value as MethodCallNode);
@@ -2541,7 +2563,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             continue;
           }
           llvmType = "i8*";
-          kind = SymbolKind.JSON;
+          kind = SymbolKind_JSON;
           defaultValue = "null";
         } else {
           const declaredIr = this.tryHandleGlobalDeclaredType(name, stmt.declaredType);
@@ -2553,7 +2575,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             const strippedDeclaredType = stripNullable(stmt.declaredType);
             if (strippedDeclaredType === "string") {
               llvmType = "i8*";
-              kind = SymbolKind.String;
+              kind = SymbolKind_String;
               defaultValue = "null";
             }
           }
@@ -2633,6 +2655,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
 
   generateParts(): string[] {
+    checkEnumDeclarations(this.ast, this.sourceCode);
     checkClosureMutations(this.ast, this.sourceCode);
     checkUnionTypes(this.ast, this.sourceCode);
     checkTypeAssertions(this.ast, this.sourceCode);

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -29,6 +29,12 @@ import {
 import { IGeneratorContext } from "../infrastructure/generator-context.js";
 import {
   SymbolKind,
+  SymbolKind_Number,
+  SymbolKind_String,
+  SymbolKind_Object,
+  SymbolKind_StringArray,
+  SymbolKind_Array,
+  SymbolKind_Class,
   ObjectArrayMetadata,
   ObjectMetadata,
   createObjectMetadata,
@@ -323,7 +329,7 @@ export class ControlFlowGenerator {
         const value = this.ctx.generateExpression(initVarDecl.value, params);
         const dblValue = this.ctx.ensureDouble(value);
         const allocaReg = this.ctx.nextAllocaReg(initVarDecl.name);
-        this.ctx.defineVariable(initVarDecl.name, allocaReg, "double", SymbolKind.Number, "local");
+        this.ctx.defineVariable(initVarDecl.name, allocaReg, "double", SymbolKind_Number, "local");
         this.emit(`${allocaReg} = alloca double`);
         this.ctx.emitStore("double", dblValue, allocaReg);
       } else if (initBase.type === "assignment") {
@@ -462,40 +468,40 @@ export class ControlFlowGenerator {
     const isStringSet = this.isStringSetExpression(forOfStmt.iterable);
     let arrayType: string = "";
     let elementType: string = "";
-    let elementKind: number = SymbolKind.Number;
+    let elementKind: number = SymbolKind_Number;
 
     if (isStringSet) {
       arrayType = "%StringSet";
       elementType = "i8*";
-      elementKind = SymbolKind.String;
+      elementKind = SymbolKind_String;
     } else if (isStringArray) {
       arrayType = "%StringArray";
       elementType = "i8*";
-      elementKind = SymbolKind.String;
+      elementKind = SymbolKind_String;
     } else if (isObjectArray) {
       arrayType = "%ObjectArray";
       elementType = "i8*";
-      elementKind = SymbolKind.Object;
+      elementKind = SymbolKind_Object;
       const iterableBase = forOfStmt.iterable as ExprBase;
       if (iterableBase.type === "variable") {
         const varName = (forOfStmt.iterable as VariableNode).name;
         const sym = this.ctx.symbolTable.lookup(varName);
         if (sym && sym.resolvedType && sym.resolvedType.arrayDepth > 1) {
           if (sym.resolvedType.base === "string") {
-            elementKind = SymbolKind.StringArray;
+            elementKind = SymbolKind_StringArray;
           } else if (sym.resolvedType.base === "number") {
-            elementKind = SymbolKind.Array;
+            elementKind = SymbolKind_Array;
           }
         }
       }
       const classElemType = this.getIterableClassElementType(forOfStmt.iterable);
       if (classElemType) {
-        elementKind = SymbolKind.Class;
+        elementKind = SymbolKind_Class;
       }
     } else {
       arrayType = "%Array";
       elementType = "double";
-      elementKind = SymbolKind.Number;
+      elementKind = SymbolKind_Number;
     }
 
     const lenPtr = this.nextTemp();
@@ -511,11 +517,11 @@ export class ControlFlowGenerator {
 
     let actualElementType = elementType;
     let forOfClassName = "";
-    if (elementKind === SymbolKind.StringArray) {
+    if (elementKind === SymbolKind_StringArray) {
       actualElementType = "%StringArray*";
-    } else if (elementKind === SymbolKind.Array && isObjectArray) {
+    } else if (elementKind === SymbolKind_Array && isObjectArray) {
       actualElementType = "%Array*";
-    } else if (elementKind === SymbolKind.Class && isObjectArray) {
+    } else if (elementKind === SymbolKind_Class && isObjectArray) {
       forOfClassName = this.getIterableClassElementType(forOfStmt.iterable) || "";
       if (forOfClassName) {
         actualElementType = `%${forOfClassName}_struct*`;
@@ -525,12 +531,12 @@ export class ControlFlowGenerator {
     const elemAlloca = this.ctx.nextAllocaReg(forOfStmt.variableName);
     this.emit(`${elemAlloca} = alloca ${actualElementType}`);
 
-    if (elementKind === SymbolKind.Class && forOfClassName) {
+    if (elementKind === SymbolKind_Class && forOfClassName) {
       this.ctx.defineVariableWithMetadata(
         forOfStmt.variableName,
         elemAlloca,
         actualElementType,
-        SymbolKind.Class,
+        SymbolKind_Class,
         "local",
         createClassMetadata({ className: forOfClassName }),
       );
@@ -544,12 +550,12 @@ export class ControlFlowGenerator {
       );
     }
 
-    if (elementKind === SymbolKind.StringArray) {
+    if (elementKind === SymbolKind_StringArray) {
       this.ctx.symbolTable.setResolvedType(
         forOfStmt.variableName,
         createResolvedType("string", {}, 1),
       );
-    } else if (elementKind === SymbolKind.Array && isObjectArray) {
+    } else if (elementKind === SymbolKind_Array && isObjectArray) {
       this.ctx.symbolTable.setResolvedType(
         forOfStmt.variableName,
         createResolvedType("number", {}, 1),
@@ -1561,7 +1567,7 @@ export class ControlFlowGenerator {
       forOfStmt.variableName,
       elemAlloca,
       "i8*",
-      SymbolKind.Object,
+      SymbolKind_Object,
       "local",
       metadata,
     );
@@ -1750,7 +1756,7 @@ export class ControlFlowGenerator {
       if (paramName) {
         const excMsg = this.ctx.emitLoad("i8*", "@__exception_message");
         this.ctx.emitStore("i8*", excMsg, paramAlloca);
-        this.ctx.defineVariable(paramName, paramAlloca, "i8*", SymbolKind.String, "local");
+        this.ctx.defineVariable(paramName, paramAlloca, "i8*", SymbolKind_String, "local");
       }
       this.ctx.generateBlock(tryStmt.catchBody, params);
     }
@@ -2277,7 +2283,7 @@ export class ControlFlowGenerator {
     this.emit(`${elemAlloca} = alloca i8*`);
     this.ctx.emitStore("i8*", "null", elemAlloca);
 
-    this.ctx.defineVariable(stmt.variableName, elemAlloca, "i8*", SymbolKind.String, "local");
+    this.ctx.defineVariable(stmt.variableName, elemAlloca, "i8*", SymbolKind_String, "local");
 
     const condLabel = this.nextLabel("forof_str_cond");
     const bodyLabel = this.nextLabel("forof_str_body");
@@ -2397,7 +2403,7 @@ export class ControlFlowGenerator {
     const valueAlloca = this.ctx.nextAllocaReg(valueName);
     this.emit(`${valueAlloca} = alloca i8*`);
 
-    this.ctx.defineVariable(keyName, keyAlloca, "i8*", SymbolKind.String, "local");
+    this.ctx.defineVariable(keyName, keyAlloca, "i8*", SymbolKind_String, "local");
 
     if (valueTypeInfo) {
       const vti = valueTypeInfo as {
@@ -2409,7 +2415,7 @@ export class ControlFlowGenerator {
           valueName,
           valueAlloca,
           "i8*",
-          SymbolKind.Object,
+          SymbolKind_Object,
           "local",
           createObjectMetadata(vti.objectMetadata),
         );
@@ -2423,15 +2429,15 @@ export class ControlFlowGenerator {
           valueName,
           valueAlloca,
           "i8*",
-          SymbolKind.Class,
+          SymbolKind_Class,
           "local",
           createClassMetadata({ className: vti.valueType }),
         );
       } else {
-        this.ctx.defineVariable(valueName, valueAlloca, "i8*", SymbolKind.String, "local");
+        this.ctx.defineVariable(valueName, valueAlloca, "i8*", SymbolKind_String, "local");
       }
     } else {
-      this.ctx.defineVariable(valueName, valueAlloca, "i8*", SymbolKind.String, "local");
+      this.ctx.defineVariable(valueName, valueAlloca, "i8*", SymbolKind_String, "local");
     }
 
     const condLabel = this.nextLabel("mapof_cond");

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -14,6 +14,12 @@ import {
 import { IGeneratorContext } from "../../infrastructure/generator-context.js";
 import {
   SymbolKind,
+  SymbolKind_Number,
+  SymbolKind_String,
+  SymbolKind_Array,
+  SymbolKind_StringArray,
+  SymbolKind_Object,
+  SymbolKind_Class,
   createObjectMetadata,
   createObjectMetadataWithInterface,
   createObjectMetadataWithInterfaceAndPointerAlloca,
@@ -1564,17 +1570,17 @@ export class ClassGenerator {
     tsType: string | undefined,
   ): void {
     if (!tsType || tsType.length === 0 || tsType === "string") {
-      let kind = SymbolKind.Object;
-      if (llvmType === "i8*") kind = SymbolKind.String;
-      else if (llvmType === "%StringArray*") kind = SymbolKind.StringArray;
-      else if (llvmType === "%Array*") kind = SymbolKind.Array;
-      else if (llvmType === "double") kind = SymbolKind.Number;
+      let kind = SymbolKind_Object;
+      if (llvmType === "i8*") kind = SymbolKind_String;
+      else if (llvmType === "%StringArray*") kind = SymbolKind_StringArray;
+      else if (llvmType === "%Array*") kind = SymbolKind_Array;
+      else if (llvmType === "double") kind = SymbolKind_Number;
       this.ctx.defineVariable(paramName, allocaReg, llvmType, kind, "local");
       return;
     }
 
     if (tsType === "number" || tsType === "boolean") {
-      this.ctx.defineVariable(paramName, allocaReg, "double", SymbolKind.Number, "local");
+      this.ctx.defineVariable(paramName, allocaReg, "double", SymbolKind_Number, "local");
       return;
     }
 
@@ -1583,14 +1589,14 @@ export class ClassGenerator {
         paramName,
         allocaReg,
         "%StringArray*",
-        SymbolKind.StringArray,
+        SymbolKind_StringArray,
         "local",
       );
       return;
     }
 
     if (tsType === "number[]" || tsType === "boolean[]") {
-      this.ctx.defineVariable(paramName, allocaReg, "%Array*", SymbolKind.Array, "local");
+      this.ctx.defineVariable(paramName, allocaReg, "%Array*", SymbolKind_Array, "local");
       return;
     }
 
@@ -1624,7 +1630,7 @@ export class ClassGenerator {
         paramName,
         allocaReg,
         "i8*",
-        SymbolKind.Object,
+        SymbolKind_Object,
         "local",
         createObjectMetadataWithInterfaceAndPointerAlloca(
           { keys, types, tsTypes },
@@ -1653,7 +1659,7 @@ export class ClassGenerator {
           paramName,
           allocaReg,
           "i8*",
-          SymbolKind.Object,
+          SymbolKind_Object,
           "local",
           createObjectMetadata(commonFields),
         );
@@ -1678,7 +1684,7 @@ export class ClassGenerator {
         paramName,
         allocaReg,
         "i8*",
-        SymbolKind.Class,
+        SymbolKind_Class,
         "local",
         createClassMetadata({ className: classDef.name }),
       );
@@ -1701,7 +1707,7 @@ export class ClassGenerator {
           paramName,
           allocaReg,
           "i8*",
-          SymbolKind.Object,
+          SymbolKind_Object,
           "local",
           createObjectMetadata({ keys, types, tsTypes }),
         );
@@ -1742,7 +1748,7 @@ export class ClassGenerator {
         paramName,
         allocaReg,
         "i8*",
-        SymbolKind.Object,
+        SymbolKind_Object,
         "local",
         createObjectMetadataWithInterface(
           { keys: builtinIfaceKeys, types: builtinIfaceTypes, tsTypes: builtinIfaceTsTypes },
@@ -1752,7 +1758,7 @@ export class ClassGenerator {
       return;
     }
 
-    this.ctx.defineVariable(paramName, allocaReg, llvmType, SymbolKind.Object, "local");
+    this.ctx.defineVariable(paramName, allocaReg, llvmType, SymbolKind_Object, "local");
   }
 
   private fieldTypeToLlvmPrimitive(fieldType: string): string | null {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -8,7 +8,7 @@ import { LLVMGenerator, LLVMGeneratorOptions, SemaSymbolData } from "./codegen/l
 import { TypeChecker } from "./typescript/type-checker.js";
 import { SemanticAnalyzer, TypedSymbol } from "./analysis/semantic-analyzer.js";
 import { AST, ImportDeclaration, ClassNode, FunctionNode } from "./ast/types.js";
-import { LogLevel, logger } from "./utils/logger.js";
+import { type LogLevel, LogLevel_Normal, LogLevel_Verbose, logger } from "./utils/logger.js";
 import { TargetInfo, resolveTarget, getHostTarget, isCrossCompiling } from "./target.js";
 import { loadTargetSDK, ensureTargetSDK, TargetSDK } from "./cross-compile.js";
 import { VERSION } from "./version.js";
@@ -164,7 +164,7 @@ const TREESITTER_TS_PATH = "node_modules/tree-sitter-typescript/tsx/src";
 export function compile(
   inputFile: string,
   outputFile: string,
-  logLevel: LogLevel = LogLevel.Normal,
+  logLevel: LogLevel = LogLevel_Normal,
 ): void {
   // Set the global logger level
   logger.setLevel(logLevel);
@@ -330,7 +330,7 @@ export function compile(
   // Compile IR to object file
   const objFile = outputFile + ".o";
   const sanitizeFlags = sanitize ? ` -fsanitize=${sanitize}` : "";
-  const llcStdio = logger.getLevel() >= LogLevel.Verbose ? "inherit" : "pipe";
+  const llcStdio = logger.getLevel() >= LogLevel_Verbose ? "inherit" : "pipe";
   const cpuFlag = crossCompiling ? `-mcpu=${target.cpu}` : `-mcpu=${targetCpu}`;
   const tripleFlag = crossCompiling ? ` -mtriple=${target.triple}` : "";
   let compileCmd: string;
@@ -519,7 +519,7 @@ export function compile(
   const userLibs = extraLinkLibs.map((l) => ` -l${l}`).join("");
   const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${strlenCacheObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${cpSpawnObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${suppressLdWarnings}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
   logger.info(` ${linkCmd}`);
-  const linkStdio = logger.getLevel() >= LogLevel.Verbose ? "inherit" : "pipe";
+  const linkStdio = logger.getLevel() >= LogLevel_Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });
 
   // Clean up intermediate files (unless --keep-temps is set)

--- a/src/semantic/enum-checker.ts
+++ b/src/semantic/enum-checker.ts
@@ -1,0 +1,21 @@
+import type { AST, SourceLocation, EnumDeclaration } from "../ast/types.js";
+import { formatCompileError } from "../diagnostics/engine.js";
+
+export function checkEnumDeclarations(ast: AST, sourceCode: string): void {
+  if (!ast.enums || ast.enums.length === 0) return;
+  for (let i = 0; i < ast.enums.length; i++) {
+    const e = ast.enums[i] as EnumDeclaration & { loc?: SourceLocation };
+    const output = formatCompileError(
+      sourceCode,
+      "enum declarations are not supported",
+      e.loc,
+      "use 'as const' objects instead: const " + e.name + " = { ... } as const",
+      [
+        "enums add significant complexity to native compilation",
+        "const objects provide the same functionality with better type safety",
+      ],
+    );
+    process.stderr.write(output);
+    process.exit(1);
+  }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,21 +1,14 @@
-// ============================================
-// LOGGING SYSTEM
-// ============================================
-// Inspired by clang's verbose output system.
-// Use --verbose, --debug, or --trace flags to control output.
-
-export enum LogLevel {
-  Silent = 0, // Only errors (for user-facing errors)
-  Normal = 1, // Errors + warnings (default)
-  Verbose = 2, // + Compilation stages and commands
-  Debug = 3, // + Internal debugging info
-  Trace = 4, // + Everything (AST dumps, IR, etc.)
-}
+export const LogLevel_Silent = 0;
+export const LogLevel_Normal = 1;
+export const LogLevel_Verbose = 2;
+export const LogLevel_Debug = 3;
+export const LogLevel_Trace = 4;
+export type LogLevel = number;
 
 export class Logger {
   private level: LogLevel;
 
-  constructor(level: LogLevel = LogLevel.Normal) {
+  constructor(level: LogLevel = LogLevel_Normal) {
     this.level = level;
   }
 
@@ -27,39 +20,33 @@ export class Logger {
     return this.level;
   }
 
-  // Always shown (user-facing errors)
   error(message: string): void {
     console.error(message);
   }
 
-  // Show at Normal level and above (warnings)
   warn(message: string): void {
-    if (this.level >= LogLevel.Normal) {
+    if (this.level >= LogLevel_Normal) {
       console.warn(message);
     }
   }
 
-  // Show at Verbose level and above (compilation steps)
   info(message: string): void {
-    if (this.level >= LogLevel.Verbose) {
+    if (this.level >= LogLevel_Verbose) {
       console.log(message);
     }
   }
 
-  // Show at Debug level and above (internal debugging)
   debug(message: string): void {
-    if (this.level >= LogLevel.Debug) {
+    if (this.level >= LogLevel_Debug) {
       console.log(`dbg: ${message}`);
     }
   }
 
-  // Show at Trace level only (everything)
   trace(message: string): void {
-    if (this.level >= LogLevel.Trace) {
+    if (this.level >= LogLevel_Trace) {
       console.log(`trc: ${message}`);
     }
   }
 }
 
-// Global logger instance
 export const logger = new Logger();

--- a/tests/fixtures/edge-cases/string-enum-usage.ts
+++ b/tests/fixtures/edge-cases/string-enum-usage.ts
@@ -1,24 +1,8 @@
+// @test-compile-error: enum declarations are not supported
+// @test-description: string enum usage is a compile error
 enum Direction {
   Up = "UP",
   Down = "DOWN",
-  Left = "LEFT",
-  Right = "RIGHT",
 }
 
-const d = Direction.Up;
-if (d !== "UP") process.exit(1);
-if (Direction.Down !== "DOWN") process.exit(1);
-if (Direction.Left !== "LEFT") process.exit(1);
-if (Direction.Right !== "RIGHT") process.exit(1);
-
-function move(dir: string): string {
-  if (dir === Direction.Up) return "moving up";
-  if (dir === Direction.Down) return "moving down";
-  return "moving sideways";
-}
-
-if (move(Direction.Up) !== "moving up") process.exit(1);
-if (move(Direction.Down) !== "moving down") process.exit(1);
-if (move(Direction.Left) !== "moving sideways") process.exit(1);
-
-console.log("TEST_PASSED");
+console.log(Direction.Up);

--- a/tests/fixtures/types/numeric-enum.ts
+++ b/tests/fixtures/types/numeric-enum.ts
@@ -1,3 +1,5 @@
+// @test-compile-error: enum declarations are not supported
+// @test-description: numeric enums are a compile error
 enum Direction {
   Up,
   Down,
@@ -5,24 +7,4 @@ enum Direction {
   Right,
 }
 
-function testNumericEnum(): void {
-  const d: number = Direction.Up;
-  if (d !== 0) {
-    console.log("FAIL: Up should be 0, got " + d);
-    process.exit(1);
-  }
-
-  if (Direction.Down !== 1) {
-    console.log("FAIL: Down should be 1");
-    process.exit(1);
-  }
-
-  if (Direction.Right !== 3) {
-    console.log("FAIL: Right should be 3");
-    process.exit(1);
-  }
-
-  console.log("TEST_PASSED");
-}
-
-testNumericEnum();
+console.log(Direction.Up);

--- a/tests/fixtures/types/string-enum.ts
+++ b/tests/fixtures/types/string-enum.ts
@@ -1,4 +1,5 @@
-// String enums map members to string literal values
+// @test-compile-error: enum declarations are not supported
+// @test-description: string enums are a compile error
 enum Direction {
   Up = "UP",
   Down = "DOWN",
@@ -6,7 +7,4 @@ enum Direction {
   Right = "RIGHT",
 }
 
-const dir: string = Direction.Up;
-if (dir === "UP") {
-  console.log("TEST_PASSED");
-}
+console.log(Direction.Up);

--- a/tests/unit/symbol-table.test.ts
+++ b/tests/unit/symbol-table.test.ts
@@ -1,16 +1,32 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { SymbolTable, SymbolKind } from "../../src/codegen/infrastructure/symbol-table.js";
+import {
+  SymbolTable,
+  SymbolKind_Number,
+  SymbolKind_String,
+  SymbolKind_Boolean,
+  SymbolKind_Array,
+  SymbolKind_StringArray,
+  SymbolKind_BooleanArray,
+  SymbolKind_ObjectArray,
+  SymbolKind_Object,
+  SymbolKind_Map,
+  SymbolKind_Set,
+  SymbolKind_Class,
+  SymbolKind_Regex,
+  SymbolKind_JSON,
+  SymbolKind_ProcessArgv,
+} from "../../src/codegen/infrastructure/symbol-table.js";
 
 describe("SymbolTable", () => {
   describe("define and lookup", () => {
     it("should define and lookup a number variable", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
 
       const symbol = table.lookup("x");
       assert.strictEqual(symbol?.name, "x");
-      assert.strictEqual(symbol?.kind, SymbolKind.Number);
+      assert.strictEqual(symbol?.kind, SymbolKind_Number);
       assert.strictEqual(symbol?.llvmType, "double");
       assert.strictEqual(symbol?.allocaRegister, "%1");
       assert.strictEqual(symbol?.scope, "local");
@@ -18,17 +34,17 @@ describe("SymbolTable", () => {
 
     it("should define and lookup a string variable", () => {
       const table = new SymbolTable();
-      table.define("name", SymbolKind.String, "i8*", "%2", "local");
+      table.define("name", SymbolKind_String, "i8*", "%2", "local");
 
       const symbol = table.lookup("name");
       assert.strictEqual(symbol?.name, "name");
-      assert.strictEqual(symbol?.kind, SymbolKind.String);
+      assert.strictEqual(symbol?.kind, SymbolKind_String);
       assert.strictEqual(symbol?.llvmType, "i8*");
     });
 
     it("should define a global variable", () => {
       const table = new SymbolTable();
-      table.define("globalVar", SymbolKind.Number, "double", "@global", "global");
+      table.define("globalVar", SymbolKind_Number, "double", "@global", "global");
 
       const symbol = table.lookup("globalVar");
       assert.strictEqual(symbol?.scope, "global");
@@ -44,7 +60,7 @@ describe("SymbolTable", () => {
   describe("has", () => {
     it("should return true for existing variable", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
       assert.strictEqual(table.has("x"), true);
     });
 
@@ -57,13 +73,13 @@ describe("SymbolTable", () => {
   describe("getType and getAlloca", () => {
     it("should get LLVM type", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
       assert.strictEqual(table.getType("x"), "double");
     });
 
     it("should get alloca register", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
       assert.strictEqual(table.getAlloca("x"), "%1");
     });
 
@@ -77,8 +93,8 @@ describe("SymbolTable", () => {
   describe("getKind", () => {
     it("should get symbol kind", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
-      assert.strictEqual(table.getKind("x"), SymbolKind.Number);
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
+      assert.strictEqual(table.getKind("x"), SymbolKind_Number);
     });
 
     it("should return undefined for non-existent variable", () => {
@@ -90,7 +106,7 @@ describe("SymbolTable", () => {
   describe("updateAlloca", () => {
     it("should update alloca register", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
       table.updateAlloca("x", "%100");
       assert.strictEqual(table.getAlloca("x"), "%100");
     });
@@ -105,9 +121,9 @@ describe("SymbolTable", () => {
   describe("clear", () => {
     it("should clear all symbols", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
-      table.define("y", SymbolKind.String, "i8*", "%2", "local");
-      table.define("z", SymbolKind.Number, "double", "@global", "global");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
+      table.define("y", SymbolKind_String, "i8*", "%2", "local");
+      table.define("z", SymbolKind_Number, "double", "@global", "global");
 
       table.clear();
 
@@ -121,8 +137,8 @@ describe("SymbolTable", () => {
   describe("clearLocals", () => {
     it("should clear only local symbols", () => {
       const table = new SymbolTable();
-      table.define("localVar", SymbolKind.Number, "double", "%1", "local");
-      table.define("globalVar", SymbolKind.Number, "double", "@global", "global");
+      table.define("localVar", SymbolKind_Number, "double", "%1", "local");
+      table.define("globalVar", SymbolKind_Number, "double", "@global", "global");
 
       table.clearLocals();
 
@@ -132,9 +148,9 @@ describe("SymbolTable", () => {
 
     it("should preserve all globals", () => {
       const table = new SymbolTable();
-      table.define("global1", SymbolKind.Number, "double", "@g1", "global");
-      table.define("global2", SymbolKind.String, "i8*", "@g2", "global");
-      table.define("local1", SymbolKind.Number, "double", "%1", "local");
+      table.define("global1", SymbolKind_Number, "double", "@g1", "global");
+      table.define("global2", SymbolKind_String, "i8*", "@g2", "global");
+      table.define("local1", SymbolKind_Number, "double", "%1", "local");
 
       table.clearLocals();
 
@@ -147,7 +163,7 @@ describe("SymbolTable", () => {
   describe("remove", () => {
     it("should remove a symbol", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
       table.remove("x");
       assert.strictEqual(table.has("x"), false);
     });
@@ -156,29 +172,29 @@ describe("SymbolTable", () => {
   describe("type predicates", () => {
     it("should identify number variables", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
       assert.strictEqual(table.isNumber("x"), true);
       assert.strictEqual(table.isString("x"), false);
     });
 
     it("should identify string variables", () => {
       const table = new SymbolTable();
-      table.define("name", SymbolKind.String, "i8*", "%1", "local");
+      table.define("name", SymbolKind_String, "i8*", "%1", "local");
       assert.strictEqual(table.isString("name"), true);
       assert.strictEqual(table.isNumber("name"), false);
     });
 
     it("should identify boolean variables", () => {
       const table = new SymbolTable();
-      table.define("flag", SymbolKind.Boolean, "i1", "%1", "local");
+      table.define("flag", SymbolKind_Boolean, "i1", "%1", "local");
       assert.strictEqual(table.isBoolean("flag"), true);
     });
 
     it("should identify array variables", () => {
       const table = new SymbolTable();
-      table.define("arr", SymbolKind.Array, "%Array*", "%1", "local");
-      table.define("strArr", SymbolKind.StringArray, "%StringArray*", "%2", "local");
-      table.define("boolArr", SymbolKind.BooleanArray, "%BooleanArray*", "%3", "local");
+      table.define("arr", SymbolKind_Array, "%Array*", "%1", "local");
+      table.define("strArr", SymbolKind_StringArray, "%StringArray*", "%2", "local");
+      table.define("boolArr", SymbolKind_BooleanArray, "%BooleanArray*", "%3", "local");
 
       assert.strictEqual(table.isArray("arr"), true);
       assert.strictEqual(table.isArray("strArr"), true);
@@ -190,43 +206,43 @@ describe("SymbolTable", () => {
 
     it("should identify object variables", () => {
       const table = new SymbolTable();
-      table.define("obj", SymbolKind.Object, "%Object*", "%1", "local");
+      table.define("obj", SymbolKind_Object, "%Object*", "%1", "local");
       assert.strictEqual(table.isObject("obj"), true);
     });
 
     it("should identify map variables", () => {
       const table = new SymbolTable();
-      table.define("map", SymbolKind.Map, "%Map*", "%1", "local");
+      table.define("map", SymbolKind_Map, "%Map*", "%1", "local");
       assert.strictEqual(table.isMap("map"), true);
     });
 
     it("should identify set variables", () => {
       const table = new SymbolTable();
-      table.define("set", SymbolKind.Set, "%Set*", "%1", "local");
+      table.define("set", SymbolKind_Set, "%Set*", "%1", "local");
       assert.strictEqual(table.isSet("set"), true);
     });
 
     it("should identify class variables", () => {
       const table = new SymbolTable();
-      table.define("instance", SymbolKind.Class, "i32*", "%1", "local");
+      table.define("instance", SymbolKind_Class, "i32*", "%1", "local");
       assert.strictEqual(table.isClass("instance"), true);
     });
 
     it("should identify regex variables", () => {
       const table = new SymbolTable();
-      table.define("pattern", SymbolKind.Regex, "i8*", "%1", "local");
+      table.define("pattern", SymbolKind_Regex, "i8*", "%1", "local");
       assert.strictEqual(table.isRegex("pattern"), true);
     });
 
     it("should identify JSON variables", () => {
       const table = new SymbolTable();
-      table.define("json", SymbolKind.JSON, "i8*", "%1", "local");
+      table.define("json", SymbolKind_JSON, "i8*", "%1", "local");
       assert.strictEqual(table.isJSON("json"), true);
     });
 
     it("should identify process.argv variables", () => {
       const table = new SymbolTable();
-      table.define("argv", SymbolKind.ProcessArgv, "i8**", "%1", "local");
+      table.define("argv", SymbolKind_ProcessArgv, "i8**", "%1", "local");
       assert.strictEqual(table.isProcessArgv("argv"), true);
     });
   });
@@ -234,7 +250,7 @@ describe("SymbolTable", () => {
   describe("metadata handling", () => {
     it("should store and retrieve object metadata", () => {
       const table = new SymbolTable();
-      table.defineWithMetadata("user", SymbolKind.Object, "%User*", "%1", "local", {
+      table.defineWithMetadata("user", SymbolKind_Object, "%User*", "%1", "local", {
         objectMetadata: {
           keys: ["name", "age"],
           types: ["i8*", "double"],
@@ -250,7 +266,7 @@ describe("SymbolTable", () => {
 
     it("should store and retrieve class metadata", () => {
       const table = new SymbolTable();
-      table.defineWithMetadata("instance", SymbolKind.Class, "i32*", "%1", "local", {
+      table.defineWithMetadata("instance", SymbolKind_Class, "i32*", "%1", "local", {
         classMetadata: {
           className: "Person",
           fields: ["name", "age"],
@@ -264,7 +280,7 @@ describe("SymbolTable", () => {
 
     it("should store and retrieve array metadata", () => {
       const table = new SymbolTable();
-      table.defineWithMetadata("arr", SymbolKind.StringArray, "%StringArray*", "%1", "local", {
+      table.defineWithMetadata("arr", SymbolKind_StringArray, "%StringArray*", "%1", "local", {
         arrayMetadata: {
           elementType: "string",
         },
@@ -278,8 +294,8 @@ describe("SymbolTable", () => {
   describe("getAll and filtering", () => {
     it("should get all symbols", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
-      table.define("name", SymbolKind.String, "i8*", "%2", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
+      table.define("name", SymbolKind_String, "i8*", "%2", "local");
 
       const all = table.getAll();
       assert.strictEqual(all.length, 2);
@@ -287,22 +303,22 @@ describe("SymbolTable", () => {
 
     it("should get symbols by kind", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
-      table.define("y", SymbolKind.Number, "double", "%2", "local");
-      table.define("name", SymbolKind.String, "i8*", "%3", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
+      table.define("y", SymbolKind_Number, "double", "%2", "local");
+      table.define("name", SymbolKind_String, "i8*", "%3", "local");
 
-      const numbers = table.getByKind(SymbolKind.Number);
+      const numbers = table.getByKind(SymbolKind_Number);
       assert.strictEqual(numbers.length, 2);
 
-      const strings = table.getByKind(SymbolKind.String);
+      const strings = table.getByKind(SymbolKind_String);
       assert.strictEqual(strings.length, 1);
     });
 
     it("should get local and global symbols separately", () => {
       const table = new SymbolTable();
-      table.define("local1", SymbolKind.Number, "double", "%1", "local");
-      table.define("local2", SymbolKind.Number, "double", "%2", "local");
-      table.define("global1", SymbolKind.Number, "double", "@g1", "global");
+      table.define("local1", SymbolKind_Number, "double", "%1", "local");
+      table.define("local2", SymbolKind_Number, "double", "%2", "local");
+      table.define("global1", SymbolKind_Number, "double", "@g1", "global");
 
       const locals = table.getLocals();
       const globals = table.getGlobals();
@@ -315,19 +331,19 @@ describe("SymbolTable", () => {
   describe("backward compatibility methods", () => {
     it("should get string alloca (legacy stringVariables.get())", () => {
       const table = new SymbolTable();
-      table.define("name", SymbolKind.String, "i8*", "%str_ptr", "local");
+      table.define("name", SymbolKind_String, "i8*", "%str_ptr", "local");
       assert.strictEqual(table.getStringAlloca("name"), "%str_ptr");
     });
 
     it("should get array alloca (legacy arrayVariables.get())", () => {
       const table = new SymbolTable();
-      table.define("arr", SymbolKind.Array, "%Array*", "%arr_ptr", "local");
+      table.define("arr", SymbolKind_Array, "%Array*", "%arr_ptr", "local");
       assert.strictEqual(table.getArrayAlloca("arr"), "%arr_ptr");
     });
 
     it("should get object info (legacy objectVariables.get())", () => {
       const table = new SymbolTable();
-      table.defineWithMetadata("user", SymbolKind.Object, "%User*", "%obj_ptr", "local", {
+      table.defineWithMetadata("user", SymbolKind_Object, "%User*", "%obj_ptr", "local", {
         objectMetadata: {
           keys: ["name", "age"],
           types: ["i8*", "double"],
@@ -342,7 +358,7 @@ describe("SymbolTable", () => {
 
     it("should get class info (legacy classInstanceVariables.get())", () => {
       const table = new SymbolTable();
-      table.defineWithMetadata("instance", SymbolKind.Class, "i32*", "%class_ptr", "local", {
+      table.defineWithMetadata("instance", SymbolKind_Class, "i32*", "%class_ptr", "local", {
         classMetadata: {
           className: "Person",
         },
@@ -357,8 +373,8 @@ describe("SymbolTable", () => {
   describe("clone and merge", () => {
     it("should clone symbol table", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
-      table.define("y", SymbolKind.String, "i8*", "%2", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
+      table.define("y", SymbolKind_String, "i8*", "%2", "local");
 
       const cloned = table.clone();
       assert.strictEqual(cloned.has("x"), true);
@@ -372,10 +388,10 @@ describe("SymbolTable", () => {
 
     it("should merge symbol tables", () => {
       const table1 = new SymbolTable();
-      table1.define("x", SymbolKind.Number, "double", "%1", "local");
+      table1.define("x", SymbolKind_Number, "double", "%1", "local");
 
       const table2 = new SymbolTable();
-      table2.define("y", SymbolKind.String, "i8*", "%2", "local");
+      table2.define("y", SymbolKind_String, "i8*", "%2", "local");
 
       table1.merge(table2);
 
@@ -388,8 +404,8 @@ describe("SymbolTable", () => {
   describe("dump", () => {
     it("should dump symbol table for debugging", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
-      table.define("name", SymbolKind.String, "i8*", "%2", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
+      table.define("name", SymbolKind_String, "i8*", "%2", "local");
 
       const output = table.dump();
       assert.match(output, /=== Symbol Table ===/);
@@ -399,7 +415,7 @@ describe("SymbolTable", () => {
 
     it("should dump object metadata", () => {
       const table = new SymbolTable();
-      table.defineWithMetadata("user", SymbolKind.Object, "%User*", "%1", "local", {
+      table.defineWithMetadata("user", SymbolKind_Object, "%User*", "%1", "local", {
         objectMetadata: {
           keys: ["name", "age"],
           types: ["i8*", "double"],
@@ -412,7 +428,7 @@ describe("SymbolTable", () => {
 
     it("should dump class metadata", () => {
       const table = new SymbolTable();
-      table.defineWithMetadata("instance", SymbolKind.Class, "i32*", "%1", "local", {
+      table.defineWithMetadata("instance", SymbolKind_Class, "i32*", "%1", "local", {
         classMetadata: {
           className: "Person",
         },
@@ -426,10 +442,10 @@ describe("SymbolTable", () => {
   describe("hierarchical scopes", () => {
     it("should push and pop scopes", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
 
       table.pushScope("block");
-      table.define("y", SymbolKind.Number, "double", "%2", "local");
+      table.define("y", SymbolKind_Number, "double", "%2", "local");
 
       assert.strictEqual(table.has("x"), true);
       assert.strictEqual(table.has("y"), true);
@@ -442,10 +458,10 @@ describe("SymbolTable", () => {
 
     it("should restore shadowed variables on pop", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
 
       table.pushScope("block");
-      table.define("x", SymbolKind.String, "i8*", "%2", "local");
+      table.define("x", SymbolKind_String, "i8*", "%2", "local");
       assert.strictEqual(table.getType("x"), "i8*");
 
       table.popScope();
@@ -457,14 +473,14 @@ describe("SymbolTable", () => {
 
     it("should support nested scopes with shadowing", () => {
       const table = new SymbolTable();
-      table.define("a", SymbolKind.Number, "double", "%1", "local");
+      table.define("a", SymbolKind_Number, "double", "%1", "local");
 
       table.pushScope("block");
-      table.define("a", SymbolKind.String, "i8*", "%2", "local");
+      table.define("a", SymbolKind_String, "i8*", "%2", "local");
       assert.strictEqual(table.getType("a"), "i8*");
 
       table.pushScope("block");
-      table.define("a", SymbolKind.Boolean, "double", "%3", "local");
+      table.define("a", SymbolKind_Boolean, "double", "%3", "local");
       assert.strictEqual(table.getAlloca("a"), "%3");
 
       table.popScope();
@@ -478,17 +494,17 @@ describe("SymbolTable", () => {
 
     it("should not pop below global scope", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "global");
+      table.define("x", SymbolKind_Number, "double", "%1", "global");
       table.popScope();
       assert.strictEqual(table.has("x"), true);
     });
 
     it("should preserve globals when popping scopes", () => {
       const table = new SymbolTable();
-      table.define("g", SymbolKind.Number, "double", "@g", "global");
+      table.define("g", SymbolKind_Number, "double", "@g", "global");
 
       table.pushScope("block");
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
       table.popScope();
 
       assert.strictEqual(table.has("g"), true);
@@ -497,10 +513,10 @@ describe("SymbolTable", () => {
 
     it("lookupLocal should only find symbols in current scope", () => {
       const table = new SymbolTable();
-      table.define("outer", SymbolKind.Number, "double", "%1", "local");
+      table.define("outer", SymbolKind_Number, "double", "%1", "local");
 
       table.pushScope("block");
-      table.define("inner", SymbolKind.Number, "double", "%2", "local");
+      table.define("inner", SymbolKind_Number, "double", "%2", "local");
 
       assert.ok(table.lookupLocal("inner"));
       assert.strictEqual(table.lookupLocal("outer"), undefined);
@@ -509,10 +525,10 @@ describe("SymbolTable", () => {
 
     it("should support closure capture across scopes", () => {
       const table = new SymbolTable();
-      table.define("x", SymbolKind.Number, "double", "%1", "local");
+      table.define("x", SymbolKind_Number, "double", "%1", "local");
 
       table.pushScope("block");
-      table.define("y", SymbolKind.String, "i8*", "%2", "local");
+      table.define("y", SymbolKind_String, "i8*", "%2", "local");
 
       const scopeVars = table.getScopeVarsForClosure();
       assert.strictEqual(scopeVars.get("x"), "double");


### PR DESCRIPTION
## Summary
- Enums now produce a clear compile error suggesting `as const` objects instead
- Removes a major source of codegen complexity (string enum params, type mapping, struct layout issues)
- Converted compiler's own 3 internal enums (SymbolKind, VarKind, LogLevel) to plain const numbers

## Test plan
- [x] Existing enum test fixtures converted to `@test-compile-error` tests
- [x] All 692 tests pass
- [x] Self-hosting Stage 0 + Stage 1 pass (`verify:quick`)
- [x] Error message suggests `as const` alternative with helpful notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)