### PR TITLE
const literals as llvm constants + noalias on pointer params

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -295,7 +295,8 @@ export class FunctionGenerator {
     }
     for (let i = 0; i < funcParams.length; i++) {
       const llvmType = paramLLVMTypes[i] || "double";
-      paramStrings.push(`${llvmType} %arg${i}`);
+      const noalias = llvmType.indexOf("*") !== -1 ? " noalias" : "";
+      paramStrings.push(`${llvmType}${noalias} %arg${i}`);
     }
     ir += paramStrings.join(", ");
     // noinline optnone for try functions (protects setjmp); no nounwind for others

--- a/src/codegen/infrastructure/symbol-table.ts
+++ b/src/codegen/infrastructure/symbol-table.ts
@@ -451,6 +451,7 @@ export class SymbolTable {
   private savedBoundaries: number[];
   private savedBoundariesCount: number = 0;
   private typeContext: TypeContext | null;
+  private llvmConstants: string[] = [];
 
   constructor(typeContext?: TypeContext) {
     this.symbols = new Map();
@@ -1568,5 +1569,16 @@ export class SymbolTable {
       }
     }
     return output;
+  }
+
+  markLLVMConstant(name: string): void {
+    this.llvmConstants.push(name);
+  }
+
+  isLLVMConstant(name: string): boolean {
+    for (let i = 0; i < this.llvmConstants.length; i++) {
+      if (this.llvmConstants[i] === name) return true;
+    }
+    return false;
   }
 }

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -502,6 +502,9 @@ export class VariableAllocator {
 
   allocate(stmt: VariableDeclaration, params: string[]): void {
     const existingScope = this.ctx.symbolTable.getScope(stmt.name);
+    if (existingScope === "global" && this.ctx.symbolTable.isLLVMConstant(stmt.name)) {
+      return;
+    }
     if (existingScope === "global" && stmt.value !== null && !this.isNullishValue(stmt.value)) {
       // For global Uint8Array vars, set wantsBinaryReturn so readFileSync etc.
       // dispatch to their binary variants (same as allocateUint8Array does for locals)

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2089,6 +2089,36 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     return null;
   }
 
+  private tryGetConstLiteralValue(
+    stmt: { kind: string; value: Expression | null; name: string },
+    llvmType: string,
+    i64Eligible: string[],
+  ): { llvmType: string; value: string } | null {
+    if (stmt.kind !== "const" || stmt.value === null) return null;
+    const val = stmt.value as { type: string; value?: number | string | boolean };
+    if (val.type === "number" && typeof val.value === "number") {
+      let isI64 = false;
+      for (let ei = 0; ei < i64Eligible.length; ei++) {
+        if (i64Eligible[ei] === stmt.name) {
+          isI64 = true;
+          break;
+        }
+      }
+      if (isI64 && val.value % 1 === 0) {
+        return { llvmType: "i64", value: String(Math.trunc(val.value)) };
+      }
+      const s = String(val.value);
+      if (s.indexOf(".") === -1 && s.indexOf("e") === -1 && s.indexOf("E") === -1) {
+        return { llvmType: "double", value: s + ".0" };
+      }
+      return { llvmType: "double", value: s };
+    }
+    if (val.type === "boolean") {
+      return { llvmType: "double", value: val.value === true ? "0x3FF0000000000000" : "0.0" };
+    }
+    return null;
+  }
+
   private generateGlobalVariableDeclarations(): string {
     let ir = "";
     const totalCount = this.topLevelStatementsCount;
@@ -2651,9 +2681,21 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
         }
 
-        ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
-        this.globalVariables.set(name, { llvmType, kind, initialized: false });
-        this.defineVariable(name, `@${name}`, llvmType, kind, "global");
+        const constLiteral = this.tryGetConstLiteralValue(stmt, llvmType, i64Eligible);
+        if (constLiteral !== null) {
+          ir += `@${name} = constant ${constLiteral.llvmType} ${constLiteral.value}` + "\n";
+          this.globalVariables.set(name, {
+            llvmType: constLiteral.llvmType,
+            kind,
+            initialized: false,
+          });
+          this.defineVariable(name, `@${name}`, constLiteral.llvmType, kind, "global");
+          this.symbolTable.markLLVMConstant(name);
+        } else {
+          ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";
+          this.globalVariables.set(name, { llvmType, kind, initialized: false });
+          this.defineVariable(name, `@${name}`, llvmType, kind, "global");
+        }
         if (stmt.declaredType) {
           this.symbolTable.setResolvedType(name, parseTypeString(stmt.declaredType));
         } else if (stmt.value) {

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -903,7 +903,8 @@ export class ClassGenerator {
       paramParts.push("i32 %__argc");
     }
     for (let pidx = 0; pidx < paramLLVMTypes.length; pidx++) {
-      paramParts.push(paramLLVMTypes[pidx] + " %arg" + pidx);
+      const noalias = paramLLVMTypes[pidx].indexOf("*") !== -1 ? " noalias" : "";
+      paramParts.push(paramLLVMTypes[pidx] + noalias + " %arg" + pidx);
     }
     if (paramParts.length > 0) {
       ir += ", " + paramParts.join(", ");
@@ -1052,7 +1053,8 @@ export class ClassGenerator {
     if (method.params.length > 0) {
       const paramParts: string[] = [];
       for (let pidx = 0; pidx < paramLLVMTypes.length; pidx++) {
-        paramParts.push(paramLLVMTypes[pidx] + " %arg" + pidx);
+        const noalias = paramLLVMTypes[pidx].indexOf("*") !== -1 ? " noalias" : "";
+        paramParts.push(paramLLVMTypes[pidx] + noalias + " %arg" + pidx);
       }
       ir += paramParts.join(", ");
     }


### PR DESCRIPTION
## Summary
- **Global `const` with literal number/boolean values** now emit as LLVM `constant` instead of `global` with runtime initialization. LLVM can inline these values, convert `fcmp` → `icmp` for integer constants, and eliminate redundant loads.
- **`noalias` on pointer-typed function parameters** (`%ObjectArray*`, `%Array*`, `%StringArray*`, `i8*`, etc.) lets LLVM hoist data pointer loads out of loops and avoid redundant re-loads after stores.

Both optimizations target the N-Body benchmark hot path where `advance()` is called 25M times with field reads/writes through ObjectArray indirection, but benefit all ChadScript programs.

## Test plan
- [x] All 756 tests pass
- [x] `npm run verify:quick` passes (Stage 0 + Stage 1 self-hosting)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)