### PR TITLE
fix callhandler returning wrong value

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -67,7 +67,7 @@ export class CallExpressionGenerator {
       }
       const callResult = this.ctx.nextTemp();
       this.ctx.emit(`${callResult} = call double ${typedFn}(${callArgsList.join(", ")})`);
-      return fnPtr;
+      return callResult;
     }
 
     const runtimeResult = this.dispatchRuntimeCalls(expr, params);


### PR DESCRIPTION
## Summary
- Fixes `callHandler` returning the function pointer instead of the actual call result, which caused incorrect values when calling function-typed variables

## Test plan
- [x] verify:quick passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)