### PR TITLE
contiguous struct arrays for all-numeric interfaces

### DIFF
--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -267,82 +267,98 @@ export class IndexAccessGenerator {
     return elem;
   }
 
+  private getContiguousStride(expr: IndexAccessNode): number {
+    const objExpr = expr.object as { type: string };
+    if (objExpr.type === "variable") {
+      const varName = (expr.object as VariableNode).name;
+      const numFields = this.ctx.symbolTable.getContiguousFieldCount(varName);
+      if (numFields > 0) return numFields * 8;
+    }
+    return 0;
+  }
+
+  private emitContiguousElementPtr(
+    arrayPtr: string,
+    arrayTypeStr: string,
+    index: string,
+    stride: number,
+  ): string {
+    const dataPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${dataPtr} = getelementptr inbounds ${arrayTypeStr}, ${arrayTypeStr}* ${arrayPtr}, i32 0, i32 0`,
+    );
+    const data = this.ctx.nextTemp();
+    this.ctx.emit(`${data} = load i8*, i8** ${dataPtr}`);
+    const indexI64 = this.ctx.nextTemp();
+    this.ctx.emit(`${indexI64} = sext i32 ${index} to i64`);
+    const offset = this.ctx.nextTemp();
+    this.ctx.emit(`${offset} = mul i64 ${indexI64}, ${stride}`);
+    const elem = this.ctx.nextTemp();
+    this.ctx.emit(`${elem} = getelementptr inbounds i8, i8* ${data}, i64 ${offset}`);
+    this.ctx.setVariableType(elem, "i8*");
+    return elem;
+  }
+
+  private emitPointerArrayElementPtr(dataRaw: string, index: string): string {
+    const dataAsPtrs = this.ctx.nextTemp();
+    this.ctx.emit(`${dataAsPtrs} = bitcast i8* ${dataRaw} to i8**`);
+    const elemPtr = this.ctx.nextTemp();
+    this.ctx.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`);
+    const elem = this.ctx.nextTemp();
+    this.ctx.emit(`${elem} = load i8*, i8** ${elemPtr}`);
+    this.ctx.setVariableType(elem, "i8*");
+    return elem;
+  }
+
   private generateObjectArrayIndex(expr: IndexAccessNode, params: string[]): string {
     const arrayPtr = this.ctx.generateExpression(expr.object, params);
     const indexDouble = this.ctx.generateExpression(expr.index, params);
 
     const index = this.toI32Index(indexDouble);
+    const contiguousStride = this.getContiguousStride(expr);
 
     const arrayType = this.ctx.getVariableType(arrayPtr);
     if (arrayType === "%ObjectArray*") {
       this.emitBoundsCheck(arrayPtr, "%ObjectArray", index);
-
+      if (contiguousStride > 0) {
+        return this.emitContiguousElementPtr(arrayPtr, "%ObjectArray", index, contiguousStride);
+      }
       const dataPtr = this.ctx.nextTemp();
       this.ctx.emit(
         `${dataPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
       );
-
       const data = this.ctx.nextTemp();
       this.ctx.emit(`${data} = load i8*, i8** ${dataPtr}`);
-
-      const dataAsPtrs = this.ctx.nextTemp();
-      this.ctx.emit(`${dataAsPtrs} = bitcast i8* ${data} to i8**`);
-
-      const elemPtr = this.ctx.nextTemp();
-      this.ctx.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`);
-
-      const elem = this.ctx.nextTemp();
-      this.ctx.emit(`${elem} = load i8*, i8** ${elemPtr}`);
-      this.ctx.setVariableType(elem, "i8*");
-      return elem;
+      return this.emitPointerArrayElementPtr(data, index);
     }
 
     if (arrayType === "i8*") {
       const arrayCast = this.ctx.nextTemp();
       this.ctx.emit(`${arrayCast} = bitcast i8* ${arrayPtr} to %ObjectArray*`);
-
       this.emitBoundsCheck(arrayCast, "%ObjectArray", index);
-
+      if (contiguousStride > 0) {
+        return this.emitContiguousElementPtr(arrayCast, "%ObjectArray", index, contiguousStride);
+      }
       const dataPtr = this.ctx.nextTemp();
       this.ctx.emit(
         `${dataPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayCast}, i32 0, i32 0`,
       );
-
       const data = this.ctx.nextTemp();
       this.ctx.emit(`${data} = load i8*, i8** ${dataPtr}`);
-
-      const dataAsPtrs = this.ctx.nextTemp();
-      this.ctx.emit(`${dataAsPtrs} = bitcast i8* ${data} to i8**`);
-
-      const elemPtr = this.ctx.nextTemp();
-      this.ctx.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`);
-
-      const elem = this.ctx.nextTemp();
-      this.ctx.emit(`${elem} = load i8*, i8** ${elemPtr}`);
-      this.ctx.setVariableType(elem, "i8*");
-      return elem;
+      return this.emitPointerArrayElementPtr(data, index);
     }
 
     this.emitBoundsCheck(arrayPtr, "%ObjectArray", index);
-
+    if (contiguousStride > 0) {
+      return this.emitContiguousElementPtr(arrayPtr, "%ObjectArray", index, contiguousStride);
+    }
     const dataPtr = this.ctx.nextTemp();
     this.ctx.emit(
       `${dataPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
     );
-
     const data = this.ctx.nextTemp();
     this.ctx.emit(`${data} = load i8*, i8** ${dataPtr}`);
-
-    const dataAsPtrs = this.ctx.nextTemp();
-    this.ctx.emit(`${dataAsPtrs} = bitcast i8* ${data} to i8**`);
-
-    const elemPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`);
-
-    const elem = this.ctx.nextTemp();
-    this.ctx.emit(`${elem} = load i8*, i8** ${elemPtr}`);
-    this.ctx.setVariableType(elem, "i8*");
-    return elem;
+    return this.emitPointerArrayElementPtr(data, index);
   }
 
   private generateUint8ArrayIndex(expr: IndexAccessNode, params: string[]): string {

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -1795,6 +1795,14 @@ export class MemberAccessGenerator {
     const structTypeFields = elementInfo.types.join(", ");
     const structType = `{ ${structTypeFields} }`;
 
+    let contiguousStride = 0;
+    const idxObj = indexAccess.object as { type: string };
+    if (idxObj.type === "variable") {
+      const arrVarName = (indexAccess.object as VariableNode).name;
+      const numFields = this.ctx.symbolTable.getContiguousFieldCount(arrVarName);
+      if (numFields > 0) contiguousStride = numFields * 8;
+    }
+
     const dataPtr = this.ctx.nextTemp();
     this.ctx.emit(
       `${dataPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
@@ -1803,15 +1811,25 @@ export class MemberAccessGenerator {
     const data = this.ctx.nextTemp();
     this.ctx.emit(`${data} = load i8*, i8** ${dataPtr}`);
 
-    const dataAsPtrs = this.ctx.emitBitcast(data, "i8*", "i8**");
-
-    const elemPtrPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${elemPtrPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`);
-
-    const elemPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${elemPtr} = load i8*, i8** ${elemPtrPtr}`);
-
-    const elemTyped = this.ctx.emitBitcast(elemPtr, "i8*", `${structType}*`);
+    let elemTyped: string;
+    if (contiguousStride > 0) {
+      const indexI64 = this.ctx.nextTemp();
+      this.ctx.emit(`${indexI64} = sext i32 ${index} to i64`);
+      const offset = this.ctx.nextTemp();
+      this.ctx.emit(`${offset} = mul i64 ${indexI64}, ${contiguousStride}`);
+      const elemRaw = this.ctx.nextTemp();
+      this.ctx.emit(`${elemRaw} = getelementptr inbounds i8, i8* ${data}, i64 ${offset}`);
+      elemTyped = this.ctx.emitBitcast(elemRaw, "i8*", `${structType}*`);
+    } else {
+      const dataAsPtrs = this.ctx.emitBitcast(data, "i8*", "i8**");
+      const elemPtrPtr = this.ctx.nextTemp();
+      this.ctx.emit(
+        `${elemPtrPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`,
+      );
+      const elemPtr = this.ctx.nextTemp();
+      this.ctx.emit(`${elemPtr} = load i8*, i8** ${elemPtrPtr}`);
+      elemTyped = this.ctx.emitBitcast(elemPtr, "i8*", `${structType}*`);
+    }
 
     const propType = elementInfo.types[propIndex];
     const propTsType = elementInfo.tsTypes[propIndex];

--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -1823,9 +1823,7 @@ export class MemberAccessGenerator {
     } else {
       const dataAsPtrs = this.ctx.emitBitcast(data, "i8*", "i8**");
       const elemPtrPtr = this.ctx.nextTemp();
-      this.ctx.emit(
-        `${elemPtrPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`,
-      );
+      this.ctx.emit(`${elemPtrPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`);
       const elemPtr = this.ctx.nextTemp();
       this.ctx.emit(`${elemPtr} = load i8*, i8** ${elemPtrPtr}`);
       elemTyped = this.ctx.emitBitcast(elemPtr, "i8*", `${structType}*`);

--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -170,8 +170,21 @@ export class ArrayAllocator {
           elementTypes: typeInfo.types,
           elementTsTypes: typeInfo.tsTypes,
         });
+        let isAllDouble = typeInfo.types.length > 0;
+        for (let ti = 0; ti < typeInfo.types.length; ti++) {
+          if (typeInfo.types[ti] !== "double") {
+            isAllDouble = false;
+            break;
+          }
+        }
+        if (isAllDouble) {
+          const stride = typeInfo.types.length * 8;
+          this.ctx.symbolTable.markContiguousObjectArray(stmt.name, typeInfo.types.length);
+          this.ctx.symbolTable.setPendingContiguousStride(stride);
+        }
         this.ctx.emit(`${allocaReg} = alloca %ObjectArray*`);
         const value = this.ctx.generateExpression(stmt.value!, params);
+        this.ctx.symbolTable.setPendingContiguousStride(0);
         this.ctx.emit(`store %ObjectArray* ${value}, %ObjectArray** ${allocaReg}`);
         return;
       }

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -608,9 +608,7 @@ export class AssignmentGenerator {
     } else {
       const dataAsPtrs = this.ctx.emitBitcast(data, "i8*", "i8**");
       const elemPtrPtr = this.ctx.nextTemp();
-      this.ctx.emit(
-        `${elemPtrPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`,
-      );
+      this.ctx.emit(`${elemPtrPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`);
       const elemPtr = this.ctx.nextTemp();
       this.ctx.emit(`${elemPtr} = load i8*, i8** ${elemPtrPtr}`);
       elemTyped = this.ctx.emitBitcast(elemPtr, "i8*", `${structType}*`);

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -580,6 +580,14 @@ export class AssignmentGenerator {
     const structTypeFields = elementInfo.types.join(", ");
     const structType = `{ ${structTypeFields} }`;
 
+    let contiguousStride = 0;
+    const idxObj = indexAccess.object as { type: string };
+    if (idxObj.type === "variable") {
+      const arrVarName = (indexAccess.object as VariableNode).name;
+      const numFields = this.ctx.symbolTable.getContiguousFieldCount(arrVarName);
+      if (numFields > 0) contiguousStride = numFields * 8;
+    }
+
     const dataPtr = this.ctx.nextTemp();
     this.ctx.emit(
       `${dataPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
@@ -588,15 +596,25 @@ export class AssignmentGenerator {
     const data = this.ctx.nextTemp();
     this.ctx.emit(`${data} = load i8*, i8** ${dataPtr}`);
 
-    const dataAsPtrs = this.ctx.emitBitcast(data, "i8*", "i8**");
-
-    const elemPtrPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${elemPtrPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`);
-
-    const elemPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${elemPtr} = load i8*, i8** ${elemPtrPtr}`);
-
-    const elemTyped = this.ctx.emitBitcast(elemPtr, "i8*", `${structType}*`);
+    let elemTyped: string;
+    if (contiguousStride > 0) {
+      const indexI64 = this.ctx.nextTemp();
+      this.ctx.emit(`${indexI64} = sext i32 ${index} to i64`);
+      const offset = this.ctx.nextTemp();
+      this.ctx.emit(`${offset} = mul i64 ${indexI64}, ${contiguousStride}`);
+      const elemRaw = this.ctx.nextTemp();
+      this.ctx.emit(`${elemRaw} = getelementptr inbounds i8, i8* ${data}, i64 ${offset}`);
+      elemTyped = this.ctx.emitBitcast(elemRaw, "i8*", `${structType}*`);
+    } else {
+      const dataAsPtrs = this.ctx.emitBitcast(data, "i8*", "i8**");
+      const elemPtrPtr = this.ctx.nextTemp();
+      this.ctx.emit(
+        `${elemPtrPtr} = getelementptr inbounds i8*, i8** ${dataAsPtrs}, i32 ${index}`,
+      );
+      const elemPtr = this.ctx.nextTemp();
+      this.ctx.emit(`${elemPtr} = load i8*, i8** ${elemPtrPtr}`);
+      elemTyped = this.ctx.emitBitcast(elemPtr, "i8*", `${structType}*`);
+    }
 
     const propType = elementInfo.types[propIndex];
     const fieldPtr = this.ctx.nextTemp();

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -116,6 +116,7 @@ export interface FunctionGeneratorContext {
   setRawInterfaceType(name: string, type: string): void;
   getUsesMathRandom(): boolean;
   getAllInterfaceFields(iface: InterfaceDeclaration): InterfaceField[];
+  markContiguousObjectArray(name: string, numFields: number): void;
 }
 
 export class FunctionGenerator {
@@ -498,6 +499,26 @@ export class FunctionGenerator {
             "local",
             createInterfacePointerAllocaMetadata(elementType),
           );
+          this.ctx.setRawInterfaceType(paramName, elementType);
+          const ctxAst = this.ctx.getAst();
+          const paramInterfaces = ctxAst ? ctxAst.interfaces || [] : [];
+          for (let pi = 0; pi < paramInterfaces.length; pi++) {
+            const iface = paramInterfaces[pi] as InterfaceDeclaration;
+            if (!iface || iface.name !== elementType) continue;
+            const ifaceFields = this.ctx.getAllInterfaceFields(iface);
+            let allDouble = ifaceFields.length > 0;
+            for (let fi = 0; fi < ifaceFields.length; fi++) {
+              const ft = (ifaceFields[fi] as { type: string }).type || "";
+              if (ft !== "number" && ft !== "boolean") {
+                allDouble = false;
+                break;
+              }
+            }
+            if (allDouble) {
+              this.ctx.markContiguousObjectArray(paramName, ifaceFields.length);
+            }
+            break;
+          }
         } else {
           this.ctx.defineVariableWithMetadata(
             paramName,

--- a/src/codegen/infrastructure/symbol-table.ts
+++ b/src/codegen/infrastructure/symbol-table.ts
@@ -452,6 +452,8 @@ export class SymbolTable {
   private savedBoundariesCount: number = 0;
   private typeContext: TypeContext | null;
   private llvmConstants: string[] = [];
+  private contiguousArrayNames: string[] = [];
+  private contiguousArrayFieldCounts: number[] = [];
 
   constructor(typeContext?: TypeContext) {
     this.symbols = new Map();
@@ -1580,5 +1582,27 @@ export class SymbolTable {
       if (this.llvmConstants[i] === name) return true;
     }
     return false;
+  }
+
+  private pendingContiguousStride: number = 0;
+
+  setPendingContiguousStride(stride: number): void {
+    this.pendingContiguousStride = stride;
+  }
+
+  getPendingContiguousStride(): number {
+    return this.pendingContiguousStride;
+  }
+
+  markContiguousObjectArray(name: string, numFields: number): void {
+    this.contiguousArrayNames.push(name);
+    this.contiguousArrayFieldCounts.push(numFields);
+  }
+
+  getContiguousFieldCount(name: string): number {
+    for (let i = 0; i < this.contiguousArrayNames.length; i++) {
+      if (this.contiguousArrayNames[i] === name) return this.contiguousArrayFieldCounts[i];
+    }
+    return 0;
   }
 }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -854,6 +854,13 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public getCurrentDeclaredSetType(): string | undefined {
     return this.currentDeclaredSetType;
   }
+  public contiguousObjectArrayStride: number = 0;
+  public setContiguousObjectArrayStride(stride: number): void {
+    this.contiguousObjectArrayStride = stride;
+  }
+  public getContiguousObjectArrayStride(): number {
+    return this.contiguousObjectArrayStride;
+  }
   public setUsesPromises(value: boolean): void {
     this.usesPromises = value ? 1 : 0;
   }
@@ -904,6 +911,10 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
   public setRawInterfaceType(name: string, type: string): void {
     this.symbolTable.setRawInterfaceType(name, type);
+  }
+
+  public markContiguousObjectArray(name: string, numFields: number): void {
+    this.symbolTable.markContiguousObjectArray(name, numFields);
   }
 
   public getTargetArch(): string {

--- a/src/codegen/types/collections/array/literal.ts
+++ b/src/codegen/types/collections/array/literal.ts
@@ -163,11 +163,7 @@ export function generateArrayLiteral(
           i === 0 && firstElemValue
             ? firstElemValue
             : gen.generateExpression(arrExpr.elements[i], params);
-        const elemCast = gen.emitBitcast(
-          elemValue,
-          gen.getVariableType(elemValue) || "i8*",
-          "i8*",
-        );
+        const elemCast = gen.emitBitcast(elemValue, gen.getVariableType(elemValue) || "i8*", "i8*");
         const offset = gen.nextTemp();
         gen.emit(`${offset} = mul i64 ${i}, ${contiguousStride}`);
         const dest = gen.nextTemp();
@@ -193,11 +189,7 @@ export function generateArrayLiteral(
           i === 0 && firstElemValue
             ? firstElemValue
             : gen.generateExpression(arrExpr.elements[i], params);
-        const elemCast = gen.emitBitcast(
-          elemValue,
-          gen.getVariableType(elemValue) || "i8*",
-          "i8*",
-        );
+        const elemCast = gen.emitBitcast(elemValue, gen.getVariableType(elemValue) || "i8*", "i8*");
         const elemPtr = gen.nextTemp();
         gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${i}`);
         gen.emitStore("i8*", elemCast, elemPtr);

--- a/src/codegen/types/collections/array/literal.ts
+++ b/src/codegen/types/collections/array/literal.ts
@@ -143,7 +143,8 @@ export function generateArrayLiteral(
     gen.setVariableType(arrayPtr, "%StringArray*");
     return arrayPtr;
   } else if (isPointerArray) {
-    // Generate pointer/object array - uses %ObjectArray with i8* data
+    const contiguousStride = gen.symbolTable.getPendingContiguousStride();
+
     const sizePtr = gen.nextTemp();
     gen.emit(`${sizePtr} = getelementptr %ObjectArray, %ObjectArray* null, i32 1`);
     const structSize = gen.nextTemp();
@@ -151,41 +152,71 @@ export function generateArrayLiteral(
     const arrayMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${structSize}`);
     const arrayPtr = gen.emitBitcast(arrayMem, "i8*", "%ObjectArray*");
 
-    // Allocate data array on heap (i8* cast to i8** for pointer storage)
     const dataCount = length === 0 ? 1 : length;
-    const dataSize = gen.nextTemp();
-    gen.emit(`${dataSize} = mul i64 ${dataCount}, 8`);
-    const dataMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
-    const dataPtr = gen.emitBitcast(dataMem, "i8*", "i8**");
+    if (contiguousStride > 0) {
+      const dataSize = gen.nextTemp();
+      gen.emit(`${dataSize} = mul i64 ${dataCount}, ${contiguousStride}`);
+      const dataMem = gen.emitCall("i8*", "@GC_malloc_atomic", `i64 ${dataSize}`);
 
-    // Store each pointer element
-    for (let i = 0; i < arrExpr.elements.length; i++) {
-      const elemValue =
-        i === 0 && firstElemValue
-          ? firstElemValue
-          : gen.generateExpression(arrExpr.elements[i], params);
-      const elemCast = gen.emitBitcast(elemValue, gen.getVariableType(elemValue) || "i8*", "i8*");
-      const elemPtr = gen.nextTemp();
-      gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${i}`);
-      gen.emitStore("i8*", elemCast, elemPtr);
+      for (let i = 0; i < arrExpr.elements.length; i++) {
+        const elemValue =
+          i === 0 && firstElemValue
+            ? firstElemValue
+            : gen.generateExpression(arrExpr.elements[i], params);
+        const elemCast = gen.emitBitcast(
+          elemValue,
+          gen.getVariableType(elemValue) || "i8*",
+          "i8*",
+        );
+        const offset = gen.nextTemp();
+        gen.emit(`${offset} = mul i64 ${i}, ${contiguousStride}`);
+        const dest = gen.nextTemp();
+        gen.emit(`${dest} = getelementptr inbounds i8, i8* ${dataMem}, i64 ${offset}`);
+        gen.emit(
+          `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${dest}, i8* ${elemCast}, i64 ${contiguousStride}, i1 false)`,
+        );
+      }
+
+      const dataPtrField = gen.nextTemp();
+      gen.emit(
+        `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+      );
+      gen.emitStore("i8*", dataMem, dataPtrField);
+    } else {
+      const dataSize = gen.nextTemp();
+      gen.emit(`${dataSize} = mul i64 ${dataCount}, 8`);
+      const dataMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${dataSize}`);
+      const dataPtr = gen.emitBitcast(dataMem, "i8*", "i8**");
+
+      for (let i = 0; i < arrExpr.elements.length; i++) {
+        const elemValue =
+          i === 0 && firstElemValue
+            ? firstElemValue
+            : gen.generateExpression(arrExpr.elements[i], params);
+        const elemCast = gen.emitBitcast(
+          elemValue,
+          gen.getVariableType(elemValue) || "i8*",
+          "i8*",
+        );
+        const elemPtr = gen.nextTemp();
+        gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${i}`);
+        gen.emitStore("i8*", elemCast, elemPtr);
+      }
+
+      const dataPtrField = gen.nextTemp();
+      gen.emit(
+        `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
+      );
+      const dataPtrCast = gen.emitBitcast(dataPtr, "i8**", "i8*");
+      gen.emitStore("i8*", dataPtrCast, dataPtrField);
     }
 
-    // Store data pointer in array struct (field 0) - cast i8** to i8*
-    const dataPtrField = gen.nextTemp();
-    gen.emit(
-      `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
-    );
-    const dataPtrCast = gen.emitBitcast(dataPtr, "i8**", "i8*");
-    gen.emitStore("i8*", dataPtrCast, dataPtrField);
-
-    // Store length in array struct (field 1)
     const lenField = gen.nextTemp();
     gen.emit(
       `${lenField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
     );
     gen.emitStore("i32", `${length}`, lenField);
 
-    // Store capacity in array struct (field 2)
     const capField = gen.nextTemp();
     gen.emit(
       `${capField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 2`,

--- a/src/codegen/types/collections/array/mutators.ts
+++ b/src/codegen/types/collections/array/mutators.ts
@@ -48,7 +48,13 @@ export function generateArrayPush(
 
   if (isObjectArray) {
     const valueType = gen.getVariableType(value) || "i8*";
-    return generateObjectArrayPush(gen, arrayPtr, value, valueType);
+    let stride = 0;
+    if (exprObjBase.type === "variable") {
+      const varName = (expr.object as VariableNode).name;
+      const numFields = gen.symbolTable.getContiguousFieldCount(varName);
+      if (numFields > 0) stride = numFields * 8;
+    }
+    return generateObjectArrayPush(gen, arrayPtr, value, valueType, stride);
   }
 
   const valueType = gen.getVariableType(value);
@@ -56,7 +62,7 @@ export function generateArrayPush(
     return generateStringArrayPush(gen, arrayPtr, value);
   }
   if (valueType && valueType.endsWith("*") && valueType !== "double*") {
-    return generateObjectArrayPush(gen, arrayPtr, value, valueType);
+    return generateObjectArrayPush(gen, arrayPtr, value, valueType, 0);
   }
 
   return generateIntArrayPush(gen, arrayPtr, value);
@@ -592,7 +598,11 @@ function generateObjectArrayPush(
   arrayPtr: string,
   value: string,
   valueType: string,
+  contiguousStride: number,
 ): string {
+  const elemSize = contiguousStride > 0 ? contiguousStride : 8;
+  const allocFn = contiguousStride > 0 ? "@GC_malloc_atomic" : "@GC_malloc";
+
   const lenPtr = gen.nextTemp();
   gen.emit(
     `${lenPtr} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 1`,
@@ -624,30 +634,24 @@ function generateObjectArrayPush(
   const newCapI64 = gen.nextTemp();
   gen.emit(`${newCapI64} = zext i32 ${newCap} to i64`);
   const newMemSize = gen.nextTemp();
-  gen.emit(`${newMemSize} = mul i64 ${newCapI64}, 8`);
-  const newMem = gen.emitCall("i8*", "@GC_malloc", `i64 ${newMemSize}`);
-  const newDataPtr = gen.emitBitcast(newMem, "i8*", "i8**");
+  gen.emit(`${newMemSize} = mul i64 ${newCapI64}, ${elemSize}`);
+  const newMem = gen.emitCall("i8*", allocFn, `i64 ${newMemSize}`);
 
   const dataPtrField = gen.nextTemp();
   gen.emit(
     `${dataPtrField} = getelementptr inbounds %ObjectArray, %ObjectArray* ${arrayPtr}, i32 0, i32 0`,
   );
   const oldDataPtrRaw = gen.emitLoad("i8*", dataPtrField);
-  const oldDataPtr = gen.emitBitcast(oldDataPtrRaw, "i8*", "i8**");
 
-  const oldDataI8 = gen.emitBitcast(oldDataPtr, "i8**", "i8*");
-  const newDataI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
   const currentLenI64 = gen.nextTemp();
   gen.emit(`${currentLenI64} = zext i32 ${currentLen} to i64`);
   const copySizeI64 = gen.nextTemp();
-  gen.emit(`${copySizeI64} = mul i64 ${currentLenI64}, 8`);
+  gen.emit(`${copySizeI64} = mul i64 ${currentLenI64}, ${elemSize}`);
   gen.emit(
-    `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newDataI8}, i8* ${oldDataI8}, i64 ${copySizeI64}, i1 false)`,
+    `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${newMem}, i8* ${oldDataPtrRaw}, i64 ${copySizeI64}, i1 false)`,
   );
 
-  const newDataPtrAsI8 = gen.emitBitcast(newDataPtr, "i8**", "i8*");
-  gen.emitStore("i8*", newDataPtrAsI8, dataPtrField);
-
+  gen.emitStore("i8*", newMem, dataPtrField);
   gen.emitStore("i32", newCap, capPtr);
 
   gen.emitBr(continueLabel);
@@ -660,12 +664,25 @@ function generateObjectArrayPush(
   );
   const dataPtrRaw = gen.nextTemp();
   gen.emit(`${dataPtrRaw} = load i8*, i8** ${dataPtrField2}`);
-  const dataPtr = gen.emitBitcast(dataPtrRaw, "i8*", "i8**");
 
-  const elemPtr = gen.nextTemp();
-  gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${currentLen}`);
-  const valueAsI8 = gen.emitBitcast(value, valueType, "i8*");
-  gen.emit(`store i8* ${valueAsI8}, i8** ${elemPtr}`);
+  if (contiguousStride > 0) {
+    const currentLenI642 = gen.nextTemp();
+    gen.emit(`${currentLenI642} = zext i32 ${currentLen} to i64`);
+    const offsetI64 = gen.nextTemp();
+    gen.emit(`${offsetI64} = mul i64 ${currentLenI642}, ${contiguousStride}`);
+    const dest = gen.nextTemp();
+    gen.emit(`${dest} = getelementptr inbounds i8, i8* ${dataPtrRaw}, i64 ${offsetI64}`);
+    const valueAsI8 = gen.emitBitcast(value, valueType, "i8*");
+    gen.emit(
+      `call void @llvm.memcpy.p0i8.p0i8.i64(i8* ${dest}, i8* ${valueAsI8}, i64 ${contiguousStride}, i1 false)`,
+    );
+  } else {
+    const dataPtr = gen.emitBitcast(dataPtrRaw, "i8*", "i8**");
+    const elemPtr = gen.nextTemp();
+    gen.emit(`${elemPtr} = getelementptr inbounds i8*, i8** ${dataPtr}, i32 ${currentLen}`);
+    const valueAsI8 = gen.emitBitcast(value, valueType, "i8*");
+    gen.emit(`store i8* ${valueAsI8}, i8** ${elemPtr}`);
+  }
 
   const newLen = gen.nextTemp();
   gen.emit(`${newLen} = add i32 ${currentLen}, 1`);


### PR DESCRIPTION
## Summary
- When an interface has only numeric fields (number/boolean), ObjectArrays of that type now store structs **inline in a contiguous buffer** instead of as an array of pointers to separate heap allocations
- Eliminates one pointer chase per field access in hot loops (`arr[i].field` goes from 3 loads to 2)
- N-Body benchmark on Mac ARM: **1.99s → 0.73s** (2.7x faster from this change alone)
- Applies automatically to function parameters, local variables, and array literals

## How it works
**Before**: `ObjectArray.data` → `[ptr0, ptr1, ptr2]` → each points to separate 56-byte allocation  
**After**: `ObjectArray.data` → `[{x,y,z,vx,vy,vz,mass}, {x,y,z,...}, ...]` — single contiguous allocation

The optimization detects all-double interfaces at declaration time and propagates through function parameters. Push uses `memcpy` to copy struct bytes inline. Resize copies the entire contiguous buffer.

## Test plan
- [x] All 756 tests pass
- [x] `npm run verify:quick` passes (Stage 0 + Stage 1 self-hosting)
- [x] N-Body benchmark produces correct energy values
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)