### PR TITLE
terminator dedup + uint8array native comparison optimization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,10 +202,9 @@ LLVM basic blocks must end with exactly one terminator instruction (`ret`, `br`,
 Rather than parsing emitted strings to detect terminators, we use a parallel `outputIsTerminator: boolean[]`
 that auto-classifies every instruction at `emit()` time. Use `ctx.lastInstructionIsTerminator()` to check.
 
-**Three-way sync requirement**: The classification logic (`classifyTerminator`) exists in three places
-that must stay identical: `BaseGenerator` (protected), `MockGeneratorContext` (private), and
-`LLVMGenerator` inherits from `BaseGenerator`. If you add a new terminator (e.g., `invoke`, `indirectbr`),
-update all three.
+**Single source of truth**: The classification logic lives in `terminator-classifier.ts` as a standalone
+function. Both `BaseGenerator` and `MockGeneratorContext` delegate to it. To add a new terminator
+(e.g., `invoke`, `indirectbr`), update `classifyTerminator()` in that one file.
 
 Builder methods (`emitRet`, `emitRetVoid`, `emitBr`, `emitBrCond`, `emitUnreachable`, `emitLabel`) are
 available on `BaseGenerator`, `LLVMGenerator`, and `MockGeneratorContext` for type-safe terminator emission.

--- a/src/codegen/expressions/operators/binary.ts
+++ b/src/codegen/expressions/operators/binary.ts
@@ -4,6 +4,7 @@ import {
   NumberNode,
   StringNode,
   MethodCallNode,
+  IndexAccessNode,
 } from "../../../ast/types.js";
 import type { IStringGenerator } from "../../infrastructure/generator-context.js";
 
@@ -33,6 +34,7 @@ export interface BinaryExpressionGeneratorContext {
   generateExpression(expr: Expression, params: string[]): string;
   emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
   emitLoad(type: string, ptr: string): string;
+  isUint8ArrayExpression(expr: Expression): boolean;
 }
 
 /**
@@ -62,6 +64,20 @@ export class BinaryExpressionGenerator {
     if (op === "===" || op === "!==" || op === "==" || op === "!=") {
       const charAtResult = this.tryOptimizeCharAtComparison(op, left, right, params);
       if (charAtResult !== "") return charAtResult;
+    }
+
+    if (
+      op === "===" ||
+      op === "!==" ||
+      op === "==" ||
+      op === "!=" ||
+      op === "<" ||
+      op === ">" ||
+      op === "<=" ||
+      op === ">="
+    ) {
+      const u8Result = this.tryOptimizeUint8ArrayComparison(op, left, right, params);
+      if (u8Result !== "") return u8Result;
     }
 
     const leftValue = this.ctx.generateExpression(left, params);
@@ -693,6 +709,85 @@ export class BinaryExpressionGenerator {
     );
     const result = this.ctx.nextTemp();
     this.ctx.emit(`${result} = sitofp i32 ${resultI32} to double`);
+    this.ctx.setVariableType(result, "double");
+    return result;
+  }
+
+  private isUint8ArrayIndexAccess(expr: Expression): boolean {
+    if (expr.type !== "index_access") return false;
+    const ia = expr as IndexAccessNode;
+    return this.ctx.isUint8ArrayExpression(ia.object);
+  }
+
+  private getSmallIntLiteral(expr: Expression): number {
+    if (expr.type !== "number") return -1;
+    const val = (expr as NumberNode).value;
+    if (val < 0 || val > 255 || Math.floor(val) !== val) return -1;
+    return val;
+  }
+
+  private tryOptimizeUint8ArrayComparison(
+    op: string,
+    left: Expression,
+    right: Expression,
+    params: string[],
+  ): string {
+    let u8Expr: IndexAccessNode;
+    let literalVal: number;
+
+    if (this.isUint8ArrayIndexAccess(left) && this.getSmallIntLiteral(right) >= 0) {
+      u8Expr = left as IndexAccessNode;
+      literalVal = this.getSmallIntLiteral(right);
+    } else if (this.isUint8ArrayIndexAccess(right) && this.getSmallIntLiteral(left) >= 0) {
+      u8Expr = right as IndexAccessNode;
+      literalVal = this.getSmallIntLiteral(left);
+    } else {
+      return "";
+    }
+
+    const arrayPtr = this.ctx.generateExpression(u8Expr.object, params);
+    const indexDouble = this.ctx.generateExpression(u8Expr.index, params);
+    const indexType = this.ctx.getVariableType(indexDouble);
+    let index = indexDouble;
+    if (indexType === "double" || !indexType) {
+      index = this.ctx.nextTemp();
+      this.ctx.emit(`${index} = fptosi double ${indexDouble} to i32`);
+    } else if (indexType === "i64") {
+      index = this.ctx.nextTemp();
+      this.ctx.emit(`${index} = trunc i64 ${indexDouble} to i32`);
+    }
+
+    const dataFieldPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${dataFieldPtr} = getelementptr inbounds %Uint8Array, %Uint8Array* ${arrayPtr}, i32 0, i32 0`,
+    );
+    const dataPtr = this.ctx.emitLoad("i8*", dataFieldPtr);
+    const elemPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${elemPtr} = getelementptr inbounds i8, i8* ${dataPtr}, i32 ${index}`);
+    const byteVal = this.ctx.emitLoad("i8", elemPtr);
+
+    const icmpPred =
+      op === "===" || op === "=="
+        ? "eq"
+        : op === "!==" || op === "!="
+          ? "ne"
+          : op === "<"
+            ? "ult"
+            : op === ">"
+              ? "ugt"
+              : op === "<="
+                ? "ule"
+                : "uge";
+
+    const swapped = this.isUint8ArrayIndexAccess(right) && this.getSmallIntLiteral(left) >= 0;
+    const lhs = swapped ? `${literalVal}` : byteVal;
+    const rhs = swapped ? byteVal : `${literalVal}`;
+    const cmpResult = this.ctx.emitIcmp(icmpPred, "i8", lhs, rhs);
+
+    const i32Result = this.ctx.nextTemp();
+    this.ctx.emit(`${i32Result} = zext i1 ${cmpResult} to i32`);
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = sitofp i32 ${i32Result} to double`);
     this.ctx.setVariableType(result, "double");
     return result;
   }

--- a/src/codegen/infrastructure/base-generator.ts
+++ b/src/codegen/infrastructure/base-generator.ts
@@ -1,4 +1,5 @@
 import { Expression } from "../../ast/types.js";
+import { classifyTerminator } from "./terminator-classifier.js";
 import {
   SymbolTable,
   SymbolKind,
@@ -468,14 +469,7 @@ export class BaseGenerator {
   }
 
   protected classifyTerminator(instruction: string): boolean {
-    const trimmed = instruction.trim();
-    return (
-      trimmed.startsWith("ret ") ||
-      trimmed === "ret void" ||
-      trimmed.startsWith("br ") ||
-      trimmed.startsWith("unreachable") ||
-      trimmed.startsWith("switch ")
-    );
+    return classifyTerminator(instruction);
   }
 
   lastInstructionIsTerminator(): boolean {

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -48,6 +48,7 @@ import type { TypeGuardInfo, FieldInfo } from "./type-resolver/types.js";
 import type { JsonObjectMeta } from "../expressions/access/member.js";
 import type { DiagnosticEngine } from "../../diagnostics/engine.js";
 import { TypeContext } from "./type-context.js";
+import { classifyTerminator } from "./terminator-classifier.js";
 
 interface ExprBase {
   type: string;
@@ -1543,18 +1544,11 @@ export class MockGeneratorContext implements IGeneratorContext {
       }
     }
     this.output.push(instruction);
-    this.outputIsTerminator.push(this.classifyTerminator(instruction));
+    this.outputIsTerminator.push(this.classifyTerminatorImpl(instruction));
   }
 
-  private classifyTerminator(instruction: string): boolean {
-    const trimmed = instruction.trim();
-    return (
-      trimmed.startsWith("ret ") ||
-      trimmed === "ret void" ||
-      trimmed.startsWith("br ") ||
-      trimmed.startsWith("unreachable") ||
-      trimmed.startsWith("switch ")
-    );
+  private classifyTerminatorImpl(instruction: string): boolean {
+    return classifyTerminator(instruction);
   }
 
   lastInstructionIsTerminator(): boolean {
@@ -1640,7 +1634,7 @@ export class MockGeneratorContext implements IGeneratorContext {
 
   pushOutput(line: string): void {
     this.output.push(line);
-    this.outputIsTerminator.push(this.classifyTerminator(line));
+    this.outputIsTerminator.push(this.classifyTerminatorImpl(line));
   }
 
   getOutputLength(): number {
@@ -1659,7 +1653,7 @@ export class MockGeneratorContext implements IGeneratorContext {
     for (let i = 0; i < this.output.length; i++) {
       if (i === index) {
         newOutput.push(line);
-        newIsTerminator.push(this.classifyTerminator(line));
+        newIsTerminator.push(this.classifyTerminatorImpl(line));
       } else {
         newOutput.push(this.output[i]);
         newIsTerminator.push(this.outputIsTerminator[i]);

--- a/src/codegen/infrastructure/terminator-classifier.ts
+++ b/src/codegen/infrastructure/terminator-classifier.ts
@@ -1,0 +1,10 @@
+export function classifyTerminator(instruction: string): boolean {
+  const trimmed = instruction.trim();
+  return (
+    trimmed.startsWith("ret ") ||
+    trimmed === "ret void" ||
+    trimmed.startsWith("br ") ||
+    trimmed.startsWith("unreachable") ||
+    trimmed.startsWith("switch ")
+  );
+}

--- a/tests/fixtures/control-flow/for-of-nested.ts
+++ b/tests/fixtures/control-flow/for-of-nested.ts
@@ -1,3 +1,4 @@
+// @test-skip
 let passed = true;
 
 const matrix: number[][] = [

--- a/tests/fixtures/control-flow/for-of-nested.ts
+++ b/tests/fixtures/control-flow/for-of-nested.ts
@@ -1,4 +1,3 @@
-// @test-skip
 let passed = true;
 
 const matrix: number[][] = [

--- a/tests/fixtures/typed-arrays/uint8array-native-compare.ts
+++ b/tests/fixtures/typed-arrays/uint8array-native-compare.ts
@@ -1,0 +1,49 @@
+let passed = true;
+
+const buf = new Uint8Array(4);
+buf[0] = 0;
+buf[1] = 65;
+buf[2] = 255;
+buf[3] = 128;
+
+if (buf[0] !== 0) {
+  console.log("FAIL: buf[0] !== 0");
+  passed = false;
+}
+if (buf[1] !== 65) {
+  console.log("FAIL: buf[1] !== 65");
+  passed = false;
+}
+if (buf[2] !== 255) {
+  console.log("FAIL: buf[2] !== 255");
+  passed = false;
+}
+if (buf[1] === 66) {
+  console.log("FAIL: buf[1] === 66 should be false");
+  passed = false;
+}
+if (buf[3] < 127) {
+  console.log("FAIL: buf[3] < 127 should be false");
+  passed = false;
+}
+if (buf[3] > 129) {
+  console.log("FAIL: buf[3] > 129 should be false");
+  passed = false;
+}
+if (buf[0] >= 1) {
+  console.log("FAIL: buf[0] >= 1 should be false");
+  passed = false;
+}
+if (buf[2] <= 254) {
+  console.log("FAIL: buf[2] <= 254 should be false");
+  passed = false;
+}
+
+if (65 !== buf[1]) {
+  console.log("FAIL: 65 !== buf[1] (swapped)");
+  passed = false;
+}
+
+if (passed) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Uint8Array comparisons against byte literals (0-255) now emit `icmp i8` directly instead of converting through `double` and using `fcmp` — eliminates 3 unnecessary instructions per comparison
- `classifyTerminator` extracted to single shared utility, eliminating the three-way sync requirement between BaseGenerator and MockGeneratorContext

## Test plan
- [x] New test fixture: `uint8array-native-compare.ts` covering ==, !=, <, >, <=, >= with byte literals
- [x] All existing uint8array tests pass
- [x] Self-hosting (Stage 1) passes
- [x] 741 tests pass (1 pre-existing failure: for-of-nested, fixed in #416)

🤖 Generated with [Claude Code](https://claude.com/claude-code)