### PR TITLE
test: unskip top-level switch string test

### DIFF
--- a/tests/fixtures/control-flow/switch-string-toplevel.ts
+++ b/tests/fixtures/control-flow/switch-string-toplevel.ts
@@ -1,4 +1,3 @@
-// @test-skip
 const s = "b";
 switch (s) {
   case "a":


### PR DESCRIPTION
## Summary
- Top-level switch statements with string cases now pass both node and native compilers
- Unskips `switch-string-toplevel.ts` test fixture (was skipped due to earlier parser limitations, now fixed by PR #399)

## Test plan
- [x] Verified test passes with node compiler
- [x] Verified test passes with native compiler
- [x] `npm run verify:quick` passes