### PR TITLE
extend union type checker to catch unsafe interface/class fields

### DIFF
--- a/src/semantic/union-type-checker.ts
+++ b/src/semantic/union-type-checker.ts
@@ -65,6 +65,34 @@ function reportUnionError(
   process.exit(1);
 }
 
+function reportFieldUnionError(
+  sourceCode: string,
+  context: string,
+  fieldName: string,
+  aliasName: string,
+  loc: SourceLocation | undefined,
+): void {
+  const output = formatCompileError(
+    sourceCode,
+    "in " +
+      context +
+      ", field '" +
+      fieldName +
+      "' has type '" +
+      aliasName +
+      "' which is a union type alias with mixed representations",
+    loc,
+    "use a common base interface or separate the types",
+    [
+      "'" +
+        aliasName +
+        "' is a type alias for a union whose members have different native types (e.g., i8* vs double)",
+    ],
+  );
+  process.stderr.write(output);
+  process.exit(1);
+}
+
 export function checkUnionTypes(ast: AST, sourceCode: string): void {
   const unsafeAliases = buildUnsafeAliases(ast);
 
@@ -93,6 +121,35 @@ export function checkUnionTypes(ast: AST, sourceCode: string): void {
         if (isUnsafeAlias(unsafeAliases, paramTypes[j])) {
           reportUnionError(sourceCode, qualName, paramTypes[j], locHolder.loc);
         }
+      }
+    }
+    for (let k = 0; k < cls.fields.length; k++) {
+      const field = cls.fields[k];
+      if (field.tsType && isUnsafeAlias(unsafeAliases, field.tsType)) {
+        const locHolder = cls as { loc?: SourceLocation };
+        reportFieldUnionError(
+          sourceCode,
+          "class '" + cls.name + "'",
+          field.name,
+          field.tsType,
+          locHolder.loc,
+        );
+      }
+    }
+  }
+
+  for (let i = 0; i < ast.interfaces.length; i++) {
+    const iface = ast.interfaces[i];
+    for (let j = 0; j < iface.fields.length; j++) {
+      const field = iface.fields[j];
+      if (isUnsafeAlias(unsafeAliases, field.type)) {
+        reportFieldUnionError(
+          sourceCode,
+          "interface '" + iface.name + "'",
+          field.name,
+          field.type,
+          undefined,
+        );
       }
     }
   }

--- a/tests/fixtures/errors/union-interface-field.ts
+++ b/tests/fixtures/errors/union-interface-field.ts
@@ -1,0 +1,9 @@
+// @test-compile-error: union type alias with mixed representations
+type Mixed = string | number;
+
+interface Config {
+  value: Mixed;
+}
+
+const c: Config = { value: "hello" };
+console.log(c.value);


### PR DESCRIPTION
## Summary
- Extends the union type validation pass to detect mixed-representation union type aliases used as interface fields and class fields
- Previously only checked function/method parameters — now catches issues like `interface Config { value: string | number }` at compile time instead of producing silently wrong native code

## Test plan
- [x] verify:quick passes
- [x] added test fixture `errors/union-interface-field.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)