### PR TITLE
implicit sync fetch: bypass promise/libuv for simple await fetch()

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -190,40 +190,63 @@ export class CallExpressionGenerator {
     return null;
   }
 
+  private parseFetchArgs(
+    expr: CallNode,
+    params: string[],
+  ): { urlValue: string; methodVal: string; headersVal: string; bodyVal: string } {
+    const urlValue = this.ctx.generateExpression(expr.args[0], params);
+    let methodVal = "null";
+    let headersVal = "null";
+    let bodyVal = "null";
+
+    if (expr.args.length >= 2) {
+      const optArg = expr.args[1] as {
+        type: string;
+        properties?: { key: string; value: unknown }[];
+      };
+      if (optArg.type === "object" && optArg.properties) {
+        for (const prop of optArg.properties) {
+          if (prop.key === "method") {
+            methodVal = this.ctx.generateExpression(prop.value as CallNode, params);
+          } else if (prop.key === "body") {
+            bodyVal = this.ctx.generateExpression(prop.value as CallNode, params);
+          } else if (prop.key === "headers") {
+            headersVal = this.generateFetchHeaders(
+              prop.value as { type: string; properties?: { key: string; value: unknown }[] },
+              params,
+            );
+          }
+        }
+      }
+    }
+    return { urlValue, methodVal, headersVal, bodyVal };
+  }
+
+  generateSyncFetch(expr: CallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("fetch() requires at least 1 argument (URL)", expr.loc);
+    }
+    const { urlValue, methodVal, headersVal, bodyVal } = this.parseFetchArgs(expr, params);
+    this.ctx.setUsesCurl(true);
+    this.ctx.setUsesJson(true);
+    const respPtr = this.ctx.emitCall(
+      "%__FetchResponse*",
+      "@fetch",
+      `i8* ${urlValue}, i8* ${methodVal}, i8* ${headersVal}, i8* ${bodyVal}`,
+    );
+    const castPtr = this.ctx.emitBitcast(respPtr, "%__FetchResponse*", "i8*");
+    return castPtr;
+  }
+
   private dispatchEncodingCalls(expr: CallNode, params: string[]): string | null {
     if (expr.name === "fetch") {
       if (expr.args.length < 1) {
         return this.ctx.emitError("fetch() requires at least 1 argument (URL)", expr.loc);
       }
-      const urlValue = this.ctx.generateExpression(expr.args[0], params);
+      const { urlValue, methodVal, headersVal, bodyVal } = this.parseFetchArgs(expr, params);
       this.ctx.setUsesPromises(true);
       this.ctx.setUsesCurl(true);
       this.ctx.setUsesJson(true);
-
-      let methodVal = "null";
-      let headersVal = "null";
-      let bodyVal = "null";
-
-      if (expr.args.length >= 2) {
-        const optArg = expr.args[1] as {
-          type: string;
-          properties?: { key: string; value: unknown }[];
-        };
-        if (optArg.type === "object" && optArg.properties) {
-          for (const prop of optArg.properties) {
-            if (prop.key === "method") {
-              methodVal = this.ctx.generateExpression(prop.value as CallNode, params);
-            } else if (prop.key === "body") {
-              bodyVal = this.ctx.generateExpression(prop.value as CallNode, params);
-            } else if (prop.key === "headers") {
-              headersVal = this.generateFetchHeaders(
-                prop.value as { type: string; properties?: { key: string; value: unknown }[] },
-                params,
-              );
-            }
-          }
-        }
-      }
 
       const temp = this.ctx.emitCall(
         "%Promise*",

--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -1,6 +1,7 @@
 import {
   Expression,
   ArrowFunctionNode,
+  CallNode,
   VariableNode,
   AwaitExpressionNode,
   TypeAssertionNode,
@@ -194,6 +195,12 @@ export class ExpressionGenerator {
   }
 
   private generateAwaitExpression(expr: AwaitExpressionNode, params: string[]): string {
+    const arg = expr.argument as { type: string; name?: string };
+    if (arg.type === "call" && arg.name === "fetch") {
+      const syncResult = this.callGen.generateSyncFetch(expr.argument as CallNode, params);
+      this.ctx.setVariableType(syncResult, "i8*");
+      return syncResult;
+    }
     const promiseReg = this.generate(expr.argument, params);
     const valueReg = this.ctx.nextTemp();
     this.ctx.emit(`${valueReg} = call i8* @__Promise_await(%Promise* ${promiseReg})`);

--- a/tests/fixtures/network/fetch-sync-options.ts
+++ b/tests/fixtures/network/fetch-sync-options.ts
@@ -1,0 +1,19 @@
+// @test-skip
+// @test-description: sync fetch with options - method, headers, body
+
+async function main(): Promise<string> {
+  const response = await fetch("http://httpbin.org/post", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: '{"key":"value"}',
+  });
+  console.log("status: " + response.status.toString());
+  if (response.ok) {
+    console.log("TEST_PASSED");
+  }
+  return "done";
+}
+
+main();

--- a/tests/fixtures/network/fetch-sync.ts
+++ b/tests/fixtures/network/fetch-sync.ts
@@ -1,0 +1,13 @@
+// @test-skip
+// @test-description: sync fetch optimization - await fetch() bypasses promise/libuv
+
+async function main(): Promise<string> {
+  const response = await fetch("http://httpbin.org/get");
+  console.log("status: " + response.status.toString());
+  if (response.ok) {
+    console.log("TEST_PASSED");
+  }
+  return "done";
+}
+
+main();


### PR DESCRIPTION
## Summary
- `await fetch(url)` now calls the sync `@fetch` runtime directly instead of going through `@fetch_async` → Promise → libuv thread pool → event loop spin → resolve
- Eliminates ~300 bytes of per-call overhead (Promise alloc, FetchWorkContext, uv_work_s) and the entire libuv event loop spin for single-fetch programs
- Programs that don't use Promise.all/race or multiple awaits no longer link libuv at all
- Concurrent fetch patterns (Promise.all, etc.) still use the async path unchanged

## How it works
- `orchestrator.ts` detects `await fetch(...)` pattern and calls `CallExpressionGenerator.generateSyncFetch()` directly
- Sync path calls `@fetch()` (existing runtime) → bitcasts `%__FetchResponse*` to `i8*` — same result type, no wrapper needed
- Skips `setUsesPromises(true)` so libuv/promise runtime isn't linked when not needed
- Bare `fetch()` without `await` still uses the async path for backwards compat

## Test plan
- [x] `npm run verify:quick` passes (tests + Stage 1 self-hosting)
- [ ] CI green
- [ ] Manual test: compile a simple `await fetch()` program, verify no libuv linking

🤖 Generated with [Claude Code](https://claude.com/claude-code)