### PR TITLE
fix native compiler sigsegv on for-of with nested arrays

### DIFF
--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -279,33 +279,46 @@ export class TypeResolver {
       if (mapMeta) {
         const keyType = parseTypeString(mapMeta.keyType);
         const valueType = parseTypeString(mapMeta.valueType);
-        resolved = createResolvedType("Map", {}, 0, [keyType, valueType]);
+        resolved = createResolvedType("Map", { isNullable: false, isOptional: false }, 0, [
+          keyType,
+          valueType,
+        ]);
       }
     }
     if (!resolved) {
       const setValueType = this.ctx.symbolTable.getSetValueType(name);
       if (setValueType) {
         const valueType = parseTypeString(setValueType);
-        resolved = createResolvedType("Set", {}, 0, [valueType]);
+        resolved = createResolvedType("Set", { isNullable: false, isOptional: false }, 0, [
+          valueType,
+        ]);
       }
     }
     if (!resolved) {
       const objArrayMeta = this.ctx.symbolTable.getObjectArrayMetadata(name);
       if (objArrayMeta) {
-        resolved = createResolvedType(objArrayMeta.elementInterfaceName, {}, 1);
+        resolved = createResolvedType(
+          objArrayMeta.elementInterfaceName,
+          { isNullable: false, isOptional: false },
+          1,
+        );
       }
     }
     if (!resolved) {
       const arrMetaElementType = this.ctx.symbolTable.getArrayMetadataElementType(name);
       if (arrMetaElementType) {
-        resolved = createResolvedType(arrMetaElementType, {}, 1);
+        resolved = createResolvedType(
+          arrMetaElementType,
+          { isNullable: false, isOptional: false },
+          1,
+        );
       }
     }
     if (!resolved && this.ctx.symbolTable.isStringArray(name)) {
-      resolved = createResolvedType("string", {}, 1);
+      resolved = createResolvedType("string", { isNullable: false, isOptional: false }, 1);
     }
     if (!resolved && this.ctx.symbolTable.isBooleanArray(name)) {
-      resolved = createResolvedType("boolean", {}, 1);
+      resolved = createResolvedType("boolean", { isNullable: false, isOptional: false }, 1);
     }
     if (!resolved) {
       const className = this.ctx.symbolTable.getClassName(name);
@@ -327,16 +340,16 @@ export class TypeResolver {
             resolved = createResolvedType("boolean");
             break;
           case "%Array*":
-            resolved = createResolvedType("number", {}, 1);
+            resolved = createResolvedType("number", { isNullable: false, isOptional: false }, 1);
             break;
           case "%StringArray*":
-            resolved = createResolvedType("string", {}, 1);
+            resolved = createResolvedType("string", { isNullable: false, isOptional: false }, 1);
             break;
           case "%Map*":
             resolved = createResolvedType("Map");
             break;
           case "%StringMap*":
-            resolved = createResolvedType("Map", {}, 0, [
+            resolved = createResolvedType("Map", { isNullable: false, isOptional: false }, 0, [
               createResolvedType("string"),
               createResolvedType("unknown"),
             ]);
@@ -345,7 +358,9 @@ export class TypeResolver {
             resolved = createResolvedType("Set");
             break;
           case "%StringSet*":
-            resolved = createResolvedType("Set", {}, 0, [createResolvedType("string")]);
+            resolved = createResolvedType("Set", { isNullable: false, isOptional: false }, 0, [
+              createResolvedType("string"),
+            ]);
             break;
           default:
             if (llvmType.startsWith("%") && llvmType.endsWith("*")) {

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -34,7 +34,7 @@ const DEFAULT_QUALIFIERS: TypeQualifiers = { isNullable: false, isOptional: fals
 
 export function createResolvedType(
   base: string,
-  qualifiers: Partial<TypeQualifiers> = {},
+  qualifiers: Partial<TypeQualifiers> = { isNullable: false, isOptional: false },
   arrayDepth: number = 0,
   typeParams?: ResolvedType[],
 ): ResolvedType {

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -553,12 +553,12 @@ export class ControlFlowGenerator {
     if (elementKind === SymbolKind_StringArray) {
       this.ctx.symbolTable.setResolvedType(
         forOfStmt.variableName,
-        createResolvedType("string", {}, 1),
+        createResolvedType("string", { isNullable: false, isOptional: false }, 1),
       );
     } else if (elementKind === SymbolKind_Array && isObjectArray) {
       this.ctx.symbolTable.setResolvedType(
         forOfStmt.variableName,
-        createResolvedType("number", {}, 1),
+        createResolvedType("number", { isNullable: false, isOptional: false }, 1),
       );
     }
 


### PR DESCRIPTION
## Summary
- Fixes SIGSEGV when the native compiler compiles `for...of` loops over nested arrays (`number[][]`, `string[][]`)
- Root cause: passing `{}` as a `Partial<TypeQualifiers>` argument to `createResolvedType` creates a 0-field struct in the native compiler, but the function accesses `.isNullable`/`.isOptional` fields on it — reading invalid memory
- Replaced all `{}` with `{ isNullable: false, isOptional: false }` across control-flow.ts, type-resolver.ts, and the default parameter in type-system.ts

## Test plan
- [x] `for-of-nested` test now passes with native compiler (was SIGSEGV)
- [x] All 742 tests pass
- [x] Self-hosting Stage 1 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)