### PR TITLE
embed lld linker for in-process linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 lld-21 llvm-21-dev liblld-21-dev \
+          sudo apt-get install -y clang-21 lld-21 llvm-21-dev \
             cmake make gcc g++ \
             autoconf automake libtool \
             libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
           sudo apt-get update
-          sudo apt-get install -y clang-21 lld-21 llvm-21-dev \
+          sudo apt-get install -y clang-21 lld-21 llvm-21-dev liblld-21-dev \
             cmake make gcc g++ \
             autoconf automake libtool \
             libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev
@@ -52,7 +52,7 @@ jobs:
           path: |
             vendor/
             c_bridges/*.o
-          key: vendor-${{ runner.os }}-${{ hashFiles('scripts/build-vendor.sh', 'scripts/vendor-pins.sh', 'c_bridges/*.c') }}
+          key: vendor-${{ runner.os }}-${{ hashFiles('scripts/build-vendor.sh', 'scripts/vendor-pins.sh', 'c_bridges/*.c', 'c_bridges/*.cpp') }}
 
       - name: Build vendor libraries
         run: bash scripts/build-vendor.sh
@@ -63,7 +63,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o c_bridges/lld-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -132,7 +132,7 @@ jobs:
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
-          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o c_bridges/lld-bridge.o release/lib/
           tar -czf chadscript-linux-x64.tar.gz -C release chad lib
 
       - name: Upload artifact
@@ -160,7 +160,7 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          brew install llvm cmake autoconf automake libtool zstd
+          brew install llvm lld cmake autoconf automake libtool zstd
           echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
           echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
 
@@ -173,7 +173,7 @@ jobs:
           path: |
             vendor/
             c_bridges/*.o
-          key: vendor-${{ runner.os }}-${{ hashFiles('scripts/build-vendor.sh', 'scripts/vendor-pins.sh', 'c_bridges/*.c') }}
+          key: vendor-${{ runner.os }}-${{ hashFiles('scripts/build-vendor.sh', 'scripts/vendor-pins.sh', 'c_bridges/*.c', 'c_bridges/*.cpp') }}
 
       - name: Build vendor libraries
         run: bash scripts/build-vendor.sh
@@ -184,7 +184,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o c_bridges/lld-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -257,7 +257,7 @@ jobs:
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
-          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o c_bridges/lld-bridge.o release/lib/
           tar -czf chadscript-macos-arm64.tar.gz -C release chad lib
 
       - name: Upload artifact
@@ -337,6 +337,7 @@ jobs:
             watch-bridge.o \
             arena-bridge.o \
             llvm-bridge.o \
+            lld-bridge.o \
             tree-sitter-typescript-parser.o \
             tree-sitter-typescript-scanner.o \
             treesitter-bridge.o; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Install system dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install llvm zstd
+          brew install llvm lld zstd
           echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
 
       - name: Download artifact

--- a/c_bridges/lld-bridge.cpp
+++ b/c_bridges/lld-bridge.cpp
@@ -1,0 +1,87 @@
+#include <lld/Common/Driver.h>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/Support/raw_ostream.h>
+#include <cstring>
+#include <cstdlib>
+#include <vector>
+#include <string>
+
+LLD_HAS_DRIVER(macho)
+LLD_HAS_DRIVER(elf)
+
+static std::vector<std::string> tokenize(const char* cmd) {
+    std::vector<std::string> tokens;
+    const char* p = cmd;
+    while (*p) {
+        while (*p == ' ' || *p == '\t') p++;
+        if (!*p) break;
+        std::string tok;
+        while (*p && *p != ' ' && *p != '\t') {
+            tok += *p++;
+        }
+        tokens.push_back(tok);
+    }
+    return tokens;
+}
+
+extern "C" {
+
+double cs_lld_available(void) {
+    return 1.0;
+}
+
+char* cs_lld_link_macho(const char* cmd_str) {
+    auto tokens = tokenize(cmd_str);
+    std::vector<const char*> argv;
+    argv.push_back("ld64.lld");
+    for (auto& t : tokens) argv.push_back(t.c_str());
+
+    std::string err_str;
+    llvm::raw_string_ostream err_stream(err_str);
+    llvm::raw_null_ostream null_stream;
+
+    lld::DriverDef drivers[] = {
+        {lld::Darwin, &lld::macho::link}
+    };
+
+    lld::Result result = lld::lldMain(
+        llvm::ArrayRef<const char*>(argv.data(), argv.size()),
+        null_stream, err_stream,
+        llvm::ArrayRef<lld::DriverDef>(drivers, 1));
+
+    if (result.retCode != 0) {
+        err_stream.flush();
+        if (!err_str.empty()) return strdup(err_str.c_str());
+        return strdup("lld macho linking failed");
+    }
+    return strdup("");
+}
+
+char* cs_lld_link_elf(const char* cmd_str) {
+    auto tokens = tokenize(cmd_str);
+    std::vector<const char*> argv;
+    argv.push_back("ld.lld");
+    for (auto& t : tokens) argv.push_back(t.c_str());
+
+    std::string err_str;
+    llvm::raw_string_ostream err_stream(err_str);
+    llvm::raw_null_ostream null_stream;
+
+    lld::DriverDef drivers[] = {
+        {lld::Gnu, &lld::elf::link}
+    };
+
+    lld::Result result = lld::lldMain(
+        llvm::ArrayRef<const char*>(argv.data(), argv.size()),
+        null_stream, err_stream,
+        llvm::ArrayRef<lld::DriverDef>(drivers, 1));
+
+    if (result.retCode != 0) {
+        err_stream.flush();
+        if (!err_str.empty()) return strdup(err_str.c_str());
+        return strdup("lld elf linking failed");
+    }
+    return strdup("");
+}
+
+}

--- a/c_bridges/lld-stub.c
+++ b/c_bridges/lld-stub.c
@@ -1,0 +1,16 @@
+#include <string.h>
+#include <stdlib.h>
+
+double cs_lld_available(void) {
+    return 0.0;
+}
+
+char* cs_lld_link_macho(const char* cmd_str) {
+    (void)cmd_str;
+    return strdup("lld not available (compiled without lld-bridge)");
+}
+
+char* cs_lld_link_elf(const char* cmd_str) {
+    (void)cmd_str;
+    return strdup("lld not available (compiled without lld-bridge)");
+}

--- a/scripts/build-target-sdk.sh
+++ b/scripts/build-target-sdk.sh
@@ -69,7 +69,7 @@ fi
 
 # Copy C bridge object files
 echo "  Copying bridge objects..."
-for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o llvm-bridge.o; do
+for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o llvm-bridge.o lld-bridge.o; do
   if [ -f "$C_BRIDGES_DIR/$bridge" ]; then
     cp "$C_BRIDGES_DIR/$bridge" "$SDK_DIR/bridges/"
   fi

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -297,37 +297,43 @@ else
   echo "==> llvm-bridge skipped (no llvm-config found)"
 fi
 
-# --- lld-bridge (requires LLD + LLVM dev libraries) ---
+# --- lld-bridge (macOS only — requires LLD dynamic libs; Linux uses stub) ---
 LLD_BRIDGE_SRC="$C_BRIDGES_DIR/lld-bridge.cpp"
 LLD_BRIDGE_OBJ="$C_BRIDGES_DIR/lld-bridge.o"
-LLD_INCLUDE=""
-if [ -d "/opt/homebrew/opt/lld/include" ]; then
-  LLD_INCLUDE="/opt/homebrew/opt/lld/include"
-elif [ -d "/usr/local/opt/lld/include" ]; then
-  LLD_INCLUDE="/usr/local/opt/lld/include"
-elif [ -d "/usr/lib/llvm-21/include/lld" ]; then
-  LLD_INCLUDE="/usr/lib/llvm-21/include"
-elif [ -d "/usr/lib/llvm-18/include/lld" ]; then
-  LLD_INCLUDE="/usr/lib/llvm-18/include"
-fi
-if [ -n "$LLVM_CONFIG" ] && [ -n "$LLD_INCLUDE" ]; then
-  if [ ! -f "$LLD_BRIDGE_OBJ" ] || [ "$LLD_BRIDGE_SRC" -nt "$LLD_BRIDGE_OBJ" ]; then
-    echo "==> Building lld-bridge (using $LLVM_CONFIG)..."
-    LLVM_CXXFLAGS=$($LLVM_CONFIG --cxxflags | sed 's/-fno-exceptions//g')
-    LLVM_BINDIR=$(dirname "$LLVM_CONFIG")
-    LLVM_CXX="$LLVM_BINDIR/clang++"
-    if [ ! -f "$LLVM_CXX" ]; then
-      LLVM_CXX="c++"
+LLD_STUB_SRC="$C_BRIDGES_DIR/lld-stub.c"
+if [ "$(uname)" = "Darwin" ]; then
+  LLD_INCLUDE=""
+  if [ -d "/opt/homebrew/opt/lld/include" ]; then
+    LLD_INCLUDE="/opt/homebrew/opt/lld/include"
+  elif [ -d "/usr/local/opt/lld/include" ]; then
+    LLD_INCLUDE="/usr/local/opt/lld/include"
+  fi
+  if [ -n "$LLVM_CONFIG" ] && [ -n "$LLD_INCLUDE" ]; then
+    if [ ! -f "$LLD_BRIDGE_OBJ" ] || [ "$LLD_BRIDGE_SRC" -nt "$LLD_BRIDGE_OBJ" ]; then
+      echo "==> Building lld-bridge (using $LLVM_CONFIG)..."
+      LLVM_CXXFLAGS=$($LLVM_CONFIG --cxxflags | sed 's/-fno-exceptions//g')
+      LLVM_BINDIR=$(dirname "$LLVM_CONFIG")
+      LLVM_CXX="$LLVM_BINDIR/clang++"
+      if [ ! -f "$LLVM_CXX" ]; then
+        LLVM_CXX="c++"
+      fi
+      $LLVM_CXX -c -O2 -fPIC $LLVM_CXXFLAGS -I"$LLD_INCLUDE" "$LLD_BRIDGE_SRC" -o "$LLD_BRIDGE_OBJ"
+      echo "  -> $LLD_BRIDGE_OBJ"
+    else
+      echo "==> lld-bridge already built, skipping"
     fi
-    $LLVM_CXX -c -O2 -fPIC $LLVM_CXXFLAGS -I"$LLD_INCLUDE" "$LLD_BRIDGE_SRC" -o "$LLD_BRIDGE_OBJ"
-    echo "  -> $LLD_BRIDGE_OBJ"
   else
-    echo "==> lld-bridge already built, skipping"
+    if [ ! -f "$LLD_BRIDGE_OBJ" ] || [ "$LLD_STUB_SRC" -nt "$LLD_BRIDGE_OBJ" ]; then
+      echo "==> Building lld-stub (no lld headers found)..."
+      cc -c -O2 -fPIC "$LLD_STUB_SRC" -o "$LLD_BRIDGE_OBJ"
+      echo "  -> $LLD_BRIDGE_OBJ (stub)"
+    else
+      echo "==> lld-bridge already built, skipping"
+    fi
   fi
 else
-  LLD_STUB_SRC="$C_BRIDGES_DIR/lld-stub.c"
   if [ ! -f "$LLD_BRIDGE_OBJ" ] || [ "$LLD_STUB_SRC" -nt "$LLD_BRIDGE_OBJ" ]; then
-    echo "==> Building lld-stub (no lld headers found)..."
+    echo "==> Building lld-stub (Linux uses clang for linking)..."
     cc -c -O2 -fPIC "$LLD_STUB_SRC" -o "$LLD_BRIDGE_OBJ"
     echo "  -> $LLD_BRIDGE_OBJ (stub)"
   else

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -297,6 +297,44 @@ else
   echo "==> llvm-bridge skipped (no llvm-config found)"
 fi
 
+# --- lld-bridge (requires LLD + LLVM dev libraries) ---
+LLD_BRIDGE_SRC="$C_BRIDGES_DIR/lld-bridge.cpp"
+LLD_BRIDGE_OBJ="$C_BRIDGES_DIR/lld-bridge.o"
+LLD_INCLUDE=""
+if [ -d "/opt/homebrew/opt/lld/include" ]; then
+  LLD_INCLUDE="/opt/homebrew/opt/lld/include"
+elif [ -d "/usr/local/opt/lld/include" ]; then
+  LLD_INCLUDE="/usr/local/opt/lld/include"
+elif [ -d "/usr/lib/llvm-21/include/lld" ]; then
+  LLD_INCLUDE="/usr/lib/llvm-21/include"
+elif [ -d "/usr/lib/llvm-18/include/lld" ]; then
+  LLD_INCLUDE="/usr/lib/llvm-18/include"
+fi
+if [ -n "$LLVM_CONFIG" ] && [ -n "$LLD_INCLUDE" ]; then
+  if [ ! -f "$LLD_BRIDGE_OBJ" ] || [ "$LLD_BRIDGE_SRC" -nt "$LLD_BRIDGE_OBJ" ]; then
+    echo "==> Building lld-bridge (using $LLVM_CONFIG)..."
+    LLVM_CXXFLAGS=$($LLVM_CONFIG --cxxflags | sed 's/-fno-exceptions//g')
+    LLVM_BINDIR=$(dirname "$LLVM_CONFIG")
+    LLVM_CXX="$LLVM_BINDIR/clang++"
+    if [ ! -f "$LLVM_CXX" ]; then
+      LLVM_CXX="c++"
+    fi
+    $LLVM_CXX -c -O2 -fPIC $LLVM_CXXFLAGS -I"$LLD_INCLUDE" "$LLD_BRIDGE_SRC" -o "$LLD_BRIDGE_OBJ"
+    echo "  -> $LLD_BRIDGE_OBJ"
+  else
+    echo "==> lld-bridge already built, skipping"
+  fi
+else
+  LLD_STUB_SRC="$C_BRIDGES_DIR/lld-stub.c"
+  if [ ! -f "$LLD_BRIDGE_OBJ" ] || [ "$LLD_STUB_SRC" -nt "$LLD_BRIDGE_OBJ" ]; then
+    echo "==> Building lld-stub (no lld headers found)..."
+    cc -c -O2 -fPIC "$LLD_STUB_SRC" -o "$LLD_BRIDGE_OBJ"
+    echo "  -> $LLD_BRIDGE_OBJ (stub)"
+  else
+    echo "==> lld-bridge already built, skipping"
+  fi
+fi
+
 # --- child-process-spawn (async, requires libuv) ---
 CP_SPAWN_SRC="$C_BRIDGES_DIR/child-process-spawn.c"
 CP_SPAWN_OBJ="$C_BRIDGES_DIR/child-process-spawn.o"

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -257,6 +257,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public usesSpawn: number = 0;
   public usesStringBuilder: number = 0;
   public usesLLVM: number = 0;
+  public usesLLD: number = 0;
   private stringBuilderSlen: Map<string, string> = new Map();
   private stringBuilderScap: Map<string, string> = new Map();
 
@@ -967,6 +968,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
   public getUsesLLVM(): boolean {
     return this.usesLLVM !== 0;
+  }
+  public getUsesLLD(): boolean {
+    return this.usesLLD !== 0;
   }
   public setCurrentDeclaredInterfaceType(type: string | undefined): void {
     this.currentDeclaredInterfaceType = type;
@@ -3177,6 +3181,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
     this.declaredExternFunctions.push(func.name);
     if (func.name.startsWith("cs_llvm_")) this.usesLLVM = 1;
+    if (func.name.startsWith("cs_lld_")) this.usesLLD = 1;
     return `declare ${retType} @${func.name}(${paramLlvmTypes.join(", ")})\n`;
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -513,8 +513,11 @@ export function compile(
     }
     const llvmConfigPath = findLLVMConfig();
     if (llvmConfigPath) {
+      const llvmComponents = generator.getUsesLLD()
+        ? "x86 aarch64 passes core irreader option"
+        : "x86 aarch64 passes core irreader";
       const llvmLibFlags = execSync(
-        `${llvmConfigPath} --ldflags --libs x86 aarch64 passes core irreader --link-static`,
+        `${llvmConfigPath} --ldflags --libs ${llvmComponents} --link-static`,
         { stdio: "pipe", encoding: "utf8" },
       )
         .trim()
@@ -561,7 +564,7 @@ export function compile(
           const llvmConfigPath = findLLVMConfig();
           if (llvmConfigPath) {
             const llvmLdFlags = execSync(
-              `${llvmConfigPath} --ldflags --libs core support --link-static`,
+              `${llvmConfigPath} --ldflags --libs core support option binaryformat targetparser demangle mc object --link-static`,
               { stdio: "pipe", encoding: "utf8" },
             )
               .trim()

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -513,9 +513,7 @@ export function compile(
     }
     const llvmConfigPath = findLLVMConfig();
     if (llvmConfigPath) {
-      const llvmComponents = generator.getUsesLLD()
-        ? "x86 aarch64 passes core irreader option"
-        : "x86 aarch64 passes core irreader";
+      const llvmComponents = "x86 aarch64 passes core irreader";
       const llvmLibFlags = execSync(
         `${llvmConfigPath} --ldflags --libs ${llvmComponents} --link-static`,
         { stdio: "pipe", encoding: "utf8" },

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -559,7 +559,7 @@ export function compile(
         fs.existsSync(`${lldDir}/liblldCommon.so`) ||
         fs.existsSync(`${lldDir}/liblldCommon.a`)
       ) {
-        linkLibs += ` -L${lldDir} -llldMachO -llldELF -llldCommon`;
+        linkLibs = `-L${lldDir} -llldMachO -llldELF -llldCommon ${linkLibs}`;
         if (!generator.getUsesLLVM()) {
           const llvmConfigPath = findLLVMConfig();
           if (llvmConfigPath) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -539,6 +539,52 @@ export function compile(
     }
   }
 
+  if (generator.getUsesLLD()) {
+    const lldBridgeObj = `${bridgePath}/lld-bridge.o`;
+    if (fs.existsSync(lldBridgeObj)) {
+      extraObjs += ` ${lldBridgeObj}`;
+    }
+    const lldLibDirs = [
+      "/opt/homebrew/opt/lld/lib",
+      "/usr/local/opt/lld/lib",
+      "/usr/lib/llvm-21/lib",
+      "/usr/lib/llvm-18/lib",
+    ];
+    for (const lldDir of lldLibDirs) {
+      if (
+        fs.existsSync(`${lldDir}/liblldCommon.dylib`) ||
+        fs.existsSync(`${lldDir}/liblldCommon.so`) ||
+        fs.existsSync(`${lldDir}/liblldCommon.a`)
+      ) {
+        linkLibs += ` -L${lldDir} -llldMachO -llldELF -llldCommon`;
+        if (!generator.getUsesLLVM()) {
+          const llvmConfigPath = findLLVMConfig();
+          if (llvmConfigPath) {
+            const llvmLdFlags = execSync(
+              `${llvmConfigPath} --ldflags --libs core support --link-static`,
+              { stdio: "pipe", encoding: "utf8" },
+            )
+              .trim()
+              .replace(/\n/g, " ");
+            const llvmSysLibs = execSync(`${llvmConfigPath} --system-libs --link-static`, {
+              stdio: "pipe",
+              encoding: "utf8",
+            })
+              .trim()
+              .replace(/\n/g, " ");
+            linkLibs += ` ${llvmLdFlags} ${llvmSysLibs}`;
+            if (hostIsMac) {
+              linkLibs += " -lc++";
+            } else {
+              linkLibs += " -lstdc++";
+            }
+          }
+        }
+        break;
+      }
+    }
+  }
+
   let linker = useClang ? linkerPath : "gcc";
   if (sanitize) {
     linker = "gcc";

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -160,7 +160,7 @@ function getLLVMLibFlags(): string {
   const cmd =
     "(" +
     cfg +
-    " --ldflags --libs x86 aarch64 passes core irreader option --link-static && " +
+    " --ldflags --libs x86 aarch64 passes core irreader --link-static && " +
     cfg +
     " --system-libs --link-static) 2>/dev/null | tr '\\n' ' ' > " +
     tmpFile;

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -160,7 +160,7 @@ function getLLVMLibFlags(): string {
   const cmd =
     "(" +
     cfg +
-    " --ldflags --libs x86 aarch64 passes core irreader --link-static && " +
+    " --ldflags --libs x86 aarch64 passes core irreader option --link-static && " +
     cfg +
     " --system-libs --link-static) 2>/dev/null | tr '\\n' ' ' > " +
     tmpFile;

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -629,7 +629,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
     }
     const lldLibResult = getLLDLibFlags();
     if (lldLibResult.length > 0) {
-      linkLibs = linkLibs + " " + lldLibResult;
+      linkLibs = lldLibResult + " " + linkLibs;
     }
   }
 

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -56,6 +56,10 @@ declare function cs_llvm_compile_ir_file(
 ): string;
 declare function cs_llvm_dispose(): void;
 
+declare function cs_lld_available(): number;
+declare function cs_lld_link_macho(cmd: string): string;
+declare function cs_lld_link_elf(cmd: string): string;
+
 function findLLVMTool(name: string): string {
   const candidates = [
     "/opt/homebrew/opt/llvm/bin/" + name,
@@ -103,6 +107,50 @@ function findLLVMConfig(): string {
     if (fs.existsSync(c)) return c;
   }
   return "";
+}
+
+let cachedMacSDKPath = "";
+function getMacSDKPath(): string {
+  if (cachedMacSDKPath.length > 0) return cachedMacSDKPath;
+  const candidates = [
+    "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+    "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c + "/usr/lib/libSystem.tbd")) {
+      cachedMacSDKPath = c;
+      return c;
+    }
+  }
+  const tmpFile = "/tmp/cs_sdk_path.txt";
+  child_process.execSync("xcrun --show-sdk-path > " + tmpFile);
+  if (fs.existsSync(tmpFile)) {
+    cachedMacSDKPath = fs.readFileSync(tmpFile).trim();
+    fs.unlinkSync(tmpFile);
+  }
+  return cachedMacSDKPath;
+}
+
+function getLLDLibFlags(): string {
+  const lldLibCandidates = [
+    "/opt/homebrew/opt/lld/lib",
+    "/usr/local/opt/lld/lib",
+    "/usr/lib/llvm-21/lib",
+    "/usr/lib/llvm-18/lib",
+  ];
+  let lldLibDir = "";
+  for (const c of lldLibCandidates) {
+    if (
+      fs.existsSync(c + "/liblldCommon.dylib") ||
+      fs.existsSync(c + "/liblldCommon.so") ||
+      fs.existsSync(c + "/liblldCommon.a")
+    ) {
+      lldLibDir = c;
+      break;
+    }
+  }
+  if (lldLibDir.length === 0) return "";
+  return "-L" + lldLibDir + " -llldMachO -llldELF -llldCommon";
 }
 
 function getLLVMLibFlags(): string {
@@ -563,6 +611,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const arenaBridgeObj = effectiveBridgePath + "/arena-bridge.o";
   const cpSpawnObj = generator.getUsesSpawn() ? effectiveBridgePath + "/child-process-spawn.o" : "";
   let llvmBridgeObj = "";
+  let lldBridgeObj = "";
   if (generator.getUsesLLVM()) {
     const llvmBridgePath = effectiveBridgePath + "/llvm-bridge.o";
     if (fs.existsSync(llvmBridgePath)) {
@@ -573,67 +622,18 @@ export function compileNative(inputFile: string, outputFile: string): void {
       linkLibs = linkLibs + " " + llvmLibResult;
     }
   }
-
-  // Sysroot and target flags for cross-compilation
-  if (hasSDK && sdkSysroot.length > 0) {
-    linkLibs = "--sysroot=" + sdkSysroot + " " + linkLibs;
-  } else if (!crossCompiling && isMac) {
-    // Only add -L flags for paths that actually exist to avoid ld warnings.
-    // Both prefixes are checked because we can't detect arch at runtime in native code.
-    if (generator.getUsesCrypto()) {
-      if (fs.existsSync("/opt/homebrew/opt/openssl/lib"))
-        linkLibs = "-L/opt/homebrew/opt/openssl/lib " + linkLibs;
-      if (fs.existsSync("/usr/local/opt/openssl/lib"))
-        linkLibs = "-L/usr/local/opt/openssl/lib " + linkLibs;
+  if (generator.getUsesLLD()) {
+    const lldBridgePath = effectiveBridgePath + "/lld-bridge.o";
+    if (fs.existsSync(lldBridgePath)) {
+      lldBridgeObj = lldBridgePath;
     }
-    if (generator.getUsesSqlite()) {
-      if (fs.existsSync("/opt/homebrew/opt/sqlite/lib"))
-        linkLibs = "-L/opt/homebrew/opt/sqlite/lib " + linkLibs;
-      if (fs.existsSync("/usr/local/opt/sqlite/lib"))
-        linkLibs = "-L/usr/local/opt/sqlite/lib " + linkLibs;
+    const lldLibResult = getLLDLibFlags();
+    if (lldLibResult.length > 0) {
+      linkLibs = linkLibs + " " + lldLibResult;
     }
-    if (generator.getUsesHttpServer()) {
-      if (fs.existsSync("/opt/homebrew/opt/zstd/lib"))
-        linkLibs = "-L/opt/homebrew/opt/zstd/lib " + linkLibs;
-      if (fs.existsSync("/usr/local/opt/zstd/lib"))
-        linkLibs = "-L/usr/local/opt/zstd/lib " + linkLibs;
-    }
-    let macLinkPrefix = "-Wl,-syslibroot,$(xcrun --show-sdk-path)";
-    if (fs.existsSync("/usr/local/lib")) macLinkPrefix = macLinkPrefix + " -L/usr/local/lib";
-    linkLibs = macLinkPrefix + " " + linkLibs;
   }
 
-  // Cross-compiled Linux binaries must link statically — the SDK sysroot only
-  // has .a archives (Ubuntu's .so files are linker scripts with hardcoded paths).
-  const shouldStatic = !targetIsDarwin && crossCompiling;
-  const staticFlag = shouldStatic ? " -static" : "";
-  const crossTargetFlag = crossCompiling ? " --target=" + targetTriple : "";
-  const debugFlag = debugInfo ? " -g" : "";
-  // Strip symbol table from release builds. Skipped on macOS (linker handles it
-  // differently) and when -g is set (stripping debug info defeats the purpose).
-  const stripFlag = !debugInfo && !isMac ? " -s" : "";
-  // Cross-compiling requires lld — the host linker can't produce foreign binaries.
-  // Use full path because Homebrew clang can't find lld by short name.
-  // Try ld.lld first (ELF-specific), fall back to lld (multicall binary, auto-detects format).
-  const crossLinker = crossCompiling ? " -fuse-ld=" + findLLD() : "";
-  const suppressLdWarnings = isMac ? " -Wl,-w" : "";
-
-  // User-provided linker flags (--link-obj, --link-lib, --link-path)
-  let userLinkObjs = "";
-  for (let _oi = 0; _oi < extraLinkObjs.length; _oi++) {
-    userLinkObjs = userLinkObjs + " " + extraLinkObjs[_oi];
-  }
-  let userLinkFlags = "";
-  for (let _pi = 0; _pi < extraLinkPaths.length; _pi++) {
-    userLinkFlags = userLinkFlags + " -L" + extraLinkPaths[_pi];
-  }
-  for (let _li = 0; _li < extraLinkLibs.length; _li++) {
-    userLinkFlags = userLinkFlags + " -l" + extraLinkLibs[_li];
-  }
-
-  const linkCmd =
-    clangTool +
-    " " +
+  let allObjs =
     objFile +
     " " +
     lwsBridgeObj +
@@ -664,26 +664,173 @@ export function compileNative(inputFile: string, outputFile: string): void {
     " " +
     llvmBridgeObj +
     " " +
-    treeSitterObjs +
-    userLinkObjs +
-    " -o " +
-    outputFile +
-    noPie +
-    debugFlag +
-    stripFlag +
-    staticFlag +
-    crossTargetFlag +
-    crossLinker +
-    suppressLdWarnings +
+    lldBridgeObj +
     " " +
-    linkLibs +
-    userLinkFlags;
-  if (verbose) {
-    console.log("Running: " + linkCmd);
+    treeSitterObjs;
+
+  let userLinkObjs = "";
+  for (let _oi = 0; _oi < extraLinkObjs.length; _oi++) {
+    userLinkObjs = userLinkObjs + " " + extraLinkObjs[_oi];
   }
-  child_process.execSync(linkCmd);
+  let userLinkFlags = "";
+  for (let _pi = 0; _pi < extraLinkPaths.length; _pi++) {
+    userLinkFlags = userLinkFlags + " -L" + extraLinkPaths[_pi];
+  }
+  for (let _li = 0; _li < extraLinkLibs.length; _li++) {
+    userLinkFlags = userLinkFlags + " -l" + extraLinkLibs[_li];
+  }
+  allObjs = allObjs + userLinkObjs;
+  linkLibs = linkLibs + userLinkFlags;
+
+  const useLLD = cs_lld_available() > 0 && !crossCompiling;
+
+  if (useLLD) {
+    let filtered = "";
+    let idx = 0;
+    while (idx < linkLibs.length) {
+      while (idx < linkLibs.length && linkLibs.charAt(idx) === " ") idx = idx + 1;
+      let end = idx;
+      while (end < linkLibs.length && linkLibs.charAt(end) !== " ") end = end + 1;
+      const tok = linkLibs.substr(idx, end - idx);
+      if (tok.length > 0 && tok.substr(0, 4) !== "-Wl,") {
+        if (filtered.length > 0) filtered = filtered + " ";
+        filtered = filtered + tok;
+      }
+      idx = end;
+    }
+    linkLibs = filtered;
+  }
+
+  if (useLLD && targetIsDarwin) {
+    if (!crossCompiling && isMac) {
+      if (generator.getUsesCrypto()) {
+        if (fs.existsSync("/opt/homebrew/opt/openssl/lib"))
+          linkLibs = "-L/opt/homebrew/opt/openssl/lib " + linkLibs;
+        if (fs.existsSync("/usr/local/opt/openssl/lib"))
+          linkLibs = "-L/usr/local/opt/openssl/lib " + linkLibs;
+      }
+      if (generator.getUsesSqlite()) {
+        if (fs.existsSync("/opt/homebrew/opt/sqlite/lib"))
+          linkLibs = "-L/opt/homebrew/opt/sqlite/lib " + linkLibs;
+        if (fs.existsSync("/usr/local/opt/sqlite/lib"))
+          linkLibs = "-L/usr/local/opt/sqlite/lib " + linkLibs;
+      }
+      if (generator.getUsesHttpServer()) {
+        if (fs.existsSync("/opt/homebrew/opt/zstd/lib"))
+          linkLibs = "-L/opt/homebrew/opt/zstd/lib " + linkLibs;
+        if (fs.existsSync("/usr/local/opt/zstd/lib"))
+          linkLibs = "-L/usr/local/opt/zstd/lib " + linkLibs;
+      }
+      if (fs.existsSync("/usr/local/lib")) linkLibs = "-L/usr/local/lib " + linkLibs;
+    }
+    const sdkPath = getMacSDKPath();
+
+    const lldCmd =
+      allObjs +
+      " -o " +
+      outputFile +
+      " -arch arm64" +
+      " -platform_version macos 11.0.0 0" +
+      " -syslibroot " +
+      sdkPath +
+      " -lSystem " +
+      linkLibs;
+    if (verbose) {
+      console.log("LLD macho: " + lldCmd);
+    }
+    const lldErr = cs_lld_link_macho(lldCmd);
+    if (lldErr.length > 0) {
+      console.log("Error: LLD linking failed: " + lldErr);
+      process.exit(1);
+    }
+  } else if (useLLD && !targetIsDarwin) {
+    const shouldStatic = crossCompiling;
+    let lldCmd = allObjs + " -o " + outputFile + " --no-pie";
+    if (shouldStatic) lldCmd = lldCmd + " -static";
+    if (!debugInfo) lldCmd = lldCmd + " --strip-all";
+    if (hasSDK && sdkSysroot.length > 0) {
+      lldCmd = lldCmd + " --sysroot=" + sdkSysroot;
+    }
+    const crtPaths = ["/usr/lib/x86_64-linux-gnu", "/usr/lib64", "/usr/lib"];
+    let crtDir = "";
+    for (const cp of crtPaths) {
+      if (fs.existsSync(cp + "/crt1.o")) {
+        crtDir = cp;
+        break;
+      }
+    }
+    if (crtDir.length > 0) {
+      lldCmd = crtDir + "/crt1.o " + crtDir + "/crti.o " + lldCmd + " " + crtDir + "/crtn.o";
+    }
+    lldCmd = lldCmd + " -lc " + linkLibs;
+    if (!shouldStatic) {
+      lldCmd = lldCmd + " --dynamic-linker /lib64/ld-linux-x86-64.so.2";
+    }
+    if (verbose) {
+      console.log("LLD elf: " + lldCmd);
+    }
+    const lldErr = cs_lld_link_elf(lldCmd);
+    if (lldErr.length > 0) {
+      console.log("Error: LLD linking failed: " + lldErr);
+      process.exit(1);
+    }
+  } else {
+    if (hasSDK && sdkSysroot.length > 0) {
+      linkLibs = "--sysroot=" + sdkSysroot + " " + linkLibs;
+    } else if (!crossCompiling && isMac) {
+      if (generator.getUsesCrypto()) {
+        if (fs.existsSync("/opt/homebrew/opt/openssl/lib"))
+          linkLibs = "-L/opt/homebrew/opt/openssl/lib " + linkLibs;
+        if (fs.existsSync("/usr/local/opt/openssl/lib"))
+          linkLibs = "-L/usr/local/opt/openssl/lib " + linkLibs;
+      }
+      if (generator.getUsesSqlite()) {
+        if (fs.existsSync("/opt/homebrew/opt/sqlite/lib"))
+          linkLibs = "-L/opt/homebrew/opt/sqlite/lib " + linkLibs;
+        if (fs.existsSync("/usr/local/opt/sqlite/lib"))
+          linkLibs = "-L/usr/local/opt/sqlite/lib " + linkLibs;
+      }
+      if (generator.getUsesHttpServer()) {
+        if (fs.existsSync("/opt/homebrew/opt/zstd/lib"))
+          linkLibs = "-L/opt/homebrew/opt/zstd/lib " + linkLibs;
+        if (fs.existsSync("/usr/local/opt/zstd/lib"))
+          linkLibs = "-L/usr/local/opt/zstd/lib " + linkLibs;
+      }
+      let macLinkPrefix = "-Wl,-syslibroot,$(xcrun --show-sdk-path)";
+      if (fs.existsSync("/usr/local/lib")) macLinkPrefix = macLinkPrefix + " -L/usr/local/lib";
+      linkLibs = macLinkPrefix + " " + linkLibs;
+    }
+    const shouldStatic = !targetIsDarwin && crossCompiling;
+    const staticFlag = shouldStatic ? " -static" : "";
+    const crossTargetFlag = crossCompiling ? " --target=" + targetTriple : "";
+    const debugFlag = debugInfo ? " -g" : "";
+    const stripFlag = !debugInfo && !isMac ? " -s" : "";
+    const crossLinker = crossCompiling ? " -fuse-ld=" + findLLD() : "";
+    const suppressLdWarnings = isMac ? " -Wl,-w" : "";
+    const noPieFlag = !targetIsDarwin && !crossCompiling ? " -no-pie" : "";
+    const linkCmd =
+      clangTool +
+      " " +
+      allObjs +
+      " -o " +
+      outputFile +
+      noPieFlag +
+      debugFlag +
+      stripFlag +
+      staticFlag +
+      crossTargetFlag +
+      crossLinker +
+      suppressLdWarnings +
+      " " +
+      linkLibs;
+    if (verbose) {
+      console.log("Running: " + linkCmd);
+    }
+    child_process.execSync(linkCmd);
+  }
+
   if (!fs.existsSync(outputFile)) {
-    console.log("Error: clang failed to produce " + outputFile);
+    console.log("Error: linker failed to produce " + outputFile);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- Native compiler now links user programs in-process via embedded LLD instead of shelling out to clang
- ~eliminates clang dependency at link time for native compiler builds
- Adds `c_bridges/lld-bridge.cpp` wrapping `lld::lldMain()` for MachO and ELF linking
- Adds `c_bridges/lld-stub.c` fallback for systems without LLD installed (falls back to clang)
- Runtime detection via `cs_lld_available()` — no behavior change on systems without LLD

## Changes
- **lld-bridge.cpp**: C++ bridge with `cs_lld_link_macho()` and `cs_lld_link_elf()` taking a single space-delimited command string
- **lld-stub.c**: Stub returning error strings, used when LLD headers/libs not available
- **native-compiler-lib.ts**: LLD linking path for macOS (ld64 flavor) and Linux (ELF flavor), with `-Wl,` flag stripping and cached SDK path resolution
- **compiler.ts**: Links `lld-bridge.o` + LLD shared libs when building programs that use LLD
- **llvm-generator.ts**: Auto-detects `cs_lld_*` extern calls and sets `usesLLD` flag
- **build-vendor.sh**: Builds real LLD bridge or stub depending on availability
- **ci.yml**: Installs `liblld-21-dev` (Linux) and `lld` (macOS), adds `lld-bridge.o` to all verification and packaging steps
- **build-target-sdk.sh**: Includes `lld-bridge.o` in cross-compile SDK

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [x] Smoke test: native compiler links hello.ts via LLD
- [x] Self-hosting: Stage 1 compiler compiles itself via LLD
- [ ] CI: Linux + macOS green