### PR TITLE
sharpen docs and readme positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,11 @@
 
 As fast as C, as ergonomic as TypeScript.
 
-ChadScript is a natively-compiled systems language with TypeScript syntax. Write familiar TypeScript, run `chad build`, get a standalone ELF or Mach-O binary via LLVM — no Node.js, no JVM, no runtime.
+ChadScript compiles TypeScript to native binaries via LLVM — the same backend behind Clang, Rust, and Swift. No Node.js, no JVM, no runtime, no cold start. Sub-2ms startup, ~250KB binaries.
 
-The compiler is self-hosting: tens of thousands of lines of TypeScript that compile themselves to a native binary. You install it with curl, not npm.
+The compiler is self-hosting: written in ChadScript, compiled by ChadScript, verified in a 3-stage bootstrap. Install with curl, not npm.
 
-**Status: Beta** — core language features work reliably with clear error messages. Safe for early adopters building real projects. Self-hosting, 621+ tests passing.
-
-| Milestone                           | Status |
-| ----------------------------------- | ------ |
-| Proof of concept                    | Done   |
-| Standard library + external linking | Done   |
-| Self-hosting (3-stage)              | Done   |
-| Performance (LLVM -O2)              | Done   |
-| Testing (620+ tests, CI)            | Done   |
-| Compile-time error coverage         | Done   |
+**Status: Beta** — self-hosting, 621+ tests, used in [production](https://chadsmith.dev/hn). Safe for early adopters.
 
 ---
 
@@ -66,18 +57,19 @@ httpServe(3000, (req: HttpRequest) => app.handle(req));
 your-app.ts  →  ChadScript parser  →  AST  →  LLVM IR  →  clang  →  ./your-app
 ```
 
-The same LLVM backend used by Clang, Rust, and Swift. Direct calls into C libraries — SQLite, libcurl, openssl — with zero FFI overhead. The output is a standard native binary: run it, ship it, containerize it.
+Every type is resolved at compile time. LLVM optimizes your code with the same passes used by C and Rust compilers — loop vectorization, inlining, dead code elimination. Direct calls into C libraries (SQLite, libcurl, openssl) with zero FFI overhead. The output is a standard native binary: run it, ship it, `scp` it, containerize it.
 
 ---
 
 ## Why TypeScript syntax?
 
-TypeScript is familiar to tens of millions of developers, and LLMs are well-trained on it. ChadScript uses a statically-safe subset where every type is known at compile time:
+TypeScript is familiar to millions of developers, and LLMs generate it fluently. ChadScript uses a statically-typed subset where every type is resolved at compile time — no `any`, no runtime type checks, no surprises:
 
 - **Null safety** — `string` is never null. Use `string | null` and `?.` for optional values.
-- **GC-managed memory** — Boehm GC handles allocation. No use-after-free, no double-frees.
-- **Compile-time checks** — type mismatches, invalid method calls, and unsafe patterns are caught before your code runs.
-- **IDE support** — `chad init` generates `tsconfig.json` with ChadScript types. VS Code language services work out of the box.
+- **No manual memory management** — Boehm GC handles allocation. No use-after-free, no double-frees, no `malloc`/`free`.
+- **Compile-time error catching** — type mismatches, invalid method calls, and unsafe patterns are caught before your code runs.
+- **Zero-cost C interop** — `declare function` binds any C library directly. No wrappers, no marshalling.
+- **IDE support** — `chad init` generates `tsconfig.json` with ChadScript types. VS Code works out of the box.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 layout: home
 hero:
   name: ChadScript
-  text: TypeScript syntax. Native binary. No runtime.
-  tagline: "Write TypeScript-style code and compile to a standalone native binary — no Node.js, no runtime overhead."
+  text: TypeScript that compiles to native binaries.
+  tagline: "LLVM-compiled. Sub-2ms startup. ~250KB binaries. No runtime."
   actions:
     - theme: brand
       text: Get Started
@@ -13,14 +13,14 @@ hero:
       link: /why-chadscript
 
 features:
-  - title: No Runtime
-    details: Compiles to a standalone native binary. No JIT warmup, no cold start.
+  - title: LLVM-Compiled
+    details: Same backend as Clang, Rust, and Swift. Full -O2 optimization — loop vectorization, inlining, dead code elimination.
   - title: TypeScript Syntax
-    details: Classes, interfaces, async/await, closures. Familiar syntax, statically-typed, compiles to native code.
+    details: Classes, generics, interfaces, async/await, closures, JSX. If you write TypeScript, you already know ChadScript.
   - title: Batteries Included
-    details: HTTP, SQLite, fetch, crypto, JSON — all built in, backed by proven C libraries. No packages to install.
-  - title: Single-Binary Deploy
-    details: Embed HTML, CSS, and assets at compile time. Ship one file.
+    details: HTTP server, SQLite, fetch, crypto, WebSocket, JSON — all built in. No npm install, no node_modules.
+  - title: Zero-Cost C Interop
+    details: Bind any C library with declare function. No wrappers, no marshalling. SQLite, libcurl, and openssl ship built in.
 ---
 
 <HeroRotator />

--- a/docs/language/architecture.md
+++ b/docs/language/architecture.md
@@ -1,22 +1,23 @@
 # How It Works
 
-ChadScript is an ahead-of-time compiler that produces standalone native binaries. The compiler is self-hosting: it is written in TypeScript and compiles itself to a native binary.
+ChadScript is an ahead-of-time compiler that produces standalone native binaries. The compiler is self-hosting: written in ChadScript, compiled by ChadScript, verified in a 3-stage bootstrap.
 
 ## Compilation Pipeline
 
 When you run `chad build app.ts -o app`, the compiler:
 
-1. Parses your TypeScript into an AST
-2. Resolves every type (all types must be known at compile time)
-3. Lowers the AST to [LLVM IR](https://llvm.org/docs/LangRef.html) — the same intermediate format used by Clang, Rust, and Swift
-4. Compiles and optimizes to object code (`clang -O2`)
-5. Links to a native binary (`clang`)
+1. Parses your TypeScript into an AST (Tree-sitter grammar)
+2. Resolves every type — all types must be known at compile time
+3. Runs semantic checks (null safety, closure safety, type validation)
+4. Lowers the AST to [LLVM IR](https://llvm.org/docs/LangRef.html) — the same intermediate format used by Clang, Rust, and Swift
+5. Optimizes with LLVM `-O2` — loop vectorization, inlining, constant folding, dead code elimination
+6. Links to a native binary via `clang`
 
-The output is a standard ELF binary (Linux) or Mach-O binary (macOS) that runs with no runtime.
+The output is a standard ELF binary (Linux) or Mach-O binary (macOS). No runtime, no interpreter, no JIT. Types map directly to machine types — `number` is a 64-bit double, `string` is a pointer, structs are contiguous memory.
 
 ## Memory Management
 
-ChadScript programs use the [Boehm GC](https://www.hboehm.info/gc/) (`libgc`), a conservative garbage collector. All heap allocations go through `GC_malloc`. You don't need to manage memory manually.
+ChadScript programs use the [Boehm GC](https://www.hboehm.info/gc/) (`libgc`), a conservative garbage collector used in production by Mono, GCJ, and Guile. All heap allocations go through `GC_malloc`. No manual memory management, no use-after-free, no double-frees.
 
 ## Platform Support
 

--- a/docs/language/features.md
+++ b/docs/language/features.md
@@ -195,12 +195,21 @@ Strings are null-terminated C strings, not JavaScript's UTF-16 strings. They wor
 
 ## Closures
 
-Arrow functions and nested functions can capture outer variables, but captures are **by value, not by reference**. Mutating a variable after a closure captures it is a **compile error**:
+Arrow functions and nested functions can capture outer variables. Captures are **by value** — the closure gets a snapshot of the variable at the point of capture. Mutating a variable after a closure captures it is a **compile error**, preventing an entire class of bugs where closures silently observe stale or unexpected state:
 
 ```typescript
 let x = 1;
 const f = () => console.log(x);
 x = 2; // error: variable 'x' is reassigned after being captured by a closure
+```
+
+This is a deliberate design choice. If you need shared mutable state, use an object:
+
+```typescript
+const state = { count: 0 };
+const inc = () => { state.count += 1; };
+inc();
+console.log(state.count); // 1
 ```
 
 Inline lambdas with captures work in array methods:

--- a/docs/why-chadscript.md
+++ b/docs/why-chadscript.md
@@ -1,18 +1,19 @@
 # What is ChadScript?
 
-ChadScript is an ahead-of-time compiler for a TypeScript-like language. Write TypeScript-style code, run `chad build`, and get a standalone native binary — no Node.js, no runtime.
+ChadScript compiles TypeScript to native binaries. Write TypeScript, run `chad build`, get a standalone executable — no Node.js, no runtime, no cold start.
 
 ## Key characteristics
 
-- **TypeScript syntax** — classes, interfaces, async/await, closures, template literals, destructuring. If you write TypeScript, the syntax is immediately familiar.
-- **Native compilation via LLVM** — produces ELF binaries on Linux and Mach-O binaries on macOS. Startup is typically sub-2ms.
-- **Batteries included** — HTTP, SQLite, fetch, crypto, JSON, filesystem — all built in, backed by proven C libraries.
-- **Single-binary deploy** — `chad build app.ts -o app` produces one self-contained file you can copy anywhere.
-- **Self-hosting** — the compiler is written in ChadScript and compiles itself to a native binary.
+- **TypeScript syntax** — classes, interfaces, generics, async/await, closures, destructuring, JSX. If you write TypeScript, you already know ChadScript.
+- **Native compilation via LLVM** — the same backend behind Clang, Rust, and Swift. Produces ELF binaries on Linux and Mach-O binaries on macOS. Sub-2ms startup, ~250KB binaries.
+- **Batteries included** — HTTP server, SQLite, fetch, crypto, WebSocket, JSON, filesystem — all built in, backed by proven C libraries. No `npm install`.
+- **Zero-cost C interop** — `declare function` binds any C library directly. No wrappers, no marshalling, no FFI overhead.
+- **Single-binary deploy** — `chad build app.ts -o app` produces one self-contained file. `scp` it to a server, drop it in a container, run it.
+- **Self-hosting** — the compiler is written in ChadScript and compiles itself to a native binary, verified in a 3-stage bootstrap.
 
 ## What ChadScript is not
 
-ChadScript is a practical, statically-typed subset of TypeScript. It is not a full TypeScript compiler. There is no `any`, no `eval`, no runtime type inspection, no dynamic imports. Most npm packages won't work. If you need full npm compatibility or dynamic JavaScript features, use Node, Bun, or Deno.
+ChadScript is a statically-typed subset of TypeScript designed for native compilation. It is not a JavaScript runtime. There is no `any`, no `eval`, no runtime type inspection, no dynamic imports. npm packages won't work unless rewritten in the ChadScript subset. If you need full Node.js compatibility, use Node, Bun, or Deno. ChadScript is for when you want a native binary.
 
 ## See it in production
 


### PR DESCRIPTION
## Summary
- Lead with concrete numbers everywhere (sub-2ms startup, ~250KB binaries)
- Add zero-cost C interop as a top-level selling point across README, landing page, and why-chadscript
- Reframe capture-by-value closures as a safety feature with idiomatic workaround example
- Remove milestone checklist from README (everything was "Done")
- Architecture page: add LLVM optimization details, Boehm GC production users, type-to-machine-type mapping

## Test plan
- [ ] Verify docs site builds (`npm run docs:dev`)
- [ ] Review landing page renders correctly with new feature cards
- [ ] Confirm no broken links