### PR TITLE
fix native compiler sigsegv from delegate interface dispatch

### DIFF
--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -12,6 +12,7 @@ import {
   MethodCallNode,
   SourceLocation,
 } from "../../ast/types.js";
+import { InterfaceAllocator } from "./interface-allocator.js";
 import {
   SymbolKind_Array,
   SymbolKind_StringArray,
@@ -66,25 +67,13 @@ export interface ArrayAllocatorContext {
   getAst(): AST | undefined;
 }
 
-export interface ArrayAllocatorDelegate {
-  isKnownClass(name: string): boolean;
-  convertTsType(tsType: string): string;
-  getInterface(name: string): InterfaceDeclaration | null;
-  getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[];
-  getTypeInfoForElementType(
-    elementType: string,
-  ): { keys: string[]; types: string[]; tsTypes: string[] } | null;
-  getInterfaceFieldTypeByName(interfaceName: string, fieldName: string): string | null;
-  parseInlineObjectType(typeStr: string): InterfaceField[] | null;
-}
-
 export class ArrayAllocator {
   private ctx: ArrayAllocatorContext;
-  private delegate: ArrayAllocatorDelegate;
+  private interfaceAlloc: InterfaceAllocator;
 
-  constructor(ctx: ArrayAllocatorContext, delegate: ArrayAllocatorDelegate) {
+  constructor(ctx: ArrayAllocatorContext, interfaceAlloc: InterfaceAllocator) {
     this.ctx = ctx;
-    this.delegate = delegate;
+    this.interfaceAlloc = interfaceAlloc;
   }
 
   allocateStringArray(stmt: VariableDeclaration, params: string[]): void {
@@ -157,7 +146,7 @@ export class ArrayAllocator {
     }
 
     if (elementType) {
-      const typeInfo = this.delegate.getTypeInfoForElementType(elementType);
+      const typeInfo = this.interfaceAlloc.getTypeInfoForElementType(elementType);
       if (typeInfo) {
         this.ctx.defineVariableWithMetadata(
           stmt.name,
@@ -186,7 +175,7 @@ export class ArrayAllocator {
         this.ctx.emit(`store %ObjectArray* ${value}, %ObjectArray** ${allocaReg}`);
         return;
       }
-      if (this.delegate.isKnownClass(elementType)) {
+      if (this.interfaceAlloc.isKnownClass(elementType)) {
         this.ctx.defineVariable(
           stmt.name,
           allocaReg,
@@ -253,7 +242,7 @@ export class ArrayAllocator {
       let tsType = "string";
       if (valType === "number") tsType = "number";
       else if (valType === "boolean") tsType = "boolean";
-      types.push(this.delegate.convertTsType(tsType));
+      types.push(this.interfaceAlloc.convertTsType(tsType));
       tsTypes.push(tsType);
     }
 
@@ -271,24 +260,24 @@ export class ArrayAllocator {
     const elementTsTypes: string[] = [];
 
     if (elementType.startsWith("{") && elementType.endsWith("}")) {
-      const inlineFields = this.delegate.parseInlineObjectType(elementType);
+      const inlineFields = this.interfaceAlloc.parseInlineObjectType(elementType);
       if (inlineFields) {
         for (let i = 0; i < inlineFields.length; i++) {
           const field = inlineFields[i] as { name: string; type: string };
           elementKeys.push(stripOptional(field.name));
-          elementTypes.push(this.delegate.convertTsType(field.type));
+          elementTypes.push(this.interfaceAlloc.convertTsType(field.type));
           elementTsTypes.push(field.type);
         }
       }
     } else {
-      const interfaceDefResult = this.delegate.getInterface(elementType);
+      const interfaceDefResult = this.interfaceAlloc.getInterface(elementType);
       if (interfaceDefResult) {
         const interfaceDef = interfaceDefResult as InterfaceDeclaration;
-        const allFields = this.delegate.getAllInterfaceFields(interfaceDef);
+        const allFields = this.interfaceAlloc.getAllInterfaceFields(interfaceDef);
         for (let i = 0; i < allFields.length; i++) {
           const field = allFields[i] as { name: string; type: string };
           elementKeys.push(stripOptional(field.name));
-          elementTypes.push(this.delegate.convertTsType(field.type));
+          elementTypes.push(this.interfaceAlloc.convertTsType(field.type));
           elementTsTypes.push(field.type);
         }
       }
@@ -384,7 +373,7 @@ export class ArrayAllocator {
       if (!varName) return null;
       const ifaceType = this.ctx.symbolTable.getInterfaceType(varName);
       if (ifaceType) {
-        return this.delegate.getTypeInfoForElementType(ifaceType);
+        return this.interfaceAlloc.getTypeInfoForElementType(ifaceType);
       }
       const objArrayMeta = this.ctx.symbolTable.getObjectArrayMetadata(varName);
       if (objArrayMeta) {
@@ -396,7 +385,7 @@ export class ArrayAllocator {
       }
       const objArrElemType = this.ctx.symbolTable.getRawInterfaceType(varName);
       if (objArrElemType) {
-        return this.delegate.getTypeInfoForElementType(objArrElemType);
+        return this.interfaceAlloc.getTypeInfoForElementType(objArrElemType);
       }
       const objMeta = this.ctx.symbolTable.getObjectMetadata(varName);
       if (objMeta && objMeta.tsTypes) {
@@ -405,7 +394,7 @@ export class ArrayAllocator {
           const firstType = tsTypes[0];
           if (firstType && firstType.endsWith("[]")) {
             const elementType = firstType.slice(0, -2);
-            return this.delegate.getTypeInfoForElementType(elementType);
+            return this.interfaceAlloc.getTypeInfoForElementType(elementType);
           }
           return {
             keys: objMeta.keys as string[],
@@ -430,7 +419,7 @@ export class ArrayAllocator {
       const returnType = this.getMethodCallReturnType(methodCall);
       if (returnType && returnType.endsWith("[]")) {
         const elementType = returnType.slice(0, -2).trim();
-        return this.delegate.getTypeInfoForElementType(elementType);
+        return this.interfaceAlloc.getTypeInfoForElementType(elementType);
       }
       return null;
     }
@@ -456,7 +445,7 @@ export class ArrayAllocator {
             if (propTsType) {
               const arrayParsed = parseArrayTypeString(propTsType);
               if (arrayParsed) {
-                return this.delegate.getTypeInfoForElementType(arrayParsed.elementType);
+                return this.interfaceAlloc.getTypeInfoForElementType(arrayParsed.elementType);
               }
             }
           }
@@ -465,11 +454,11 @@ export class ArrayAllocator {
 
       const paramType = this.ctx.getParameterTypeFromAST(varName);
       if (paramType) {
-        const fieldType = this.delegate.getInterfaceFieldTypeByName(paramType, propertyName);
+        const fieldType = this.interfaceAlloc.getInterfaceFieldTypeByName(paramType, propertyName);
         if (fieldType) {
           const arrayParsed = parseArrayTypeString(fieldType);
           if (arrayParsed) {
-            return this.delegate.getTypeInfoForElementType(arrayParsed.elementType);
+            return this.interfaceAlloc.getTypeInfoForElementType(arrayParsed.elementType);
           }
         }
       }
@@ -485,7 +474,7 @@ export class ArrayAllocator {
       };
       const elementType = this.resolveNestedMemberArrayType(memberAccessTyped as MemberAccessNode);
       if (elementType) {
-        return this.delegate.getTypeInfoForElementType(elementType);
+        return this.interfaceAlloc.getTypeInfoForElementType(elementType);
       }
     }
 
@@ -499,7 +488,7 @@ export class ArrayAllocator {
     const classFieldInfo = this.ctx.classGenGetFieldInfo(objectType, memberAccess.property);
     const classFieldTsType = classFieldInfo ? (classFieldInfo as FieldInfo).tsType : null;
     const fieldType =
-      this.delegate.getInterfaceFieldTypeByName(objectType, memberAccess.property) ||
+      this.interfaceAlloc.getInterfaceFieldTypeByName(objectType, memberAccess.property) ||
       classFieldTsType;
     if (!fieldType) return null;
 
@@ -543,7 +532,10 @@ export class ArrayAllocator {
       }
       const objectType = this.resolveMemberAccessObjectType(member.object);
       if (objectType) {
-        const fieldType = this.delegate.getInterfaceFieldTypeByName(objectType, member.property);
+        const fieldType = this.interfaceAlloc.getInterfaceFieldTypeByName(
+          objectType,
+          member.property,
+        );
         return fieldType;
       }
     }

--- a/src/codegen/infrastructure/class-allocator.ts
+++ b/src/codegen/infrastructure/class-allocator.ts
@@ -9,6 +9,8 @@ import {
   MemberAccessNode,
   IndexAccessNode,
 } from "../../ast/types.js";
+import { InterfaceAllocator } from "./interface-allocator.js";
+import type { MapAllocator } from "./map-allocator.js";
 import {
   SymbolKind_Class,
   SymbolTable,
@@ -46,18 +48,19 @@ export interface ClassAllocatorContext {
   readonly symbolTable: SymbolTable;
 }
 
-export interface ClassAllocatorDelegate {
-  isKnownClass(name: string): boolean;
-  getMapGetClassName(methodExpr: MethodCallNode): string | null;
-}
-
 export class ClassAllocator {
   private ctx: ClassAllocatorContext;
-  private delegate: ClassAllocatorDelegate;
+  private interfaceAlloc: InterfaceAllocator;
+  private mapAlloc: MapAllocator;
 
-  constructor(ctx: ClassAllocatorContext, delegate: ClassAllocatorDelegate) {
+  constructor(
+    ctx: ClassAllocatorContext,
+    interfaceAlloc: InterfaceAllocator,
+    mapAlloc: MapAllocator,
+  ) {
     this.ctx = ctx;
-    this.delegate = delegate;
+    this.interfaceAlloc = interfaceAlloc;
+    this.mapAlloc = mapAlloc;
   }
 
   allocateClassInstance(stmt: VariableDeclaration, params: string[]): void {
@@ -71,7 +74,7 @@ export class ClassAllocator {
     } else if (valueBase.type === "method_call") {
       const methodExpr = stmt.value as MethodCallNode;
       className =
-        this.delegate.getMapGetClassName(methodExpr) ||
+        this.mapAlloc.getMapGetClassName(methodExpr) ||
         this.getMethodCallReturnClassName(methodExpr) ||
         "Unknown";
     } else if (valueBase.type === "call") {
@@ -87,7 +90,7 @@ export class ClassAllocator {
       className = srcMeta ? srcMeta.className : "Unknown";
     } else if (valueBase.type === "ternary") {
       const resolved = stmt.value ? this.ctx.resolveExpressionType(stmt.value) : null;
-      if (resolved && this.delegate.isKnownClass(resolved.base)) {
+      if (resolved && this.interfaceAlloc.isKnownClass(resolved.base)) {
         className = resolved.base;
       } else {
         className = "Unknown";
@@ -147,7 +150,7 @@ export class ClassAllocator {
           const m = cls.methods[j];
           if (m && m.name === methodExpr.method && m.returnType) {
             const rt = stripNullable(m.returnType);
-            if (this.delegate.isKnownClass(rt)) {
+            if (this.interfaceAlloc.isKnownClass(rt)) {
               return this.ctx.resolveImportAlias(rt);
             }
           }
@@ -165,7 +168,7 @@ export class ClassAllocator {
       const fn = ast.functions[i];
       if (fn && fn.name === callExpr.name && fn.returnType) {
         const rt = stripNullable(fn.returnType);
-        if (this.delegate.isKnownClass(rt)) {
+        if (this.interfaceAlloc.isKnownClass(rt)) {
           return this.ctx.resolveImportAlias(rt);
         }
       }
@@ -176,7 +179,7 @@ export class ClassAllocator {
         const fn = ast.functions[i];
         if (fn && fn.name === resolved && fn.returnType) {
           const rt = stripNullable(fn.returnType);
-          if (this.delegate.isKnownClass(rt)) {
+          if (this.interfaceAlloc.isKnownClass(rt)) {
             return this.ctx.resolveImportAlias(rt);
           }
         }
@@ -195,12 +198,12 @@ export class ClassAllocator {
     if (objBase.type === "variable") {
       const varName = (indexExpr.object as VariableNode).name;
       const rawType = this.ctx.symbolTable.getRawInterfaceType(varName);
-      if (rawType && this.delegate.isKnownClass(rawType)) return rawType;
+      if (rawType && this.interfaceAlloc.isKnownClass(rawType)) return rawType;
       const objArrayMeta = this.ctx.symbolTable.getObjectArrayMetadata(varName);
       if (
         objArrayMeta &&
         objArrayMeta.elementInterfaceName &&
-        this.delegate.isKnownClass(objArrayMeta.elementInterfaceName)
+        this.interfaceAlloc.isKnownClass(objArrayMeta.elementInterfaceName)
       ) {
         return objArrayMeta.elementInterfaceName;
       }
@@ -229,7 +232,7 @@ export class ClassAllocator {
           }
           if (tsType.endsWith("[]")) {
             const elemType = tsType.substring(0, tsType.length - 2);
-            if (this.delegate.isKnownClass(elemType)) return elemType;
+            if (this.interfaceAlloc.isKnownClass(elemType)) return elemType;
           }
         }
       }
@@ -264,7 +267,7 @@ export class ClassAllocator {
           if (field.name === memberExpr.property) {
             const rawType = field.tsType || field.fieldType;
             const tsType = stripNullable(rawType);
-            if (this.delegate.isKnownClass(tsType)) return tsType;
+            if (this.interfaceAlloc.isKnownClass(tsType)) return tsType;
           }
         }
       }

--- a/src/codegen/infrastructure/interface-allocator.ts
+++ b/src/codegen/infrastructure/interface-allocator.ts
@@ -8,7 +8,9 @@ import {
   VariableDeclaration,
   InterfaceDeclaration,
   InterfaceField,
+  TypeAliasDeclaration,
   TypeAssertionNode,
+  CommonField,
 } from "../../ast/types.js";
 import {
   SymbolKind,
@@ -41,6 +43,9 @@ export interface InterfaceAllocatorContext {
   setCurrentDeclaredInterfaceType(type: string | undefined): void;
   setLastTypeAssertionSourceVar(name: string | null): void;
   getLastTypeAssertionSourceVar(): string | null;
+  resolveImportAlias(localName: string): string;
+  typeResolverAreTypesCompatible(type1: string, type2: string): boolean | null;
+  typeResolverNormalizeType(type: string): string | null;
 }
 
 export class InterfaceAllocator {
@@ -270,6 +275,182 @@ export class InterfaceAllocator {
     }
 
     this.ctx.emit(`store i8* ${objPtr}, i8** ${allocaReg}`);
+  }
+
+  isKnownClass(name: string): boolean {
+    if (!name) return false;
+    const resolved = this.ctx.resolveImportAlias(name);
+    const ast = this.ctx.getAst();
+    if (!ast || !ast.classes) return false;
+    for (let i = 0; i < ast.classes.length; i++) {
+      const cls = ast.classes[i];
+      if (cls && (cls.name === name || cls.name === resolved)) return true;
+    }
+    return false;
+  }
+
+  getInterfaceFieldTypeByName(interfaceName: string, fieldName: string): string | null {
+    const ifaceResult = this.getInterface(interfaceName);
+    if (!ifaceResult) return null;
+    const iface = ifaceResult as InterfaceDeclaration;
+    const allFields = this.getAllInterfaceFields(iface);
+    for (let i = 0; i < allFields.length; i++) {
+      const f = allFields[i] as { name: string; type: string };
+      if (f.name === fieldName) {
+        return f.type;
+      }
+    }
+    return null;
+  }
+
+  getTypeInfoForElementType(
+    elementType: string,
+  ): { keys: string[]; types: string[]; tsTypes: string[] } | null {
+    if (elementType.startsWith("{")) {
+      const inlineFields = this.parseInlineObjectType(elementType + "[]");
+      if (inlineFields) {
+        const keys: string[] = [];
+        const types: string[] = [];
+        const tsTypes: string[] = [];
+        for (let i = 0; i < inlineFields.length; i++) {
+          const field = inlineFields[i] as { name: string; type: string };
+          keys.push(stripOptional(field.name));
+          types.push(this.convertTsType(field.type));
+          tsTypes.push(field.type);
+        }
+        return { keys, types, tsTypes };
+      }
+    }
+
+    const interfaceDefResult = this.getInterface(elementType);
+    if (interfaceDefResult) {
+      const interfaceDef = interfaceDefResult as InterfaceDeclaration;
+      const keys: string[] = [];
+      const types: string[] = [];
+      const tsTypes: string[] = [];
+      const allFields = this.getAllInterfaceFields(interfaceDef);
+      for (let i = 0; i < allFields.length; i++) {
+        const field = allFields[i] as { name: string; type: string };
+        keys.push(stripOptional(field.name));
+        types.push(this.convertTsType(field.type));
+        tsTypes.push(field.type);
+      }
+      return { keys, types, tsTypes };
+    }
+
+    const typeAliasRaw = this.getTypeAlias(elementType);
+    if (typeAliasRaw) {
+      const typeAlias = typeAliasRaw as TypeAliasDeclaration;
+      if (typeAlias.unionMembers) {
+        const commonFields = this.getUnionCommonFields(typeAlias.unionMembers);
+        if (commonFields.keys.length > 0) {
+          return commonFields;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private getTypeAlias(name: string): TypeAliasDeclaration | null {
+    if (!name) return null;
+    const result = this.ctx.typeResolver?.getTypeAlias(name);
+    if (result) {
+      return result;
+    }
+    const ast = this.ctx.getAst();
+    if (!ast || !ast.typeAliases) return null;
+    for (let i = 0; i < ast.typeAliases.length; i++) {
+      const ta = ast.typeAliases[i] as TypeAliasDeclaration;
+      if (!ta || !ta.name) continue;
+      if (ta.name === name) {
+        return ta;
+      }
+    }
+    return null;
+  }
+
+  private getUnionCommonFields(memberNames: string[]): {
+    keys: string[];
+    types: string[];
+    tsTypes: string[];
+  } {
+    const result = this.ctx.typeResolver?.getUnionCommonFields(memberNames);
+    if (result && result.keys.length > 0) {
+      return { keys: result.keys, types: result.types, tsTypes: result.tsTypes };
+    }
+    const interfaces: InterfaceDeclaration[] = [];
+    for (let i = 0; i < memberNames.length; i++) {
+      const ifaceResult = this.getInterface(memberNames[i]);
+      if (ifaceResult) {
+        interfaces.push(ifaceResult as InterfaceDeclaration);
+      }
+    }
+
+    if (interfaces.length === 0) {
+      return { keys: [], types: [], tsTypes: [] };
+    }
+
+    const firstInterface = interfaces[0] as InterfaceDeclaration;
+    const firstFields = this.getAllInterfaceFields(firstInterface);
+    const commonFields: CommonField[] = [];
+
+    for (let fi = 0; fi < firstFields.length; fi++) {
+      const field = firstFields[fi] as { name: string; type: string };
+      let isCommon = true;
+      for (let ii = 0; ii < interfaces.length; ii++) {
+        const ifaceTyped = interfaces[ii] as InterfaceDeclaration;
+        const ifaceFields = this.getAllInterfaceFields(ifaceTyped);
+        let found = false;
+        for (let fj = 0; fj < ifaceFields.length; fj++) {
+          const f = ifaceFields[fj] as { name: string; type: string };
+          if (f.name === field.name && this.areTypesCompatible(f.type, field.type)) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          isCommon = false;
+          break;
+        }
+      }
+      if (isCommon) {
+        commonFields.push({ name: field.name, type: this.normalizeType(field.type) });
+      }
+    }
+
+    const keys: string[] = [];
+    const types: string[] = [];
+    const tsTypes: string[] = [];
+    for (let i = 0; i < commonFields.length; i++) {
+      const cf = commonFields[i] as CommonField;
+      keys.push(stripOptional(cf.name));
+      types.push(this.convertTsType(cf.type));
+      tsTypes.push(cf.type);
+    }
+
+    return { keys, types, tsTypes };
+  }
+
+  private areTypesCompatible(type1: string, type2: string): boolean {
+    const result = this.ctx.typeResolverAreTypesCompatible(type1, type2);
+    if (result) {
+      return result;
+    }
+    if (type1 === type2) return true;
+    const norm1 = this.normalizeType(type1);
+    const norm2 = this.normalizeType(type2);
+    return norm1 === norm2;
+  }
+
+  private normalizeType(type: string): string {
+    const result = this.ctx.typeResolverNormalizeType(type);
+    if (result && result !== type) {
+      return result;
+    }
+    if (type.startsWith("'") && type.endsWith("'")) return "string";
+    if (type.startsWith('"') && type.endsWith('"')) return "string";
+    return type;
   }
 
   allocateMemberAccessInterface(

--- a/src/codegen/infrastructure/map-allocator.ts
+++ b/src/codegen/infrastructure/map-allocator.ts
@@ -11,6 +11,7 @@ import {
   MapNode,
   SourceLocation,
 } from "../../ast/types.js";
+import { InterfaceAllocator } from "./interface-allocator.js";
 import {
   SymbolKind_Map,
   SymbolKind_Set,
@@ -72,22 +73,13 @@ export interface MapAllocatorContext {
   emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
 }
 
-export interface MapAllocatorDelegate {
-  convertTsType(tsType: string): string;
-  getInterface(name: string): InterfaceDeclaration | null;
-  getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[];
-  getTypeInfoForElementType(
-    elementType: string,
-  ): { keys: string[]; types: string[]; tsTypes: string[] } | null;
-}
-
 export class MapAllocator {
   private ctx: MapAllocatorContext;
-  private delegate: MapAllocatorDelegate;
+  private interfaceAlloc: InterfaceAllocator;
 
-  constructor(ctx: MapAllocatorContext, delegate: MapAllocatorDelegate) {
+  constructor(ctx: MapAllocatorContext, interfaceAlloc: InterfaceAllocator) {
     this.ctx = ctx;
-    this.delegate = delegate;
+    this.interfaceAlloc = interfaceAlloc;
   }
 
   allocateMap(stmt: VariableDeclaration, params: string[]): void {
@@ -159,7 +151,7 @@ export class MapAllocator {
     mapTypeInfo: MapTypeInfo,
   ): void {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    const llvmValueType = this.delegate.convertTsType(mapTypeInfo.valueType);
+    const llvmValueType = this.interfaceAlloc.convertTsType(mapTypeInfo.valueType);
 
     this.ctx.defineVariableWithMetadata(
       stmt.name,
@@ -319,7 +311,7 @@ export class MapAllocator {
     setTypeInfo: SetTypeInfo,
   ): void {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
-    const llvmValueType = this.delegate.convertTsType(setTypeInfo.valueType);
+    const llvmValueType = this.interfaceAlloc.convertTsType(setTypeInfo.valueType);
 
     this.ctx.defineVariableWithMetadata(
       stmt.name,
@@ -394,7 +386,7 @@ export class MapAllocator {
       return valueType;
     }
 
-    const interfaceDefResult = this.delegate.getInterface(valueType);
+    const interfaceDefResult = this.interfaceAlloc.getInterface(valueType);
     if (!interfaceDefResult) return null;
 
     return valueType;
@@ -409,7 +401,7 @@ export class MapAllocator {
       this.allocateMapGetArray(stmt, params, interfaceName);
       return;
     }
-    const interfaceDefResult = this.delegate.getInterface(interfaceName);
+    const interfaceDefResult = this.interfaceAlloc.getInterface(interfaceName);
     if (!interfaceDefResult) {
       return this.ctx.emitError(
         `interface '${interfaceName}' not found when allocating Map.get() return variable '${stmt.name}'`,
@@ -420,11 +412,11 @@ export class MapAllocator {
     const keys: string[] = [];
     const types: string[] = [];
     const tsTypes: string[] = [];
-    const allFields = this.delegate.getAllInterfaceFields(interfaceDef);
+    const allFields = this.interfaceAlloc.getAllInterfaceFields(interfaceDef);
     for (let i = 0; i < allFields.length; i++) {
       const field = allFields[i] as { name: string; type: string };
       keys.push(stripOptional(field.name));
-      types.push(this.delegate.convertTsType(field.type));
+      types.push(this.interfaceAlloc.convertTsType(field.type));
       tsTypes.push(field.type);
     }
     const llvmType = `%${interfaceName}*`;
@@ -455,7 +447,7 @@ export class MapAllocator {
     } else if (elementType === "number" || elementType === "boolean") {
       this.ctx.defineVariable(stmt.name, allocaReg, "i8*", SymbolKind_Array, "local");
     } else {
-      const typeInfo = this.delegate.getTypeInfoForElementType(elementType);
+      const typeInfo = this.interfaceAlloc.getTypeInfoForElementType(elementType);
       if (typeInfo) {
         this.ctx.defineVariableWithMetadata(
           stmt.name,

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -205,9 +205,9 @@ export class VariableAllocator {
 
   constructor(private ctx: VariableAllocatorContext) {
     this.interfaceAlloc = new InterfaceAllocator(ctx as any);
-    this.mapAlloc = new MapAllocator(ctx as any, this);
-    this.classAlloc = new ClassAllocator(ctx as any, this);
-    this.arrayAlloc = new ArrayAllocator(ctx as any, this);
+    this.mapAlloc = new MapAllocator(ctx as any, this.interfaceAlloc);
+    this.classAlloc = new ClassAllocator(ctx as any, this.interfaceAlloc, this.mapAlloc);
+    this.arrayAlloc = new ArrayAllocator(ctx as any, this.interfaceAlloc);
   }
 
   getMapGetClassName(m: MethodCallNode): string | null {


### PR DESCRIPTION
## Summary
- Replaces delegate interfaces (`ArrayAllocatorDelegate`, `MapAllocatorDelegate`, `ClassAllocatorDelegate`) with concrete class references (`InterfaceAllocator`, `MapAllocator`)
- Moves shared helper methods (`isKnownClass`, `getInterfaceFieldTypeByName`, `getTypeInfoForElementType`) into `InterfaceAllocator` so sub-allocators can call them directly on the concrete class
- Fixes SIGSEGV in self-hosted compiler caused by interface method dispatch on class fields — a known native compiler limitation

## Test plan
- [x] `npm run build` — TypeScript compiles
- [x] `npm test` — 744 tests pass
- [x] `npm run verify` — full self-hosting (Stage 0 + Stage 1 + Stage 2) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)