### PR TITLE
perf: lazy gc init for faster cold start

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -1046,7 +1046,6 @@ export class FunctionGenerator {
       " {\n";
     ir += "entry:\n";
 
-    ir += "  call void @GC_init()\n";
     if (this.ctx.getUsesMathRandom()) {
       ir += "  %__seed_time = call i64 @time(i8* null)\n";
       ir += "  call void @srand48(i64 %__seed_time)\n";

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -25,8 +25,7 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "declare i8* @calloc(i64, i64)\n";
   ir += "declare void @free(i8*)\n";
 
-  ir += "; Boehm GC - automatic garbage collection\n";
-  ir += "declare void @GC_init()\n";
+  ir += "; Boehm GC - automatic garbage collection (lazy init on first GC_malloc)\n";
   ir += "declare noalias i8* @GC_malloc(i64)\n";
   ir += "declare noalias i8* @GC_malloc_atomic(i64)\n";
   ir += "declare noalias i8* @GC_malloc_uncollectable(i64)\n";


### PR DESCRIPTION
## Summary
- Removes explicit `GC_init()` call from `main()` — Boehm auto-initializes on first `GC_malloc`
- Programs that never allocate GC memory (like hello world) skip GC init entirely
- ~0.35ms faster cold start (13% improvement on hello world benchmark)

## Test plan
- [x] `npm run verify:quick` passes
- [x] Before/after startup benchmark confirms improvement