### PR TITLE
arena reset between top-level statements in main

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -1005,6 +1005,9 @@ export class FunctionGenerator {
     if (topLevelItemsCount > 0) {
       for (let itemIdx = 0; itemIdx < topLevelItemsCount; itemIdx++) {
         this.ctx.processTopLevelItem(itemIdx);
+        if (!this.ctx.lastInstructionIsTerminator()) {
+          this.ctx.emit("call void @cs_arena_reset()");
+        }
       }
     } else {
       for (let i = 0; i < topLevelStatementsCount; i++) {


### PR DESCRIPTION
## Summary
- Emits `call void @cs_arena_reset()` after each top-level statement in `main()`, reclaiming arena memory between statements
- Prevents unbounded arena growth in programs with many top-level statements
- Conservative approach: only resets between top-level statements, NOT inside loops (strings created in loop bodies can escape via array push etc.)

## Test plan
- [x] npm run verify:quick passes (tests + self-hosting stage 0+1)