### PR TITLE
replace clang ir-to-object step with llvm c api in native compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,12 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 lld-21 \
+          sudo apt-get install -y clang-21 lld-21 llvm-21-dev \
             cmake make gcc g++ \
             autoconf automake libtool \
             libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev
           sudo ln -sf /usr/bin/clang-21 /usr/bin/clang
+          sudo ln -sf /usr/bin/llvm-config-21 /usr/bin/llvm-config
           clang --version 2>&1 | head -2
 
       - name: Install npm dependencies
@@ -62,7 +63,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -131,7 +132,7 @@ jobs:
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
-          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o release/lib/
           tar -czf chadscript-linux-x64.tar.gz -C release chad lib
 
       - name: Upload artifact
@@ -183,7 +184,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -256,7 +257,7 @@ jobs:
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
-          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o release/lib/
           tar -czf chadscript-macos-arm64.tar.gz -C release chad lib
 
       - name: Upload artifact
@@ -335,6 +336,7 @@ jobs:
             dotenv-bridge.o \
             watch-bridge.o \
             arena-bridge.o \
+            llvm-bridge.o \
             tree-sitter-typescript-parser.o \
             tree-sitter-typescript-scanner.o \
             treesitter-bridge.o; do

--- a/c_bridges/llvm-bridge.c
+++ b/c_bridges/llvm-bridge.c
@@ -1,0 +1,228 @@
+#include <llvm-c/Core.h>
+#include <llvm-c/IRReader.h>
+#include <llvm-c/Target.h>
+#include <llvm-c/TargetMachine.h>
+#include <llvm-c/Transforms/PassBuilder.h>
+#include <stdlib.h>
+#include <string.h>
+
+static LLVMContextRef g_context = NULL;
+static LLVMModuleRef g_module = NULL;
+static LLVMTargetMachineRef g_target_machine = NULL;
+
+static int g_targets_initialized = 0;
+
+static void ensure_targets(void) {
+    if (g_targets_initialized) return;
+    LLVMInitializeX86TargetInfo();
+    LLVMInitializeX86Target();
+    LLVMInitializeX86TargetMC();
+    LLVMInitializeX86AsmPrinter();
+    LLVMInitializeX86AsmParser();
+    LLVMInitializeAArch64TargetInfo();
+    LLVMInitializeAArch64Target();
+    LLVMInitializeAArch64TargetMC();
+    LLVMInitializeAArch64AsmPrinter();
+    LLVMInitializeAArch64AsmParser();
+    g_targets_initialized = 1;
+}
+
+static void cleanup_module(void) {
+    if (g_target_machine) {
+        LLVMDisposeTargetMachine(g_target_machine);
+        g_target_machine = NULL;
+    }
+    if (g_module) {
+        LLVMDisposeModule(g_module);
+        g_module = NULL;
+    }
+    if (g_context) {
+        LLVMContextDispose(g_context);
+        g_context = NULL;
+    }
+}
+
+static char* setup_target(const char* triple,
+                          const char* cpu,
+                          const char* features) {
+    char* default_triple = NULL;
+    char* default_cpu = NULL;
+    char* default_features = NULL;
+
+    const char* effective_triple = triple;
+    if (!effective_triple || effective_triple[0] == '\0') {
+        default_triple = LLVMGetDefaultTargetTriple();
+        effective_triple = default_triple;
+    }
+
+    const char* effective_cpu = cpu;
+    if (!effective_cpu || effective_cpu[0] == '\0' ||
+        (effective_cpu[0] == 'n' && strcmp(effective_cpu, "native") == 0)) {
+        default_cpu = LLVMGetHostCPUName();
+        effective_cpu = default_cpu;
+    }
+
+    const char* effective_features = features;
+    if (!effective_features || effective_features[0] == '\0') {
+        default_features = LLVMGetHostCPUFeatures();
+        effective_features = default_features;
+    }
+
+    LLVMSetTarget(g_module, effective_triple);
+
+    LLVMTargetRef target;
+    char* err_msg = NULL;
+    if (LLVMGetTargetFromTriple(effective_triple, &target, &err_msg)) {
+        char* result = strdup(err_msg ? err_msg : "invalid target triple");
+        LLVMDisposeMessage(err_msg);
+        if (default_triple) LLVMDisposeMessage(default_triple);
+        if (default_cpu) LLVMDisposeMessage(default_cpu);
+        if (default_features) LLVMDisposeMessage(default_features);
+        return result;
+    }
+
+    if (g_target_machine) LLVMDisposeTargetMachine(g_target_machine);
+    g_target_machine = LLVMCreateTargetMachine(
+        target, effective_triple, effective_cpu, effective_features,
+        LLVMCodeGenLevelDefault, LLVMRelocDefault, LLVMCodeModelDefault
+    );
+
+    if (default_triple) LLVMDisposeMessage(default_triple);
+    if (default_cpu) LLVMDisposeMessage(default_cpu);
+    if (default_features) LLVMDisposeMessage(default_features);
+
+    if (!g_target_machine) return strdup("failed to create target machine");
+
+    LLVMTargetDataRef data_layout = LLVMCreateTargetDataLayout(g_target_machine);
+    LLVMSetModuleDataLayout(g_module, data_layout);
+    LLVMDisposeTargetData(data_layout);
+
+    return NULL;
+}
+
+static char* run_optimization(int opt_level) {
+    if (opt_level <= 0) return NULL;
+
+    const char* passes;
+    switch (opt_level) {
+        case 1: passes = "default<O1>"; break;
+        case 3: passes = "default<O3>"; break;
+        default: passes = "default<O2>"; break;
+    }
+
+    LLVMPassBuilderOptionsRef opts = LLVMCreatePassBuilderOptions();
+    LLVMErrorRef err = LLVMRunPasses(g_module, passes, g_target_machine, opts);
+    LLVMDisposePassBuilderOptions(opts);
+
+    if (err) {
+        char* msg = LLVMGetErrorMessage(err);
+        char* result = strdup(msg);
+        LLVMDisposeErrorMessage(msg);
+        return result;
+    }
+    return NULL;
+}
+
+static char* emit_object_file(const char* output_path) {
+    char* err_msg = NULL;
+    if (LLVMTargetMachineEmitToFile(g_target_machine, g_module,
+                                     output_path, LLVMObjectFile, &err_msg)) {
+        char* result = strdup(err_msg ? err_msg : "emit failed");
+        LLVMDisposeMessage(err_msg);
+        return result;
+    }
+    return NULL;
+}
+
+static char* parse_ir_from_buffer(const char* ir_text, size_t len) {
+    cleanup_module();
+    g_context = LLVMContextCreate();
+
+    LLVMMemoryBufferRef buf = LLVMCreateMemoryBufferWithMemoryRangeCopy(
+        ir_text, len, "input.ll"
+    );
+
+    char* err_msg = NULL;
+    if (LLVMParseIRInContext(g_context, buf, &g_module, &err_msg)) {
+        char* result = strdup(err_msg ? err_msg : "unknown parse error");
+        LLVMDisposeMessage(err_msg);
+        g_context = NULL;
+        return result;
+    }
+    return NULL;
+}
+
+char* cs_llvm_compile_ir(const char* ir_text,
+                         const char* output_path,
+                         double opt_level_d,
+                         const char* triple,
+                         const char* cpu,
+                         const char* features) {
+    int opt_level = (int)opt_level_d;
+    char* err;
+    ensure_targets();
+
+    err = parse_ir_from_buffer(ir_text, strlen(ir_text));
+    if (err) return err;
+
+    err = setup_target(triple, cpu, features);
+    if (err) { cleanup_module(); return err; }
+
+    err = run_optimization(opt_level);
+    if (err) { cleanup_module(); return err; }
+
+    err = emit_object_file(output_path);
+    cleanup_module();
+    if (err) return err;
+    return strdup("");
+}
+
+char* cs_llvm_compile_ir_file(const char* ir_file,
+                              const char* output_path,
+                              double opt_level_d,
+                              const char* triple,
+                              const char* cpu,
+                              const char* features) {
+    int opt_level = (int)opt_level_d;
+    ensure_targets();
+
+    LLVMMemoryBufferRef file_buf = NULL;
+    char* err_msg = NULL;
+    if (LLVMCreateMemoryBufferWithContentsOfFile(ir_file, &file_buf, &err_msg)) {
+        char* result = strdup(err_msg ? err_msg : "failed to read file");
+        LLVMDisposeMessage(err_msg);
+        return result;
+    }
+
+    size_t len = LLVMGetBufferSize(file_buf);
+    const char* data = LLVMGetBufferStart(file_buf);
+
+    cleanup_module();
+    g_context = LLVMContextCreate();
+
+    LLVMMemoryBufferRef ir_buf = LLVMCreateMemoryBufferWithMemoryRangeCopy(data, len, "input.ll");
+    LLVMDisposeMemoryBuffer(file_buf);
+
+    if (LLVMParseIRInContext(g_context, ir_buf, &g_module, &err_msg)) {
+        char* result = strdup(err_msg ? err_msg : "unknown parse error");
+        LLVMDisposeMessage(err_msg);
+        g_context = NULL;
+        return result;
+    }
+
+    char* err;
+    err = setup_target(triple, cpu, features);
+    if (err) { cleanup_module(); return err; }
+
+    err = run_optimization(opt_level);
+    if (err) { cleanup_module(); return err; }
+
+    err = emit_object_file(output_path);
+    cleanup_module();
+    if (err) return err;
+    return strdup("");
+}
+
+void cs_llvm_dispose(void) {
+    cleanup_module();
+}

--- a/scripts/build-target-sdk.sh
+++ b/scripts/build-target-sdk.sh
@@ -69,7 +69,7 @@ fi
 
 # Copy C bridge object files
 echo "  Copying bridge objects..."
-for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o; do
+for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o llvm-bridge.o; do
   if [ -f "$C_BRIDGES_DIR/$bridge" ]; then
     cp "$C_BRIDGES_DIR/$bridge" "$SDK_DIR/bridges/"
   fi

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -264,6 +264,39 @@ if [ ! -f "$URI_BRIDGE_OBJ" ] || [ "$URI_BRIDGE_SRC" -nt "$URI_BRIDGE_OBJ" ]; th
 else
   echo "==> uri-bridge already built, skipping"
 fi
+# --- llvm-bridge (requires LLVM dev libraries) ---
+LLVM_BRIDGE_SRC="$C_BRIDGES_DIR/llvm-bridge.c"
+LLVM_BRIDGE_OBJ="$C_BRIDGES_DIR/llvm-bridge.o"
+LLVM_CONFIG=""
+if command -v llvm-config >/dev/null 2>&1; then
+  LLVM_CONFIG="llvm-config"
+elif [ -f "/opt/homebrew/opt/llvm/bin/llvm-config" ]; then
+  LLVM_CONFIG="/opt/homebrew/opt/llvm/bin/llvm-config"
+elif [ -f "/usr/local/opt/llvm/bin/llvm-config" ]; then
+  LLVM_CONFIG="/usr/local/opt/llvm/bin/llvm-config"
+elif [ -f "/usr/lib/llvm-21/bin/llvm-config" ]; then
+  LLVM_CONFIG="/usr/lib/llvm-21/bin/llvm-config"
+elif [ -f "/usr/lib/llvm-18/bin/llvm-config" ]; then
+  LLVM_CONFIG="/usr/lib/llvm-18/bin/llvm-config"
+fi
+if [ -n "$LLVM_CONFIG" ]; then
+  if [ ! -f "$LLVM_BRIDGE_OBJ" ] || [ "$LLVM_BRIDGE_SRC" -nt "$LLVM_BRIDGE_OBJ" ]; then
+    echo "==> Building llvm-bridge (using $LLVM_CONFIG)..."
+    LLVM_CFLAGS=$($LLVM_CONFIG --cflags)
+    LLVM_BINDIR=$(dirname "$LLVM_CONFIG")
+    LLVM_CC="$LLVM_BINDIR/clang"
+    if [ ! -f "$LLVM_CC" ]; then
+      LLVM_CC="cc"
+    fi
+    $LLVM_CC -c -O2 -fPIC $LLVM_CFLAGS "$LLVM_BRIDGE_SRC" -o "$LLVM_BRIDGE_OBJ"
+    echo "  -> $LLVM_BRIDGE_OBJ"
+  else
+    echo "==> llvm-bridge already built, skipping"
+  fi
+else
+  echo "==> llvm-bridge skipped (no llvm-config found)"
+fi
+
 # --- child-process-spawn (async, requires libuv) ---
 CP_SPAWN_SRC="$C_BRIDGES_DIR/child-process-spawn.c"
 CP_SPAWN_OBJ="$C_BRIDGES_DIR/child-process-spawn.o"

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -256,6 +256,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public usesChildProcess: number = 0;
   public usesSpawn: number = 0;
   public usesStringBuilder: number = 0;
+  public usesLLVM: number = 0;
   private stringBuilderSlen: Map<string, string> = new Map();
   private stringBuilderScap: Map<string, string> = new Map();
 
@@ -963,6 +964,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
   public setUsesMathRandom(value: boolean): void {
     this.usesMathRandom = value ? 1 : 0;
+  }
+  public getUsesLLVM(): boolean {
+    return this.usesLLVM !== 0;
   }
   public setCurrentDeclaredInterfaceType(type: string | undefined): void {
     this.currentDeclaredInterfaceType = type;
@@ -3172,6 +3176,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     }
 
     this.declaredExternFunctions.push(func.name);
+    if (func.name.startsWith("cs_llvm_")) this.usesLLVM = 1;
     return `declare ${retType} @${func.name}(${paramLlvmTypes.join(", ")})\n`;
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -42,6 +42,26 @@ function findLLVMTool(name: string): string {
   );
 }
 
+function findLLVMConfig(): string | null {
+  const candidates = [
+    "/opt/homebrew/opt/llvm/bin/llvm-config",
+    "/usr/local/opt/llvm/bin/llvm-config",
+    "/usr/lib/llvm-21/bin/llvm-config",
+    "/usr/lib/llvm-18/bin/llvm-config",
+  ];
+  try {
+    return execSync("which llvm-config", { stdio: "pipe", encoding: "utf8" }).trim();
+  } catch (e) {
+    // not in PATH
+  }
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 // Find lld for cross-linking ELF binaries. Homebrew LLVM on macOS may only
 // install ld64.lld (Mach-O). Since lld is a multicall binary that uses argv[0]
 // to pick its flavor, we can symlink ld64.lld as ld.lld to get ELF mode.
@@ -483,6 +503,39 @@ export function compile(
 
       extraObjs = ` ${tsParserObj} ${tsScannerObj} ${bridgeObj}`;
       linkLibs += ` ${TREESITTER_LIB_PATH}/libtree-sitter.a`;
+    }
+  }
+
+  if (generator.getUsesLLVM()) {
+    const llvmBridgeObj = `${bridgePath}/llvm-bridge.o`;
+    if (fs.existsSync(llvmBridgeObj)) {
+      extraObjs += ` ${llvmBridgeObj}`;
+    }
+    const llvmConfigPath = findLLVMConfig();
+    if (llvmConfigPath) {
+      const llvmLibFlags = execSync(
+        `${llvmConfigPath} --ldflags --libs x86 aarch64 passes core irreader --link-static`,
+        { stdio: "pipe", encoding: "utf8" },
+      )
+        .trim()
+        .replace(/\n/g, " ");
+      const llvmSysFlags = execSync(`${llvmConfigPath} --system-libs --link-static`, {
+        stdio: "pipe",
+        encoding: "utf8",
+      })
+        .trim()
+        .replace(/\n/g, " ");
+      linkLibs += ` ${llvmLibFlags} ${llvmSysFlags}`;
+      if (hostIsMac) {
+        linkLibs += " -lc++";
+        const brewZstd =
+          process.arch === "arm64" ? "/opt/homebrew/opt/zstd/lib" : "/usr/local/opt/zstd/lib";
+        if (fs.existsSync(brewZstd)) {
+          linkLibs += ` -L${brewZstd}`;
+        }
+      } else {
+        linkLibs += " -lstdc++";
+      }
     }
   }
 

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -46,6 +46,16 @@ declare const process: {
 
 declare function __gc_disable(): void;
 
+declare function cs_llvm_compile_ir_file(
+  ir_file: string,
+  output_path: string,
+  opt_level: number,
+  triple: string,
+  cpu: string,
+  features: string,
+): string;
+declare function cs_llvm_dispose(): void;
+
 function findLLVMTool(name: string): string {
   const candidates = [
     "/opt/homebrew/opt/llvm/bin/" + name,
@@ -80,6 +90,45 @@ function findLLD(): string {
     return lldLink;
   }
   return "lld";
+}
+
+function findLLVMConfig(): string {
+  const candidates = [
+    "/opt/homebrew/opt/llvm/bin/llvm-config",
+    "/usr/local/opt/llvm/bin/llvm-config",
+    "/usr/lib/llvm-21/bin/llvm-config",
+    "/usr/lib/llvm-18/bin/llvm-config",
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return "";
+}
+
+function getLLVMLibFlags(): string {
+  const cfg = findLLVMConfig();
+  if (cfg.length === 0) return "";
+  const tmpFile = "/tmp/cs_llvm_lib_flags.txt";
+  const cmd =
+    "(" +
+    cfg +
+    " --ldflags --libs x86 aarch64 passes core irreader --link-static && " +
+    cfg +
+    " --system-libs --link-static) 2>/dev/null | tr '\\n' ' ' > " +
+    tmpFile;
+  child_process.execSync(cmd);
+  if (!fs.existsSync(tmpFile)) return "";
+  const flags = fs.readFileSync(tmpFile);
+  fs.unlinkSync(tmpFile);
+  const isMacForLLVM = process.platform === "darwin";
+  if (isMacForLLVM) {
+    let result = flags + " -lc++";
+    if (fs.existsSync("/opt/homebrew/opt/zstd/lib"))
+      result = result + " -L/opt/homebrew/opt/zstd/lib";
+    if (fs.existsSync("/usr/local/opt/zstd/lib")) result = result + " -L/usr/local/opt/zstd/lib";
+    return result;
+  }
+  return flags + " -lstdc++";
 }
 
 export let skipSemanticAnalysis = false;
@@ -392,24 +441,19 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const objFile = outputFile + ".o";
   const clangTool = findLLVMTool("clang");
 
-  const cpuFlag = crossCompiling ? "" : "-march=" + targetCpu;
-  const tripleFlag = crossCompiling ? " --target=" + targetTriple : "";
-
-  const compileCmd =
-    clangTool +
-    " -c -Wno-override-module -O2 " +
-    cpuFlag +
-    tripleFlag +
-    " " +
-    irFile +
-    " -o " +
-    objFile;
+  const effectiveTriple = crossCompiling ? targetTriple : "";
+  const effectiveCpu = crossCompiling ? "" : targetCpu;
   if (verbose) {
-    console.log("Running: " + compileCmd);
+    console.log("Compiling IR via LLVM C API: " + irFile + " -> " + objFile);
   }
-  child_process.execSync(compileCmd);
+  const llvmErr = cs_llvm_compile_ir_file(irFile, objFile, 2, effectiveTriple, effectiveCpu, "");
+  if (llvmErr.length > 0) {
+    console.log("Error: LLVM compilation failed: " + llvmErr);
+    process.exit(1);
+  }
+  cs_llvm_dispose();
   if (!fs.existsSync(objFile)) {
-    console.log("Error: clang failed to produce " + objFile);
+    console.log("Error: LLVM failed to produce " + objFile);
     process.exit(1);
   }
 
@@ -518,6 +562,17 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const watchBridgeObj = effectiveBridgePath + "/watch-bridge.o";
   const arenaBridgeObj = effectiveBridgePath + "/arena-bridge.o";
   const cpSpawnObj = generator.getUsesSpawn() ? effectiveBridgePath + "/child-process-spawn.o" : "";
+  let llvmBridgeObj = "";
+  if (generator.getUsesLLVM()) {
+    const llvmBridgePath = effectiveBridgePath + "/llvm-bridge.o";
+    if (fs.existsSync(llvmBridgePath)) {
+      llvmBridgeObj = llvmBridgePath;
+    }
+    const llvmLibResult = getLLVMLibFlags();
+    if (llvmLibResult.length > 0) {
+      linkLibs = linkLibs + " " + llvmLibResult;
+    }
+  }
 
   // Sysroot and target flags for cross-compilation
   if (hasSDK && sdkSysroot.length > 0) {
@@ -606,6 +661,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
     arenaBridgeObj +
     " " +
     cpSpawnObj +
+    " " +
+    llvmBridgeObj +
     " " +
     treeSitterObjs +
     userLinkObjs +


### PR DESCRIPTION
## Summary

- Native compiler now uses LLVM C API directly to compile IR to object files instead of shelling out to `clang -c`
- Eliminates one `execSync` call per compilation, keeping IR in-process
- Node compiler path unchanged (still uses clang for bootstrap)
- Binary size increases to ~94MB due to statically linked LLVM libraries (acceptable — rustc is ~200MB)

## Changes

- **`c_bridges/llvm-bridge.c`** (new): wraps LLVM-C API — `cs_llvm_compile_ir_file()` does parse → target setup → optimize → emit in one call
- **`src/native-compiler-lib.ts`**: replaces `execSync(clang -c ...)` with `cs_llvm_compile_ir_file()` call
- **`src/compiler.ts`**: links llvm-bridge.o + LLVM static libs when `usesLLVM` flag is set (building the compiler)
- **`src/codegen/llvm-generator.ts`**: adds `usesLLVM` feature flag, auto-detected from `declare function cs_llvm_*`
- **`scripts/build-vendor.sh`**: detects LLVM via `llvm-config` and compiles llvm-bridge
- **CI + SDK**: adds llvm-bridge.o to verify loops, release packaging, and target SDK

## Test plan

- [x] All 741/742 tests pass (1 failure is pre-existing for-of-nested, PR #416)
- [x] Self-hosting passes (Stage 0 + Stage 1)
- [x] Smoke test: `chad build examples/hello.ts` works with LLVM API path
- [ ] CI verifies on Linux (needs `llvm-21-dev` package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)