### PR TITLE
fix: labeled statements emit compile error instead of silent wrong results

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -126,6 +126,16 @@ function transformProgram(node: TreeSitterNode): AST {
 }
 
 function transformTopLevelNode(node: TreeSitterNode, ast: AST): void {
+  if ((node as NodeBase).type === "labeled_statement") {
+    const line = getLineFromIndex((node as NodeBase).source, (node as NodeBase).startIndex);
+    console.error(
+      currentFile +
+        ":" +
+        line +
+        ": error: labeled statements (e.g., 'outer: for') are not supported; use a flag variable with regular break instead",
+    );
+    process.exit(1);
+  }
   switch (node.type) {
     case "import_statement":
       const importDecl = transformImportStatement(node);
@@ -270,6 +280,7 @@ function transformTopLevelNode(node: TreeSitterNode, ast: AST): void {
     case "ambient_declaration":
       handleAmbientDeclaration(node, ast);
       break;
+
   }
 }
 
@@ -1579,6 +1590,16 @@ function transformTypeofExpression(node: TreeSitterNode): UnaryNode {
 }
 
 function transformStatement(node: TreeSitterNode): Statement | null {
+  if ((node as NodeBase).type === "labeled_statement") {
+    const line = getLineFromIndex((node as NodeBase).source, (node as NodeBase).startIndex);
+    console.error(
+      currentFile +
+        ":" +
+        line +
+        ": error: labeled statements (e.g., 'outer: for') are not supported; use a flag variable with regular break instead",
+    );
+    process.exit(1);
+  }
   switch (node.type) {
     case "lexical_declaration":
     case "variable_declaration":

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -280,7 +280,6 @@ function transformTopLevelNode(node: TreeSitterNode, ast: AST): void {
     case "ambient_declaration":
       handleAmbientDeclaration(node, ast);
       break;
-
   }
 }
 

--- a/src/parser-ts/handlers/statements.ts
+++ b/src/parser-ts/handlers/statements.ts
@@ -86,6 +86,20 @@ export function transformStatement(
     case ts.SyntaxKind.SwitchStatement:
       return transformSwitchToIfElse(node as ts.SwitchStatement, checker);
 
+    case ts.SyntaxKind.LabeledStatement: {
+      const loc = getLoc(node);
+      console.error(
+        loc.file +
+          ":" +
+          loc.line +
+          ":" +
+          loc.column +
+          ": error: labeled statements (e.g., 'outer: for') are not supported; use a flag variable with regular break instead",
+      );
+      process.exit(1);
+      break;
+    }
+
     default:
       return null;
   }

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -359,6 +359,20 @@ function transformTopLevelStatement(
       break;
     }
 
+    case ts.SyntaxKind.LabeledStatement: {
+      const loc = getLoc(node);
+      console.error(
+        loc.file +
+          ":" +
+          loc.line +
+          ":" +
+          loc.column +
+          ": error: labeled statements (e.g., 'outer: for') are not supported; use a flag variable with regular break instead",
+      );
+      process.exit(1);
+      break;
+    }
+
     default:
       break;
   }

--- a/tests/fixtures/edge-cases/labeled-statement.ts
+++ b/tests/fixtures/edge-cases/labeled-statement.ts
@@ -1,0 +1,11 @@
+// @test-compile-error: labeled statements
+let found = -1;
+outer: for (let i = 0; i < 3; i++) {
+  for (let j = 0; j < 3; j++) {
+    if (i === 1 && j === 1) {
+      found = i * 10 + j;
+      break outer;
+    }
+  }
+}
+console.log(found);


### PR DESCRIPTION
## Summary
- Labeled statements (e.g., `outer: for ... break outer`) were silently dropped by both parsers, causing wrong results at runtime
- Both parsers now emit a clear compile error suggesting to use a flag variable with regular break instead
- Native parser uses `if` check before switch (workaround for native switch codegen not matching certain string cases)

## Test plan
- [x] New test fixture `edge-cases/labeled-statement.ts` with `@test-compile-error`
- [x] Both node and native compilers reject labeled statements
- [x] `npm run verify:quick` passes