### PR TITLE
enhanced integer inference for loop counters and arithmetic

### DIFF
--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -954,6 +954,7 @@ export interface IGeneratorContext {
 
   ensureDouble(value: string): string;
   ensureI64(value: string): string;
+  getI64EligibleVars(): string[];
 
   /**
    * Env pointer for the last inline lambda that had captures.
@@ -2125,6 +2126,10 @@ export class MockGeneratorContext implements IGeneratorContext {
       return temp;
     }
     return value;
+  }
+
+  getI64EligibleVars(): string[] {
+    return [];
   }
 
   ensureI64(value: string): string {

--- a/src/codegen/infrastructure/integer-analysis.ts
+++ b/src/codegen/infrastructure/integer-analysis.ts
@@ -10,12 +10,77 @@ import type {
   IfStatement,
   ForStatement,
   NumberNode,
+  BinaryNode,
+  UnaryNode,
+  VariableNode,
 } from "../../ast/types.js";
 
 class IntegerAnalyzer {
+  private candidateSet: Set<string> = new Set();
+
   private isIntegerLiteral(val: Expression): boolean {
     if (val.type !== "number") return false;
     return (val as NumberNode).value % 1 === 0;
+  }
+
+  private isIntegerExpression(val: Expression): boolean {
+    if (this.isIntegerLiteral(val)) return true;
+
+    if (val.type === "variable") {
+      return this.candidateSet.has((val as VariableNode).name);
+    }
+
+    if (val.type === "binary") {
+      const bin = val as BinaryNode;
+      const op = bin.op;
+      if (
+        op === "+" ||
+        op === "-" ||
+        op === "*" ||
+        op === "%" ||
+        op === "&" ||
+        op === "|" ||
+        op === "^" ||
+        op === "<<" ||
+        op === ">>" ||
+        op === ">>>"
+      ) {
+        return this.isIntegerExpression(bin.left) && this.isIntegerExpression(bin.right);
+      }
+      return false;
+    }
+
+    if (val.type === "unary") {
+      const un = val as UnaryNode;
+      if (un.op === "-" || un.op === "~" || un.op === "+") {
+        return this.isIntegerExpression(un.operand);
+      }
+    }
+
+    return false;
+  }
+
+  private collectVarDecls(stmts: Statement[], out: VariableDeclaration[]): void {
+    for (const stmt of stmts) {
+      if (stmt.type === "variable_declaration") {
+        out.push(stmt as VariableDeclaration);
+      } else if (stmt.type === "for") {
+        const forStmt = stmt as ForStatement;
+        if (forStmt.init && forStmt.init.type === "variable_declaration") {
+          out.push(forStmt.init as VariableDeclaration);
+        }
+        this.collectVarDecls(forStmt.body.statements, out);
+      } else if (stmt.type === "while" || stmt.type === "do_while") {
+        const loop = stmt as WhileStatement;
+        this.collectVarDecls(loop.body.statements, out);
+      } else if (stmt.type === "if") {
+        const ifStmt = stmt as IfStatement;
+        this.collectVarDecls(ifStmt.thenBlock.statements, out);
+        if (ifStmt.elseBlock) {
+          this.collectVarDecls(ifStmt.elseBlock.statements, out);
+        }
+      }
+    }
   }
 
   private collectNestedAssignments(stmts: Statement[], out: AssignmentStatement[]): void {
@@ -33,6 +98,12 @@ class IntegerAnalyzer {
         }
       } else if (stmt.type === "for") {
         const forStmt = stmt as ForStatement;
+        if (forStmt.update && (forStmt.update as Statement).type === "assignment") {
+          out.push(forStmt.update as AssignmentStatement);
+        }
+        if (forStmt.init && (forStmt.init as Statement).type === "assignment") {
+          out.push(forStmt.init as AssignmentStatement);
+        }
         this.collectNestedAssignments(forStmt.body.statements, out);
       }
     }
@@ -41,13 +112,13 @@ class IntegerAnalyzer {
   findI64EligibleVariables(statements: Statement[]): string[] {
     if (!statements || !statements.length) return [];
 
+    const allDecls: VariableDeclaration[] = [];
+    this.collectVarDecls(statements, allDecls);
+
     const candidates: string[] = [];
     const isConst: boolean[] = [];
 
-    // Pass 1: Collect variables initialized with integer literals
-    for (const stmt of statements) {
-      if (stmt.type !== "variable_declaration") continue;
-      const varDecl = stmt as VariableDeclaration;
+    for (const varDecl of allDecls) {
       if (!varDecl.value) continue;
       if (this.isIntegerLiteral(varDecl.value)) {
         candidates.push(varDecl.name);
@@ -57,8 +128,8 @@ class IntegerAnalyzer {
 
     if (candidates.length === 0) return [];
 
-    // Pass 2: Scan all assignments (including inside loops/branches) to demote
-    // variables that are ever assigned a non-integer value.
+    this.candidateSet = new Set(candidates);
+
     const isDemoted: boolean[] = [];
     for (let k = 0; k < candidates.length; k++) {
       isDemoted.push(false);
@@ -67,19 +138,24 @@ class IntegerAnalyzer {
     const allAssignments: AssignmentStatement[] = [];
     this.collectNestedAssignments(statements, allAssignments);
 
-    for (const stmt of allAssignments) {
-      for (let j = 0; j < candidates.length; j++) {
-        if (candidates[j] === stmt.name) {
-          if (isConst[j]) break;
-          if (!this.isIntegerLiteral(stmt.value)) {
-            isDemoted[j] = true;
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const stmt of allAssignments) {
+        for (let j = 0; j < candidates.length; j++) {
+          if (candidates[j] === stmt.name) {
+            if (isConst[j]) break;
+            if (!isDemoted[j] && !this.isIntegerExpression(stmt.value)) {
+              isDemoted[j] = true;
+              this.candidateSet.delete(candidates[j]);
+              changed = true;
+            }
+            break;
           }
-          break;
         }
       }
     }
 
-    // Build result: candidates minus demoted
     const result: string[] = [];
     for (let i = 0; i < candidates.length; i++) {
       if (!isDemoted[i]) {

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -327,11 +327,33 @@ export class ControlFlowGenerator {
           return this.ctx.emitError("Variable declaration in for loop must have an initializer");
         }
         const value = this.ctx.generateExpression(initVarDecl.value, params);
-        const dblValue = this.ctx.ensureDouble(value);
+        const valueType = this.ctx.getVariableType(value) || "double";
+        const eligible = this.ctx.getI64EligibleVars();
+        let useI64 = false;
+        for (let ei = 0; ei < eligible.length; ei++) {
+          if (eligible[ei] === initVarDecl.name) {
+            useI64 = true;
+            break;
+          }
+        }
         const allocaReg = this.ctx.nextAllocaReg(initVarDecl.name);
-        this.ctx.defineVariable(initVarDecl.name, allocaReg, "double", SymbolKind_Number, "local");
-        this.emit(`${allocaReg} = alloca double`);
-        this.ctx.emitStore("double", dblValue, allocaReg);
+        if (useI64 && (valueType === "i64" || valueType === "double")) {
+          const i64Val = valueType === "double" ? this.ctx.ensureI64(value) : value;
+          this.ctx.defineVariable(initVarDecl.name, allocaReg, "i64", SymbolKind_Number, "local");
+          this.emit(`${allocaReg} = alloca i64`);
+          this.ctx.emitStore("i64", i64Val, allocaReg);
+        } else {
+          const dblValue = this.ctx.ensureDouble(value);
+          this.ctx.defineVariable(
+            initVarDecl.name,
+            allocaReg,
+            "double",
+            SymbolKind_Number,
+            "local",
+          );
+          this.emit(`${allocaReg} = alloca double`);
+          this.ctx.emitStore("double", dblValue, allocaReg);
+        }
       } else if (initBase.type === "assignment") {
         const initAssign = forStmt.init as AssignmentStatement;
         let value = this.ctx.generateExpression(initAssign.value, params);


### PR DESCRIPTION
## Summary
- Loop counters and accumulator variables now use native `i64` instead of `double`
- `for (let i = 0; i < n; i++)` loop counters, `let sum = 0; sum = sum + i` accumulators all emit integer ops
- Integer-preserving expression analysis: `+`, `-`, `*`, `%`, bitwise ops between integer candidates stay i64
- Fixed-point iteration handles dependencies between candidates (e.g., `sum = sum + i` needs both to be eligible)
- For-loop init variables now check i64 eligibility instead of always using double

### Before (loop body):
```llvm
%11 = load double, double* %sum.addr.0
%12 = load double, double* %i.addr.1
%13 = fadd double %11, %12           ; floating-point add
```

### After:
```llvm
%7 = load i64, i64* %sum.addr.0
%8 = load i64, i64* %i.addr.1
%9 = add i64 %7, %8                  ; native integer add
```

This eliminates `fptosi`/`sitofp` round-trips in loops and enables LLVM's integer optimizations (LICM, IndVarSimplify, strength reduction).

## Test plan
- [x] `npm run verify` (full, including Stage 2 self-hosting)
- [x] Prime sieve 1M: correct results with i64 loop vars
- [x] Sum loop: correct results
- [ ] CI: Linux + macOS green