### PR TITLE
fix try-catch return: skip unreachable finally when both branches terminate

### DIFF
--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -955,6 +955,15 @@ export class SemanticAnalyzer {
           }
         }
       }
+      if (t === "try") {
+        const tryStmt = stmt as TryStatement;
+        if (
+          this.blockAlwaysReturns(tryStmt.tryBlock) &&
+          (!tryStmt.catchBody || this.blockAlwaysReturns(tryStmt.catchBody))
+        ) {
+          return true;
+        }
+      }
     }
     return false;
   }

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -610,6 +610,10 @@ export class ControlFlowGenerator {
       this.ctx.emitBr(finallyLabel);
     }
 
+    if (tryHasTerminator && catchHasTerminator && !tryStmt.finallyBlock) {
+      return "0";
+    }
+
     this.ctx.emitLabel(finallyLabel);
     this.ctx.setCurrentLabel(finallyLabel);
 

--- a/tests/fixtures/error-handling/try-catch-return.ts
+++ b/tests/fixtures/error-handling/try-catch-return.ts
@@ -1,0 +1,21 @@
+function getValueReturnBoth(): string {
+  try {
+    return "success";
+  } catch (e) {
+    return "fail";
+  }
+}
+
+function getValueReturnThrow(): string {
+  try {
+    return "success";
+  } catch (e) {
+    throw e;
+  }
+}
+
+const r1 = getValueReturnBoth();
+const r2 = getValueReturnThrow();
+if (r1 === "success" && r2 === "success") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Functions with return/throw in both try and catch blocks now compile correctly instead of failing with "use of undefined value"
- No more false "may not return a value on all paths" warning for these patterns

## Root cause
The try-catch codegen always emitted a `finally_block` label with a fallback return, even when both try and catch already terminated (returned or threw). The fallback return referenced an undefined SSA variable since no code path reached it.

## Changes
- **control-flow.ts**: Skip emitting the finally label entirely when both try and catch have terminators and there's no finally block
- **semantic-analyzer.ts**: `blockAlwaysReturns` now recognizes try/catch — eliminates false warning

## Test plan
- [x] New fixture: `try-catch-return.ts` (return in both, return+throw)
- [x] All 755 tests pass
- [ ] CI full verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)