### PR TITLE
support module-level let without initializer and = undefined

### DIFF
--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -223,6 +223,16 @@ export class SemanticAnalyzer {
     return sym.schemaTypes;
   }
 
+  private isNullishExpression(expr: Expression): boolean {
+    const e = expr as ExpressionBase;
+    if (e.type === "null" || e.type === "undefined") return true;
+    if (e.type === "variable") {
+      const v = expr as VariableNode;
+      if (v.name === "undefined" || v.name === "null") return true;
+    }
+    return false;
+  }
+
   private inferDeclaredType(declaredType: string | undefined): {
     type: SymbolType;
     llvmType: string;
@@ -253,7 +263,7 @@ export class SemanticAnalyzer {
       }
     }
 
-    if (!stmt.value) {
+    if (!stmt.value || this.isNullishExpression(stmt.value)) {
       const inferred = this.inferDeclaredType(stmt.declaredType);
       this.symbols.set(stmt.name, {
         name: stmt.name,
@@ -265,7 +275,7 @@ export class SemanticAnalyzer {
 
     this.checkUntypedGenericConstructor(stmt);
 
-    const inferredType = this.inferExpressionType(stmt.value, stmt.declaredType);
+    const inferredType = this.inferExpressionType(stmt.value!, stmt.declaredType);
     if (!inferredType) return;
     const symbolEntry = {
       name: stmt.name,

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -491,7 +491,7 @@ export class VariableAllocator {
 
   private isNullishValue(value: Expression | null): boolean {
     if (value === null) return true;
-    const v = value as { type: string; name?: string };
+    const v = value as VariableNode;
     if (v.type === "null" || v.type === "undefined") return true;
     if (v.type === "variable" && (v.name === "undefined" || v.name === "null")) return true;
     return false;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -491,9 +491,12 @@ export class VariableAllocator {
 
   private isNullishValue(value: Expression | null): boolean {
     if (value === null) return true;
-    const v = value as VariableNode;
-    if (v.type === "null" || v.type === "undefined") return true;
-    if (v.type === "variable" && (v.name === "undefined" || v.name === "null")) return true;
+    const vType = (value as VariableNode).type as string;
+    if (vType === "null" || vType === "undefined") return true;
+    if (vType === "variable") {
+      const vName = (value as VariableNode).name;
+      if (vName === "undefined" || vName === "null") return true;
+    }
     return false;
   }
 

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -489,9 +489,17 @@ export class VariableAllocator {
     };
   }
 
+  private isNullishValue(value: Expression | null): boolean {
+    if (value === null) return true;
+    const v = value as { type: string; name?: string };
+    if (v.type === "null" || v.type === "undefined") return true;
+    if (v.type === "variable" && (v.name === "undefined" || v.name === "null")) return true;
+    return false;
+  }
+
   allocate(stmt: VariableDeclaration, params: string[]): void {
     const existingScope = this.ctx.symbolTable.getScope(stmt.name);
-    if (existingScope === "global" && stmt.value !== null) {
+    if (existingScope === "global" && stmt.value !== null && !this.isNullishValue(stmt.value)) {
       // For global Uint8Array vars, set wantsBinaryReturn so readFileSync etc.
       // dispatch to their binary variants (same as allocateUint8Array does for locals)
       const sym = this.ctx.symbolTable.lookup(stmt.name);
@@ -527,6 +535,7 @@ export class VariableAllocator {
       }
       return;
     }
+    if (existingScope === "global") return;
 
     const stmtValueAsVar = stmt.value as VariableNode;
     const isAstNullLiteral =

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2105,6 +2105,19 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       if (stmt.value !== null) {
         const name = stmt.name;
 
+        const stmtValNode = stmt.value as { type: string; name?: string };
+        const isUndefinedValue =
+          stmtValNode.type === "undefined" ||
+          (stmtValNode.type === "variable" && stmtValNode.name === "undefined") ||
+          stmtValNode.type === "null";
+        if (isUndefinedValue && stmt.declaredType) {
+          const globalIr = this.handleUninitializedGlobalVar(name, stmt.declaredType);
+          if (globalIr) {
+            ir += globalIr;
+            continue;
+          }
+        }
+
         if ((stmt.value as { type: string }).type === "call") {
           const callNode = stmt.value as CallNode;
           if (callNode.name) {
@@ -2587,6 +2600,23 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               llvmType = "i8*";
               kind = SymbolKind_String;
               defaultValue = "null";
+            } else if (strippedDeclaredType === "number") {
+              llvmType = "double";
+              kind = SymbolKind_Number;
+              defaultValue = "0.0";
+            } else if (strippedDeclaredType === "boolean") {
+              llvmType = "double";
+              kind = SymbolKind_Boolean;
+              defaultValue = "0.0";
+            } else if (strippedDeclaredType === "string[]") {
+              isStringArray = true;
+            } else if (
+              strippedDeclaredType === "number[]" ||
+              strippedDeclaredType === "boolean[]"
+            ) {
+              isArray = true;
+            } else if (strippedDeclaredType.endsWith("[]")) {
+              isObjectArray = true;
             }
           }
 
@@ -2628,12 +2658,79 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             this.symbolTable.setResolvedType(name, resolved);
           }
         }
+      } else if (stmt.declaredType) {
+        const name = stmt.name;
+        const globalIr = this.handleUninitializedGlobalVar(name, stmt.declaredType);
+        if (globalIr) {
+          ir += globalIr;
+        }
       }
     }
     if (ir.length > 0) {
       ir += "\n";
     }
     return ir;
+  }
+
+  private handleUninitializedGlobalVar(name: string, declaredType: string): string {
+    const baseType = stripNullable(declaredType);
+    if (baseType === "string") {
+      this.globalVariables.set(name, {
+        llvmType: "i8*",
+        kind: SymbolKind_String,
+        initialized: false,
+      });
+      this.defineVariable(name, `@${name}`, "i8*", SymbolKind_String, "global");
+      return `@${name} = global i8* null\n`;
+    }
+    if (baseType === "number") {
+      this.globalVariables.set(name, {
+        llvmType: "double",
+        kind: SymbolKind_Number,
+        initialized: false,
+      });
+      this.defineVariable(name, `@${name}`, "double", SymbolKind_Number, "global");
+      return `@${name} = global double 0.0\n`;
+    }
+    if (baseType === "boolean") {
+      this.globalVariables.set(name, {
+        llvmType: "double",
+        kind: SymbolKind_Boolean,
+        initialized: false,
+      });
+      this.defineVariable(name, `@${name}`, "double", SymbolKind_Boolean, "global");
+      return `@${name} = global double 0.0\n`;
+    }
+    if (baseType === "string[]") {
+      this.globalVariables.set(name, {
+        llvmType: "%StringArray*",
+        kind: SymbolKind_StringArray,
+        initialized: false,
+      });
+      this.defineVariable(name, `@${name}`, "%StringArray*", SymbolKind_StringArray, "global");
+      return `@${name} = global %StringArray* null\n`;
+    }
+    if (baseType === "number[]" || baseType === "boolean[]") {
+      this.globalVariables.set(name, {
+        llvmType: "%Array*",
+        kind: SymbolKind_Array,
+        initialized: false,
+      });
+      this.defineVariable(name, `@${name}`, "%Array*", SymbolKind_Array, "global");
+      return `@${name} = global %Array* null\n`;
+    }
+    if (baseType.endsWith("[]")) {
+      this.globalVariables.set(name, {
+        llvmType: "%ObjectArray*",
+        kind: SymbolKind_ObjectArray,
+        initialized: false,
+      });
+      this.defineVariable(name, `@${name}`, "%ObjectArray*", SymbolKind_ObjectArray, "global");
+      return `@${name} = global %ObjectArray* null\n`;
+    }
+    const declaredIr = this.tryHandleGlobalDeclaredType(name, declaredType);
+    if (declaredIr) return declaredIr;
+    return "";
   }
 
   /**

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2105,11 +2105,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       if (stmt.value !== null) {
         const name = stmt.name;
 
-        const stmtValNode = stmt.value as VariableNode;
+        const stmtValType = (stmt.value as VariableNode).type as string;
         const isUndefinedValue =
-          stmtValNode.type === "undefined" ||
-          (stmtValNode.type === "variable" && stmtValNode.name === "undefined") ||
-          stmtValNode.type === "null";
+          stmtValType === "undefined" ||
+          (stmtValType === "variable" && (stmt.value as VariableNode).name === "undefined") ||
+          stmtValType === "null";
         if (isUndefinedValue && stmt.declaredType) {
           const globalIr = this.handleUninitializedGlobalVar(name, stmt.declaredType);
           if (globalIr) {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2105,7 +2105,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       if (stmt.value !== null) {
         const name = stmt.name;
 
-        const stmtValNode = stmt.value as { type: string; name?: string };
+        const stmtValNode = stmt.value as VariableNode;
         const isUndefinedValue =
           stmtValNode.type === "undefined" ||
           (stmtValNode.type === "variable" && stmtValNode.name === "undefined") ||

--- a/tests/fixtures/variables/module-let-undefined-init.ts
+++ b/tests/fixtures/variables/module-let-undefined-init.ts
@@ -1,0 +1,9 @@
+let name: string | undefined = undefined;
+let count: number | undefined = undefined;
+
+name = "hello";
+count = 42;
+
+if (name === "hello" && count === 42) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/variables/module-let-uninitialized.ts
+++ b/tests/fixtures/variables/module-let-uninitialized.ts
@@ -1,0 +1,11 @@
+let name: string;
+let count: number;
+let flag: boolean;
+
+name = "hello";
+count = 42;
+flag = true;
+
+if (flag && count === 42 && name === "hello") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- `let name: string;` at module level no longer errors with "Unknown variable" — globals are now declared with null/zero defaults based on declared type
- `let x: string | undefined = undefined;` no longer errors with "cannot determine type" — undefined/null init values are recognized and handled like uninitialized vars
- Handles string, number, boolean, string[], number[], boolean[], and object[] declared types

## Changes
- **llvm-generator.ts**: New `handleUninitializedGlobalVar()` method, early exit for undefined/null init values, broadened `strippedDeclaredType` fallback to handle arrays and primitives
- **variable-allocator.ts**: Skip expression generation for nullish global init values, early return for globals with no init
- **semantic-analyzer.ts**: Treat undefined/null init expressions like missing values — infer type from declared type annotation

## Test plan
- [x] New fixtures: `module-let-uninitialized.ts`, `module-let-undefined-init.ts`
- [x] Both pass with node and native compiler
- [ ] CI full verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)