### PR TITLE
inline bounds checks for better llvm loop optimization

### DIFF
--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -188,7 +188,23 @@ export class IndexAccessGenerator {
     );
     const len = this.ctx.nextTemp();
     this.ctx.emit(`${len} = load i32, i32* ${lenPtr}`);
-    this.ctx.emit(`call void @__cs_bounds_check(i32 ${index}, i32 ${len})`);
+    this.emitInlineBoundsCheck(index, len);
+  }
+
+  private emitInlineBoundsCheck(index: string, len: string): void {
+    const oobHi = this.ctx.nextTemp();
+    this.ctx.emit(`${oobHi} = icmp sge i32 ${index}, ${len}`);
+    const oobLo = this.ctx.nextTemp();
+    this.ctx.emit(`${oobLo} = icmp slt i32 ${index}, 0`);
+    const oob = this.ctx.nextTemp();
+    this.ctx.emit(`${oob} = or i1 ${oobHi}, ${oobLo}`);
+    const failLabel = this.ctx.nextLabel("bounds_fail");
+    const okLabel = this.ctx.nextLabel("bounds_ok");
+    this.ctx.emit(`br i1 ${oob}, label %${failLabel}, label %${okLabel}`);
+    this.ctx.emit(`${failLabel}:`);
+    this.ctx.emit(`call void @__cs_bounds_fail(i32 ${index}, i32 ${len})`);
+    this.ctx.emit(`unreachable`);
+    this.ctx.emit(`${okLabel}:`);
   }
 
   private generateStringArrayIndex(expr: IndexAccessNode, params: string[]): string {
@@ -412,7 +428,7 @@ export class IndexAccessGenerator {
     this.ctx.emit(`${strLen64} = call i64 @strlen(i8* ${objPtr})`);
     const strLen = this.ctx.nextTemp();
     this.ctx.emit(`${strLen} = trunc i64 ${strLen64} to i32`);
-    this.ctx.emit(`call void @__cs_bounds_check(i32 ${index}, i32 ${strLen})`);
+    this.emitInlineBoundsCheck(index, strLen);
 
     const indexI64 = this.ctx.nextTemp();
     this.ctx.emit(`${indexI64} = sext i32 ${index} to i64`);

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -331,6 +331,14 @@ export function getBoundsCheckHelper(): string {
   let ir = "";
   ir +=
     '@.str.oob_fmt = private unnamed_addr constant [49 x i8] c"Error: array index %d out of bounds (length %d)\\0A\\00", align 1\n';
+  ir += "define void @__cs_bounds_fail(i32 %index, i32 %length) cold noinline {\n";
+  ir += "entry:\n";
+  ir += "  %stderr = load i8*, i8** @stderr\n";
+  ir +=
+    "  call i32 (i8*, i8*, ...) @fprintf(i8* %stderr, i8* getelementptr([49 x i8], [49 x i8]* @.str.oob_fmt, i32 0, i32 0), i32 %index, i32 %length)\n";
+  ir += "  call void @exit(i32 1)\n";
+  ir += "  unreachable\n";
+  ir += "}\n\n";
   ir += "define void @__cs_bounds_check(i32 %index, i32 %length) {\n";
   ir += "entry:\n";
   ir += "  %too_high = icmp sge i32 %index, %length\n";
@@ -338,10 +346,7 @@ export function getBoundsCheckHelper(): string {
   ir += "  %oob = or i1 %too_high, %too_low\n";
   ir += "  br i1 %oob, label %fail, label %ok\n";
   ir += "fail:\n";
-  ir += "  %stderr = load i8*, i8** @stderr\n";
-  ir +=
-    "  call i32 (i8*, i8*, ...) @fprintf(i8* %stderr, i8* getelementptr([49 x i8], [49 x i8]* @.str.oob_fmt, i32 0, i32 0), i32 %index, i32 %length)\n";
-  ir += "  call void @exit(i32 1)\n";
+  ir += "  call void @__cs_bounds_fail(i32 %index, i32 %length)\n";
   ir += "  unreachable\n";
   ir += "ok:\n";
   ir += "  ret void\n";


### PR DESCRIPTION
## Summary
- Array and string bounds checks are now emitted inline (`icmp + or + br`) instead of calling the opaque `@__cs_bounds_check` function
- LLVM can now see through bounds checks to perform loop optimizations (LICM, IndVarSimplify, SCEV-based redundant check elimination)
- Cold error path calls new `@__cs_bounds_fail` (marked `cold noinline`) so it stays out of the hot path
- `@__cs_bounds_check` wrapper kept for backwards compatibility

## Test plan
- [x] `npm run build` passes
- [x] Self-hosting Stage 0 + Stage 1 pass
- [x] 592/593 compiler tests pass (1 pre-existing SIGSEGV in `for-of-nested`, unrelated)
- [x] Verified the pre-existing failure exists on unmodified code too