### PR TITLE
fix 6 correctness bugs across codegen and c bridges

### DIFF
--- a/c_bridges/yyjson-bridge.c
+++ b/c_bridges/yyjson-bridge.c
@@ -29,7 +29,7 @@ void *csyyjson_parse(const char *str) {
     if (!doc) return NULL;
     yyjson_val *root = yyjson_doc_get_root(doc);
     if (!root) { yyjson_doc_free(doc); return NULL; }
-    store_doc(doc, root);
+    if (store_doc(doc, root) < 0) { yyjson_doc_free(doc); return NULL; }
     return (void *)root;
 }
 

--- a/src/codegen/types/collections/array/combine.ts
+++ b/src/codegen/types/collections/array/combine.ts
@@ -479,8 +479,12 @@ function generateNumericArrayJoin(
   gen.emit(
     `${written} = call i32 (i8*, i64, i8*, ...) @snprintf(i8* ${dest}, i64 ${remaining}, i8* ${fmt}, double ${elemVal})`,
   );
+  const writtenNeg = gen.nextTemp();
+  gen.emit(`${writtenNeg} = icmp slt i32 ${written}, 0`);
+  const writtenClamped = gen.nextTemp();
+  gen.emit(`${writtenClamped} = select i1 ${writtenNeg}, i32 0, i32 ${written}`);
   const writtenI64 = gen.nextTemp();
-  gen.emit(`${writtenI64} = sext i32 ${written} to i64`);
+  gen.emit(`${writtenI64} = sext i32 ${writtenClamped} to i64`);
   const newOff = gen.nextTemp();
   gen.emit(`${newOff} = add i64 ${curOff}, ${writtenI64}`);
   gen.emitStore("i64", newOff, offsetPtr);

--- a/src/codegen/types/collections/string/manipulation.ts
+++ b/src/codegen/types/collections/string/manipulation.ts
@@ -83,8 +83,13 @@ export function generateRepeat(ctx: IGeneratorContext, strPtr: string, count: st
   const clampedCount = ctx.nextTemp();
   ctx.emit(`${clampedCount} = select i1 ${isNeg}, i32 0, i32 ${count}`);
 
+  const maxCount = 1048576;
+  const tooBig = ctx.emitIcmp("sgt", "i32", clampedCount, `${maxCount}`);
+  const safeCount = ctx.nextTemp();
+  ctx.emit(`${safeCount} = select i1 ${tooBig}, i32 ${maxCount}, i32 ${clampedCount}`);
+
   const countI64 = ctx.nextTemp();
-  ctx.emit(`${countI64} = sext i32 ${clampedCount} to i64`);
+  ctx.emit(`${countI64} = sext i32 ${safeCount} to i64`);
 
   const totalLen = ctx.nextTemp();
   ctx.emit(`${totalLen} = mul i64 ${strLen}, ${countI64}`);
@@ -108,7 +113,7 @@ export function generateRepeat(ctx: IGeneratorContext, strPtr: string, count: st
 
   ctx.emitLabel(loopLabel);
   const counterVal = ctx.emitLoad("i32", counterPtr);
-  const loopCond = ctx.emitIcmp("slt", "i32", counterVal, clampedCount);
+  const loopCond = ctx.emitIcmp("slt", "i32", counterVal, safeCount);
   ctx.emitBrCond(loopCond, loopBodyLabel, loopEndLabel);
 
   ctx.emitLabel(loopBodyLabel);
@@ -131,6 +136,11 @@ export function generatePadStart(
   targetLength: string,
   padString: string,
 ): string {
+  const maxPadLen = 1048576;
+  const padTooBig = ctx.emitIcmp("sgt", "i32", targetLength, `${maxPadLen}`);
+  const safePadTarget = ctx.nextTemp();
+  ctx.emit(`${safePadTarget} = select i1 ${padTooBig}, i32 ${maxPadLen}, i32 ${targetLength}`);
+
   const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
@@ -140,7 +150,7 @@ export function generatePadStart(
   ctx.emit(`${padLenI32} = trunc i64 ${padLen} to i32`);
 
   const paddingNeeded = ctx.nextTemp();
-  ctx.emit(`${paddingNeeded} = sub i32 ${targetLength}, ${strLenI32}`);
+  ctx.emit(`${paddingNeeded} = sub i32 ${safePadTarget}, ${strLenI32}`);
 
   const needsPaddingRaw = ctx.emitIcmp("sgt", "i32", paddingNeeded, "0");
   const padNonEmpty = ctx.emitIcmp("sgt", "i32", padLenI32, "0");
@@ -158,7 +168,7 @@ export function generatePadStart(
 
   ctx.emitLabel(noPadLabel);
   const targetLenI64NoPad = ctx.nextTemp();
-  ctx.emit(`${targetLenI64NoPad} = sext i32 ${targetLength} to i64`);
+  ctx.emit(`${targetLenI64NoPad} = sext i32 ${safePadTarget} to i64`);
   const allocLen1 = ctx.nextTemp();
   ctx.emit(`${allocLen1} = add i64 ${targetLenI64NoPad}, 1`);
   const noPadResult = ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${allocLen1}`);
@@ -167,7 +177,7 @@ export function generatePadStart(
 
   ctx.emitLabel(doPadLabel);
   const targetLenI64Pad = ctx.nextTemp();
-  ctx.emit(`${targetLenI64Pad} = sext i32 ${targetLength} to i64`);
+  ctx.emit(`${targetLenI64Pad} = sext i32 ${safePadTarget} to i64`);
   const allocLen2 = ctx.nextTemp();
   ctx.emit(`${allocLen2} = add i64 ${targetLenI64Pad}, 1`);
   const padResult = ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${allocLen2}`);
@@ -238,6 +248,11 @@ export function generatePadEnd(
   targetLength: string,
   padString: string,
 ): string {
+  const maxPadLen = 1048576;
+  const padTooBig = ctx.emitIcmp("sgt", "i32", targetLength, `${maxPadLen}`);
+  const safePadTarget = ctx.nextTemp();
+  ctx.emit(`${safePadTarget} = select i1 ${padTooBig}, i32 ${maxPadLen}, i32 ${targetLength}`);
+
   const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
   const strLenI32 = ctx.nextTemp();
   ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
@@ -247,7 +262,7 @@ export function generatePadEnd(
   ctx.emit(`${padLenI32} = trunc i64 ${padLen} to i32`);
 
   const paddingNeeded = ctx.nextTemp();
-  ctx.emit(`${paddingNeeded} = sub i32 ${targetLength}, ${strLenI32}`);
+  ctx.emit(`${paddingNeeded} = sub i32 ${safePadTarget}, ${strLenI32}`);
 
   const needsPaddingRaw = ctx.emitIcmp("sgt", "i32", paddingNeeded, "0");
   const padNonEmpty = ctx.emitIcmp("sgt", "i32", padLenI32, "0");
@@ -274,7 +289,7 @@ export function generatePadEnd(
 
   ctx.emitLabel(doPadLabel);
   const targetLenI64Pad = ctx.nextTemp();
-  ctx.emit(`${targetLenI64Pad} = sext i32 ${targetLength} to i64`);
+  ctx.emit(`${targetLenI64Pad} = sext i32 ${safePadTarget} to i64`);
   const allocLen2 = ctx.nextTemp();
   ctx.emit(`${allocLen2} = add i64 ${targetLenI64Pad}, 1`);
   const padResult = ctx.emitCall("i8*", "@cs_arena_alloc", `i64 ${allocLen2}`);

--- a/src/codegen/types/collections/string/split.ts
+++ b/src/codegen/types/collections/string/split.ts
@@ -149,16 +149,14 @@ export function generateSplit(ctx: IGeneratorContext, strPtr: string, delimiter:
   );
   const isMatch = ctx.emitIcmp("eq", "i32", cmpResult, "0");
 
-  ctx.emitBrCond(isMatch, countCheckLabel, countCheckLabel);
+  ctx.emitBr(countCheckLabel);
 
   ctx.emitLabel(countCheckLabel);
   const partCount = ctx.emitLoad("i32", partCountPtr);
-  const newPartCount = ctx.nextTemp();
-  ctx.emit(`${newPartCount} = select i1 ${isMatch}, i32 ${partCount}, i32 ${partCount}`);
   const incPartCount = ctx.nextTemp();
-  ctx.emit(`${incPartCount} = add i32 ${newPartCount}, 1`);
+  ctx.emit(`${incPartCount} = add i32 ${partCount}, 1`);
   const finalPartCount = ctx.nextTemp();
-  ctx.emit(`${finalPartCount} = select i1 ${isMatch}, i32 ${incPartCount}, i32 ${newPartCount}`);
+  ctx.emit(`${finalPartCount} = select i1 ${isMatch}, i32 ${incPartCount}, i32 ${partCount}`);
   ctx.emitStore("i32", finalPartCount, partCountPtr);
 
   const skipAmount = ctx.nextTemp();

--- a/src/semantic/uninitialized-field-checker.ts
+++ b/src/semantic/uninitialized-field-checker.ts
@@ -120,9 +120,16 @@ class UninitializedFieldChecker {
       }
     } else if (s.type === "if") {
       const ifStmt = stmt as IfStatement;
-      this.walkStatements(ifStmt.thenBlock.statements, assigned);
+      const thenAssigned: string[] = [];
+      this.walkStatements(ifStmt.thenBlock.statements, thenAssigned);
       if (ifStmt.elseBlock) {
-        this.walkStatements(ifStmt.elseBlock.statements, assigned);
+        const elseAssigned: string[] = [];
+        this.walkStatements(ifStmt.elseBlock.statements, elseAssigned);
+        for (let j = 0; j < thenAssigned.length; j++) {
+          if (this.arrayContains(elseAssigned, thenAssigned[j])) {
+            assigned.push(thenAssigned[j]);
+          }
+        }
       }
     } else if (s.type === "while") {
       const w = stmt as WhileStatement;


### PR DESCRIPTION
## Summary
- **Safer JSON parsing**: `yyjson_parse` now returns NULL instead of leaking memory when the 4096 doc table is full
- **Prevents heap corruption in array join**: `snprintf` error returns (-1) are clamped to 0 instead of decrementing the write offset
- **Prevents buffer overflow in string.repeat**: repeat count clamped to 1M to avoid integer overflow in allocation size
- **Prevents unbounded allocation in padStart/padEnd**: target length clamped to 1M
- **Fixes false-positive in uninitialized field checker**: fields assigned in only one `if` branch are no longer considered initialized — both branches must assign
- **Removes dead IR in string split**: dead conditional branch and dead select that picked the same value either way

## Test plan
- [x] `npm run verify:quick` passes