### PR TITLE
remove llc/opt references from docs and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,12 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
           sudo apt-get update
-          sudo apt-get install -y llvm-21 llvm-21-dev clang-21 lld-21 \
+          sudo apt-get install -y clang-21 lld-21 \
             cmake make gcc g++ \
             autoconf automake libtool \
             libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev
-          sudo ln -sf /usr/bin/llc-21 /usr/bin/llc
-          sudo ln -sf /usr/bin/opt-21 /usr/bin/opt
           sudo ln -sf /usr/bin/clang-21 /usr/bin/clang
           clang --version 2>&1 | head -2
-          llc --version 2>&1 | head -4
 
       - name: Install npm dependencies
         run: npm install
@@ -294,9 +291,7 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
           sudo apt-get update
-          sudo apt-get install -y llvm-21 clang-21 libsqlite3-dev libzstd-dev zlib1g-dev
-          sudo ln -sf /usr/bin/llc-21 /usr/bin/llc
-          sudo ln -sf /usr/bin/opt-21 /usr/bin/opt
+          sudo apt-get install -y clang-21 libsqlite3-dev libzstd-dev zlib1g-dev
           sudo ln -sf /usr/bin/clang-21 /usr/bin/clang
 
       - name: Install system dependencies (macOS)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,7 +249,7 @@ Existing bridges: `regex-bridge.c`, `yyjson-bridge.c`, `os-bridge.c`, `child-pro
 6. **`ret void` not `unreachable`** at end of void functions
 7. **Class structs: boolean is `i1`; Interface structs: boolean is `double`**
 8. **Propagate declared type before generating RHS for collection fields** — when a class field is typed `Set<string>`, `Map<K,V>`, etc., call `setCurrentDeclaredSetType` / `setCurrentDeclaredMapType` before `generateExpression` on the RHS so that `new Set()` / `new Map()` without explicit type args picks the right generator. See `handleClassFieldAssignment` in `assignment-generator.ts`.
-9. **Set feature flags when emitting gated extern calls** — runtime declarations for C bridges (yyjson, curl, etc.) are conditionally emitted behind flags like `usesJson`, `usesCurl`. Any code path that emits `call @csyyjson_*` must call `ctx.setUsesJson(true)`, etc. Missing this causes "undefined value" errors from `opt` because the `declare` is never emitted.
+9. **Set feature flags when emitting gated extern calls** — runtime declarations for C bridges (yyjson, curl, etc.) are conditionally emitted behind flags like `usesJson`, `usesCurl`. Any code path that emits `call @csyyjson_*` must call `ctx.setUsesJson(true)`, etc. Missing this causes "undefined value" errors from `clang` because the `declare` is never emitted.
 
 ## Interface Field Iteration
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ httpServe(3000, (req: HttpRequest) => app.handle(req));
 ## How it works
 
 ```
-your-app.ts  →  ChadScript parser  →  AST  →  LLVM IR  →  opt  →  llc  →  clang  →  ./your-app
+your-app.ts  →  ChadScript parser  →  AST  →  LLVM IR  →  clang  →  ./your-app
 ```
 
 The same LLVM backend used by Clang, Rust, and Swift. Direct calls into C libraries — SQLite, libcurl, openssl — with zero FFI overhead. The output is a standard native binary: run it, ship it, containerize it.

--- a/c_bridges/child-process-bridge.c
+++ b/c_bridges/child-process-bridge.c
@@ -1,6 +1,6 @@
 // child-process-bridge.c — C bridge for child_process sync operations.
 // cs_execSync (popen-based) and cs_spawnSync (fork/execvp with pipes).
-// Always linked: the native compiler itself uses cs_execSync for running clang/llc.
+// Always linked: the native compiler itself uses cs_execSync for running clang.
 // Async spawn lives in child-process-spawn.c (linked only when libuv is available).
 
 #include <stdio.h>

--- a/docs/language/architecture.md
+++ b/docs/language/architecture.md
@@ -9,9 +9,8 @@ When you run `chad build app.ts -o app`, the compiler:
 1. Parses your TypeScript into an AST
 2. Resolves every type (all types must be known at compile time)
 3. Lowers the AST to [LLVM IR](https://llvm.org/docs/LangRef.html) — the same intermediate format used by Clang, Rust, and Swift
-4. Runs LLVM's optimizer (`opt`)
-5. Assembles to object code (`llc`)
-6. Links to a native binary (`clang`)
+4. Compiles and optimizes to object code (`clang -O2`)
+5. Links to a native binary (`clang`)
 
 The output is a standard ELF binary (Linux) or Mach-O binary (macOS) that runs with no runtime.
 

--- a/install.sh
+++ b/install.sh
@@ -59,12 +59,12 @@ prompt_yn() {
 }
 
 check_llvm() {
-  command -v llc >/dev/null 2>&1 || [ -x /opt/homebrew/opt/llvm/bin/llc ] || [ -x /usr/local/opt/llvm/bin/llc ]
+  command -v clang >/dev/null 2>&1 || [ -x /opt/homebrew/opt/llvm/bin/clang ] || [ -x /usr/local/opt/llvm/bin/clang ]
 }
 
 show_llvm_install_help() {
   printf "\n"
-  printf "  ${YELLOW}${BOLD}LLVM is required${RESET} — ChadScript needs ${BOLD}llc${RESET} and ${BOLD}clang${RESET} to compile.\n"
+  printf "  ${YELLOW}${BOLD}LLVM is required${RESET} — ChadScript needs ${BOLD}clang${RESET} to compile.\n"
   printf "\n"
   case "$1" in
     macos)


### PR DESCRIPTION
## Summary
- Only `clang` is needed now — removed all references to `llc` and `opt` from docs, CI, install script
- CI no longer installs `llvm-21` package (just `clang-21`)
- Removes `llc`/`opt` symlink setup from CI
- Updates README pipeline diagram, architecture docs, CLAUDE.md, install.sh

## Test plan
- [ ] CI passes (this PR changes CI install steps)
- [x] No remaining `llc` references in docs/CI/scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)