### PR TITLE
add fetch(url, options) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -204,7 +204,7 @@ jobs:
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
-          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o release/lib/
           tar -czf chadscript-linux-x64.tar.gz -C release chad lib
 
       - name: Upload artifact
@@ -256,7 +256,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -329,7 +329,7 @@ jobs:
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
-          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o release/lib/
           tar -czf chadscript-macos-arm64.tar.gz -C release chad lib
 
       - name: Upload artifact

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm clang lld cmake make gcc g++ \
             autoconf automake libtool linux-headers-generic git \
-            libzstd-dev zlib1g-dev libsqlite3-dev file
+            libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev file
 
       - name: Install npm dependencies
         run: npm install

--- a/c_bridges/curl-bridge.c
+++ b/c_bridges/curl-bridge.c
@@ -1,0 +1,31 @@
+#include <stdlib.h>
+#include <string.h>
+#include <curl/curl.h>
+
+struct curl_slist* cs_curl_set_headers(CURL *curl, const char *headers_str) {
+    struct curl_slist *slist = NULL;
+    if (!headers_str || headers_str[0] == '\0') return NULL;
+
+    const char *p = headers_str;
+    while (*p) {
+        const char *end = strchr(p, '\n');
+        if (!end) end = p + strlen(p);
+        size_t len = end - p;
+        if (len > 0) {
+            char *line = (char *)malloc(len + 1);
+            memcpy(line, p, len);
+            line[len] = '\0';
+            if (line[len - 1] == '\r') line[len - 1] = '\0';
+            if (line[0] != '\0') {
+                slist = curl_slist_append(slist, line);
+            }
+            free(line);
+        }
+        p = *end ? end + 1 : end;
+    }
+
+    if (slist) {
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
+    }
+    return slist;
+}

--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -221,7 +221,13 @@ interface Response {
   ok: boolean;
 }
 
-declare function fetch(url: string): Promise<Response>;
+interface FetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+declare function fetch(url: string, options?: FetchOptions): Promise<Response>;
 
 interface HttpRequest {
   method: string;

--- a/examples/cli-tools/chttp.ts
+++ b/examples/cli-tools/chttp.ts
@@ -2,10 +2,14 @@ import { ArgumentParser } from "chadscript/argparse";
 
 const parser = new ArgumentParser("chttp", "HTTP client — like curl, but blazing fast");
 parser.addFlag("verbose", "v", "Show response status and info");
+parser.addFlag("head", "I", "Show only response headers");
 parser.addFlag("silent", "s", "Silent mode, no progress or errors");
 parser.addFlag("no-color", "C", "Disable colorized output");
+parser.addOption("method", "X", "HTTP method (GET, POST, PUT, DELETE)", "GET");
+parser.addOption("header", "H", "Add a request header (Key: Value)", "");
+parser.addOption("data", "d", "Request body data", "");
 parser.addOption("output", "o", "Write response body to file", "");
-parser.addPositional("url", "URL to fetch (GET)");
+parser.addPositional("url", "URL to request");
 parser.parse(process.argv);
 
 const url = parser.getPositional(0);
@@ -16,10 +20,19 @@ if (url.length === 0) {
 }
 
 const verbose = parser.getFlag("verbose");
+const headOnly = parser.getFlag("head");
 const silent = parser.getFlag("silent");
 const noColor = parser.getFlag("no-color");
+let method = parser.getOption("method");
+const headerStr = parser.getOption("header");
+const bodyData = parser.getOption("data");
 const outputFile = parser.getOption("output");
 
+if (bodyData.length > 0 && method === "GET") {
+  method = "POST";
+}
+
+const colorCyan = "\x1b[36m";
 const colorGreen = "\x1b[32m";
 const colorYellow = "\x1b[33m";
 const colorMagenta = "\x1b[35m";
@@ -33,18 +46,44 @@ function colorStatus(status: number): string {
   return "\x1b[31m" + status + colorReset;
 }
 
+function printHeader(key: string, val: string): void {
+  if (val.length === 0) return;
+  if (noColor) {
+    console.log(key + ": " + val);
+  } else {
+    console.log(colorCyan + key + colorReset + ": " + val);
+  }
+}
+
 async function run(): Promise<string> {
-  const response = await fetch(url);
+  const options: RequestInit = { method };
+
+  if (bodyData.length > 0) {
+    options.body = bodyData;
+  }
+
+  if (headerStr.length > 0) {
+    const colonIdx = headerStr.indexOf(":");
+    if (colonIdx !== -1) {
+      const hKey = headerStr.substring(0, colonIdx).trim();
+      const hVal = headerStr.substring(colonIdx + 1, headerStr.length).trim();
+      const headers: Record<string, string> = {};
+      headers[hKey] = hVal;
+      options.headers = headers;
+    }
+  }
+
+  const response = await fetch(url, options);
   const status = response.status;
   const body = response.text();
 
-  if (verbose) {
+  if (verbose || headOnly) {
     if (noColor) {
-      console.log("GET " + url + " " + status);
+      console.log(method + " " + url + " " + status);
     } else {
       console.log(
         colorBold +
-          "GET" +
+          method +
           colorReset +
           " " +
           colorMagenta +
@@ -54,7 +93,13 @@ async function run(): Promise<string> {
           colorStatus(status),
       );
     }
-    console.log("Body length: " + body.length + " bytes");
+
+    const contentType = response.headers.get("content-type");
+    printHeader("Content-Type", contentType);
+    const contentLength = response.headers.get("content-length");
+    printHeader("Content-Length", contentLength);
+
+    if (headOnly) return "done";
     console.log("");
   }
 

--- a/scripts/build-target-sdk.sh
+++ b/scripts/build-target-sdk.sh
@@ -69,7 +69,7 @@ fi
 
 # Copy C bridge object files
 echo "  Copying bridge objects..."
-for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o llvm-bridge.o llvm-builder-bridge.o lld-bridge.o; do
+for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o curl-bridge.o llvm-bridge.o llvm-builder-bridge.o lld-bridge.o; do
   if [ -f "$C_BRIDGES_DIR/$bridge" ]; then
     cp "$C_BRIDGES_DIR/$bridge" "$SDK_DIR/bridges/"
   fi

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -232,6 +232,17 @@ else
   echo "==> arena-bridge already built, skipping"
 fi
 
+# --- curl-bridge (libcurl header parsing helper) ---
+CURL_BRIDGE_SRC="$C_BRIDGES_DIR/curl-bridge.c"
+CURL_BRIDGE_OBJ="$C_BRIDGES_DIR/curl-bridge.o"
+if [ ! -f "$CURL_BRIDGE_OBJ" ] || [ "$CURL_BRIDGE_SRC" -nt "$CURL_BRIDGE_OBJ" ]; then
+  echo "==> Building curl-bridge..."
+  cc -c -O2 -fPIC "$CURL_BRIDGE_SRC" -o "$CURL_BRIDGE_OBJ"
+  echo "  -> $CURL_BRIDGE_OBJ"
+else
+  echo "==> curl-bridge already built, skipping"
+fi
+
 # --- base64-bridge ---
 BASE64_BRIDGE_SRC="$C_BRIDGES_DIR/base64-bridge.c"
 BASE64_BRIDGE_OBJ="$C_BRIDGES_DIR/base64-bridge.o"

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -232,13 +232,17 @@ else
   echo "==> arena-bridge already built, skipping"
 fi
 
-# --- curl-bridge (libcurl header parsing helper) ---
+# --- curl-bridge (libcurl header parsing helper, needs curl headers) ---
 CURL_BRIDGE_SRC="$C_BRIDGES_DIR/curl-bridge.c"
 CURL_BRIDGE_OBJ="$C_BRIDGES_DIR/curl-bridge.o"
 if [ ! -f "$CURL_BRIDGE_OBJ" ] || [ "$CURL_BRIDGE_SRC" -nt "$CURL_BRIDGE_OBJ" ]; then
-  echo "==> Building curl-bridge..."
-  cc -c -O2 -fPIC "$CURL_BRIDGE_SRC" -o "$CURL_BRIDGE_OBJ"
-  echo "  -> $CURL_BRIDGE_OBJ"
+  if echo '#include <curl/curl.h>' | cc -xc -fsyntax-only - 2>/dev/null; then
+    echo "==> Building curl-bridge..."
+    cc -c -O2 -fPIC "$CURL_BRIDGE_SRC" -o "$CURL_BRIDGE_OBJ"
+    echo "  -> $CURL_BRIDGE_OBJ"
+  else
+    echo "==> curl-bridge skipped (no curl headers found)"
+  fi
 else
   echo "==> curl-bridge already built, skipping"
 fi

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -199,7 +199,37 @@ export class CallExpressionGenerator {
       this.ctx.setUsesPromises(true);
       this.ctx.setUsesCurl(true);
       this.ctx.setUsesJson(true);
-      const temp = this.ctx.emitCall("%Promise*", "@fetch_async", `i8* ${urlValue}`);
+
+      let methodVal = "null";
+      let headersVal = "null";
+      let bodyVal = "null";
+
+      if (expr.args.length >= 2) {
+        const optArg = expr.args[1] as {
+          type: string;
+          properties?: { key: string; value: unknown }[];
+        };
+        if (optArg.type === "object" && optArg.properties) {
+          for (const prop of optArg.properties) {
+            if (prop.key === "method") {
+              methodVal = this.ctx.generateExpression(prop.value as CallNode, params);
+            } else if (prop.key === "body") {
+              bodyVal = this.ctx.generateExpression(prop.value as CallNode, params);
+            } else if (prop.key === "headers") {
+              headersVal = this.generateFetchHeaders(
+                prop.value as { type: string; properties?: { key: string; value: unknown }[] },
+                params,
+              );
+            }
+          }
+        }
+      }
+
+      const temp = this.ctx.emitCall(
+        "%Promise*",
+        "@fetch_async",
+        `i8* ${urlValue}, i8* ${methodVal}, i8* ${headersVal}, i8* ${bodyVal}`,
+      );
       return temp;
     }
 
@@ -1540,5 +1570,48 @@ export class CallExpressionGenerator {
 
     this.ctx.setVariableType(structRaw, "i8*");
     return structRaw;
+  }
+
+  private generateFetchHeaders(
+    headersObj: { type: string; properties?: { key: string; value: unknown }[] },
+    params: string[],
+  ): string {
+    if (
+      headersObj.type !== "object" ||
+      !headersObj.properties ||
+      headersObj.properties.length === 0
+    ) {
+      return "null";
+    }
+
+    let result = createStringConstant(this.ctx, "");
+    for (const prop of headersObj.properties) {
+      const keyStr = createStringConstant(this.ctx, prop.key + ": ");
+      const valStr = this.ctx.generateExpression(prop.value as CallNode, params);
+      const nlStr = createStringConstant(this.ctx, "\n");
+
+      const keyLen = this.ctx.emitCall("i64", "@strlen", `i8* ${keyStr}`);
+      const valLen = this.ctx.emitCall("i64", "@strlen", `i8* ${valStr}`);
+      const nlLen = this.ctx.emitCall("i64", "@strlen", `i8* ${nlStr}`);
+      const prevLen = this.ctx.emitCall("i64", "@strlen", `i8* ${result}`);
+
+      const totalLen = this.ctx.nextTemp();
+      this.ctx.emit(`${totalLen} = add i64 ${prevLen}, ${keyLen}`);
+      const totalLen2 = this.ctx.nextTemp();
+      this.ctx.emit(`${totalLen2} = add i64 ${totalLen}, ${valLen}`);
+      const totalLen3 = this.ctx.nextTemp();
+      this.ctx.emit(`${totalLen3} = add i64 ${totalLen2}, ${nlLen}`);
+      const allocSize = this.ctx.nextTemp();
+      this.ctx.emit(`${allocSize} = add i64 ${totalLen3}, 1`);
+
+      const buf = this.ctx.emitCall("i8*", "@GC_malloc_atomic", `i64 ${allocSize}`);
+      this.ctx.emitCallVoid("@strcpy", `i8* ${buf}, i8* ${result}`);
+      this.ctx.emitCallVoid("@strcat", `i8* ${buf}, i8* ${keyStr}`);
+      this.ctx.emitCallVoid("@strcat", `i8* ${buf}, i8* ${valStr}`);
+      this.ctx.emitCallVoid("@strcat", `i8* ${buf}, i8* ${nlStr}`);
+      result = buf;
+    }
+    this.ctx.setVariableType(result, "i8*");
+    return result;
   }
 }

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -249,8 +249,12 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
     ir += "@CURLOPT_USERAGENT = constant i32 10018\n";
     ir += "@CURLOPT_HEADERFUNCTION = constant i32 20079\n";
     ir += "@CURLOPT_HEADERDATA = constant i32 10029\n";
+    ir += "@CURLOPT_CUSTOMREQUEST = constant i32 10036\n";
+    ir += "@CURLOPT_POSTFIELDS = constant i32 10015\n";
     ir += "@CURLINFO_EFFECTIVE_URL = constant i32 1048577\n";
     ir += "@CURLINFO_REDIRECT_COUNT = constant i32 2097172\n";
+    ir += "declare i8* @cs_curl_set_headers(i8*, i8*)\n";
+    ir += "declare void @curl_slist_free_all(i8*)\n";
     ir += "\n";
   }
 

--- a/src/codegen/runtime/runtime.ts
+++ b/src/codegen/runtime/runtime.ts
@@ -73,7 +73,7 @@ export class RuntimeGenerator {
     ir += "  ret i64 %total_size\n";
     ir += "}\n\n";
 
-    ir += "define %__FetchResponse* @fetch(i8* %url) {\n";
+    ir += "define %__FetchResponse* @fetch(i8* %url, i8* %method, i8* %headers, i8* %body) {\n";
     ir += "entry:\n";
     ir += "  %curl = call i8* @curl_easy_init()\n";
     ir += "  %curl_null = icmp eq i8* %curl, null\n";
@@ -120,7 +120,38 @@ export class RuntimeGenerator {
     ir += "  %follow_opt = load i32, i32* @CURLOPT_FOLLOWLOCATION\n";
     ir +=
       "  %follow_result = call i32 (i8*, i32, ...) @curl_easy_setopt(i8* %curl, i32 %follow_opt, i64 1)\n";
+
+    ir += "  %has_method = icmp ne i8* %method, null\n";
+    ir += "  br i1 %has_method, label %set_method, label %check_body\n\n";
+    ir += "set_method:\n";
+    ir += "  %method_opt = load i32, i32* @CURLOPT_CUSTOMREQUEST\n";
+    ir += "  call i32 (i8*, i32, ...) @curl_easy_setopt(i8* %curl, i32 %method_opt, i8* %method)\n";
+    ir += "  br label %check_body\n\n";
+
+    ir += "check_body:\n";
+    ir += "  %has_body = icmp ne i8* %body, null\n";
+    ir += "  br i1 %has_body, label %set_body, label %check_headers\n\n";
+    ir += "set_body:\n";
+    ir += "  %body_opt = load i32, i32* @CURLOPT_POSTFIELDS\n";
+    ir += "  call i32 (i8*, i32, ...) @curl_easy_setopt(i8* %curl, i32 %body_opt, i8* %body)\n";
+    ir += "  br label %check_headers\n\n";
+
+    ir += "check_headers:\n";
+    ir += "  %has_req_headers = icmp ne i8* %headers, null\n";
+    ir += "  br i1 %has_req_headers, label %set_headers, label %do_perform\n\n";
+    ir += "set_headers:\n";
+    ir += "  %slist = call i8* @cs_curl_set_headers(i8* %curl, i8* %headers)\n";
+    ir += "  br label %do_perform\n\n";
+
+    ir += "do_perform:\n";
+    ir += "  %slist_phi = phi i8* [null, %check_headers], [%slist, %set_headers]\n";
     ir += "  %perform_result = call i32 @curl_easy_perform(i8* %curl)\n";
+    ir += "  %has_slist = icmp ne i8* %slist_phi, null\n";
+    ir += "  br i1 %has_slist, label %free_slist, label %check_perform\n\n";
+    ir += "free_slist:\n";
+    ir += "  call void @curl_slist_free_all(i8* %slist_phi)\n";
+    ir += "  br label %check_perform\n\n";
+    ir += "check_perform:\n";
     ir += "  %perform_ok = icmp eq i32 %perform_result, 0\n";
     ir += "  br i1 %perform_ok, label %get_status, label %fetch_error\n\n";
 
@@ -223,9 +254,10 @@ export class RuntimeGenerator {
   generateFetchAsyncWrapper(): string {
     let ir = "; fetch_async() - Promise-returning wrapper around sync fetch\n";
     ir += "; This enables await fetch(url) syntax\n";
-    ir += "define %Promise* @fetch_async(i8* %url) {\n";
+    ir += "define %Promise* @fetch_async(i8* %url, i8* %method, i8* %headers, i8* %body) {\n";
     ir += "entry:\n";
-    ir += "  %response = call %__FetchResponse* @fetch(i8* %url)\n";
+    ir +=
+      "  %response = call %__FetchResponse* @fetch(i8* %url, i8* %method, i8* %headers, i8* %body)\n";
     ir += "  %response_i8 = bitcast %__FetchResponse* %response to i8*\n";
     ir += "  %promise = call %Promise* @__Promise_resolve_static(i8* %response_i8)\n";
     ir += "  ret %Promise* %promise\n";

--- a/src/codegen/stdlib/libuv.ts
+++ b/src/codegen/stdlib/libuv.ts
@@ -51,8 +51,8 @@ export class LibuvGenerator {
     ir += "declare i8* @uv_req_get_data(i8*)\n\n";
 
     if (includePromiseTypes) {
-      ir += "; FetchWorkContext: { url: i8*, response: %__FetchResponse*, promise: %Promise* }\n";
-      ir += "%FetchWorkContext = type { i8*, %__FetchResponse*, %Promise* }\n\n";
+      ir += "; FetchWorkContext: { url, method, headers, body, response, promise }\n";
+      ir += "%FetchWorkContext = type { i8*, i8*, i8*, i8*, %__FetchResponse*, %Promise* }\n\n";
     }
 
     return ir;
@@ -184,9 +184,19 @@ export class LibuvGenerator {
     ir +=
       "  %url_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 0\n";
     ir += "  %url = load i8*, i8** %url_ptr\n";
-    ir += "  %response = call %__FetchResponse* @fetch(i8* %url)\n";
     ir +=
-      "  %resp_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 1\n";
+      "  %method_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 1\n";
+    ir += "  %method = load i8*, i8** %method_ptr\n";
+    ir +=
+      "  %headers_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 2\n";
+    ir += "  %hdrs = load i8*, i8** %headers_ptr\n";
+    ir +=
+      "  %body_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 3\n";
+    ir += "  %body = load i8*, i8** %body_ptr\n";
+    ir +=
+      "  %response = call %__FetchResponse* @fetch(i8* %url, i8* %method, i8* %hdrs, i8* %body)\n";
+    ir +=
+      "  %resp_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 4\n";
     ir += "  store %__FetchResponse* %response, %__FetchResponse** %resp_ptr\n";
     ir += "  ret void\n";
     ir += "}\n\n";
@@ -198,10 +208,10 @@ export class LibuvGenerator {
     ir += "  %data = call i8* @uv_req_get_data(i8* %req_i8)\n";
     ir += "  %ctx = bitcast i8* %data to %FetchWorkContext*\n";
     ir +=
-      "  %resp_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 1\n";
+      "  %resp_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 4\n";
     ir += "  %response = load %__FetchResponse*, %__FetchResponse** %resp_ptr\n";
     ir +=
-      "  %promise_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 2\n";
+      "  %promise_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 5\n";
     ir += "  %promise = load %Promise*, %Promise** %promise_ptr\n";
     ir += "  %response_i8 = bitcast %__FetchResponse* %response to i8*\n";
     ir += "  call void @__Promise_resolve(%Promise* %promise, i8* %response_i8)\n";
@@ -212,21 +222,30 @@ export class LibuvGenerator {
   }
 
   generateFetchAsync(): string {
-    let ir = "; fetch_async(url) -> %Promise*\n";
+    let ir = "; fetch_async(url, method, headers, body) -> %Promise*\n";
     ir += "; Queues a fetch on the libuv thread pool, returns a pending promise\n";
-    ir += "define %Promise* @fetch_async(i8* %url) {\n";
+    ir += "define %Promise* @fetch_async(i8* %url, i8* %method, i8* %headers, i8* %body) {\n";
     ir += "entry:\n";
     ir += "  %promise = call %Promise* @__Promise_new()\n";
-    ir += "  %ctx_mem = call i8* @GC_malloc(i64 24)\n";
+    ir += "  %ctx_mem = call i8* @GC_malloc(i64 48)\n";
     ir += "  %ctx = bitcast i8* %ctx_mem to %FetchWorkContext*\n";
     ir +=
       "  %url_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 0\n";
     ir += "  store i8* %url, i8** %url_ptr\n";
     ir +=
-      "  %resp_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 1\n";
+      "  %method_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 1\n";
+    ir += "  store i8* %method, i8** %method_ptr\n";
+    ir +=
+      "  %headers_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 2\n";
+    ir += "  store i8* %headers, i8** %headers_ptr\n";
+    ir +=
+      "  %body_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 3\n";
+    ir += "  store i8* %body, i8** %body_ptr\n";
+    ir +=
+      "  %resp_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 4\n";
     ir += "  store %__FetchResponse* null, %__FetchResponse** %resp_ptr\n";
     ir +=
-      "  %promise_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 2\n";
+      "  %promise_ptr = getelementptr inbounds %FetchWorkContext, %FetchWorkContext* %ctx, i32 0, i32 5\n";
     ir += "  store %Promise* %promise, %Promise** %promise_ptr\n";
     ir += "  %req_mem = call i8* @GC_malloc(i64 128)\n";
     ir += "  %req = bitcast i8* %req_mem to %struct.uv_work_s*\n";

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -453,6 +453,7 @@ export function compile(
   const watchBridgeObj = `${bridgePath}/watch-bridge.o`;
   const arenaBridgeObj = `${bridgePath}/arena-bridge.o`;
   const cpSpawnObj = generator.getUsesSpawn() ? `${bridgePath}/child-process-spawn.o` : "";
+  const curlBridgeObj = generator.usesCurl ? `${bridgePath}/curl-bridge.o` : "";
   let extraObjs = "";
 
   if (generator.getUsesTreeSitter()) {
@@ -616,7 +617,7 @@ export function compile(
   const userObjs = extraLinkObjs.length > 0 ? " " + extraLinkObjs.join(" ") : "";
   const userPaths = extraLinkPaths.map((p) => ` -L${p}`).join("");
   const userLibs = extraLinkLibs.map((l) => ` -l${l}`).join("");
-  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${strlenCacheObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${arenaBridgeObj} ${cpSpawnObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${suppressLdWarnings}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
+  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${strlenCacheObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${arenaBridgeObj} ${cpSpawnObj} ${curlBridgeObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${suppressLdWarnings}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
   logger.info(` ${linkCmd}`);
   const linkStdio = logger.getLevel() >= LogLevel_Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -689,6 +689,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const watchBridgeObj = effectiveBridgePath + "/watch-bridge.o";
   const arenaBridgeObj = effectiveBridgePath + "/arena-bridge.o";
   const cpSpawnObj = generator.getUsesSpawn() ? effectiveBridgePath + "/child-process-spawn.o" : "";
+  const curlBridgeObj = generator.getUsesCurl() ? effectiveBridgePath + "/curl-bridge.o" : "";
   let llvmBridgeObj = "";
   let llvmBuilderObj = "";
   let lldBridgeObj = "";
@@ -745,6 +746,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
     arenaBridgeObj +
     " " +
     cpSpawnObj +
+    " " +
+    curlBridgeObj +
     " " +
     llvmBridgeObj +
     " " +

--- a/tests/fixtures/network/fetch-options.ts
+++ b/tests/fixtures/network/fetch-options.ts
@@ -1,0 +1,31 @@
+// @test-skip
+// Tests fetch() with method, headers, and body options.
+// Requires a running HTTP server to validate — skipped in CI.
+
+async function main() {
+  const resp = await fetch("http://httpbin.org/post", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Custom": "hello",
+    },
+    body: '{"key":"value"}',
+  });
+  console.log(resp.status);
+  console.log(resp.text());
+
+  const putResp = await fetch("http://httpbin.org/put", {
+    method: "PUT",
+    body: "updated data",
+  });
+  console.log(putResp.status);
+
+  const getResp = await fetch("http://httpbin.org/get", {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+  console.log(getResp.status);
+}
+
+main();


### PR DESCRIPTION
## Summary
- `fetch()` now accepts an optional second argument: `{ method, headers, body }`
- Enables POST, PUT, DELETE and custom headers via the existing libcurl backend
- New `c_bridges/curl-bridge.c` handles `\n`-delimited header string → `curl_slist` conversion
- Backward compatible — `fetch(url)` still works as before

## Test plan
- [ ] CI passes (tests + self-hosting)
- [ ] Manual test: `fetch(url, { method: "POST", body: "hello" })` against httpbin
- [ ] Manual test: custom headers propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)