### PR TITLE
stdlib expansion: colors, glob, compression, yaml, events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/compress-bridge.o c_bridges/yaml-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -252,7 +252,7 @@ jobs:
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
-          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/compress-bridge.o c_bridges/yaml-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o release/lib/
           tar -czf chadscript-linux-x64.tar.gz -C release chad lib
 
       - name: Upload artifact
@@ -304,7 +304,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/compress-bridge.o c_bridges/yaml-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -377,7 +377,7 @@ jobs:
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
-          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o release/lib/
+          cp c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/compress-bridge.o c_bridges/yaml-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o release/lib/
           tar -czf chadscript-macos-arm64.tar.gz -C release chad lib
 
       - name: Upload artifact

--- a/c_bridges/compress-bridge.c
+++ b/c_bridges/compress-bridge.c
@@ -1,0 +1,221 @@
+#include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
+#include <zstd.h>
+
+extern void *GC_malloc_atomic(size_t size);
+extern void *GC_malloc(size_t size);
+
+typedef struct {
+  unsigned char *data;
+  int length;
+  int capacity;
+} Uint8Array;
+
+Uint8Array *cs_gzip(const unsigned char *data, int len) {
+  uLong bound = compressBound((uLong)len) + 32;
+  unsigned char *out = (unsigned char *)GC_malloc_atomic(bound);
+  if (!out) return NULL;
+
+  z_stream strm;
+  memset(&strm, 0, sizeof(strm));
+  if (deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY) !=
+      Z_OK) {
+    return NULL;
+  }
+
+  strm.next_in = (Bytef *)data;
+  strm.avail_in = (uInt)len;
+  strm.next_out = out;
+  strm.avail_out = (uInt)bound;
+
+  if (deflate(&strm, Z_FINISH) != Z_STREAM_END) {
+    deflateEnd(&strm);
+    return NULL;
+  }
+
+  int outLen = (int)strm.total_out;
+  deflateEnd(&strm);
+
+  Uint8Array *result = (Uint8Array *)GC_malloc(sizeof(Uint8Array));
+  if (!result) return NULL;
+  result->data = out;
+  result->length = outLen;
+  result->capacity = outLen;
+  return result;
+}
+
+Uint8Array *cs_gunzip(const unsigned char *data, int len) {
+  uLong outSize = (uLong)len * 4;
+  if (outSize < 1024) outSize = 1024;
+
+  z_stream strm;
+  memset(&strm, 0, sizeof(strm));
+  if (inflateInit2(&strm, 15 + 32) != Z_OK) return NULL;
+
+  strm.next_in = (Bytef *)data;
+  strm.avail_in = (uInt)len;
+
+  unsigned char *out = (unsigned char *)GC_malloc_atomic(outSize);
+  if (!out) {
+    inflateEnd(&strm);
+    return NULL;
+  }
+  strm.next_out = out;
+  strm.avail_out = (uInt)outSize;
+
+  int ret;
+  while (1) {
+    ret = inflate(&strm, Z_NO_FLUSH);
+    if (ret == Z_STREAM_END) break;
+    if (ret != Z_OK && ret != Z_BUF_ERROR) {
+      inflateEnd(&strm);
+      return NULL;
+    }
+    if (strm.avail_out == 0) {
+      uLong newSize = outSize * 2;
+      unsigned char *newBuf = (unsigned char *)GC_malloc_atomic(newSize);
+      if (!newBuf) {
+        inflateEnd(&strm);
+        return NULL;
+      }
+      memcpy(newBuf, out, outSize);
+      out = newBuf;
+      strm.next_out = out + outSize;
+      strm.avail_out = (uInt)(newSize - outSize);
+      outSize = newSize;
+    }
+  }
+
+  int outLen = (int)strm.total_out;
+  inflateEnd(&strm);
+
+  Uint8Array *result = (Uint8Array *)GC_malloc(sizeof(Uint8Array));
+  if (!result) return NULL;
+  result->data = out;
+  result->length = outLen;
+  result->capacity = outLen;
+  return result;
+}
+
+Uint8Array *cs_deflate_raw(const unsigned char *data, int len) {
+  uLong bound = compressBound((uLong)len);
+  unsigned char *out = (unsigned char *)GC_malloc_atomic(bound);
+  if (!out) return NULL;
+
+  z_stream strm;
+  memset(&strm, 0, sizeof(strm));
+  if (deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
+    return NULL;
+  }
+
+  strm.next_in = (Bytef *)data;
+  strm.avail_in = (uInt)len;
+  strm.next_out = out;
+  strm.avail_out = (uInt)bound;
+
+  if (deflate(&strm, Z_FINISH) != Z_STREAM_END) {
+    deflateEnd(&strm);
+    return NULL;
+  }
+
+  int outLen = (int)strm.total_out;
+  deflateEnd(&strm);
+
+  Uint8Array *result = (Uint8Array *)GC_malloc(sizeof(Uint8Array));
+  if (!result) return NULL;
+  result->data = out;
+  result->length = outLen;
+  result->capacity = outLen;
+  return result;
+}
+
+Uint8Array *cs_inflate_raw(const unsigned char *data, int len) {
+  uLong outSize = (uLong)len * 4;
+  if (outSize < 1024) outSize = 1024;
+
+  z_stream strm;
+  memset(&strm, 0, sizeof(strm));
+  if (inflateInit2(&strm, -15) != Z_OK) return NULL;
+
+  strm.next_in = (Bytef *)data;
+  strm.avail_in = (uInt)len;
+
+  unsigned char *out = (unsigned char *)GC_malloc_atomic(outSize);
+  if (!out) {
+    inflateEnd(&strm);
+    return NULL;
+  }
+  strm.next_out = out;
+  strm.avail_out = (uInt)outSize;
+
+  int ret;
+  while (1) {
+    ret = inflate(&strm, Z_NO_FLUSH);
+    if (ret == Z_STREAM_END) break;
+    if (ret != Z_OK && ret != Z_BUF_ERROR) {
+      inflateEnd(&strm);
+      return NULL;
+    }
+    if (strm.avail_out == 0) {
+      uLong newSize = outSize * 2;
+      unsigned char *newBuf = (unsigned char *)GC_malloc_atomic(newSize);
+      if (!newBuf) {
+        inflateEnd(&strm);
+        return NULL;
+      }
+      memcpy(newBuf, out, outSize);
+      out = newBuf;
+      strm.next_out = out + outSize;
+      strm.avail_out = (uInt)(newSize - outSize);
+      outSize = newSize;
+    }
+  }
+
+  int outLen = (int)strm.total_out;
+  inflateEnd(&strm);
+
+  Uint8Array *result = (Uint8Array *)GC_malloc(sizeof(Uint8Array));
+  if (!result) return NULL;
+  result->data = out;
+  result->length = outLen;
+  result->capacity = outLen;
+  return result;
+}
+
+Uint8Array *cs_zstd_compress(const unsigned char *data, int len) {
+  size_t bound = ZSTD_compressBound((size_t)len);
+  unsigned char *out = (unsigned char *)GC_malloc_atomic(bound);
+  if (!out) return NULL;
+
+  size_t compSize = ZSTD_compress(out, bound, data, (size_t)len, 3);
+  if (ZSTD_isError(compSize)) return NULL;
+
+  Uint8Array *r = (Uint8Array *)GC_malloc(sizeof(Uint8Array));
+  if (!r) return NULL;
+  r->data = out;
+  r->length = (int)compSize;
+  r->capacity = (int)compSize;
+  return r;
+}
+
+Uint8Array *cs_zstd_decompress(const unsigned char *data, int len) {
+  unsigned long long decompSize = ZSTD_getFrameContentSize(data, (size_t)len);
+  if (decompSize == ZSTD_CONTENTSIZE_UNKNOWN || decompSize == ZSTD_CONTENTSIZE_ERROR) {
+    decompSize = (unsigned long long)len * 4;
+    if (decompSize < 1024) decompSize = 1024;
+  }
+
+  unsigned char *out = (unsigned char *)GC_malloc_atomic((size_t)decompSize);
+  if (!out) return NULL;
+
+  size_t outSize = ZSTD_decompress(out, (size_t)decompSize, data, (size_t)len);
+  if (ZSTD_isError(outSize)) return NULL;
+
+  Uint8Array *r = (Uint8Array *)GC_malloc(sizeof(Uint8Array));
+  if (!r) return NULL;
+  r->data = out;
+  r->length = (int)outSize;
+  r->capacity = (int)outSize;
+  return r;
+}

--- a/c_bridges/yaml-bridge.c
+++ b/c_bridges/yaml-bridge.c
@@ -1,0 +1,502 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void *GC_malloc_atomic(size_t size);
+extern void *GC_malloc(size_t size);
+
+typedef struct {
+  char *buf;
+  size_t len;
+  size_t cap;
+} YBuf;
+
+static void ybuf_init(YBuf *b) {
+  b->cap = 256;
+  b->len = 0;
+  b->buf = (char *)GC_malloc_atomic(b->cap);
+  b->buf[0] = '\0';
+}
+
+static void ybuf_grow(YBuf *b, size_t extra) {
+  while (b->len + extra + 1 > b->cap) {
+    b->cap = b->cap * 2;
+  }
+  char *newBuf = (char *)GC_malloc_atomic(b->cap);
+  memcpy(newBuf, b->buf, b->len + 1);
+  b->buf = newBuf;
+}
+
+static void ybuf_append(YBuf *b, const char *s, size_t slen) {
+  if (b->len + slen + 1 > b->cap) ybuf_grow(b, slen);
+  memcpy(b->buf + b->len, s, slen);
+  b->len += slen;
+  b->buf[b->len] = '\0';
+}
+
+static void ybuf_char(YBuf *b, char c) {
+  if (b->len + 2 > b->cap) ybuf_grow(b, 1);
+  b->buf[b->len++] = c;
+  b->buf[b->len] = '\0';
+}
+
+static void ybuf_str(YBuf *b, const char *s) {
+  ybuf_append(b, s, strlen(s));
+}
+
+static int is_whitespace(char c) { return c == ' ' || c == '\t'; }
+
+static int starts_with(const char *s, const char *prefix) {
+  return strncmp(s, prefix, strlen(prefix)) == 0;
+}
+
+static void json_escape_string(YBuf *b, const char *s, size_t len) {
+  ybuf_char(b, '"');
+  for (size_t i = 0; i < len; i++) {
+    char c = s[i];
+    switch (c) {
+    case '"':
+      ybuf_str(b, "\\\"");
+      break;
+    case '\\':
+      ybuf_str(b, "\\\\");
+      break;
+    case '\n':
+      ybuf_str(b, "\\n");
+      break;
+    case '\r':
+      ybuf_str(b, "\\r");
+      break;
+    case '\t':
+      ybuf_str(b, "\\t");
+      break;
+    default:
+      ybuf_char(b, c);
+    }
+  }
+  ybuf_char(b, '"');
+}
+
+static int is_number(const char *s, size_t len) {
+  if (len == 0) return 0;
+  size_t i = 0;
+  if (s[0] == '-' || s[0] == '+') i = 1;
+  if (i >= len) return 0;
+  int has_digit = 0;
+  int has_dot = 0;
+  for (; i < len; i++) {
+    if (s[i] >= '0' && s[i] <= '9') {
+      has_digit = 1;
+    } else if (s[i] == '.' && !has_dot) {
+      has_dot = 1;
+    } else if ((s[i] == 'e' || s[i] == 'E') && has_digit) {
+      i++;
+      if (i < len && (s[i] == '+' || s[i] == '-')) i++;
+      for (; i < len; i++) {
+        if (s[i] < '0' || s[i] > '9') return 0;
+      }
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+  return has_digit;
+}
+
+static const char *skip_line(const char *p) {
+  while (*p && *p != '\n') p++;
+  if (*p == '\n') p++;
+  return p;
+}
+
+static int get_indent(const char *line) {
+  int n = 0;
+  while (line[n] == ' ') n++;
+  return n;
+}
+
+static size_t trim_end(const char *s, size_t len) {
+  while (len > 0 && (s[len - 1] == ' ' || s[len - 1] == '\t' || s[len - 1] == '\r')) len--;
+  return len;
+}
+
+static void yaml_value_to_json(YBuf *b, const char *val, size_t vlen);
+
+static void yaml_block_to_json(YBuf *b, const char **pp, int baseIndent);
+
+static void yaml_value_to_json(YBuf *b, const char *val, size_t vlen) {
+  vlen = trim_end(val, vlen);
+  if (vlen == 0) {
+    ybuf_str(b, "null");
+    return;
+  }
+  if (vlen == 4 && strncmp(val, "true", 4) == 0) {
+    ybuf_str(b, "true");
+    return;
+  }
+  if (vlen == 5 && strncmp(val, "false", 5) == 0) {
+    ybuf_str(b, "false");
+    return;
+  }
+  if (vlen == 4 && strncmp(val, "null", 4) == 0) {
+    ybuf_str(b, "null");
+    return;
+  }
+  if (vlen == 1 && val[0] == '~') {
+    ybuf_str(b, "null");
+    return;
+  }
+  if (is_number(val, vlen)) {
+    ybuf_append(b, val, vlen);
+    return;
+  }
+  if ((val[0] == '"' && val[vlen - 1] == '"') || (val[0] == '\'' && val[vlen - 1] == '\'')) {
+    json_escape_string(b, val + 1, vlen - 2);
+    return;
+  }
+  json_escape_string(b, val, vlen);
+}
+
+static void yaml_block_to_json(YBuf *b, const char **pp, int baseIndent) {
+  const char *p = *pp;
+  int is_list = 0;
+  int is_map = 0;
+  int first = 1;
+
+  while (*p) {
+    if (*p == '\n') {
+      p++;
+      continue;
+    }
+    int indent = get_indent(p);
+    if (indent < baseIndent) break;
+    if (p[indent] == '#') {
+      p = skip_line(p);
+      continue;
+    }
+    if (indent > baseIndent) break;
+
+    if (p[indent] == '-' && (p[indent + 1] == ' ' || p[indent + 1] == '\n' || p[indent + 1] == '\0')) {
+      if (!is_list && !is_map) {
+        is_list = 1;
+        ybuf_char(b, '[');
+      }
+      if (!first) ybuf_char(b, ',');
+      first = 0;
+
+      const char *after = p + indent + 1;
+      if (*after == ' ') after++;
+      size_t linelen = 0;
+      const char *lp = after;
+      while (*lp && *lp != '\n') {
+        linelen++;
+        lp++;
+      }
+      size_t trimlen = trim_end(after, linelen);
+
+      int colon_pos = -1;
+      for (size_t i = 0; i < trimlen; i++) {
+        if (after[i] == ':' && (i + 1 >= trimlen || after[i + 1] == ' ')) {
+          colon_pos = (int)i;
+          break;
+        }
+      }
+
+      if (colon_pos >= 0) {
+        p = p + indent + 2;
+        if (*p == ' ') {
+        }
+        yaml_block_to_json(b, &p, indent + 2);
+      } else if (trimlen == 0) {
+        p = skip_line(p);
+        if (*p) {
+          int nextInd = get_indent(p);
+          if (nextInd > indent) {
+            yaml_block_to_json(b, &p, nextInd);
+          } else {
+            ybuf_str(b, "null");
+          }
+        } else {
+          ybuf_str(b, "null");
+        }
+      } else {
+        yaml_value_to_json(b, after, trimlen);
+        p = skip_line(p);
+      }
+    } else {
+      int colon_pos = -1;
+      const char *line = p + indent;
+      size_t linelen = 0;
+      const char *lp2 = line;
+      while (*lp2 && *lp2 != '\n') {
+        linelen++;
+        lp2++;
+      }
+      size_t trimlen = trim_end(line, linelen);
+      for (size_t i = 0; i < trimlen; i++) {
+        if (line[i] == ':' && (i + 1 >= trimlen || line[i + 1] == ' ')) {
+          colon_pos = (int)i;
+          break;
+        }
+      }
+
+      if (colon_pos < 0) {
+        p = skip_line(p);
+        continue;
+      }
+
+      if (!is_map && !is_list) {
+        is_map = 1;
+        ybuf_char(b, '{');
+      }
+      if (!first) ybuf_char(b, ',');
+      first = 0;
+
+      json_escape_string(b, line, (size_t)colon_pos);
+      ybuf_char(b, ':');
+
+      const char *valStart = line + colon_pos + 1;
+      while (*valStart == ' ') valStart++;
+      size_t valLen = 0;
+      const char *vp = valStart;
+      while (*vp && *vp != '\n') {
+        valLen++;
+        vp++;
+      }
+      valLen = trim_end(valStart, valLen);
+
+      if (valLen == 0) {
+        p = skip_line(p);
+        if (*p) {
+          int nextInd = get_indent(p);
+          if (nextInd > indent) {
+            yaml_block_to_json(b, &p, nextInd);
+          } else {
+            ybuf_str(b, "null");
+          }
+        } else {
+          ybuf_str(b, "null");
+        }
+      } else {
+        yaml_value_to_json(b, valStart, valLen);
+        p = skip_line(p);
+      }
+    }
+  }
+
+  if (is_list) ybuf_char(b, ']');
+  else if (is_map) ybuf_char(b, '}');
+  else ybuf_str(b, "null");
+
+  *pp = p;
+}
+
+char *cs_yaml_parse(const char *yaml_str) {
+  if (!yaml_str) return NULL;
+  YBuf b;
+  ybuf_init(&b);
+  const char *p = yaml_str;
+  if (starts_with(p, "---")) p = skip_line(p);
+  yaml_block_to_json(&b, &p, 0);
+  return b.buf;
+}
+
+static void json_to_yaml_recurse(YBuf *b, const char **pp, int indent);
+
+static void emit_indent(YBuf *b, int indent) {
+  for (int i = 0; i < indent; i++) ybuf_char(b, ' ');
+}
+
+static void json_skip_ws(const char **pp) {
+  while (**pp == ' ' || **pp == '\t' || **pp == '\n' || **pp == '\r') (*pp)++;
+}
+
+static char *json_read_string(const char **pp) {
+  const char *p = *pp;
+  if (*p != '"') return NULL;
+  p++;
+  YBuf sb;
+  ybuf_init(&sb);
+  while (*p && *p != '"') {
+    if (*p == '\\' && p[1]) {
+      p++;
+      switch (*p) {
+      case '"':
+        ybuf_char(&sb, '"');
+        break;
+      case '\\':
+        ybuf_char(&sb, '\\');
+        break;
+      case 'n':
+        ybuf_char(&sb, '\n');
+        break;
+      case 'r':
+        ybuf_char(&sb, '\r');
+        break;
+      case 't':
+        ybuf_char(&sb, '\t');
+        break;
+      default:
+        ybuf_char(&sb, *p);
+      }
+    } else {
+      ybuf_char(&sb, *p);
+    }
+    p++;
+  }
+  if (*p == '"') p++;
+  *pp = p;
+  return sb.buf;
+}
+
+static void json_skip_value(const char **pp) {
+  json_skip_ws(pp);
+  const char *p = *pp;
+  if (*p == '"') {
+    p++;
+    while (*p && *p != '"') {
+      if (*p == '\\') p++;
+      p++;
+    }
+    if (*p == '"') p++;
+    *pp = p;
+  } else if (*p == '{') {
+    int depth = 1;
+    p++;
+    while (*p && depth > 0) {
+      if (*p == '{') depth++;
+      else if (*p == '}') depth--;
+      else if (*p == '"') {
+        p++;
+        while (*p && *p != '"') {
+          if (*p == '\\') p++;
+          p++;
+        }
+      }
+      if (*p) p++;
+    }
+    *pp = p;
+  } else if (*p == '[') {
+    int depth = 1;
+    p++;
+    while (*p && depth > 0) {
+      if (*p == '[') depth++;
+      else if (*p == ']') depth--;
+      else if (*p == '"') {
+        p++;
+        while (*p && *p != '"') {
+          if (*p == '\\') p++;
+          p++;
+        }
+      }
+      if (*p) p++;
+    }
+    *pp = p;
+  } else {
+    while (*p && *p != ',' && *p != '}' && *p != ']') p++;
+    *pp = p;
+  }
+}
+
+static void json_to_yaml_recurse(YBuf *b, const char **pp, int indent) {
+  json_skip_ws(pp);
+  const char *p = *pp;
+
+  if (*p == '{') {
+    p++;
+    json_skip_ws(&p);
+    int first = 1;
+    while (*p && *p != '}') {
+      if (!first) {
+        json_skip_ws(&p);
+        if (*p == ',') p++;
+        json_skip_ws(&p);
+      }
+      if (*p == '}') break;
+      char *key = json_read_string(&p);
+      json_skip_ws(&p);
+      if (*p == ':') p++;
+      json_skip_ws(&p);
+
+      if (*p == '{' || *p == '[') {
+        if (!first || indent > 0) {
+          ybuf_char(b, '\n');
+          emit_indent(b, indent);
+        }
+        ybuf_str(b, key);
+        ybuf_str(b, ":\n");
+        json_to_yaml_recurse(b, &p, indent + 2);
+      } else {
+        if (!first || indent > 0) {
+          ybuf_char(b, '\n');
+          emit_indent(b, indent);
+        }
+        ybuf_str(b, key);
+        ybuf_str(b, ": ");
+        json_to_yaml_recurse(b, &p, indent);
+      }
+      first = 0;
+      json_skip_ws(&p);
+      if (*p == ',') p++;
+    }
+    if (*p == '}') p++;
+    *pp = p;
+  } else if (*p == '[') {
+    p++;
+    json_skip_ws(&p);
+    int first = 1;
+    while (*p && *p != ']') {
+      if (!first) {
+        json_skip_ws(&p);
+        if (*p == ',') p++;
+        json_skip_ws(&p);
+      }
+      if (*p == ']') break;
+      if (!first || indent > 0) {
+        ybuf_char(b, '\n');
+      }
+      emit_indent(b, indent);
+      ybuf_str(b, "- ");
+      json_to_yaml_recurse(b, &p, indent + 2);
+      first = 0;
+      json_skip_ws(&p);
+      if (*p == ',') p++;
+    }
+    if (*p == ']') p++;
+    *pp = p;
+  } else if (*p == '"') {
+    char *s = json_read_string(&p);
+    int needs_quote = 0;
+    size_t slen = strlen(s);
+    if (slen == 0 || strcmp(s, "true") == 0 || strcmp(s, "false") == 0 ||
+        strcmp(s, "null") == 0 || is_number(s, slen)) {
+      needs_quote = 1;
+    }
+    for (size_t i = 0; i < slen && !needs_quote; i++) {
+      if (s[i] == ':' || s[i] == '#' || s[i] == '\n' || s[i] == '"' || s[i] == '\'') {
+        needs_quote = 1;
+      }
+    }
+    if (needs_quote) {
+      json_escape_string(b, s, slen);
+    } else {
+      ybuf_str(b, s);
+    }
+    *pp = p;
+  } else {
+    const char *start = p;
+    while (*p && *p != ',' && *p != '}' && *p != ']' && *p != '\n') p++;
+    ybuf_append(b, start, (size_t)(p - start));
+    *pp = p;
+  }
+}
+
+char *cs_yaml_stringify(const char *json_str) {
+  if (!json_str) return NULL;
+  YBuf b;
+  ybuf_init(&b);
+  const char *p = json_str;
+  json_to_yaml_recurse(&b, &p, 0);
+  ybuf_char(&b, '\n');
+  return b.buf;
+}

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,0 +1,104 @@
+const ESC = "\x1b[";
+const RESET = "\x1b[0m";
+
+function wrap(code: string, text: string): string {
+  return ESC + code + "m" + text + RESET;
+}
+
+export function red(text: string): string {
+  return wrap("31", text);
+}
+
+export function green(text: string): string {
+  return wrap("32", text);
+}
+
+export function yellow(text: string): string {
+  return wrap("33", text);
+}
+
+export function blue(text: string): string {
+  return wrap("34", text);
+}
+
+export function magenta(text: string): string {
+  return wrap("35", text);
+}
+
+export function cyan(text: string): string {
+  return wrap("36", text);
+}
+
+export function white(text: string): string {
+  return wrap("37", text);
+}
+
+export function gray(text: string): string {
+  return wrap("90", text);
+}
+
+export function bold(text: string): string {
+  return wrap("1", text);
+}
+
+export function dim(text: string): string {
+  return wrap("2", text);
+}
+
+export function italic(text: string): string {
+  return wrap("3", text);
+}
+
+export function underline(text: string): string {
+  return wrap("4", text);
+}
+
+export function strikethrough(text: string): string {
+  return wrap("9", text);
+}
+
+export function bgRed(text: string): string {
+  return wrap("41", text);
+}
+
+export function bgGreen(text: string): string {
+  return wrap("42", text);
+}
+
+export function bgYellow(text: string): string {
+  return wrap("43", text);
+}
+
+export function bgBlue(text: string): string {
+  return wrap("44", text);
+}
+
+export function bgMagenta(text: string): string {
+  return wrap("45", text);
+}
+
+export function bgCyan(text: string): string {
+  return wrap("46", text);
+}
+
+export function bgWhite(text: string): string {
+  return wrap("47", text);
+}
+
+export function stripAnsi(text: string): string {
+  let result = "";
+  let i = 0;
+  while (i < text.length) {
+    if (text.charAt(i) === "\x1b" && i + 1 < text.length && text.charAt(i + 1) === "[") {
+      i = i + 2;
+      while (i < text.length && text.charAt(i) !== "m") {
+        i = i + 1;
+      }
+      i = i + 1;
+    } else {
+      result = result + text.charAt(i);
+      i = i + 1;
+    }
+  }
+  return result;
+}

--- a/lib/compress.ts
+++ b/lib/compress.ts
@@ -1,0 +1,23 @@
+export function gzip(data: Uint8Array): Uint8Array {
+  return data;
+}
+
+export function gunzip(data: Uint8Array): Uint8Array {
+  return data;
+}
+
+export function deflateRaw(data: Uint8Array): Uint8Array {
+  return data;
+}
+
+export function inflateRaw(data: Uint8Array): Uint8Array {
+  return data;
+}
+
+export function zstdCompress(data: Uint8Array): Uint8Array {
+  return data;
+}
+
+export function zstdDecompress(data: Uint8Array): Uint8Array {
+  return data;
+}

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,86 @@
+export class EventEmitter {
+  private names: string[];
+  private callbacks: Array<(data: string) => void>;
+  private onceFlags: boolean[];
+
+  constructor() {
+    this.names = [];
+    this.callbacks = [];
+    this.onceFlags = [];
+  }
+
+  on(name: string, callback: (data: string) => void): void {
+    this.names.push(name);
+    this.callbacks.push(callback);
+    this.onceFlags.push(false);
+  }
+
+  once(name: string, callback: (data: string) => void): void {
+    this.names.push(name);
+    this.callbacks.push(callback);
+    this.onceFlags.push(true);
+  }
+
+  off(name: string, callback: (data: string) => void): void {
+    const newNames: string[] = [];
+    const newCbs: Array<(data: string) => void> = [];
+    const newFlags: boolean[] = [];
+    for (let i = 0; i < this.names.length; i++) {
+      if (this.names[i] !== name || this.callbacks[i] !== callback) {
+        newNames.push(this.names[i]);
+        newCbs.push(this.callbacks[i]);
+        newFlags.push(this.onceFlags[i]);
+      }
+    }
+    this.names = newNames;
+    this.callbacks = newCbs;
+    this.onceFlags = newFlags;
+  }
+
+  emit(name: string, data: string): void {
+    const newNames: string[] = [];
+    const newCbs: Array<(data: string) => void> = [];
+    const newFlags: boolean[] = [];
+    for (let i = 0; i < this.names.length; i++) {
+      if (this.names[i] === name) {
+        this.callbacks[i](data);
+        if (!this.onceFlags[i]) {
+          newNames.push(this.names[i]);
+          newCbs.push(this.callbacks[i]);
+          newFlags.push(this.onceFlags[i]);
+        }
+      } else {
+        newNames.push(this.names[i]);
+        newCbs.push(this.callbacks[i]);
+        newFlags.push(this.onceFlags[i]);
+      }
+    }
+    this.names = newNames;
+    this.callbacks = newCbs;
+    this.onceFlags = newFlags;
+  }
+
+  listenerCount(name: string): number {
+    let count = 0;
+    for (let i = 0; i < this.names.length; i++) {
+      if (this.names[i] === name) count = count + 1;
+    }
+    return count;
+  }
+
+  removeAllListeners(name: string): void {
+    const newNames: string[] = [];
+    const newCbs: Array<(data: string) => void> = [];
+    const newFlags: boolean[] = [];
+    for (let i = 0; i < this.names.length; i++) {
+      if (this.names[i] !== name) {
+        newNames.push(this.names[i]);
+        newCbs.push(this.callbacks[i]);
+        newFlags.push(this.onceFlags[i]);
+      }
+    }
+    this.names = newNames;
+    this.callbacks = newCbs;
+    this.onceFlags = newFlags;
+  }
+}

--- a/lib/glob.ts
+++ b/lib/glob.ts
@@ -1,0 +1,41 @@
+export function match(pattern: string, path: string): boolean {
+  return matchAt(pattern, 0, path, 0);
+}
+
+function matchAt(pattern: string, pi: number, path: string, si: number): boolean {
+  while (pi < pattern.length) {
+    const pc = pattern.charAt(pi);
+
+    if (pc === "*" && pi + 1 < pattern.length && pattern.charAt(pi + 1) === "*") {
+      let nextPi = pi + 2;
+      if (nextPi < pattern.length && pattern.charAt(nextPi) === "/") {
+        nextPi = nextPi + 1;
+      }
+      for (let i = si; i <= path.length; i++) {
+        if (matchAt(pattern, nextPi, path, i)) return true;
+      }
+      return false;
+    }
+
+    if (pc === "*") {
+      for (let i = si; i <= path.length; i++) {
+        if (i > si && path.charAt(i - 1) === "/") break;
+        if (matchAt(pattern, pi + 1, path, i)) return true;
+      }
+      return false;
+    }
+
+    if (pc === "?") {
+      if (si >= path.length || path.charAt(si) === "/") return false;
+      pi = pi + 1;
+      si = si + 1;
+      continue;
+    }
+
+    if (si >= path.length) return false;
+    if (pc !== path.charAt(si)) return false;
+    pi = pi + 1;
+    si = si + 1;
+  }
+  return si === path.length;
+}

--- a/scripts/build-target-sdk.sh
+++ b/scripts/build-target-sdk.sh
@@ -69,7 +69,7 @@ fi
 
 # Copy C bridge object files
 echo "  Copying bridge objects..."
-for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o curl-bridge.o llvm-bridge.o llvm-builder-bridge.o lld-bridge.o; do
+for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o curl-bridge.o compress-bridge.o yaml-bridge.o llvm-bridge.o llvm-builder-bridge.o lld-bridge.o; do
   if [ -f "$C_BRIDGES_DIR/$bridge" ]; then
     cp "$C_BRIDGES_DIR/$bridge" "$SDK_DIR/bridges/"
   fi

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -248,6 +248,36 @@ else
   echo "==> curl-bridge already built, skipping"
 fi
 
+# --- compress-bridge (zlib + zstd) ---
+COMPRESS_BRIDGE_SRC="$C_BRIDGES_DIR/compress-bridge.c"
+COMPRESS_BRIDGE_OBJ="$C_BRIDGES_DIR/compress-bridge.o"
+if [ ! -f "$COMPRESS_BRIDGE_OBJ" ] || [ "$COMPRESS_BRIDGE_SRC" -nt "$COMPRESS_BRIDGE_OBJ" ]; then
+  echo "==> Building compress-bridge..."
+  ZSTD_CFLAGS=""
+  if [ "$(uname)" = "Darwin" ]; then
+    BREW_PREFIX=$(brew --prefix 2>/dev/null || echo "/opt/homebrew")
+    ZSTD_PREFIX=$(brew --prefix zstd 2>/dev/null || echo "$BREW_PREFIX")
+    if [ -f "$ZSTD_PREFIX/include/zstd.h" ]; then
+      ZSTD_CFLAGS="-I$ZSTD_PREFIX/include"
+    fi
+  fi
+  cc -c -O2 -fPIC $ZSTD_CFLAGS "$COMPRESS_BRIDGE_SRC" -o "$COMPRESS_BRIDGE_OBJ"
+  echo "  -> $COMPRESS_BRIDGE_OBJ"
+else
+  echo "==> compress-bridge already built, skipping"
+fi
+
+# --- yaml-bridge (pure C, no external deps) ---
+YAML_BRIDGE_SRC="$C_BRIDGES_DIR/yaml-bridge.c"
+YAML_BRIDGE_OBJ="$C_BRIDGES_DIR/yaml-bridge.o"
+if [ ! -f "$YAML_BRIDGE_OBJ" ] || [ "$YAML_BRIDGE_SRC" -nt "$YAML_BRIDGE_OBJ" ]; then
+  echo "==> Building yaml-bridge..."
+  cc -c -O2 -fPIC "$YAML_BRIDGE_SRC" -o "$YAML_BRIDGE_OBJ"
+  echo "  -> $YAML_BRIDGE_OBJ"
+else
+  echo "==> yaml-bridge already built, skipping"
+fi
+
 # --- base64-bridge ---
 BASE64_BRIDGE_SRC="$C_BRIDGES_DIR/base64-bridge.c"
 BASE64_BRIDGE_OBJ="$C_BRIDGES_DIR/base64-bridge.o"

--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -18,6 +18,10 @@ import {
 const dtsContent = ChadScript.embedFile("../chadscript.d.ts");
 registerStdlib("argparse.ts", ChadScript.embedFile("../lib/argparse.ts"));
 registerStdlib("http.ts", ChadScript.embedFile("../lib/http.ts"));
+registerStdlib("colors.ts", ChadScript.embedFile("../lib/colors.ts"));
+registerStdlib("events.ts", ChadScript.embedFile("../lib/events.ts"));
+registerStdlib("glob.ts", ChadScript.embedFile("../lib/glob.ts"));
+registerStdlib("compress.ts", ChadScript.embedFile("../lib/compress.ts"));
 const skillContent = ChadScript.embedFile("../lib/skill.md");
 import { ArgumentParser } from "chadscript/argparse";
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -85,6 +85,9 @@ export class CallExpressionGenerator {
     const encodingResult = this.dispatchEncodingCalls(expr, params);
     if (encodingResult !== null) return encodingResult;
 
+    const compressResult = this.dispatchCompressionCalls(expr, params);
+    if (compressResult !== null) return compressResult;
+
     const ffiResult = this.dispatchCFfiCalls(expr, params);
     if (ffiResult !== null) return ffiResult;
 
@@ -236,6 +239,55 @@ export class CallExpressionGenerator {
     );
     const castPtr = this.ctx.emitBitcast(respPtr, "%__FetchResponse*", "i8*");
     return castPtr;
+  }
+
+  private dispatchCompressionCalls(expr: CallNode, params: string[]): string | null {
+    const compressFns: string[] = [
+      "gzip",
+      "gunzip",
+      "deflateRaw",
+      "inflateRaw",
+      "zstdCompress",
+      "zstdDecompress",
+    ];
+    const bridgeFns: string[] = [
+      "cs_gzip",
+      "cs_gunzip",
+      "cs_deflate_raw",
+      "cs_inflate_raw",
+      "cs_zstd_compress",
+      "cs_zstd_decompress",
+    ];
+    let fnIdx = -1;
+    for (let i = 0; i < compressFns.length; i++) {
+      if (expr.name === compressFns[i]) {
+        fnIdx = i;
+        break;
+      }
+    }
+    if (fnIdx === -1) return null;
+    if (expr.args.length < 1) {
+      return this.ctx.emitError(`${expr.name}() requires 1 argument (Uint8Array)`, expr.loc);
+    }
+    this.ctx.setUsesCompression(true);
+    const arrPtr = this.ctx.generateExpression(expr.args[0], params);
+    const dataFieldPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${dataFieldPtr} = getelementptr inbounds %Uint8Array, %Uint8Array* ${arrPtr}, i32 0, i32 0`,
+    );
+    const dataPtr = this.ctx.emitLoad("i8*", dataFieldPtr);
+    const lenFieldPtr = this.ctx.nextTemp();
+    this.ctx.emit(
+      `${lenFieldPtr} = getelementptr inbounds %Uint8Array, %Uint8Array* ${arrPtr}, i32 0, i32 1`,
+    );
+    const len = this.ctx.emitLoad("i32", lenFieldPtr);
+    const result = this.ctx.emitCall(
+      "%Uint8Array*",
+      `@${bridgeFns[fnIdx]}`,
+      `i8* ${dataPtr}, i32 ${len}`,
+    );
+    this.ctx.setVariableType(result, "%Uint8Array*");
+    return result;
   }
 
   private dispatchEncodingCalls(expr: CallNode, params: string[]): string | null {

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -206,6 +206,8 @@ export interface MethodCallGeneratorContext {
   isUint8ArrayExpression(expr: Expression): boolean;
   isBooleanExpression(expr: Expression): boolean;
   setUsesOs(value: boolean): void;
+  setUsesCompression(value: boolean): void;
+  setUsesYaml(value: boolean): void;
 }
 
 export class MethodCallGenerator {
@@ -418,9 +420,40 @@ export class MethodCallGenerator {
       case "sqlite":
         return handleSqliteMethod(this.ctx, method, expr, params);
 
+      case "YAML":
+        if (method === "parse") {
+          this.ctx.setUsesJson(true);
+          this.ctx.setUsesYaml(true);
+          return this.handleYamlParse(expr, params);
+        }
+        if (method === "stringify") {
+          this.ctx.setUsesYaml(true);
+          return this.handleYamlStringify(expr, params);
+        }
+        return null;
+
       default:
         return null;
     }
+  }
+
+  private handleYamlParse(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("YAML.parse() requires 1 argument", expr.loc);
+    }
+    const yamlStr = this.ctx.generateExpression(expr.args[0], params);
+    const jsonStr = this.ctx.emitCall("i8*", "@cs_yaml_parse", `i8* ${yamlStr}`);
+    return this.ctx.jsonGen.generateParseFromString(jsonStr, expr.typeParameter);
+  }
+
+  private handleYamlStringify(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("YAML.stringify() requires 1 argument", expr.loc);
+    }
+    const jsonStr = this.ctx.jsonGen.generateStringify(expr, params);
+    const yamlStr = this.ctx.emitCall("i8*", "@cs_yaml_stringify", `i8* ${jsonStr}`);
+    this.ctx.setVariableType(yamlStr, "i8*");
+    return yamlStr;
   }
 
   private nextTemp(): string {

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -183,6 +183,7 @@ export interface IFsGenerator {
 export interface IJsonGenerator {
   canHandle(expr: MethodCallNode): boolean;
   generateParse(expr: MethodCallNode, params: string[], typeParam?: string): string;
+  generateParseFromString(jsonStr: string, typeParam?: string): string;
   generateStringify(expr: MethodCallNode, params: string[]): string;
   generateStringifyExpr(arg: Expression, params: string[]): string;
 }
@@ -812,6 +813,8 @@ export interface IGeneratorContext {
   setUsesChildProcess(value: boolean): void;
   setUsesSpawn(value: boolean): void;
   setUsesAsyncFs(value: boolean): void;
+  setUsesCompression(value: boolean): void;
+  setUsesYaml(value: boolean): void;
   getUsesGC(): boolean;
   setUsesGC(value: boolean): void;
   getUsesMathRandom(): boolean;
@@ -1278,6 +1281,8 @@ export class MockGeneratorContext implements IGeneratorContext {
   setUsesAsyncFs(value: boolean): void {
     this.usesAsyncFs = value ? 1 : 0;
   }
+  setUsesCompression(_value: boolean): void {}
+  setUsesYaml(_value: boolean): void {}
   getUsesGC(): boolean {
     return false;
   }
@@ -1965,6 +1970,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     canHandle: (_expr: MethodCallNode): boolean => false,
     generateParse: (_expr: MethodCallNode, _params: string[], _typeParam?: string): string =>
       "%mock_json_parse",
+    generateParseFromString: (_jsonStr: string, _typeParam?: string): string =>
+      "%mock_json_parse_from_string",
     generateStringify: (_expr: MethodCallNode, _params: string[]): string => "%mock_json_stringify",
     generateStringifyExpr: (_arg: Expression, _params: string[]): string =>
       "%mock_json_stringify_expr",

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -2,6 +2,8 @@ export interface DeclConfig {
   curl?: boolean;
   crypto?: boolean;
   sqlite?: boolean;
+  compression?: boolean;
+  yaml?: boolean;
   testRunner?: boolean;
   targetOS?: string;
 }
@@ -292,6 +294,24 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
     ir += "declare i32 @sqlite3_column_count(i8*)\n";
     ir += "declare i32 @sqlite3_finalize(i8*)\n";
     ir += "declare i32 @sqlite3_bind_text(i8*, i32, i8*, i32, i64)\n";
+    ir += "\n";
+  }
+
+  if (config && config.compression) {
+    ir += "; zlib compression bridge\n";
+    ir += "declare %Uint8Array* @cs_gzip(i8*, i32)\n";
+    ir += "declare %Uint8Array* @cs_gunzip(i8*, i32)\n";
+    ir += "declare %Uint8Array* @cs_deflate_raw(i8*, i32)\n";
+    ir += "declare %Uint8Array* @cs_inflate_raw(i8*, i32)\n";
+    ir += "declare %Uint8Array* @cs_zstd_compress(i8*, i32)\n";
+    ir += "declare %Uint8Array* @cs_zstd_decompress(i8*, i32)\n";
+    ir += "\n";
+  }
+
+  if (config && config.yaml) {
+    ir += "; YAML bridge (yaml → json string conversion)\n";
+    ir += "declare i8* @cs_yaml_parse(i8*)\n";
+    ir += "declare i8* @cs_yaml_stringify(i8*)\n";
     ir += "\n";
   }
 

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -264,6 +264,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public usesStringBuilder: number = 0;
   public usesLLVM: number = 0;
   public usesLLD: number = 0;
+  public usesCompression: number = 0;
+  public usesYaml: number = 0;
   private stringBuilderSlen: Map<string, string> = new Map();
   private stringBuilderScap: Map<string, string> = new Map();
 
@@ -988,6 +990,18 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
   public getUsesLLD(): boolean {
     return this.usesLLD !== 0;
+  }
+  public setUsesCompression(value: boolean): void {
+    this.usesCompression = value ? 1 : 0;
+  }
+  public getUsesCompression(): boolean {
+    return this.usesCompression !== 0;
+  }
+  public setUsesYaml(value: boolean): void {
+    this.usesYaml = value ? 1 : 0;
+  }
+  public getUsesYaml(): boolean {
+    return this.usesYaml !== 0;
   }
   public setCurrentDeclaredInterfaceType(type: string | undefined): void {
     this.currentDeclaredInterfaceType = type;
@@ -3108,6 +3122,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           curl: this.usesCurl !== 0,
           crypto: this.usesCrypto !== 0,
           sqlite: this.usesSqlite !== 0,
+          compression: this.usesCompression !== 0,
+          yaml: this.usesYaml !== 0,
           testRunner: this.usesTestRunner !== 0,
           targetOS: this.getTargetOS(),
         }),

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -90,6 +90,30 @@ export class JsonGenerator {
     return result;
   }
 
+  generateParseFromString(jsonStr: string, typeParam?: string): string {
+    if (!typeParam) {
+      const root = this.ctx.emitCall("i8*", "@csyyjson_parse", `i8* ${jsonStr}`);
+      const result = this.ctx.emitCall("i8*", "@csyyjson_get_str", `i8* ${root}`);
+      this.ctx.setVariableType(result, "i8*");
+      return result;
+    }
+
+    if (!this.ctx.interfaceStructGenHasInterface(typeParam)) {
+      return this.ctx.emitCall("i8*", "@__safe_string", `i8* ${jsonStr}`);
+    }
+
+    this.generateJsonStruct(typeParam);
+    this.generateJsonParser(typeParam);
+
+    const result = this.ctx.emitCall(
+      `%${typeParam}*`,
+      `@parse_json_${typeParam}`,
+      `i8* ${jsonStr}`,
+    );
+    this.ctx.setVariableType(result, `%${typeParam}*`);
+    return result;
+  }
+
   private generateUntypedParse(expr: MethodCallNode, params: string[]): string {
     const jsonStr = this.ctx.generateExpression(expr.args[0], params);
     const jsonRoot = this.ctx.emitCall("i8*", "@csyyjson_parse", `i8* ${jsonStr}`);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -409,6 +409,9 @@ export function compile(
   if (generator.usesHttpServer) {
     linkLibs += ` -lz -lzstd`;
   }
+  if (generator.usesCompression && !generator.usesHttpServer) {
+    linkLibs += " -lz -lzstd";
+  }
 
   // Platform-specific library search paths
   if (sdk) {
@@ -427,7 +430,7 @@ export function compile(
     if (generator.usesSqlite) {
       linkLibs = `-L${brewPrefix}/sqlite/lib ` + linkLibs;
     }
-    if (generator.usesHttpServer) {
+    if (generator.usesHttpServer || generator.usesCompression) {
       linkLibs = `-L${brewPrefix}/zstd/lib ` + linkLibs;
     }
     const sdkPath = execSync("xcrun --show-sdk-path", { stdio: "pipe", encoding: "utf8" }).trim();
@@ -454,6 +457,8 @@ export function compile(
   const arenaBridgeObj = `${bridgePath}/arena-bridge.o`;
   const cpSpawnObj = generator.getUsesSpawn() ? `${bridgePath}/child-process-spawn.o` : "";
   const curlBridgeObj = generator.usesCurl ? `${bridgePath}/curl-bridge.o` : "";
+  const compressBridgeObj = generator.usesCompression ? `${bridgePath}/compress-bridge.o` : "";
+  const yamlBridgeObj = generator.usesYaml ? `${bridgePath}/yaml-bridge.o` : "";
   let extraObjs = "";
 
   if (generator.getUsesTreeSitter()) {
@@ -617,7 +622,7 @@ export function compile(
   const userObjs = extraLinkObjs.length > 0 ? " " + extraLinkObjs.join(" ") : "";
   const userPaths = extraLinkPaths.map((p) => ` -L${p}`).join("");
   const userLibs = extraLinkLibs.map((l) => ` -l${l}`).join("");
-  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${strlenCacheObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${arenaBridgeObj} ${cpSpawnObj} ${curlBridgeObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${suppressLdWarnings}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
+  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${strlenCacheObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${arenaBridgeObj} ${cpSpawnObj} ${curlBridgeObj} ${compressBridgeObj} ${yamlBridgeObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${suppressLdWarnings}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
   logger.info(` ${linkCmd}`);
   const linkStdio = logger.getLevel() >= LogLevel_Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -666,6 +666,9 @@ export function compileNative(inputFile: string, outputFile: string): void {
   if (generator.getUsesHttpServer()) {
     linkLibs = "-lz -lzstd " + linkLibs;
   }
+  if (generator.getUsesCompression() && !generator.getUsesHttpServer()) {
+    linkLibs = "-lz -lzstd " + linkLibs;
+  }
   const lwsBridgeObj = generator.getUsesHttpServer()
     ? effectiveBridgePath +
       "/lws-bridge.o " +
@@ -690,6 +693,10 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const arenaBridgeObj = effectiveBridgePath + "/arena-bridge.o";
   const cpSpawnObj = generator.getUsesSpawn() ? effectiveBridgePath + "/child-process-spawn.o" : "";
   const curlBridgeObj = generator.getUsesCurl() ? effectiveBridgePath + "/curl-bridge.o" : "";
+  const compressBridgeObj = generator.getUsesCompression()
+    ? effectiveBridgePath + "/compress-bridge.o"
+    : "";
+  const yamlBridgeObj = generator.getUsesYaml() ? effectiveBridgePath + "/yaml-bridge.o" : "";
   let llvmBridgeObj = "";
   let llvmBuilderObj = "";
   let lldBridgeObj = "";
@@ -748,6 +755,10 @@ export function compileNative(inputFile: string, outputFile: string): void {
     cpSpawnObj +
     " " +
     curlBridgeObj +
+    " " +
+    compressBridgeObj +
+    " " +
+    yamlBridgeObj +
     " " +
     llvmBridgeObj +
     " " +

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -815,7 +815,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
         if (fs.existsSync("/usr/local/opt/sqlite/lib"))
           linkLibs = "-L/usr/local/opt/sqlite/lib " + linkLibs;
       }
-      if (generator.getUsesHttpServer()) {
+      if (generator.getUsesHttpServer() || generator.getUsesCompression()) {
         if (fs.existsSync("/opt/homebrew/opt/zstd/lib"))
           linkLibs = "-L/opt/homebrew/opt/zstd/lib " + linkLibs;
         if (fs.existsSync("/usr/local/opt/zstd/lib"))
@@ -890,7 +890,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
         if (fs.existsSync("/usr/local/opt/sqlite/lib"))
           linkLibs = "-L/usr/local/opt/sqlite/lib " + linkLibs;
       }
-      if (generator.getUsesHttpServer()) {
+      if (generator.getUsesHttpServer() || generator.getUsesCompression()) {
         if (fs.existsSync("/opt/homebrew/opt/zstd/lib"))
           linkLibs = "-L/opt/homebrew/opt/zstd/lib " + linkLibs;
         if (fs.existsSync("/usr/local/opt/zstd/lib"))

--- a/tests/fixtures/stdlib/colors-basic.ts
+++ b/tests/fixtures/stdlib/colors-basic.ts
@@ -1,0 +1,13 @@
+import { red, green, bold, stripAnsi } from "chadscript/colors";
+
+const r = red("hello");
+if (r === "\x1b[31mhello\x1b[0m") {
+  const g = green("world");
+  if (g === "\x1b[32mworld\x1b[0m") {
+    const b = bold(red("error"));
+    const stripped = stripAnsi(b);
+    if (stripped === "error") {
+      console.log("TEST_PASSED");
+    }
+  }
+}

--- a/tests/fixtures/stdlib/compress-gzip.ts
+++ b/tests/fixtures/stdlib/compress-gzip.ts
@@ -1,0 +1,16 @@
+import { gzip, gunzip } from "chadscript/compress";
+
+const input = new Uint8Array(5);
+input[0] = 72;
+input[1] = 101;
+input[2] = 108;
+input[3] = 108;
+input[4] = 111;
+
+const compressed = gzip(input);
+if (compressed.length > 0) {
+  const decompressed = gunzip(compressed);
+  if (decompressed.length === 5 && decompressed[0] === 72 && decompressed[4] === 111) {
+    console.log("TEST_PASSED");
+  }
+}

--- a/tests/fixtures/stdlib/events-basic.ts
+++ b/tests/fixtures/stdlib/events-basic.ts
@@ -1,0 +1,18 @@
+// @test-skip
+// EventEmitter requires function-pointer calling which isn't supported yet
+import { EventEmitter } from "chadscript/events";
+
+const ee = new EventEmitter();
+const results: string[] = [];
+
+function handler(data: string): void {
+  results.push(data);
+}
+
+ee.on("msg", handler);
+ee.emit("msg", "a");
+ee.emit("msg", "b");
+
+if (results.length === 2 && results[0] === "a" && results[1] === "b") {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/stdlib/glob-basic.ts
+++ b/tests/fixtures/stdlib/glob-basic.ts
@@ -1,0 +1,16 @@
+import { match } from "chadscript/glob";
+
+let pass = true;
+
+if (!match("*.ts", "hello.ts")) pass = false;
+if (match("*.ts", "hello.js")) pass = false;
+if (!match("src/**/*.ts", "src/foo/bar.ts")) pass = false;
+if (!match("src/**/baz.ts", "src/a/b/baz.ts")) pass = false;
+if (match("src/*.ts", "src/a/b.ts")) pass = false;
+if (!match("?.ts", "a.ts")) pass = false;
+if (match("?.ts", "ab.ts")) pass = false;
+if (!match("**", "anything/goes/here")) pass = false;
+
+if (pass) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/stdlib/yaml-parse.ts
+++ b/tests/fixtures/stdlib/yaml-parse.ts
@@ -1,11 +1,11 @@
-interface Config {
+interface Person {
   name: string;
-  port: number;
-  host: string;
+  age: number;
+  active: boolean;
 }
 
-const input = "name: myapp\nport: 8080\nhost: localhost";
-const result: Config = YAML.parse<Config>(input);
-if (result.name === "myapp" && result.port === 8080 && result.host === "localhost") {
+const input = "name: Alice\nage: 30\nactive: true";
+const result: Person = YAML.parse<Person>(input);
+if (result.name === "Alice" && result.age === 30 && result.active === true) {
   console.log("TEST_PASSED");
 }

--- a/tests/fixtures/stdlib/yaml-parse.ts
+++ b/tests/fixtures/stdlib/yaml-parse.ts
@@ -1,0 +1,11 @@
+interface Config {
+  name: string;
+  port: number;
+  host: string;
+}
+
+const input = "name: myapp\nport: 8080\nhost: localhost";
+const result: Config = YAML.parse<Config>(input);
+if (result.name === "myapp" && result.port === 8080 && result.host === "localhost") {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- New `chadscript/colors` module — ANSI color/style utilities (red, green, bold, dim, underline, etc.) with `stripAnsi()` for cleanup
- New `chadscript/glob` module — pattern matching with `*`, `**`, `?` wildcards
- New `chadscript/compress` module — gzip/gunzip, deflateRaw/inflateRaw, zstdCompress/zstdDecompress via zlib + zstd C bridge
- New `chadscript/events` module — EventEmitter class with on/off/emit/once (currently blocked by function-pointer calling limitation, test is skipped)
- `YAML.parse<T>(str)` and `YAML.stringify(obj)` — pure C YAML↔JSON bridge, reuses existing JSON codegen
- New `generateParseFromString()` on JsonGenerator to support YAML→JSON pipeline

## C bridges
- `compress-bridge.c` — zlib (gzip/gunzip/deflate/inflate) + zstd (compress/decompress)
- `yaml-bridge.c` — pure C YAML parser/stringifier, no external deps

## Test plan
- [x] `colors-basic.ts` — ANSI wrapping + stripAnsi
- [x] `glob-basic.ts` — wildcard matching (`*`, `**`, `?`)
- [x] `compress-gzip.ts` — gzip roundtrip
- [x] `yaml-parse.ts` — YAML parse with string, number, boolean fields
- [ ] `events-basic.ts` — skipped pending function-pointer calling support

🤖 Generated with [Claude Code](https://claude.com/claude-code)