### PR TITLE
add charset=utf-8 to http content-type headers

### DIFF
--- a/c_bridges/lws-bridge.c
+++ b/c_bridges/lws-bridge.c
@@ -344,11 +344,11 @@ static void send_http_response(http_conn_t *conn, int status, const char *resp_c
 static const char *sniff_content_type(const char *path, const char *body) {
     const char *dot = strrchr(path, '.');
     if (dot) {
-        if (!strcmp(dot, ".css")) return "text/css";
-        if (!strcmp(dot, ".js")) return "text/javascript";
-        if (!strcmp(dot, ".json")) return "application/json";
-        if (!strcmp(dot, ".html") || !strcmp(dot, ".htm")) return "text/html";
-        if (!strcmp(dot, ".svg")) return "image/svg+xml";
+        if (!strcmp(dot, ".css")) return "text/css; charset=utf-8";
+        if (!strcmp(dot, ".js")) return "text/javascript; charset=utf-8";
+        if (!strcmp(dot, ".json")) return "application/json; charset=utf-8";
+        if (!strcmp(dot, ".html") || !strcmp(dot, ".htm")) return "text/html; charset=utf-8";
+        if (!strcmp(dot, ".svg")) return "image/svg+xml; charset=utf-8";
         if (!strcmp(dot, ".png")) return "image/png";
         if (!strcmp(dot, ".jpg") || !strcmp(dot, ".jpeg")) return "image/jpeg";
         if (!strcmp(dot, ".gif")) return "image/gif";
@@ -359,21 +359,21 @@ static const char *sniff_content_type(const char *path, const char *body) {
         if (!strcmp(dot, ".ttf")) return "font/ttf";
         if (!strcmp(dot, ".otf")) return "font/opentype";
         if (!strcmp(dot, ".wasm")) return "application/wasm";
-        if (!strcmp(dot, ".xml")) return "application/xml";
+        if (!strcmp(dot, ".xml")) return "application/xml; charset=utf-8";
         if (!strcmp(dot, ".pdf")) return "application/pdf";
         if (!strcmp(dot, ".mp4")) return "video/mp4";
         if (!strcmp(dot, ".webm")) return "video/webm";
         if (!strcmp(dot, ".mp3")) return "audio/mpeg";
         if (!strcmp(dot, ".ogg")) return "audio/ogg";
-        if (!strcmp(dot, ".txt")) return "text/plain";
-        if (!strcmp(dot, ".map")) return "application/json";
-        if (body && body[0] == '<') return "text/html";
-        if (body && (body[0] == '{' || body[0] == '[')) return "application/json";
+        if (!strcmp(dot, ".txt")) return "text/plain; charset=utf-8";
+        if (!strcmp(dot, ".map")) return "application/json; charset=utf-8";
+        if (body && body[0] == '<') return "text/html; charset=utf-8";
+        if (body && (body[0] == '{' || body[0] == '[')) return "application/json; charset=utf-8";
     } else {
-        if (body && body[0] == '<') return "text/html";
-        if (body && (body[0] == '{' || body[0] == '[')) return "application/json";
+        if (body && body[0] == '<') return "text/html; charset=utf-8";
+        if (body && (body[0] == '{' || body[0] == '[')) return "application/json; charset=utf-8";
     }
-    return "text/plain";
+    return "text/plain; charset=utf-8";
 }
 
 /* ---- HTTP request dispatch ---- */

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -128,7 +128,7 @@ export class Context {
   }
 
   text(body: string): HttpResponse {
-    let hdrs = "Content-Type: text/plain";
+    let hdrs = "Content-Type: text/plain; charset=utf-8";
     if (this._extraHeaders.length > 0) {
       hdrs = hdrs + "\n" + this._extraHeaders;
     }
@@ -139,7 +139,7 @@ export class Context {
   }
 
   json(data: any): HttpResponse {
-    let hdrs = "Content-Type: application/json";
+    let hdrs = "Content-Type: application/json; charset=utf-8";
     if (this._extraHeaders.length > 0) {
       hdrs = hdrs + "\n" + this._extraHeaders;
     }
@@ -150,7 +150,7 @@ export class Context {
   }
 
   html(body: string): HttpResponse {
-    let hdrs = "Content-Type: text/html";
+    let hdrs = "Content-Type: text/html; charset=utf-8";
     if (this._extraHeaders.length > 0) {
       hdrs = hdrs + "\n" + this._extraHeaders;
     }


### PR DESCRIPTION
## Summary
- UTF-8 characters (em dashes, accented chars, etc.) rendered as mojibake because Content-Type headers lacked `; charset=utf-8`
- Added `; charset=utf-8` to `c.text()`, `c.json()`, and `c.html()` in `lib/http.ts`
- Added `; charset=utf-8` to all text-based sniffed types in `sniff_content_type()` in `c_bridges/lws-bridge.c` (html, json, plain, css, js, xml, svg). Binary types (images, fonts, wasm) unchanged.

## Test plan
- [x] `npm run verify:quick` — self-hosting stages pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)