### PR TITLE
fix benchmark pr comments: update-in-place, sorted, clean formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           RESULTS=$(python3 -c "
           import json
-          d = json.load(open('docs/public/benchmarks.json'))
+          d = json.load(open('docs/public/benchmarks-all.json'))
           lines = ['### Benchmark Results (Linux x86-64)\n', '| Benchmark | C | ChadScript | Go | Node | Bun |', '|---|---|---|---|---|---|']
           def fmt(val_str):
               try:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,14 +80,36 @@ jobs:
           import json
           d = json.load(open('docs/public/benchmarks.json'))
           lines = ['### Benchmark Results (Linux x86-64)\n', '| Benchmark | C | ChadScript | Go | Node | Bun |', '|---|---|---|---|---|---|']
-          for k, b in d['benchmarks'].items():
+          def fmt(val_str):
+              try:
+                  v = float(val_str.rstrip('smsg/req'))
+                  suffix = ''
+                  for s in ['ms', 'msg/s', 'req/s', 's']:
+                      if val_str.endswith(s):
+                          suffix = s
+                          break
+                  if suffix == 'ms':
+                      return f'{v:.1f}{suffix}'
+                  elif '/' in suffix:
+                      return f'{int(v):,}{suffix}'
+                  else:
+                      return f'{v:.3f}{suffix}'
+              except (ValueError, TypeError):
+                  return val_str
+          for k, b in sorted(d['benchmarks'].items(), key=lambda x: x[1]['name']):
               r = b['results']
               def g(lang):
-                  return r.get(lang, {}).get('label', '—')
+                  v = r.get(lang, {}).get('label', '—')
+                  return fmt(v) if v != '—' else v
               lines.append(f\"| {b['name']} | {g('c')} | **{g('chadscript')}** | {g('go')} | {g('node')} | {g('bun')} |\")
           print('\n'.join(lines))
           ")
-          gh pr comment ${{ github.event.pull_request.number }} --body "$RESULTS"
+          EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("### Benchmark"))) | .id] | last')
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/$EXISTING -X PATCH -f body="$RESULTS"
+          else
+            gh pr comment ${{ github.event.pull_request.number }} --body "$RESULTS"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/benchmarks/assemble_json.py
+++ b/benchmarks/assemble_json.py
@@ -25,7 +25,8 @@ META = {
     "stringsearch":  {"name": "String Search", "desc": "Recursive directory search for 'console.log' in src/.", "metric": "s", "lower_is_better": True},
 }
 
-benchmarks = {}
+all_benchmarks = {}
+filtered_benchmarks = {}
 
 for fname in sorted(os.listdir(json_dir)):
     if not fname.endswith(".json"):
@@ -43,8 +44,7 @@ for fname in sorted(os.listdir(json_dir)):
             continue
         lang, value, label = parts[0], parts[1], parts[2]
         try:
-            v = float(value)
-            results[lang] = {"value": round(v, 3), "label": label}
+            results[lang] = {"value": round(float(value), 3), "label": label}
         except ValueError:
             continue
         if lang == "chadscript":
@@ -57,7 +57,7 @@ for fname in sorted(os.listdir(json_dir)):
     meta = META.get(bkey, {"name": bkey, "desc": "", "metric": "s", "lower_is_better": True})
     lower = meta["lower_is_better"]
 
-    benchmarks[bkey] = {
+    entry = {
         "name": meta["name"],
         "desc": meta["desc"],
         "metric": meta["metric"],
@@ -65,13 +65,32 @@ for fname in sorted(os.listdir(json_dir)):
         "results": results,
     }
 
-output = {
-    "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "benchmarks": benchmarks,
-}
+    all_benchmarks[bkey] = entry
+
+    dominated = False
+    for lang, r in results.items():
+        if lang in ("chadscript", "c"):
+            continue
+        if lower and r["value"] < chad_val:
+            dominated = True
+            break
+        if not lower and r["value"] > chad_val:
+            dominated = True
+            break
+
+    if dominated:
+        print(f"  Filtered from docs: {meta['name']} (ChadScript not 1st or 2nd behind C)")
+    else:
+        filtered_benchmarks[bkey] = entry
+
+ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 os.makedirs(os.path.dirname(outfile), exist_ok=True)
 with open(outfile, "w") as f:
-    json.dump(output, f, indent=2)
+    json.dump({"timestamp": ts, "benchmarks": filtered_benchmarks}, f, indent=2)
+print(f"  Wrote {len(filtered_benchmarks)} benchmarks to {outfile} (docs, filtered)")
 
-print(f"  Wrote {len(benchmarks)} benchmarks to {outfile}")
+all_outfile = outfile.replace(".json", "-all.json")
+with open(all_outfile, "w") as f:
+    json.dump({"timestamp": ts, "benchmarks": all_benchmarks}, f, indent=2)
+print(f"  Wrote {len(all_benchmarks)} benchmarks to {all_outfile} (PR comments, unfiltered)")

--- a/benchmarks/assemble_json.py
+++ b/benchmarks/assemble_json.py
@@ -43,7 +43,8 @@ for fname in sorted(os.listdir(json_dir)):
             continue
         lang, value, label = parts[0], parts[1], parts[2]
         try:
-            results[lang] = {"value": float(value), "label": label}
+            v = float(value)
+            results[lang] = {"value": round(v, 3), "label": label}
         except ValueError:
             continue
         if lang == "chadscript":
@@ -55,21 +56,6 @@ for fname in sorted(os.listdir(json_dir)):
 
     meta = META.get(bkey, {"name": bkey, "desc": "", "metric": "s", "lower_is_better": True})
     lower = meta["lower_is_better"]
-
-    dominated = False
-    for lang, r in results.items():
-        if lang in ("chadscript", "c"):
-            continue
-        if lower and r["value"] < chad_val:
-            dominated = True
-            break
-        if not lower and r["value"] > chad_val:
-            dominated = True
-            break
-
-    if dominated:
-        print(f"  Filtered: {meta['name']} (ChadScript not 1st or 2nd behind C)")
-        continue
 
     benchmarks[bkey] = {
         "name": meta["name"],


### PR DESCRIPTION
## Summary
- Benchmark PR comments now **update in place** instead of posting a new comment on every push
- Benchmarks sorted **alphabetically** by name
- Numbers rounded to **3 decimal places** (no more `1.3568037109375s`)
- **All benchmarks shown**, not just ones where ChadScript places 1st/2nd behind C

## Test plan
- [ ] CI posts a single benchmark comment on this PR
- [ ] Subsequent pushes update the same comment instead of adding new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)