### PR TITLE
fix: restore .ll file write for bootstrap verification

### DIFF
--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -555,9 +555,10 @@ export function compileNative(inputFile: string, outputFile: string): void {
     irText = irText + irParts[pi];
   }
 
+  const irFile = outputFile + ".ll";
+  fs.writeFileSync(irFile, irText);
+
   if (emitLLVMOnly) {
-    const irFile = outputFile + ".ll";
-    fs.writeFileSync(irFile, irText);
     if (verbose) {
       console.log("LLVM IR written to " + irFile);
     }


### PR DESCRIPTION
## Summary
- PR #421 stopped writing .ll files during normal compilation (only for --emit-llvm)
- The self-hosting bootstrap test compares .ll files from Stage 1/2/3 compilers
- Without the .ll files, bootstrap verification fails with file-not-found

This restores writing the .ll file alongside in-memory IR compilation.

## Test plan
- [x] `npm run verify:quick` passes
- [ ] CI: full self-hosting passes