### PR TITLE
replace opt+llc with single clang -c pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ bash scripts/build-vendor.sh
 
 ## What It Is
 
-TypeScript-to-native compiler using LLVM IR. Compiles .ts/.js files to native binaries via: Parser → AST → Semantic Analysis → LLVM IR Codegen → llc (assembler) → clang (linker) → native binary.
+TypeScript-to-native compiler using LLVM IR. Compiles .ts/.js files to native binaries via: Parser → AST → Semantic Analysis → LLVM IR Codegen → clang (compile + link) → native binary.
 
 ## Key Directories
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coverage:report": "c8 report",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "git config core.hooksPath .git/hooks && cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
+    "prepare": "HOOKS=$(git rev-parse --git-common-dir)/hooks && git config core.hooksPath \"$HOOKS\" && cp scripts/pre-commit \"$HOOKS/pre-commit\" && chmod +x \"$HOOKS/pre-commit\""
   },
   "keywords": [
     "compiler",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -180,8 +180,6 @@ export function compile(
   logger.info(`InstalledDir: ${process.cwd()}`);
 
   // Check for required build tools
-  const llcPath = findLLVMTool("llc");
-  const optPath = findLLVMTool("opt");
   let linkerPath: string;
   let useClang = true;
 
@@ -327,27 +325,23 @@ export function compile(
     return;
   }
 
-  // Compile IR to object file
+  // Compile IR to object file via clang (single pass: optimize + assemble)
   const objFile = outputFile + ".o";
   const sanitizeFlags = sanitize ? ` -fsanitize=${sanitize}` : "";
-  const llcStdio = logger.getLevel() >= LogLevel_Verbose ? "inherit" : "pipe";
+  const compileStdio = logger.getLevel() >= LogLevel_Verbose ? "inherit" : "pipe";
   const cpuFlag = crossCompiling ? `-mcpu=${target.cpu}` : `-mcpu=${targetCpu}`;
-  const tripleFlag = crossCompiling ? ` -mtriple=${target.triple}` : "";
+  const tripleFlag = crossCompiling ? ` --target=${target.triple}` : "";
+  const clangPath = useClang ? linkerPath : findLLVMTool("clang");
   let compileCmd: string;
-  let optFile: string | null = null;
   if (sanitize) {
-    compileCmd = `${linkerPath} -c${sanitizeFlags} ${irFile} -o ${objFile}`;
+    compileCmd = `${clangPath} -c -Wno-override-module${sanitizeFlags} ${irFile} -o ${objFile}`;
   } else if (debugInfo) {
-    compileCmd = `${llcPath} -O0${tripleFlag} -filetype=obj ${irFile} -o ${objFile}`;
+    compileCmd = `${clangPath} -c -Wno-override-module -O0${tripleFlag} ${irFile} -o ${objFile}`;
   } else {
-    optFile = irFile.replace(".ll", ".opt.bc");
-    const optCmd = `${optPath} -O2 ${cpuFlag}${tripleFlag} ${irFile} -o ${optFile}`;
-    logger.info(` ${optCmd}`);
-    execSync(optCmd, { stdio: llcStdio });
-    compileCmd = `${llcPath} -O2 ${cpuFlag}${tripleFlag} -filetype=obj ${optFile} -o ${objFile}`;
+    compileCmd = `${clangPath} -c -Wno-override-module -O2 ${cpuFlag}${tripleFlag} ${irFile} -o ${objFile}`;
   }
   logger.info(` ${compileCmd}`);
-  execSync(compileCmd, { stdio: llcStdio });
+  execSync(compileCmd, { stdio: compileStdio });
 
   // Link to executable - only link libraries that the program actually uses.
   // When cross-compiling, we use pre-built libraries from the target SDK
@@ -532,13 +526,6 @@ export function compile(
     if (!debugInfo) {
       try {
         fs.unlinkSync(irFile);
-      } catch (e) {
-        // File may already be deleted, ignore
-      }
-    }
-    if (optFile) {
-      try {
-        fs.unlinkSync(optFile);
       } catch (e) {
         // File may already be deleted, ignore
       }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -329,7 +329,7 @@ export function compile(
   const objFile = outputFile + ".o";
   const sanitizeFlags = sanitize ? ` -fsanitize=${sanitize}` : "";
   const compileStdio = logger.getLevel() >= LogLevel_Verbose ? "inherit" : "pipe";
-  const cpuFlag = crossCompiling ? `-mcpu=${target.cpu}` : `-mcpu=${targetCpu}`;
+  const cpuFlag = crossCompiling ? "" : `-march=${targetCpu}`;
   const tripleFlag = crossCompiling ? ` --target=${target.triple}` : "";
   const clangPath = useClang ? linkerPath : findLLVMTool("clang");
   let compileCmd: string;

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -392,7 +392,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const objFile = outputFile + ".o";
   const clangTool = findLLVMTool("clang");
 
-  const cpuFlag = crossCompiling ? "-mcpu=generic" : "-mcpu=" + targetCpu;
+  const cpuFlag = crossCompiling ? "" : "-march=" + targetCpu;
   const tripleFlag = crossCompiling ? " --target=" + targetTriple : "";
 
   const compileCmd =

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -396,7 +396,14 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const tripleFlag = crossCompiling ? " --target=" + targetTriple : "";
 
   const compileCmd =
-    clangTool + " -c -Wno-override-module -O2 " + cpuFlag + tripleFlag + " " + irFile + " -o " + objFile;
+    clangTool +
+    " -c -Wno-override-module -O2 " +
+    cpuFlag +
+    tripleFlag +
+    " " +
+    irFile +
+    " -o " +
+    objFile;
   if (verbose) {
     console.log("Running: " + compileCmd);
   }

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -390,28 +390,19 @@ export function compileNative(inputFile: string, outputFile: string): void {
   }
 
   const objFile = outputFile + ".o";
-  const optFile = irFile.replace(".ll", ".opt.bc");
-  const optTool = findLLVMTool("opt");
-  const llcTool = findLLVMTool("llc");
   const clangTool = findLLVMTool("clang");
 
-  // Cross-compilation: add triple flags to opt/llc
   const cpuFlag = crossCompiling ? "-mcpu=generic" : "-mcpu=" + targetCpu;
-  const tripleFlag = crossCompiling ? " -mtriple=" + targetTriple : "";
+  const tripleFlag = crossCompiling ? " --target=" + targetTriple : "";
 
-  const optCmd = optTool + " -O2 " + cpuFlag + tripleFlag + " " + irFile + " -o " + optFile;
+  const compileCmd =
+    clangTool + " -c -Wno-override-module -O2 " + cpuFlag + tripleFlag + " " + irFile + " -o " + objFile;
   if (verbose) {
-    console.log("Running: " + optCmd);
+    console.log("Running: " + compileCmd);
   }
-  child_process.execSync(optCmd);
-  const llcCmd =
-    llcTool + " -O2 " + cpuFlag + tripleFlag + " -filetype=obj " + optFile + " -o " + objFile;
-  if (verbose) {
-    console.log("Running: " + llcCmd);
-  }
-  child_process.execSync(llcCmd);
+  child_process.execSync(compileCmd);
   if (!fs.existsSync(objFile)) {
-    console.log("Error: llc failed to produce " + objFile);
+    console.log("Error: clang failed to produce " + objFile);
     process.exit(1);
   }
 
@@ -630,7 +621,6 @@ export function compileNative(inputFile: string, outputFile: string): void {
   }
 
   fs.unlinkSync(objFile);
-  fs.unlinkSync(optFile);
   if (verbose) {
     console.log("Compiled: " + outputFile);
   }


### PR DESCRIPTION
## Summary
- Users no longer need `opt` or `llc` installed — only `clang` is required
- Compilation pipeline simplified: `.ll` → `clang -c -O2` → `.o` → `clang` (link) → binary
- Eliminates intermediate `.opt.bc` file and double IR parsing overhead
- Both node and native compiler paths updated

## Test plan
- [x] `npm run verify:quick` passes (tests + stage 0 + stage 1)
- [ ] CI (full verify with stage 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)