### PR TITLE
fix boolean class fields and map/filter on class field arrays

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -1969,7 +1969,7 @@ export class MemberAccessGenerator {
   private classFieldToLlvm(fi: FieldInfo): string {
     const ft = fi.type;
     if (ft === "string") return "i8*";
-    if (ft === "boolean") return "i1";
+    if (ft === "boolean") return "double";
     if (ft === "string[]") return "%StringArray*";
     if (ft === "number[]") return "%Array*";
     if (ft === "boolean[]") return "%Array*";

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -1,7 +1,12 @@
 // Array iteration operations: filter, forEach, reduce, map
 // Exported functions accept (gen, expr, params) and handle callback resolution internally.
 
-import { MethodCallNode, VariableNode, ArrowFunctionNode } from "../../../../ast/types.js";
+import {
+  MethodCallNode,
+  VariableNode,
+  ArrowFunctionNode,
+  MemberAccessNode,
+} from "../../../../ast/types.js";
 import {
   IGeneratorContext,
   loadArrayMeta,
@@ -11,6 +16,38 @@ import {
 
 interface ExprBase {
   type: string;
+}
+
+function resolveObjectArrayElementType(gen: IGeneratorContext, objectExpr: ExprBase): string {
+  if (objectExpr.type === "variable") {
+    const varName = (objectExpr as VariableNode).name;
+    return gen.symbolTable.getObjectArrayElementType(varName) || "";
+  }
+  if (objectExpr.type === "member_access") {
+    const memberExpr = objectExpr as MemberAccessNode;
+    const memberObj = memberExpr.object as ExprBase;
+    let className = "";
+    if (memberObj.type === "this") {
+      className = gen.getCurrentClassName() || "";
+    } else if (memberObj.type === "variable") {
+      const varName = (memberObj as VariableNode).name;
+      const rawType = gen.symbolTable.getRawInterfaceType(varName);
+      if (rawType) className = rawType;
+    }
+    if (className) {
+      const tsType = gen.classGenGetFieldTsType(className, memberExpr.property);
+      if (
+        tsType &&
+        tsType.endsWith("[]") &&
+        tsType !== "string[]" &&
+        tsType !== "number[]" &&
+        tsType !== "boolean[]"
+      ) {
+        return tsType.slice(0, -2);
+      }
+    }
+  }
+  return "";
 }
 
 function getCallbackParamCount(callbackArg: ExprBase): number {
@@ -67,11 +104,7 @@ export function generateArrayFilter(
 
   let elementType = "";
   if (isObjectArray) {
-    const exprObjBase = expr.object as ExprBase;
-    if (exprObjBase.type === "variable") {
-      const varName = (expr.object as VariableNode).name;
-      elementType = gen.symbolTable.getObjectArrayElementType(varName) || "";
-    }
+    elementType = resolveObjectArrayElementType(gen, expr.object as ExprBase);
   }
 
   const callbackArg = expr.args[0];
@@ -330,11 +363,7 @@ export function generateArrayForEach(
 
   let elementType = "";
   if (isObjectArray) {
-    const exprObjBase = expr.object as ExprBase;
-    if (exprObjBase.type === "variable") {
-      const varName = (expr.object as VariableNode).name;
-      elementType = gen.symbolTable.getObjectArrayElementType(varName) || "";
-    }
+    elementType = resolveObjectArrayElementType(gen, expr.object as ExprBase);
   }
 
   const callbackArg = expr.args[0];
@@ -491,11 +520,7 @@ export function generateArrayReduce(
 
   let elementType = "";
   if (isObjectArray) {
-    const exprObjBase = expr.object as ExprBase;
-    if (exprObjBase.type === "variable") {
-      const varName = (expr.object as VariableNode).name;
-      elementType = gen.symbolTable.getObjectArrayElementType(varName) || "";
-    }
+    elementType = resolveObjectArrayElementType(gen, expr.object as ExprBase);
   }
 
   const callbackArg = expr.args[0];
@@ -805,11 +830,7 @@ export function generateArrayMap(
 
   let elementType = "";
   if (isObjectArray) {
-    const exprObjBase = expr.object as ExprBase;
-    if (exprObjBase.type === "variable") {
-      const varName = (expr.object as VariableNode).name;
-      elementType = gen.symbolTable.getObjectArrayElementType(varName) || "";
-    }
+    elementType = resolveObjectArrayElementType(gen, expr.object as ExprBase);
   }
 
   const callbackArg = expr.args[0];

--- a/tests/fixtures/classes/class-boolean-field.ts
+++ b/tests/fixtures/classes/class-boolean-field.ts
@@ -1,0 +1,29 @@
+class Toggle {
+  label: string;
+  active: boolean;
+  constructor(label: string, active: boolean) {
+    this.label = label;
+    this.active = active;
+  }
+}
+
+function main(): void {
+  const on = new Toggle("light", true);
+  const off = new Toggle("fan", false);
+
+  let result = "";
+  if (on.active) {
+    result = result + on.label + ":on,";
+  }
+  if (!off.active) {
+    result = result + off.label + ":off";
+  }
+
+  if (result === "light:on,fan:off") {
+    console.log("TEST_PASSED");
+  } else {
+    console.log("FAIL: " + result);
+  }
+}
+
+main();

--- a/tests/fixtures/classes/class-field-array-map-filter.ts
+++ b/tests/fixtures/classes/class-field-array-map-filter.ts
@@ -1,0 +1,55 @@
+class Item {
+  name: string;
+  value: number;
+  constructor(name: string, value: number) {
+    this.name = name;
+    this.value = value;
+  }
+}
+
+class Inventory {
+  items: Item[];
+  constructor() {
+    this.items = [];
+  }
+
+  addItem(name: string, value: number): void {
+    this.items.push(new Item(name, value));
+  }
+
+  describeExpensive(): string {
+    const expensive = this.items.filter((item: Item): boolean => item.value >= 50);
+    let result = "";
+    for (const e of expensive) {
+      result = result + e.name + ",";
+    }
+    return result;
+  }
+
+  listNames(): string {
+    const names = this.items.map((item: Item): string => item.name);
+    let result = "";
+    for (const n of names) {
+      result = result + n + ",";
+    }
+    return result;
+  }
+}
+
+function main(): void {
+  const inv = new Inventory();
+  inv.addItem("sword", 100);
+  inv.addItem("potion", 25);
+  inv.addItem("shield", 75);
+
+  const expensive = inv.describeExpensive();
+  const names = inv.listNames();
+
+  if (expensive === "sword,shield," && names === "sword,potion,shield,") {
+    console.log("TEST_PASSED");
+  } else {
+    console.log("FAIL filter=" + expensive + " map=" + names);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- **Boolean class fields now work correctly** — field access no longer reads wrong offsets due to `i1`/`double` type mismatch in GEP calculations
- **`.map()`/`.filter()` on class instance arrays stored as class fields** now correctly resolve element types in callbacks, so field access in callbacks returns real values instead of garbage

## Changes
- `member.ts`: fix `classFieldToLlvm()` to return `double` for boolean (matching actual class struct layout)
- `iteration.ts`: add `resolveObjectArrayElementType()` helper that handles `member_access` expressions (e.g. `this.items`) in addition to simple variables, used by filter/forEach/reduce/map
- New test fixtures for both fixes

## Test plan
- [x] `class-boolean-field.ts` — boolean field access on class instances
- [x] `class-field-array-map-filter.ts` — filter/map on `this.items` inside class methods
- [x] Full `npm run verify` passes (all 758 tests + 3-stage self-hosting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)