### PR TITLE
use canonical llvm null instead of inttoptr for null pointers

### DIFF
--- a/src/codegen/expressions/variables.ts
+++ b/src/codegen/expressions/variables.ts
@@ -52,18 +52,9 @@ export class VariableExpressionGenerator {
    * Checks SymbolTable and loads with correct LLVM type
    */
   generate(name: string): string {
-    if (name === "null") {
-      const temp = this.ctx.nextTemp();
-      this.ctx.emit(`${temp} = inttoptr i64 0 to i8*`);
-      this.ctx.setVariableType(temp, "i8*");
-      return temp;
-    }
-
-    if (name === "undefined") {
-      const temp = this.ctx.nextTemp();
-      this.ctx.emit(`${temp} = inttoptr i64 0 to i8*`);
-      this.ctx.setVariableType(temp, "i8*");
-      return temp;
+    if (name === "null" || name === "undefined") {
+      this.ctx.setVariableType("null", "i8*");
+      return "null";
     }
 
     if (name === "NaN") {

--- a/src/codegen/types/collections/array/mutators.ts
+++ b/src/codegen/types/collections/array/mutators.ts
@@ -240,8 +240,6 @@ function generateObjectArrayPop(gen: IGeneratorContext, arrayPtr: string): strin
   gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
   gen.emitLabel(emptyLabel);
-  const nullPtr = gen.nextTemp();
-  gen.emit(`${nullPtr} = inttoptr i64 0 to i8*`);
   gen.emitBr(endLabel);
 
   gen.emitLabel(notEmptyLabel);
@@ -267,9 +265,7 @@ function generateObjectArrayPop(gen: IGeneratorContext, arrayPtr: string): strin
 
   gen.emitLabel(endLabel);
   const result = gen.nextTemp();
-  gen.emit(
-    `${result} = phi i8* [ ${nullPtr}, %${emptyLabel} ], [ ${lastElem}, %${notEmptyLabel} ]`,
-  );
+  gen.emit(`${result} = phi i8* [ null, %${emptyLabel} ], [ ${lastElem}, %${notEmptyLabel} ]`);
   gen.setVariableType(result, "i8*");
 
   return result;
@@ -292,8 +288,6 @@ function generatePointerArrayPop(gen: IGeneratorContext, arrayPtr: string): stri
   gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
   gen.emitLabel(emptyLabel);
-  const nullPtr = gen.nextTemp();
-  gen.emit(`${nullPtr} = inttoptr i64 0 to i8*`);
   gen.emitBr(endLabel);
 
   gen.emitLabel(notEmptyLabel);
@@ -318,9 +312,7 @@ function generatePointerArrayPop(gen: IGeneratorContext, arrayPtr: string): stri
 
   gen.emitLabel(endLabel);
   const result = gen.nextTemp();
-  gen.emit(
-    `${result} = phi i8* [ ${nullPtr}, %${emptyLabel} ], [ ${lastElem}, %${notEmptyLabel} ]`,
-  );
+  gen.emit(`${result} = phi i8* [ null, %${emptyLabel} ], [ ${lastElem}, %${notEmptyLabel} ]`);
   gen.setVariableType(result, "i8*");
 
   return result;

--- a/src/codegen/types/collections/array/reorder.ts
+++ b/src/codegen/types/collections/array/reorder.ts
@@ -316,8 +316,6 @@ function generateObjectArrayShift(gen: IGeneratorContext, arrayPtr: string): str
   gen.emitBrCond(isEmpty, emptyLabel, notEmptyLabel);
 
   gen.emitLabel(emptyLabel);
-  const nullPtr = gen.nextTemp();
-  gen.emit(`${nullPtr} = inttoptr i64 0 to i8*`);
   gen.emitBr(endLabel);
 
   gen.emitLabel(notEmptyLabel);
@@ -350,9 +348,7 @@ function generateObjectArrayShift(gen: IGeneratorContext, arrayPtr: string): str
 
   gen.emitLabel(endLabel);
   const result = gen.nextTemp();
-  gen.emit(
-    `${result} = phi i8* [ ${nullPtr}, %${emptyLabel} ], [ ${firstElem}, %${notEmptyLabel} ]`,
-  );
+  gen.emit(`${result} = phi i8* [ null, %${emptyLabel} ], [ ${firstElem}, %${notEmptyLabel} ]`);
   gen.setVariableType(result, "i8*");
   return result;
 }

--- a/src/codegen/types/collections/array/search.ts
+++ b/src/codegen/types/collections/array/search.ts
@@ -765,12 +765,10 @@ function generateObjectArrayAt(
   gen.emitBr(endLabel);
 
   gen.emitLabel(oobLabel);
-  const nullPtr = gen.nextTemp();
-  gen.emit(`${nullPtr} = inttoptr i64 0 to i8*`);
   gen.emitBr(endLabel);
 
   gen.emitLabel(endLabel);
   const resultObj = gen.nextTemp();
-  gen.emit(`${resultObj} = phi i8* [${validVal}, %${validLabel}], [${nullPtr}, %${oobLabel}]`);
+  gen.emit(`${resultObj} = phi i8* [${validVal}, %${validLabel}], [null, %${oobLabel}]`);
   return resultObj;
 }


### PR DESCRIPTION
## Summary
- Replaces `inttoptr i64 0 to i8*` with LLVM's canonical `null` constant across all null pointer creation sites
- Eliminates potential alias analysis confusion from inttoptr and enables better LLVM optimizations

## Test plan
- [x] full verify passes (including Stage 2 self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)