### PR TITLE
extend integer inference and boolean condition fast path

### DIFF
--- a/src/codegen/expressions/condition-generator.ts
+++ b/src/codegen/expressions/condition-generator.ts
@@ -1,0 +1,9 @@
+let wantsI1 = false;
+
+export function setWantsI1(val: boolean): void {
+  wantsI1 = val;
+}
+
+export function getWantsI1(): boolean {
+  return wantsI1;
+}

--- a/src/codegen/expressions/operators/binary.ts
+++ b/src/codegen/expressions/operators/binary.ts
@@ -7,6 +7,7 @@ import {
   IndexAccessNode,
 } from "../../../ast/types.js";
 import type { IStringGenerator } from "../../infrastructure/generator-context.js";
+import { getWantsI1, setWantsI1 } from "../condition-generator.js";
 
 interface ControlFlowGeneratorLike {
   generateLogicalOp(op: string, left: Expression, right: Expression, params: string[]): string;
@@ -54,7 +55,11 @@ export class BinaryExpressionGenerator {
 
   generate(op: string, left: Expression, right: Expression, params: string[]): string {
     if (op === "&&" || op === "||" || op === "??") {
-      return this.ctx.controlFlowGen.generateLogicalOp(op, left, right, params);
+      const savedI1 = getWantsI1();
+      setWantsI1(false);
+      const result = this.ctx.controlFlowGen.generateLogicalOp(op, left, right, params);
+      setWantsI1(savedI1);
+      return result;
     }
 
     if (op === "+" && (this.ctx.isStringExpression(left) || this.ctx.isStringExpression(right))) {
@@ -521,6 +526,10 @@ export class BinaryExpressionGenerator {
                   ? "eq"
                   : "ne";
       const cmpResult = this.ctx.emitIcmp(icmpCond, "i64", left, right);
+      if (getWantsI1()) {
+        setWantsI1(false);
+        return cmpResult;
+      }
       const i64Result = this.ctx.nextTemp();
       this.ctx.emit(`${i64Result} = zext i1 ${cmpResult} to i64`);
       this.ctx.setVariableType(i64Result, "i64");
@@ -561,7 +570,12 @@ export class BinaryExpressionGenerator {
     const cmpResult = this.ctx.nextTemp();
     this.ctx.emit(`${cmpResult} = fcmp ${cond} double ${leftDouble}, ${rightDouble}`);
 
-    // Convert boolean result to double (JavaScript semantics: comparisons return numbers)
+    if (getWantsI1()) {
+      setWantsI1(false);
+      this.ctx.setVariableType(cmpResult, "i1");
+      return cmpResult;
+    }
+
     const i32Result = this.ctx.nextTemp();
     this.ctx.emit(`${i32Result} = zext i1 ${cmpResult} to i32`);
     const doubleResult = this.ctx.nextTemp();

--- a/src/codegen/infrastructure/integer-analysis.ts
+++ b/src/codegen/infrastructure/integer-analysis.ts
@@ -13,6 +13,9 @@ import type {
   BinaryNode,
   UnaryNode,
   VariableNode,
+  MemberAccessNode,
+  MethodCallNode,
+  CallNode,
 } from "../../ast/types.js";
 
 class IntegerAnalyzer {
@@ -55,6 +58,35 @@ class IntegerAnalyzer {
       if (un.op === "-" || un.op === "~" || un.op === "+") {
         return this.isIntegerExpression(un.operand);
       }
+    }
+
+    if (val.type === "member_access") {
+      const ma = val as MemberAccessNode;
+      if (ma.property === "length") return true;
+    }
+
+    if (val.type === "method_call") {
+      const mc = val as MethodCallNode;
+      const method = mc.method;
+      if (
+        method === "indexOf" ||
+        method === "lastIndexOf" ||
+        method === "findIndex" ||
+        method === "charCodeAt"
+      ) {
+        return true;
+      }
+      const obj = mc.object as VariableNode;
+      if (obj.type === "variable" && obj.name === "Math") {
+        if (method === "floor" || method === "ceil" || method === "round" || method === "trunc") {
+          return true;
+        }
+      }
+    }
+
+    if (val.type === "call") {
+      const call = val as CallNode;
+      if (call.name === "parseInt") return true;
     }
 
     return false;

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -30,6 +30,7 @@ import { IGeneratorContext } from "../infrastructure/generator-context.js";
 import { SymbolKind_Number, SymbolKind_String } from "../infrastructure/symbol-table.js";
 import type { FieldInfo } from "../infrastructure/type-resolver/types.js";
 import { stripOptional } from "../infrastructure/type-system.js";
+import { setWantsI1 } from "../expressions/condition-generator.js";
 
 interface ExprBase {
   type: string;
@@ -105,6 +106,42 @@ export class ControlFlowGenerator {
     }
   }
 
+  private isSimpleComparisonForBranch(expr: Expression): boolean {
+    if (expr.type !== "binary") return false;
+    const bin = expr as BinaryNode;
+    const op = bin.op;
+    if (
+      op !== "<" &&
+      op !== ">" &&
+      op !== "<=" &&
+      op !== ">=" &&
+      op !== "==" &&
+      op !== "!=" &&
+      op !== "===" &&
+      op !== "!=="
+    ) {
+      return false;
+    }
+    const lt = bin.left.type;
+    const rt = bin.right.type;
+    if (lt === "binary" || rt === "binary") return false;
+    if (lt === "call" || rt === "call") return false;
+    if (lt === "method_call" || rt === "method_call") return false;
+    if (lt === "conditional" || rt === "conditional") return false;
+    return true;
+  }
+
+  private generateBranchCondition(expr: Expression, params: string[]): string {
+    if (this.isSimpleComparisonForBranch(expr)) {
+      setWantsI1(true);
+      const condValue = this.ctx.generateExpression(expr, params);
+      setWantsI1(false);
+      return this.convertToBool(condValue);
+    }
+    const condValue = this.ctx.generateExpression(expr, params);
+    return this.convertToBool(condValue);
+  }
+
   private convertToNonNullish(value: string, valueType: string): string {
     if (
       valueType === "i1" ||
@@ -144,8 +181,7 @@ export class ControlFlowGenerator {
 
     const typeGuard = this.detectTypeGuard(ifStmt.condition);
 
-    const condValue = this.ctx.generateExpression(ifStmt.condition, params);
-    const condBool = this.convertToBool(condValue);
+    const condBool = this.generateBranchCondition(ifStmt.condition, params);
 
     if (ifStmt.elseBlock) {
       this.ctx.emitBrCond(condBool, thenLabel, elseLabel);
@@ -222,8 +258,7 @@ export class ControlFlowGenerator {
 
     // Condition block
     this.ctx.emitLabel(condLabel);
-    const condValue = this.ctx.generateExpression(whileStmt.condition, params);
-    const condBool = this.convertToBool(condValue);
+    const condBool = this.generateBranchCondition(whileStmt.condition, params);
     this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
 
     // Body block - push loop context for break/continue
@@ -277,9 +312,8 @@ export class ControlFlowGenerator {
     // Condition block — evaluated after body
     this.ctx.emitLabel(condLabel);
     this.ctx.setCurrentLabel(condLabel);
-    const condValue = this.ctx.generateExpression(doWhileStmt.condition, params);
-    const condBool = this.convertToBool(condValue);
-    this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
+    const condBool2 = this.generateBranchCondition(doWhileStmt.condition, params);
+    this.ctx.emitBrCond(condBool2, bodyLabel, endLabel);
 
     // End block
     this.ctx.emitLabel(endLabel);
@@ -372,9 +406,8 @@ export class ControlFlowGenerator {
     // Condition block
     this.ctx.emitLabel(condLabel);
     if (forStmt.condition) {
-      const condValue = this.ctx.generateExpression(forStmt.condition, params);
-      const condBool = this.convertToBool(condValue);
-      this.ctx.emitBrCond(condBool, bodyLabel, endLabel);
+      const condBool3 = this.generateBranchCondition(forStmt.condition, params);
+      this.ctx.emitBrCond(condBool3, bodyLabel, endLabel);
     } else {
       // No condition means infinite loop
       this.ctx.emitBr(bodyLabel);

--- a/tests/fixtures/globals/integer-length-inference.ts
+++ b/tests/fixtures/globals/integer-length-inference.ts
@@ -1,0 +1,19 @@
+const arr = [1, 2, 3, 4, 5];
+let total = 0;
+for (let i = 0; i < arr.length; i++) {
+  total = total + 1;
+}
+
+const str = "hello world";
+let count = 0;
+for (let j = 0; j < str.length; j++) {
+  count = count + 1;
+}
+
+let x = 0;
+x = str.indexOf("world");
+const sum = total + count + x;
+
+if (total === 5 && count === 11 && sum === 22) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary

- Compiled programs now generate fewer instructions for numeric comparisons in branch conditions (if/while/for), eliminating a 3-instruction `i1→i32→double→i1` roundtrip
- Integer variables (`let i = 0`) are no longer demoted to double when reassigned from `.length`, `indexOf`, `Math.floor`, and similar integer-producing expressions
- Covers the hot paths in compute-heavy code: loop conditions, bounds checks, and integer counters

## Changes

- **integer-analysis.ts**: `isIntegerExpression` recognizes `.length`, `indexOf`, `lastIndexOf`, `findIndex`, `charCodeAt`, `Math.floor/ceil/round/trunc`, `parseInt`
- **condition-generator.ts**: Module-level `wantsI1` flag for branch condition optimization
- **control-flow.ts**: Simple comparisons in branch sites (`if (a < b)`) skip the boolean-to-double roundtrip
- **binary.ts**: `generateNumericComparison` returns `i1` directly when `wantsI1` is set; saves/restores flag around logical ops

## Test plan

- [x] New test: `integer-length-inference.ts`
- [x] All 745 tests pass (node + native)
- [x] Full 3-stage self-hosting verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)