### PR TITLE
arena allocator for array/collection data buffers

### DIFF
--- a/src/codegen/expressions/method-calls/object-static.ts
+++ b/src/codegen/expressions/method-calls/object-static.ts
@@ -214,7 +214,7 @@ export function generateObjectValues(
 
     const dataSize = ctx.nextTemp();
     ctx.emit(`${dataSize} = mul i64 ${length}, 8`);
-    const dataMem = ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+    const dataMem = ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${dataSize}`);
     const dataPtr = ctx.emitBitcast(dataMem, "i8*", "double*");
 
     for (let i = 0; i < length; i++) {

--- a/src/codegen/runtime/runtime.ts
+++ b/src/codegen/runtime/runtime.ts
@@ -467,7 +467,7 @@ export class RuntimeGenerator {
     ir += "  %was_zero = icmp eq i64 %cur_cap, 0\n";
     ir += "  br i1 %was_zero, label %fresh_alloc, label %realloc\n";
     ir += "fresh_alloc:\n";
-    ir += "  %fresh = call i8* @GC_malloc_atomic(i64 %new_cap)\n";
+    ir += "  %fresh = call i8* @cs_arena_alloc(i64 %new_cap)\n";
     ir += "  %has_old = icmp ne i64 %cur_len, 0\n";
     ir += "  br i1 %has_old, label %copy_old, label %store_fresh\n";
     ir += "copy_old:\n";
@@ -479,7 +479,9 @@ export class RuntimeGenerator {
     ir += "  store i64 %new_cap, i64* %cap\n";
     ir += "  br label %do_copy\n";
     ir += "realloc:\n";
-    ir += "  %grown = call i8* @GC_realloc(i8* %cur_ptr, i64 %new_cap)\n";
+    ir += "  %grown = call i8* @cs_arena_alloc(i64 %new_cap)\n";
+    ir +=
+      "  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %grown, i8* %cur_ptr, i64 %cur_len, i1 false)\n";
     ir += "  store i8* %grown, i8** %ptr\n";
     ir += "  store i64 %new_cap, i64* %cap\n";
     ir += "  br label %do_copy\n";

--- a/src/codegen/types/collections/array/combine.ts
+++ b/src/codegen/types/collections/array/combine.ts
@@ -81,7 +81,7 @@ export function generateArrayLiteralWithSpread(
   gen.emit(`${totalLenI64} = zext i32 ${totalLen} to i64`);
   const dataSize = gen.nextTemp();
   gen.emit(`${dataSize} = mul i64 ${totalLenI64}, 8`);
-  const dataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+  const dataMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${dataSize}`);
   const dataPtr = gen.emitBitcast(dataMem, "i8*", "double*");
 
   const offsetPtr = gen.nextTemp();
@@ -404,7 +404,7 @@ function generateNumericArrayJoin(
   const dataPtr = gen.emitLoad("double*", dataPtrField);
 
   const bufferSize = 8192;
-  const resultBuffer = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${bufferSize}`);
+  const resultBuffer = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${bufferSize}`);
   gen.emitStore("i8", "0", resultBuffer);
 
   const offsetPtr = gen.nextAllocaReg("join_off");
@@ -573,7 +573,7 @@ function generateStringArrayJoin(
   gen.emit(`${totalWithSep} = add i64 ${elemTotal}, ${totalSepLen}`);
   const finalSize = gen.nextTemp();
   gen.emit(`${finalSize} = add i64 ${totalWithSep}, 1`);
-  const resultBuffer = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${finalSize}`);
+  const resultBuffer = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${finalSize}`);
 
   // Second pass: copy elements with separators
   const offsetPtr = gen.nextAllocaReg("join_offset");
@@ -743,7 +743,7 @@ export function generateArraySlice(
   gen.emit(`${sliceLenI64} = zext i32 ${finalSliceLen} to i64`);
   const dataSize = gen.nextTemp();
   gen.emit(`${dataSize} = mul i64 ${sliceLenI64}, 8`);
-  const dataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+  const dataMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${dataSize}`);
   const newDataPtr = gen.emitBitcast(dataMem, "i8*", "double*");
 
   const srcStartPtr = gen.nextTemp();
@@ -928,7 +928,7 @@ export function generateArrayConcat(
   gen.emit(`${totalLenI64} = zext i32 ${totalLen} to i64`);
   const dataSize = gen.nextTemp();
   gen.emit(`${dataSize} = mul i64 ${totalLenI64}, 8`);
-  const dataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+  const dataMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${dataSize}`);
   const newDataPtr = gen.emitBitcast(dataMem, "i8*", "double*");
 
   // Copy first array

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -130,7 +130,7 @@ function generateNumericArrayFilter(
   gen.emit(`${lengthI64} = zext i32 ${length} to i64`);
   const dataSizeI64 = gen.nextTemp();
   gen.emit(`${dataSizeI64} = mul i64 ${lengthI64}, ${doubleSize}`);
-  const dataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSizeI64}`);
+  const dataMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${dataSizeI64}`);
   const resultDataPtr = gen.emitBitcast(dataMem, "i8*", "double*");
 
   const resultDataPtrField = gen.nextTemp();
@@ -918,7 +918,7 @@ function generateNumericArrayMap(
   gen.emit(`${lengthI64} = zext i32 ${length} to i64`);
   const resultSizeI64 = gen.nextTemp();
   gen.emit(`${resultSizeI64} = mul i64 ${lengthI64}, ${doubleSize}`);
-  const resultMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${resultSizeI64}`);
+  const resultMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${resultSizeI64}`);
   const resultDataPtr = gen.emitBitcast(resultMem, "i8*", "double*");
 
   const resultDataPtrField = gen.nextTemp();
@@ -1009,7 +1009,7 @@ function generateObjectArrayToNumericMap(
   gen.emit(`${lengthI64} = zext i32 ${length} to i64`);
   const resultSizeI64 = gen.nextTemp();
   gen.emit(`${resultSizeI64} = mul i64 ${lengthI64}, ${doubleSize}`);
-  const resultMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${resultSizeI64}`);
+  const resultMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${resultSizeI64}`);
   const resultDataPtr = gen.emitBitcast(resultMem, "i8*", "double*");
 
   const resultDataPtrField = gen.nextTemp();

--- a/src/codegen/types/collections/array/literal.ts
+++ b/src/codegen/types/collections/array/literal.ts
@@ -209,7 +209,7 @@ export function generateArrayLiteral(
     const dataCount = length === 0 ? 1 : length; // Allocate at least 1 element
     const dataSize = gen.nextTemp();
     gen.emit(`${dataSize} = mul i64 ${dataCount}, 8`);
-    const dataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+    const dataMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${dataSize}`);
     const dataPtr = gen.emitBitcast(dataMem, "i8*", "double*");
 
     // Store each element

--- a/src/codegen/types/collections/array/mutators.ts
+++ b/src/codegen/types/collections/array/mutators.ts
@@ -182,7 +182,7 @@ function generateStringArrayPop(gen: IGeneratorContext, arrayPtr: string): strin
 
   // Empty case - return empty string
   gen.emitLabel(emptyLabel);
-  const emptyStr = gen.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  const emptyStr = gen.emitCall("i8*", "@cs_arena_alloc", "i64 1");
   gen.emitStore("i8", "0", emptyStr);
   gen.emitBr(endLabel);
 
@@ -364,7 +364,7 @@ function generateIntArrayPush(gen: IGeneratorContext, arrayPtr: string, value: s
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
   gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newMemSize}`);
+  const newMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${newMemSize}`);
   const newDataPtr = gen.emitBitcast(newMem, "i8*", "double*");
 
   // Copy old data to new array

--- a/src/codegen/types/collections/array/reorder.ts
+++ b/src/codegen/types/collections/array/reorder.ts
@@ -257,7 +257,7 @@ function generateStringArrayShift(gen: IGeneratorContext, arrayPtr: string): str
   gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
   gen.emitLabel(emptyLabel);
-  const emptyStr = gen.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  const emptyStr = gen.emitCall("i8*", "@cs_arena_alloc", "i64 1");
   gen.emitStore("i8", "0", emptyStr);
   gen.emitBr(endLabel);
 
@@ -420,7 +420,7 @@ function generateNumericArrayUnshift(
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
   gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newMemSize}`);
+  const newMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${newMemSize}`);
   const newDataPtr = gen.emitBitcast(newMem, "i8*", "double*");
 
   const dataPtrField = gen.nextTemp();

--- a/src/codegen/types/collections/array/search.ts
+++ b/src/codegen/types/collections/array/search.ts
@@ -718,7 +718,7 @@ function generateStringArrayAt(
   gen.emitBr(endLabel);
 
   gen.emitLabel(oobLabel);
-  const emptyStr = gen.emitCall("i8*", "@GC_malloc_atomic", "i64 1");
+  const emptyStr = gen.emitCall("i8*", "@cs_arena_alloc", "i64 1");
   gen.emitStore("i8", "0", emptyStr);
   gen.emitBr(endLabel);
 

--- a/src/codegen/types/collections/array/splice.ts
+++ b/src/codegen/types/collections/array/splice.ts
@@ -108,7 +108,7 @@ function generateNumericArraySplice(
   gen.emit(`${dcI64} = zext i32 ${deleteCount} to i64`);
   const resultDataSize = gen.nextTemp();
   gen.emit(`${resultDataSize} = mul i64 ${dcI64}, 8`);
-  const resultDataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${resultDataSize}`);
+  const resultDataMem = gen.emitCall("i8*", "@cs_arena_alloc", `i64 ${resultDataSize}`);
   const resultDataPtr = gen.emitBitcast(resultDataMem, "i8*", "double*");
 
   const srcOffset = gen.nextTemp();

--- a/src/codegen/types/collections/map.ts
+++ b/src/codegen/types/collections/map.ts
@@ -58,7 +58,7 @@ export class MapGenerator {
     this.emit(`${keysCapI64} = zext i32 ${initialCapacity} to i64`);
     const keysSize = this.nextTemp();
     this.emit(`${keysSize} = mul i64 ${keysCapI64}, ${doubleSize}`);
-    const keysMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${keysSize}`);
+    const keysMem = this.ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${keysSize}`);
     const keysPtr = this.ctx.emitBitcast(keysMem, "i8*", "double*");
 
     // Allocate values array - use double* for JavaScript semantics
@@ -66,7 +66,7 @@ export class MapGenerator {
     this.emit(`${valuesCapI64} = zext i32 ${initialCapacity} to i64`);
     const valuesSize = this.nextTemp();
     this.emit(`${valuesSize} = mul i64 ${valuesCapI64}, ${doubleSize}`);
-    const valuesMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${valuesSize}`);
+    const valuesMem = this.ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${valuesSize}`);
     const valuesPtr = this.ctx.emitBitcast(valuesMem, "i8*", "double*");
 
     // Store keys pointer in Map struct
@@ -194,7 +194,7 @@ export class MapGenerator {
     const doubleSize = this.getDoubleSize();
     const newKeysSize = this.nextTemp();
     this.emit(`${newKeysSize} = mul i64 ${newCapI64}, ${doubleSize}`);
-    const newKeysMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newKeysSize}`);
+    const newKeysMem = this.ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${newKeysSize}`);
     const newKeysPtr = this.ctx.emitBitcast(newKeysMem, "i8*", "double*");
     const oldKeysI8 = this.ctx.emitBitcast(keysPtr, "double*", "i8*");
     const oldCapI64 = this.nextTemp();
@@ -207,7 +207,7 @@ export class MapGenerator {
     this.ctx.emitStore("double*", newKeysPtr, keysFieldPtr);
     const newValuesSize = this.nextTemp();
     this.emit(`${newValuesSize} = mul i64 ${newCapI64}, ${doubleSize}`);
-    const newValuesMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newValuesSize}`);
+    const newValuesMem = this.ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${newValuesSize}`);
     const newValuesPtr = this.ctx.emitBitcast(newValuesMem, "i8*", "double*");
     const oldValuesI8 = this.ctx.emitBitcast(valuesPtr, "double*", "i8*");
     this.emit(
@@ -521,7 +521,7 @@ export class MapGenerator {
     this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
-    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+    const dataMem = this.ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${dataSize}`);
     const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "double*");
 
     const dataPtrField = this.nextTemp();
@@ -581,7 +581,7 @@ export class MapGenerator {
     this.emit(`${mapSizeI64} = zext i32 ${mapSize} to i64`);
     const dataSize = this.nextTemp();
     this.emit(`${dataSize} = mul i64 ${mapSizeI64}, 8`);
-    const dataMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
+    const dataMem = this.ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${dataSize}`);
     const dataPtr = this.ctx.emitBitcast(dataMem, "i8*", "double*");
 
     const dataPtrField = this.nextTemp();

--- a/src/codegen/types/collections/set.ts
+++ b/src/codegen/types/collections/set.ts
@@ -47,7 +47,7 @@ export class SetGenerator {
     this.emit(`${valuesCapI64} = zext i32 ${initialCapacity} to i64`);
     const valuesSize = this.nextTemp();
     this.emit(`${valuesSize} = mul i64 ${valuesCapI64}, ${doubleSize}`);
-    const valuesMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${valuesSize}`);
+    const valuesMem = this.ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${valuesSize}`);
     const valuesPtr = this.ctx.emitBitcast(valuesMem, "i8*", "double*");
 
     // Store values pointer in Set struct
@@ -169,7 +169,7 @@ export class SetGenerator {
     this.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
     const newMemSize = this.nextTemp();
     this.emit(`${newMemSize} = mul i64 ${newCapI64}, ${this.getDoubleSize()}`);
-    const newMem = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${newMemSize}`);
+    const newMem = this.ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${newMemSize}`);
     const newDataPtr = this.ctx.emitBitcast(newMem, "i8*", "double*");
     const oldDataI8 = this.ctx.emitBitcast(valuesPtr, "double*", "i8*");
     const newDataI8 = this.ctx.emitBitcast(newDataPtr, "double*", "i8*");


### PR DESCRIPTION
## Summary
- Extends arena allocator to numeric array data buffers (double*), Map keys/values, Set values, and array operation results (splice, concat, flat, map, filter)
- Replaces GC_realloc in string builder runtime with cs_arena_alloc + memcpy (no realloc needed — just bump-allocate fresh and copy)
- Also converts remaining string allocations in array ops (empty strings for pop/shift, join buffers)
- ~25 more GC_malloc_atomic → cs_arena_alloc conversions, 1 GC_realloc elimination

## Test plan
- [x] npm run verify:quick passes (tests + self-hosting stage 0+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)