### PR TITLE
fix json.parse boolean fields returning false for true values

### DIFF
--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -427,7 +427,7 @@ export class JsonGenerator {
           lines.push("  store i8* %value_" + fieldIndex + ", i8** %field_ptr_" + fieldIndex);
           lines.push("  br label %" + nextLabel);
           lines.push("");
-        } else if (fieldType === "number" || fieldType === "boolean") {
+        } else if (fieldType === "number") {
           lines.push("field_" + fieldIndex + "_extract:");
           lines.push(
             "  %value_" +
@@ -435,6 +435,31 @@ export class JsonGenerator {
               " = call double @csyyjson_get_num(i8* %item_" +
               fieldIndex +
               ")",
+          );
+          lines.push(
+            "  %field_ptr_" +
+              fieldIndex +
+              " = getelementptr inbounds %" +
+              typeName +
+              ", %" +
+              typeName +
+              "* %struct_ptr, i32 0, i32 " +
+              fieldIndex,
+          );
+          lines.push("  store double %value_" + fieldIndex + ", double* %field_ptr_" + fieldIndex);
+          lines.push("  br label %" + nextLabel);
+          lines.push("");
+        } else if (fieldType === "boolean") {
+          lines.push("field_" + fieldIndex + "_extract:");
+          lines.push(
+            "  %bool_i32_" +
+              fieldIndex +
+              " = call i32 @csyyjson_is_true(i8* %item_" +
+              fieldIndex +
+              ")",
+          );
+          lines.push(
+            "  %value_" + fieldIndex + " = sitofp i32 %bool_i32_" + fieldIndex + " to double",
           );
           lines.push(
             "  %field_ptr_" +

--- a/tests/fixtures/builtins/json-parse-bool-test.ts
+++ b/tests/fixtures/builtins/json-parse-bool-test.ts
@@ -17,6 +17,15 @@ if (item.name !== "widget") {
 if (item.value !== 3.14) {
   throw new Error("Expected value to be 3.14");
 }
+if (!item.active) {
+  throw new Error("Expected active to be true");
+}
+
+const falseJson = '{"id":1,"name":"off","value":0,"active":false}';
+const falseItem = JSON.parse<Item>(falseJson);
+if (falseItem.active) {
+  throw new Error("Expected active to be false");
+}
 
 const items: Item[] = [];
 let i = 0;


### PR DESCRIPTION
## Summary
- JSON.parse was using `csyyjson_get_num()` for boolean fields, which returns 0.0 for booleans regardless of value
- Now uses `csyyjson_is_true()` → `sitofp i32 to double` to correctly extract boolean values
- Test updated to verify both `true` and `false` JSON boolean parsing

## Test plan
- [x] `json-parse-bool-test.ts` now checks `item.active === true` and `falseItem.active === false`
- [ ] CI passes