### PR TITLE
broaden i64 integer inference to .length, indexOf, Math.floor

### DIFF
--- a/src/codegen/infrastructure/integer-analysis.ts
+++ b/src/codegen/infrastructure/integer-analysis.ts
@@ -26,6 +26,62 @@ class IntegerAnalyzer {
     return (val as NumberNode).value % 1 === 0;
   }
 
+  private isIntegerExpressionForCandidacy(val: Expression): boolean {
+    if (this.isIntegerLiteral(val)) return true;
+    if (val.type === "member_access") {
+      const ma = val as MemberAccessNode;
+      if (ma.property === "length") return true;
+    }
+    if (val.type === "method_call") {
+      const mc = val as MethodCallNode;
+      const method = mc.method;
+      if (
+        method === "indexOf" ||
+        method === "lastIndexOf" ||
+        method === "findIndex" ||
+        method === "charCodeAt"
+      )
+        return true;
+      const obj = mc.object as VariableNode;
+      if (obj.type === "variable" && obj.name === "Math") {
+        if (method === "floor" || method === "ceil" || method === "round" || method === "trunc")
+          return true;
+      }
+    }
+    if (val.type === "call") {
+      const call = val as CallNode;
+      if (call.name === "parseInt") return true;
+    }
+    if (val.type === "binary") {
+      const bin = val as BinaryNode;
+      const op = bin.op;
+      if (
+        op === "+" ||
+        op === "-" ||
+        op === "*" ||
+        op === "%" ||
+        op === "&" ||
+        op === "|" ||
+        op === "^" ||
+        op === "<<" ||
+        op === ">>" ||
+        op === ">>>"
+      ) {
+        return (
+          this.isIntegerExpressionForCandidacy(bin.left) &&
+          this.isIntegerExpressionForCandidacy(bin.right)
+        );
+      }
+    }
+    if (val.type === "unary") {
+      const un = val as UnaryNode;
+      if (un.op === "-" || un.op === "~" || un.op === "+") {
+        return this.isIntegerExpressionForCandidacy(un.operand);
+      }
+    }
+    return false;
+  }
+
   private isIntegerExpression(val: Expression): boolean {
     if (this.isIntegerLiteral(val)) return true;
 
@@ -152,7 +208,7 @@ class IntegerAnalyzer {
 
     for (const varDecl of allDecls) {
       if (!varDecl.value) continue;
-      if (this.isIntegerLiteral(varDecl.value)) {
+      if (this.isIntegerExpressionForCandidacy(varDecl.value)) {
         candidates.push(varDecl.name);
         isConst.push(varDecl.kind === "const");
       }

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1779,10 +1779,23 @@ export class VariableAllocator {
         stmt.value!.type === "boolean" ||
         (stmt.declaredType && stripNullable(stmt.declaredType) === "boolean");
       const symKind = isBoolVal ? SymbolKind_Boolean : SymbolKind_Number;
-      if (valueType === "i64" && this.isI64Eligible(stmt.name)) {
+      if (
+        this.isI64Eligible(stmt.name) &&
+        (valueType === "i64" || valueType === "double" || valueType === "i32")
+      ) {
         this.ctx.defineVariable(stmt.name, allocaReg, "i64", symKind, "local");
         this.ctx.emit(`${allocaReg} = alloca i64`);
-        this.ctx.emit(`store i64 ${value}, i64* ${allocaReg}`);
+        if (valueType === "double") {
+          const converted = this.ctx.nextTemp();
+          this.ctx.emit(`${converted} = fptosi double ${value} to i64`);
+          this.ctx.emit(`store i64 ${converted}, i64* ${allocaReg}`);
+        } else if (valueType === "i32") {
+          const converted = this.ctx.nextTemp();
+          this.ctx.emit(`${converted} = sext i32 ${value} to i64`);
+          this.ctx.emit(`store i64 ${converted}, i64* ${allocaReg}`);
+        } else {
+          this.ctx.emit(`store i64 ${value}, i64* ${allocaReg}`);
+        }
       } else {
         this.ctx.defineVariable(stmt.name, allocaReg, "double", symKind, "local");
         this.ctx.emit(`${allocaReg} = alloca double`);


### PR DESCRIPTION
## Summary
- Variables initialized from `.length`, `indexOf`, `lastIndexOf`, `findIndex`, `charCodeAt`, `Math.floor/ceil/round/trunc`, and `parseInt` are now i64 candidates
- Variable allocator converts init values to i64 from double (fptosi) or i32 (sext)
- Uses a separate `isIntegerExpressionForCandidacy` to avoid a native compiler self-hosting crash caused by reusing `isIntegerExpression` (which references `candidateSet`) at candidacy time

## Test plan
- [x] All 747 tests pass
- [ ] CI verify (full 3-stage self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)