### PR TITLE
re-enable missing return and arg count compile-time checkers

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -158,7 +158,11 @@ import { analyzeEscapes } from "../semantic/escape-analysis.js";
 // binary-type-checker.ts: original top-level-only checker kept for reference; deep version is in safety-checks.ts
 import { checkEnumDeclarations } from "../semantic/enum-checker.js";
 import { checkAsyncAwait } from "../semantic/async-await-checker.js";
-import { checkBinaryTypesDeep } from "../semantic/safety-checks.js";
+import {
+  checkBinaryTypesDeep,
+  checkMissingReturns,
+  checkArgumentCounts,
+} from "../semantic/safety-checks.js";
 import { DebugMetadataBuilder } from "./infrastructure/debug-metadata.js";
 
 export interface SemaSymbolData {
@@ -2671,6 +2675,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     checkTypeAssertions(this.ast, this.sourceCode);
     checkUninitializedFields(this.ast, this.sourceCode);
     checkBinaryTypesDeep(this.ast, this.sourceCode);
+    checkMissingReturns(this.ast, this.sourceCode);
+    checkArgumentCounts(this.ast, this.sourceCode);
     checkAsyncAwait(this.ast, this.sourceCode);
     this.stackEligibleVars = analyzeEscapes(this.ast);
 

--- a/src/semantic/safety-checks.ts
+++ b/src/semantic/safety-checks.ts
@@ -291,206 +291,247 @@ export function checkBinaryTypesDeep(ast: AST, sourceCode: string): void {
 }
 
 // --- Argument count checker ---
-// Module-level vars to avoid 5+ param functions (native compiler infinite loop workaround)
 
-let argNames: string[] = [];
-let argMins: number[] = [];
-let argMaxes: number[] = [];
-let argAliasNames: string[] = [];
-let argAliasOriginals: string[] = [];
-let argSrc: string = "";
+class ArgCheckState {
+  names: string[] = [];
+  mins: number[] = [];
+  maxes: number[] = [];
+  aliasNames: string[] = [];
+  aliasOriginals: string[] = [];
+  src: string = "";
+  dupNames: string[] = [];
 
-function argResolveName(name: string): string {
-  for (let i = 0; i < argAliasNames.length; i++) {
-    if (argAliasNames[i] === name) return argAliasOriginals[i];
-  }
-  return name;
-}
-
-function argLookup(name: string): number {
-  for (let i = 0; i < argNames.length; i++) {
-    if (argNames[i] === name) return i;
-  }
-  return -1;
-}
-
-function argCheckCall(name: string, argCount: number, loc: SourceLocation | undefined): void {
-  const resolved = argResolveName(name);
-  const idx = argLookup(resolved);
-  if (idx < 0) return;
-  const min = argMins[idx];
-  const max = argMaxes[idx];
-  if (argCount < min) {
-    process.stderr.write(
-      formatCompileError(
-        argSrc,
-        "function '" + name + "' expects at least " + min + " argument(s) but got " + argCount,
-        loc as SourceLocation | undefined,
-        "check the function signature",
-        [],
-      ),
-    );
-    process.exit(1);
-  }
-  if (argCount > max) {
-    process.stderr.write(
-      formatCompileError(
-        argSrc,
-        "function '" + name + "' expects at most " + max + " argument(s) but got " + argCount,
-        loc as SourceLocation | undefined,
-        "check the function signature",
-        [],
-      ),
-    );
-    process.exit(1);
-  }
-}
-
-function argCheckExpr(expr: Expression): void {
-  if (!expr) return;
-  if (expr.type === "call") {
-    const c = expr as CallNode;
-    argCheckCall(c.name, c.args.length, c.loc);
-    for (let i = 0; i < c.args.length; i++) argCheckExpr(c.args[i]);
-  } else if (expr.type === "binary") {
-    const b = expr as BinaryNode;
-    argCheckExpr(b.left);
-    argCheckExpr(b.right);
-  } else if (expr.type === "unary") {
-    argCheckExpr((expr as UnaryNode).operand);
-  } else if (expr.type === "conditional") {
-    const c = expr as ConditionalExpressionNode;
-    argCheckExpr(c.condition);
-    argCheckExpr(c.consequent);
-    argCheckExpr(c.alternate);
-  } else if (expr.type === "method_call") {
-    const mc = expr as MethodCallNode;
-    if (mc.object) argCheckExpr(mc.object);
-    for (let i = 0; i < mc.args.length; i++) argCheckExpr(mc.args[i]);
-  }
-}
-
-function argWalkStmt(stmt: Statement): void {
-  const stype = (stmt as { type: string }).type;
-  if (stype === "variable_declaration") {
-    const d = stmt as VariableDeclaration;
-    if (d.value) argCheckExpr(d.value as Expression);
-  } else if (stype === "assignment") {
-    argCheckExpr((stmt as AssignmentStatement).value);
-  } else if (stype === "if") {
-    const i = stmt as IfStatement;
-    argCheckExpr(i.condition);
-    argWalkBlk(i.thenBlock);
-    if (i.elseBlock) argWalkBlk(i.elseBlock);
-  } else if (stype === "while") {
-    const w = stmt as WhileStatement;
-    argCheckExpr(w.condition);
-    argWalkBlk(w.body);
-  } else if (stype === "do_while") {
-    const d = stmt as DoWhileStatement;
-    argWalkBlk(d.body);
-    argCheckExpr(d.condition);
-  } else if (stype === "for") {
-    const f = stmt as ForStatement;
-    if (f.init) argWalkStmt(f.init as Statement);
-    if (f.condition) argCheckExpr(f.condition);
-    if (f.update) {
-      if ((f.update as { type: string }).type === "assignment") argWalkStmt(f.update as Statement);
-      else argCheckExpr(f.update as Expression);
+  resolveName(name: string): string {
+    for (let i = 0; i < this.aliasNames.length; i++) {
+      if (this.aliasNames[i] === name) return this.aliasOriginals[i];
     }
-    argWalkBlk(f.body);
-  } else if (stype === "for_of") {
-    const fo = stmt as ForOfStatement;
-    argCheckExpr(fo.iterable);
-    argWalkBlk(fo.body);
-  } else if (stype === "try") {
-    const t = stmt as TryStatement;
-    argWalkBlk(t.tryBlock);
-    if (t.catchBody) argWalkBlk(t.catchBody);
-    if (t.finallyBlock) argWalkBlk(t.finallyBlock);
-  } else if (stype === "switch") {
-    const sw = stmt as SwitchStatement;
-    argCheckExpr(sw.discriminant);
-    for (let ci = 0; ci < sw.cases.length; ci++) {
-      const c = sw.cases[ci];
-      if (c.test) argCheckExpr(c.test as Expression);
-      argWalkStmts(c.consequent);
+    return name;
+  }
+
+  lookup(name: string): number {
+    for (let i = 0; i < this.names.length; i++) {
+      if (this.names[i] === name) return i;
     }
-  } else if (stype === "return") {
-    const r = stmt as ReturnStatement;
-    if (r.value) argCheckExpr(r.value as Expression);
-  } else if (stype === "throw") {
-    argCheckExpr((stmt as ThrowStatement).argument);
-  } else if (stype === "block") {
-    argWalkBlk(stmt as BlockStatement);
-  } else if (stype === "call") {
-    const c = stmt as unknown as CallNode;
-    argCheckCall(c.name, c.args.length, c.loc);
-    for (let i = 0; i < c.args.length; i++) argCheckExpr(c.args[i]);
-  } else if (stype === "method_call") {
-    const mc = stmt as unknown as MethodCallNode;
-    if (mc.object) argCheckExpr(mc.object);
-    for (let i = 0; i < mc.args.length; i++) argCheckExpr(mc.args[i]);
-  } else if (stype !== "break" && stype !== "continue") {
-    argCheckExpr(stmt as Expression);
+    return -1;
+  }
+
+  isDuplicate(name: string): boolean {
+    for (let i = 0; i < this.dupNames.length; i++) {
+      if (this.dupNames[i] === name) return true;
+    }
+    return false;
+  }
+
+  checkCall(name: string, argCount: number, loc: SourceLocation | undefined): void {
+    const resolved = this.resolveName(name);
+    if (this.isDuplicate(resolved)) return;
+    const idx = this.lookup(resolved);
+    if (idx < 0) return;
+    const min = this.mins[idx];
+    const max = this.maxes[idx];
+    if (argCount < min) {
+      process.stderr.write(
+        formatCompileError(
+          this.src,
+          "function '" + name + "' expects at least " + min + " argument(s) but got " + argCount,
+          loc,
+          "check the function signature",
+          [],
+        ),
+      );
+      process.exit(1);
+    }
+    if (argCount > max) {
+      process.stderr.write(
+        formatCompileError(
+          this.src,
+          "function '" + name + "' expects at most " + max + " argument(s) but got " + argCount,
+          loc,
+          "check the function signature",
+          [],
+        ),
+      );
+      process.exit(1);
+    }
+  }
+
+  hasSpread(args: Expression[]): boolean {
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] && args[i].type === "spread_element") return true;
+    }
+    return false;
+  }
+
+  checkExpr(expr: Expression): void {
+    if (!expr) return;
+    if (expr.type === "call") {
+      const c = expr as CallNode;
+      if (!this.hasSpread(c.args)) this.checkCall(c.name, c.args.length, c.loc);
+      for (let i = 0; i < c.args.length; i++) this.checkExpr(c.args[i]);
+    } else if (expr.type === "binary") {
+      const b = expr as BinaryNode;
+      this.checkExpr(b.left);
+      this.checkExpr(b.right);
+    } else if (expr.type === "unary") {
+      this.checkExpr((expr as UnaryNode).operand);
+    } else if (expr.type === "conditional") {
+      const c = expr as ConditionalExpressionNode;
+      this.checkExpr(c.condition);
+      this.checkExpr(c.consequent);
+      this.checkExpr(c.alternate);
+    } else if (expr.type === "method_call") {
+      const mc = expr as MethodCallNode;
+      if (mc.object) this.checkExpr(mc.object);
+      for (let i = 0; i < mc.args.length; i++) this.checkExpr(mc.args[i]);
+    }
+  }
+
+  walkStmt(stmt: Statement): void {
+    const stype = (stmt as { type: string }).type;
+    if (stype === "variable_declaration") {
+      const d = stmt as VariableDeclaration;
+      if (d.value) this.checkExpr(d.value as Expression);
+    } else if (stype === "assignment") {
+      this.checkExpr((stmt as AssignmentStatement).value);
+    } else if (stype === "if") {
+      const i = stmt as IfStatement;
+      this.checkExpr(i.condition);
+      this.walkBlk(i.thenBlock);
+      if (i.elseBlock) this.walkBlk(i.elseBlock);
+    } else if (stype === "while") {
+      const w = stmt as WhileStatement;
+      this.checkExpr(w.condition);
+      this.walkBlk(w.body);
+    } else if (stype === "do_while") {
+      const d = stmt as DoWhileStatement;
+      this.walkBlk(d.body);
+      this.checkExpr(d.condition);
+    } else if (stype === "for") {
+      const f = stmt as ForStatement;
+      if (f.init) this.walkStmt(f.init as Statement);
+      if (f.condition) this.checkExpr(f.condition);
+      if (f.update) {
+        if ((f.update as { type: string }).type === "assignment")
+          this.walkStmt(f.update as Statement);
+        else this.checkExpr(f.update as Expression);
+      }
+      this.walkBlk(f.body);
+    } else if (stype === "for_of") {
+      const fo = stmt as ForOfStatement;
+      this.checkExpr(fo.iterable);
+      this.walkBlk(fo.body);
+    } else if (stype === "try") {
+      const t = stmt as TryStatement;
+      this.walkBlk(t.tryBlock);
+      if (t.catchBody) this.walkBlk(t.catchBody);
+      if (t.finallyBlock) this.walkBlk(t.finallyBlock);
+    } else if (stype === "switch") {
+      const sw = stmt as SwitchStatement;
+      this.checkExpr(sw.discriminant);
+      for (let ci = 0; ci < sw.cases.length; ci++) {
+        const c = sw.cases[ci];
+        if (c.test) this.checkExpr(c.test as Expression);
+        this.walkStmts(c.consequent);
+      }
+    } else if (stype === "return") {
+      const r = stmt as ReturnStatement;
+      if (r.value) this.checkExpr(r.value as Expression);
+    } else if (stype === "throw") {
+      this.checkExpr((stmt as ThrowStatement).argument);
+    } else if (stype === "block") {
+      this.walkBlk(stmt as BlockStatement);
+    } else if (stype === "call") {
+      const c = stmt as unknown as CallNode;
+      if (!this.hasSpread(c.args)) this.checkCall(c.name, c.args.length, c.loc);
+      for (let i = 0; i < c.args.length; i++) this.checkExpr(c.args[i]);
+    } else if (stype === "method_call") {
+      const mc = stmt as unknown as MethodCallNode;
+      if (mc.object) this.checkExpr(mc.object);
+      for (let i = 0; i < mc.args.length; i++) this.checkExpr(mc.args[i]);
+    } else if (stype !== "break" && stype !== "continue") {
+      this.checkExpr(stmt as Expression);
+    }
+  }
+
+  walkStmts(stmts: Statement[]): void {
+    for (let i = 0; i < stmts.length; i++) this.walkStmt(stmts[i]);
+  }
+
+  walkBlk(block: BlockStatement): void {
+    this.walkStmts(block.statements);
   }
 }
 
-function argWalkStmts(stmts: Statement[]): void {
-  for (let i = 0; i < stmts.length; i++) argWalkStmt(stmts[i]);
-}
-
-function argWalkBlk(block: BlockStatement): void {
-  argWalkStmts(block.statements);
-}
-
-function argCountParams(fn: FunctionNode): { min: number; max: number } {
-  if (!fn.parameters) return { min: fn.params.length, max: fn.params.length };
+function argCountMin(fn: FunctionNode): number {
+  if (!fn.parameters) return fn.params.length;
   let min = 0;
-  const max = fn.parameters.length;
   for (let i = 0; i < fn.parameters.length; i++) {
     if (!fn.parameters[i].optional && !fn.parameters[i].defaultValue) min++;
     else break;
   }
-  return { min, max };
+  return min;
+}
+
+function argHasRest(fn: FunctionNode): boolean {
+  for (let i = 0; i < fn.params.length; i++) {
+    if (fn.params[i].indexOf("...") === 0) return true;
+  }
+  if (fn.parameters) {
+    for (let i = 0; i < fn.parameters.length; i++) {
+      if (fn.parameters[i].name.indexOf("...") === 0) return true;
+    }
+  }
+  return false;
+}
+
+function argCountMax(fn: FunctionNode): number {
+  if (!fn.parameters) return fn.params.length;
+  return fn.parameters.length;
 }
 
 export function checkArgumentCounts(ast: AST, sourceCode: string): void {
-  argNames = [];
-  argMins = [];
-  argMaxes = [];
-  argAliasNames = ast.importAliasNames ? ast.importAliasNames : [];
-  argAliasOriginals = ast.importAliasOriginals ? ast.importAliasOriginals : [];
-  argSrc = sourceCode;
+  const state = new ArgCheckState();
+  state.src = sourceCode;
+  if (ast.importAliasNames) state.aliasNames = ast.importAliasNames;
+  if (ast.importAliasOriginals) state.aliasOriginals = ast.importAliasOriginals;
 
   for (let i = 0; i < ast.functions.length; i++) {
     const fn = ast.functions[i];
-    const existing = argLookup(fn.name);
-    if (existing >= 0) {
-      argNames.splice(existing, 1);
-      argMins.splice(existing, 1);
-      argMaxes.splice(existing, 1);
+    if (state.lookup(fn.name) >= 0) {
+      state.dupNames.push(fn.name);
       continue;
     }
-    const counts = argCountParams(fn);
-    argNames.push(fn.name);
-    argMins.push(counts.min);
-    argMaxes.push(counts.max);
+    if (argHasRest(fn)) continue;
+    state.names.push(fn.name);
+    state.mins.push(argCountMin(fn));
+    state.maxes.push(argCountMax(fn));
   }
 
   const items = ast.topLevelItems;
-  if (items) argWalkStmts(items as Statement[]);
-  for (let i = 0; i < ast.functions.length; i++) argWalkBlk(ast.functions[i].body);
+  if (items) state.walkStmts(items as Statement[]);
+  for (let i = 0; i < ast.functions.length; i++) state.walkBlk(ast.functions[i].body);
   for (let i = 0; i < ast.classes.length; i++) {
     const cls = ast.classes[i];
-    for (let j = 0; j < cls.methods.length; j++) argWalkBlk(cls.methods[j].body);
+    for (let j = 0; j < cls.methods.length; j++) state.walkBlk(cls.methods[j].body);
   }
+}
+
+function mrSkipReturnType(rt: string): boolean {
+  if (rt === "void") return true;
+  if (rt === "never") return true;
+  if (rt.indexOf("Promise") === 0) return true;
+  return false;
 }
 
 export function checkMissingReturns(ast: AST, sourceCode: string): void {
   const nn: string[] = ["process.exit"];
+  const fnNames: string[] = [];
+  const fnBodies: BlockStatement[] = [];
+  const fnLocs: (SourceLocation | undefined)[] = [];
+
   for (let i = 0; i < ast.functions.length; i++) {
-    if (ast.functions[i].returnType === "never") nn.push(ast.functions[i].name);
+    const fn = ast.functions[i];
+    if (fn.returnType === "never") nn.push(fn.name);
   }
   for (let i = 0; i < ast.classes.length; i++) {
     const cls = ast.classes[i];
@@ -502,15 +543,22 @@ export function checkMissingReturns(ast: AST, sourceCode: string): void {
   for (let i = 0; i < ast.functions.length; i++) {
     const fn = ast.functions[i];
     if (fn.declare) continue;
-    if (!fn.returnType || fn.returnType === "void" || fn.returnType === "never") continue;
     if (fn.async) continue;
-    if (fn.returnType.indexOf("Promise") === 0) continue;
-    if (!mrAllReturn(fn.body.statements, nn)) {
+    const rt = fn.returnType;
+    if (!rt || rt.length === 0) continue;
+    if (mrSkipReturnType(rt)) continue;
+    fnNames.push(fn.name);
+    fnBodies.push(fn.body);
+    fnLocs.push(fn.loc);
+  }
+
+  for (let i = 0; i < fnNames.length; i++) {
+    if (!mrAllReturn(fnBodies[i].statements, nn)) {
       process.stderr.write(
         formatCompileError(
           sourceCode,
-          "function '" + fn.name + "' does not return a value on all code paths",
-          fn.loc,
+          "function '" + fnNames[i] + "' does not return a value on all code paths",
+          fnLocs[i],
           "add a return statement to all branches",
           [],
         ),
@@ -518,13 +566,15 @@ export function checkMissingReturns(ast: AST, sourceCode: string): void {
       process.exit(1);
     }
   }
+
   for (let i = 0; i < ast.classes.length; i++) {
     const cls = ast.classes[i];
     for (let j = 0; j < cls.methods.length; j++) {
       const method = cls.methods[j];
       if (method.isConstructor) continue;
-      if (!method.returnType || method.returnType === "void" || method.returnType === "never")
-        continue;
+      const mrt = method.returnType;
+      if (!mrt) continue;
+      if (mrSkipReturnType(mrt)) continue;
       if (!mrAllReturn(method.body.statements, nn)) {
         process.stderr.write(
           formatCompileError(

--- a/src/semantic/safety-checks.ts
+++ b/src/semantic/safety-checks.ts
@@ -20,6 +20,8 @@ import type {
   UnaryNode,
   ConditionalExpressionNode,
   MethodCallNode,
+  FunctionNode,
+  SourceLocation,
 } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
 
@@ -285,6 +287,203 @@ export function checkBinaryTypesDeep(ast: AST, sourceCode: string): void {
   for (let i = 0; i < ast.classes.length; i++) {
     const cls = ast.classes[i];
     for (let j = 0; j < cls.methods.length; j++) binWalkBlk(cls.methods[j].body, sourceCode);
+  }
+}
+
+// --- Argument count checker ---
+// Module-level vars to avoid 5+ param functions (native compiler infinite loop workaround)
+
+let argNames: string[] = [];
+let argMins: number[] = [];
+let argMaxes: number[] = [];
+let argAliasNames: string[] = [];
+let argAliasOriginals: string[] = [];
+let argSrc: string = "";
+
+function argResolveName(name: string): string {
+  for (let i = 0; i < argAliasNames.length; i++) {
+    if (argAliasNames[i] === name) return argAliasOriginals[i];
+  }
+  return name;
+}
+
+function argLookup(name: string): number {
+  for (let i = 0; i < argNames.length; i++) {
+    if (argNames[i] === name) return i;
+  }
+  return -1;
+}
+
+function argCheckCall(name: string, argCount: number, loc: SourceLocation | undefined): void {
+  const resolved = argResolveName(name);
+  const idx = argLookup(resolved);
+  if (idx < 0) return;
+  const min = argMins[idx];
+  const max = argMaxes[idx];
+  if (argCount < min) {
+    process.stderr.write(
+      formatCompileError(
+        argSrc,
+        "function '" + name + "' expects at least " + min + " argument(s) but got " + argCount,
+        loc as SourceLocation | undefined,
+        "check the function signature",
+        [],
+      ),
+    );
+    process.exit(1);
+  }
+  if (argCount > max) {
+    process.stderr.write(
+      formatCompileError(
+        argSrc,
+        "function '" + name + "' expects at most " + max + " argument(s) but got " + argCount,
+        loc as SourceLocation | undefined,
+        "check the function signature",
+        [],
+      ),
+    );
+    process.exit(1);
+  }
+}
+
+function argCheckExpr(expr: Expression): void {
+  if (!expr) return;
+  if (expr.type === "call") {
+    const c = expr as CallNode;
+    argCheckCall(c.name, c.args.length, c.loc);
+    for (let i = 0; i < c.args.length; i++) argCheckExpr(c.args[i]);
+  } else if (expr.type === "binary") {
+    const b = expr as BinaryNode;
+    argCheckExpr(b.left);
+    argCheckExpr(b.right);
+  } else if (expr.type === "unary") {
+    argCheckExpr((expr as UnaryNode).operand);
+  } else if (expr.type === "conditional") {
+    const c = expr as ConditionalExpressionNode;
+    argCheckExpr(c.condition);
+    argCheckExpr(c.consequent);
+    argCheckExpr(c.alternate);
+  } else if (expr.type === "method_call") {
+    const mc = expr as MethodCallNode;
+    if (mc.object) argCheckExpr(mc.object);
+    for (let i = 0; i < mc.args.length; i++) argCheckExpr(mc.args[i]);
+  }
+}
+
+function argWalkStmt(stmt: Statement): void {
+  const stype = (stmt as { type: string }).type;
+  if (stype === "variable_declaration") {
+    const d = stmt as VariableDeclaration;
+    if (d.value) argCheckExpr(d.value as Expression);
+  } else if (stype === "assignment") {
+    argCheckExpr((stmt as AssignmentStatement).value);
+  } else if (stype === "if") {
+    const i = stmt as IfStatement;
+    argCheckExpr(i.condition);
+    argWalkBlk(i.thenBlock);
+    if (i.elseBlock) argWalkBlk(i.elseBlock);
+  } else if (stype === "while") {
+    const w = stmt as WhileStatement;
+    argCheckExpr(w.condition);
+    argWalkBlk(w.body);
+  } else if (stype === "do_while") {
+    const d = stmt as DoWhileStatement;
+    argWalkBlk(d.body);
+    argCheckExpr(d.condition);
+  } else if (stype === "for") {
+    const f = stmt as ForStatement;
+    if (f.init) argWalkStmt(f.init as Statement);
+    if (f.condition) argCheckExpr(f.condition);
+    if (f.update) {
+      if ((f.update as { type: string }).type === "assignment") argWalkStmt(f.update as Statement);
+      else argCheckExpr(f.update as Expression);
+    }
+    argWalkBlk(f.body);
+  } else if (stype === "for_of") {
+    const fo = stmt as ForOfStatement;
+    argCheckExpr(fo.iterable);
+    argWalkBlk(fo.body);
+  } else if (stype === "try") {
+    const t = stmt as TryStatement;
+    argWalkBlk(t.tryBlock);
+    if (t.catchBody) argWalkBlk(t.catchBody);
+    if (t.finallyBlock) argWalkBlk(t.finallyBlock);
+  } else if (stype === "switch") {
+    const sw = stmt as SwitchStatement;
+    argCheckExpr(sw.discriminant);
+    for (let ci = 0; ci < sw.cases.length; ci++) {
+      const c = sw.cases[ci];
+      if (c.test) argCheckExpr(c.test as Expression);
+      argWalkStmts(c.consequent);
+    }
+  } else if (stype === "return") {
+    const r = stmt as ReturnStatement;
+    if (r.value) argCheckExpr(r.value as Expression);
+  } else if (stype === "throw") {
+    argCheckExpr((stmt as ThrowStatement).argument);
+  } else if (stype === "block") {
+    argWalkBlk(stmt as BlockStatement);
+  } else if (stype === "call") {
+    const c = stmt as unknown as CallNode;
+    argCheckCall(c.name, c.args.length, c.loc);
+    for (let i = 0; i < c.args.length; i++) argCheckExpr(c.args[i]);
+  } else if (stype === "method_call") {
+    const mc = stmt as unknown as MethodCallNode;
+    if (mc.object) argCheckExpr(mc.object);
+    for (let i = 0; i < mc.args.length; i++) argCheckExpr(mc.args[i]);
+  } else if (stype !== "break" && stype !== "continue") {
+    argCheckExpr(stmt as Expression);
+  }
+}
+
+function argWalkStmts(stmts: Statement[]): void {
+  for (let i = 0; i < stmts.length; i++) argWalkStmt(stmts[i]);
+}
+
+function argWalkBlk(block: BlockStatement): void {
+  argWalkStmts(block.statements);
+}
+
+function argCountParams(fn: FunctionNode): { min: number; max: number } {
+  if (!fn.parameters) return { min: fn.params.length, max: fn.params.length };
+  let min = 0;
+  const max = fn.parameters.length;
+  for (let i = 0; i < fn.parameters.length; i++) {
+    if (!fn.parameters[i].optional && !fn.parameters[i].defaultValue) min++;
+    else break;
+  }
+  return { min, max };
+}
+
+export function checkArgumentCounts(ast: AST, sourceCode: string): void {
+  argNames = [];
+  argMins = [];
+  argMaxes = [];
+  argAliasNames = ast.importAliasNames ? ast.importAliasNames : [];
+  argAliasOriginals = ast.importAliasOriginals ? ast.importAliasOriginals : [];
+  argSrc = sourceCode;
+
+  for (let i = 0; i < ast.functions.length; i++) {
+    const fn = ast.functions[i];
+    const existing = argLookup(fn.name);
+    if (existing >= 0) {
+      argNames.splice(existing, 1);
+      argMins.splice(existing, 1);
+      argMaxes.splice(existing, 1);
+      continue;
+    }
+    const counts = argCountParams(fn);
+    argNames.push(fn.name);
+    argMins.push(counts.min);
+    argMaxes.push(counts.max);
+  }
+
+  const items = ast.topLevelItems;
+  if (items) argWalkStmts(items as Statement[]);
+  for (let i = 0; i < ast.functions.length; i++) argWalkBlk(ast.functions[i].body);
+  for (let i = 0; i < ast.classes.length; i++) {
+    const cls = ast.classes[i];
+    for (let j = 0; j < cls.methods.length; j++) argWalkBlk(cls.methods[j].body);
   }
 }
 

--- a/tests/fixtures/arrays/array-includes-test.js
+++ b/tests/fixtures/arrays/array-includes-test.js
@@ -1,5 +1,5 @@
 // Test array.includes() - verifies includes method works correctly
-function testArrayIncludes(): number {
+function testArrayIncludes(): void {
   const arr = [10, 20, 30, 40, 50];
 
   // Test that includes returns 1 for existing element

--- a/tests/fixtures/arrays/array-pop-test.js
+++ b/tests/fixtures/arrays/array-pop-test.js
@@ -1,5 +1,5 @@
 // Test array.pop() - verifies pop removes and returns last element
-function testArrayPop(): number {
+function testArrayPop(): void {
   const arr = [10, 20, 30, 40, 50];
 
   // Pop should return the last element (50)

--- a/tests/fixtures/arrays/array-slice.ts
+++ b/tests/fixtures/arrays/array-slice.ts
@@ -1,4 +1,4 @@
-function testArraySlice(): number {
+function testArraySlice(): void {
   const arr: number[] = [1, 2, 3, 4, 5];
 
   const sliced = arr.slice(1, 3);

--- a/tests/fixtures/arrays/string-array-basic.js
+++ b/tests/fixtures/arrays/string-array-basic.js
@@ -1,5 +1,5 @@
 // Test basic string array - verifies string array creation and access
-function testStringArray(): number {
+function testStringArray(): void {
   const arr = ["hello", "world", "test"];
 
   if (arr.length !== 3) {

--- a/tests/fixtures/semantic/arg-count-optional.ts
+++ b/tests/fixtures/semantic/arg-count-optional.ts
@@ -1,0 +1,12 @@
+function format(value: number, prefix?: string): string {
+  if (prefix) {
+    return prefix + String(value);
+  }
+  return String(value);
+}
+
+const a = format(42);
+const b = format(42, "$");
+if (a === "42" && b === "$42") {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/semantic/arg-count-too-few.ts
+++ b/tests/fixtures/semantic/arg-count-too-few.ts
@@ -1,0 +1,7 @@
+// @test-description: reject call with too few arguments
+// @test-compile-error: expects at least 2 argument(s) but got 1
+function add(a: number, b: number): number {
+  return a + b;
+}
+
+add(1);

--- a/tests/fixtures/semantic/arg-count-too-many.ts
+++ b/tests/fixtures/semantic/arg-count-too-many.ts
@@ -1,0 +1,7 @@
+// @test-description: reject call with too many arguments
+// @test-compile-error: expects at most 1 argument(s) but got 3
+function greet(name: string): void {
+  console.log("hello " + name);
+}
+
+greet("a", "b", "c");

--- a/tests/fixtures/semantic/missing-return-complete.ts
+++ b/tests/fixtures/semantic/missing-return-complete.ts
@@ -1,0 +1,12 @@
+function classify(x: number): string {
+  if (x > 0) {
+    return "positive";
+  } else {
+    return "non-positive";
+  }
+}
+
+const result = classify(5);
+if (result === "positive") {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/semantic/missing-return-if.ts
+++ b/tests/fixtures/semantic/missing-return-if.ts
@@ -1,0 +1,9 @@
+// @test-description: reject function with missing return in else branch
+// @test-compile-error: does not return a value on all code paths
+function check(x: number): number {
+  if (x > 0) {
+    return 1;
+  }
+}
+
+check(5);


### PR DESCRIPTION
## Summary
- Users now get clear compile errors for functions that don't return on all code paths and for calls with wrong argument counts
- Fixes 4 test fixtures that declared `: number` return type but never returned (now `: void`)
- Arg count checker uses parallel arrays instead of Map for native compiler compatibility

## Test plan
- [ ] 3 new compile-error fixtures: missing-return-if, arg-count-too-few, arg-count-too-many
- [ ] 2 new valid fixtures: missing-return-complete, arg-count-optional
- [ ] All existing tests pass
- [ ] Self-hosting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)