### PR TITLE
docs: update landing page benchmarks to ci numbers

### DIFF
--- a/docs/.vitepress/theme/HeroBenchmarks.vue
+++ b/docs/.vitepress/theme/HeroBenchmarks.vue
@@ -2,11 +2,11 @@
 import { ref, onMounted } from 'vue'
 
 const entries = [
-  { name: 'C', val: '1.7ms', pct: 3, hero: false },
-  { name: 'ChadScript', val: '1.9ms', pct: 4, hero: true },
-  { name: 'Go', val: '3.7ms', pct: 7, hero: false },
-  { name: 'Bun', val: '19ms', pct: 35, hero: false },
-  { name: 'Node.js', val: '54ms', pct: 100, hero: false },
+  { name: 'C', val: '0.8ms', pct: 3, hero: false },
+  { name: 'ChadScript', val: '0.8ms', pct: 3, hero: true },
+  { name: 'Go', val: '1.2ms', pct: 5, hero: false },
+  { name: 'Bun', val: '9.6ms', pct: 37, hero: false },
+  { name: 'Node.js', val: '26.2ms', pct: 100, hero: false },
 ]
 
 const visible = ref(false)

--- a/docs/.vitepress/theme/IRShowcase.vue
+++ b/docs/.vitepress/theme/IRShowcase.vue
@@ -59,7 +59,7 @@ async function run() {
   phase.value = 'output'
   execOutput.value = 'Hello from ChadScript!'
   await delay(200)
-  execTime.value = '1.9ms'
+  execTime.value = '0.8ms'
   await delay(400)
   phase.value = 'done'
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 hero:
   name: ChadScript
   text: TypeScript that compiles to native binaries.
-  tagline: "Sub-2ms startup. ~250KB binaries. No runtime. No dependencies."
+  tagline: "Sub-millisecond startup. ~250KB binaries. No runtime. No dependencies."
   actions:
     - theme: brand
       text: Get Started

--- a/docs/why-chadscript.md
+++ b/docs/why-chadscript.md
@@ -5,7 +5,7 @@ ChadScript compiles TypeScript to native binaries. Write TypeScript, run `chad b
 ## Key characteristics
 
 - **TypeScript syntax** — classes, interfaces, generics, async/await, closures, destructuring, JSX. If you write TypeScript, you already know ChadScript.
-- **Native compilation** — compiles to optimized machine code with the same optimization passes used by C and Rust compilers. Sub-2ms startup, ~250KB binaries.
+- **Native compilation** — compiles to optimized machine code with the same optimization passes used by C and Rust compilers. Sub-millisecond startup, ~250KB binaries.
 - **No dependencies** — install with `curl`, not `npm`. Everything is bundled in the compiler.
 - **Batteries included** — HTTP server, SQLite, fetch, crypto, WebSocket, JSON, filesystem — all built in. No packages to install.
 - **Single-binary deploy** — `chad build app.ts -o app` produces one self-contained file. Copy it to a server, drop it in a container, run it.


### PR DESCRIPTION
## Summary
- Update cold start numbers from old local measurements (1.7-54ms) to CI-verified numbers (0.8-26.2ms)
- ChadScript now ties C at 0.8ms cold start, update tagline from "Sub-2ms" to "Sub-millisecond"
- Update IRShowcase demo animation to show 0.8ms

## Test plan
- [ ] Verify docs site renders correctly with new numbers