### PR TITLE
promote function parameters to i64 when integer-eligible

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -307,6 +307,21 @@ export class FunctionGenerator {
     ir += "entry:\n";
     this.ctx.setCurrentLabel("entry");
 
+    const bodyStmts = func.body ? func.body.statements : [];
+    const numericParamNames: string[] = [];
+    for (let i = 0; i < funcParams.length; i++) {
+      if (paramLLVMTypes[i] === "double") {
+        numericParamNames.push(funcParams[i]);
+      }
+    }
+    const eligible = findI64EligibleVariables(
+      bodyStmts,
+      numericParamNames.length > 0 ? numericParamNames : undefined,
+    );
+    this.ctx.setI64EligibleVars(eligible);
+
+    let eligibleSet: string[] = eligible;
+
     for (let i = 0; i < funcParams.length; i++) {
       const paramName = funcParams[i];
       if (!paramName) continue;
@@ -608,12 +623,31 @@ export class FunctionGenerator {
           this.ctx.emit(`store ${llvmType} %arg${i}, ${llvmType}* ${allocaReg}`);
         }
       } else {
-        this.ctx.defineVariable(paramName, allocaReg, "double", SymbolKind_Number, "local");
-        this.ctx.emit(`${allocaReg} = alloca double`);
-        if (isOptional && hasOptionalParams) {
-          this.generateOptionalParamInit(i, allocaReg, llvmType, paramInfo!, funcParams);
+        let paramIsI64 = false;
+        for (let ei = 0; ei < eligibleSet.length; ei++) {
+          if (eligibleSet[ei] === paramName) {
+            paramIsI64 = true;
+            break;
+          }
+        }
+        if (paramIsI64) {
+          this.ctx.defineVariable(paramName, allocaReg, "i64", SymbolKind_Number, "local");
+          this.ctx.emit(`${allocaReg} = alloca i64`);
+          if (isOptional && hasOptionalParams) {
+            this.generateOptionalParamInitI64(i, allocaReg, paramInfo!, funcParams);
+          } else {
+            const i64Val = this.ctx.nextTemp();
+            this.ctx.emit(`${i64Val} = fptosi double %arg${i} to i64`);
+            this.ctx.emit(`store i64 ${i64Val}, i64* ${allocaReg}`);
+          }
         } else {
-          this.ctx.emit(`store double %arg${i}, double* ${allocaReg}`);
+          this.ctx.defineVariable(paramName, allocaReg, "double", SymbolKind_Number, "local");
+          this.ctx.emit(`${allocaReg} = alloca double`);
+          if (isOptional && hasOptionalParams) {
+            this.generateOptionalParamInit(i, allocaReg, llvmType, paramInfo!, funcParams);
+          } else {
+            this.ctx.emit(`store double %arg${i}, double* ${allocaReg}`);
+          }
         }
       }
     }
@@ -652,14 +686,6 @@ export class FunctionGenerator {
       this.ctx.setAsyncResultPromise(resultPromise);
       this.ctx.emit(`${resultPromise} = call %Promise* @__Promise_new()`);
     }
-
-    // Access func.body.statements directly to preserve struct type info.
-    // funcBody (from `func.body || {...}`) is an opaque i8* in the native compiler,
-    // which means .statements access doesn't GEP into the struct. Using func.body
-    // directly preserves the FunctionNode → BlockStatement type chain.
-    const bodyStmts = func.body ? func.body.statements : [];
-    const eligible = findI64EligibleVariables(bodyStmts);
-    this.ctx.setI64EligibleVars(eligible);
 
     const result = this.ctx.generateBlock(funcBody, funcParams);
 
@@ -977,6 +1003,42 @@ export class FunctionGenerator {
     } else {
       const defaultVal = this.getDefaultValue(llvmType);
       this.ctx.emit(`store ${llvmType} ${defaultVal}, ${ptrType} ${allocaReg}`);
+    }
+    this.ctx.emit(`br label %${doneLabel}`);
+
+    this.ctx.emit(`${doneLabel}:`);
+  }
+
+  private generateOptionalParamInitI64(
+    paramIndex: number,
+    allocaReg: string,
+    paramInfo: FunctionParameter,
+    params: string[],
+  ): void {
+    const labelId = this.labelCounter++;
+    const hasArgLabel = `has_arg_${labelId}`;
+    const noArgLabel = `no_arg_${labelId}`;
+    const doneLabel = `done_arg_${labelId}`;
+
+    const cmpReg = this.ctx.nextTemp();
+    this.ctx.emit(`${cmpReg} = icmp sgt i32 %__argc, ${paramIndex}`);
+    this.ctx.emit(`br i1 ${cmpReg}, label %${hasArgLabel}, label %${noArgLabel}`);
+
+    this.ctx.emit(`${hasArgLabel}:`);
+    const i64Val = this.ctx.nextTemp();
+    this.ctx.emit(`${i64Val} = fptosi double %arg${paramIndex} to i64`);
+    this.ctx.emit(`store i64 ${i64Val}, i64* ${allocaReg}`);
+    this.ctx.emit(`br label %${doneLabel}`);
+
+    this.ctx.emit(`${noArgLabel}:`);
+    if (paramInfo.defaultValue) {
+      const defaultReg = this.ctx.generateExpression(paramInfo.defaultValue, params);
+      const coerced = this.ctx.ensureDouble(defaultReg);
+      const defI64 = this.ctx.nextTemp();
+      this.ctx.emit(`${defI64} = fptosi double ${coerced} to i64`);
+      this.ctx.emit(`store i64 ${defI64}, i64* ${allocaReg}`);
+    } else {
+      this.ctx.emit(`store i64 0, i64* ${allocaReg}`);
     }
     this.ctx.emit(`br label %${doneLabel}`);
 

--- a/src/codegen/infrastructure/integer-analysis.ts
+++ b/src/codegen/infrastructure/integer-analysis.ts
@@ -214,7 +214,7 @@ class IntegerAnalyzer {
     }
   }
 
-  findI64EligibleVariables(statements: Statement[]): string[] {
+  findI64EligibleVariables(statements: Statement[], paramNames?: string[]): string[] {
     if (!statements || !statements.length) return [];
 
     const allDecls: VariableDeclaration[] = [];
@@ -224,8 +224,15 @@ class IntegerAnalyzer {
     const isConst: boolean[] = [];
     const pendingDecls: VariableDeclaration[] = [];
 
-    // Pass 1: collect candidates with simple integer initializers (no variable refs)
     this.candidateNames = [];
+    if (paramNames) {
+      for (let pi = 0; pi < paramNames.length; pi++) {
+        candidates.push(paramNames[pi]);
+        isConst.push(false);
+        this.candidateNames.push(paramNames[pi]);
+      }
+    }
+
     for (let di = 0; di < allDecls.length; di++) {
       const varDecl = allDecls[di];
       if (!varDecl.value) continue;
@@ -299,6 +306,6 @@ class IntegerAnalyzer {
   }
 }
 
-export function findI64EligibleVariables(statements: Statement[]): string[] {
-  return new IntegerAnalyzer().findI64EligibleVariables(statements);
+export function findI64EligibleVariables(statements: Statement[], paramNames?: string[]): string[] {
+  return new IntegerAnalyzer().findI64EligibleVariables(statements, paramNames);
 }

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -156,7 +156,8 @@ describe(`ChadScript Compiler (${compilerLabel})`, () => {
         assert.ok(llContent.includes("define i32 @main"), "Should define main function");
         assert.ok(llContent.includes("ret"), "Should have return statements");
         assert.ok(
-          llContent.includes("fadd") && llContent.includes("double"),
+          (llContent.includes("fadd") && llContent.includes("double")) ||
+            llContent.includes("add nsw i64"),
           "Should have add instruction",
         );
       } finally {

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -157,7 +157,7 @@ describe(`ChadScript Compiler (${compilerLabel})`, () => {
         assert.ok(llContent.includes("ret"), "Should have return statements");
         assert.ok(
           (llContent.includes("fadd") && llContent.includes("double")) ||
-            llContent.includes("add nsw i64"),
+            llContent.includes("add i64"),
           "Should have add instruction",
         );
       } finally {

--- a/tests/fixtures/optimization/param-i64-promotion.ts
+++ b/tests/fixtures/optimization/param-i64-promotion.ts
@@ -1,0 +1,40 @@
+function swap(arr: number[], a: number, b: number): void {
+  const tmp = arr[a];
+  arr[a] = arr[b];
+  arr[b] = tmp;
+}
+
+function partition(arr: number[], lo: number, hi: number): number {
+  const pivot = arr[hi];
+  let i = lo - 1;
+  for (let j = lo; j < hi; j++) {
+    if (arr[j] <= pivot) {
+      i = i + 1;
+      swap(arr, i, j);
+    }
+  }
+  swap(arr, i + 1, hi);
+  return i + 1;
+}
+
+function quicksort(arr: number[], lo: number, hi: number): void {
+  if (lo < hi) {
+    const p = partition(arr, lo, hi);
+    quicksort(arr, lo, p - 1);
+    quicksort(arr, p + 1, hi);
+  }
+}
+
+const data = [5, 3, 8, 1, 9, 2, 7, 4, 6, 0];
+quicksort(data, 0, data.length - 1);
+
+let sorted = true;
+for (let i = 0; i < data.length; i++) {
+  if (data[i] !== i) {
+    sorted = false;
+  }
+}
+
+if (sorted) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary
- Numeric function params (like `lo`, `hi` in quicksort) are now promoted to `i64` when integer analysis determines they're only used in integer contexts
- Eliminates `sitofp i64→double` + `fcmp` conversions on every loop iteration, replacing them with pure `icmp i64` comparisons
- Extends the existing local variable i64 optimization (PR #475) to function parameters

## Test plan
- [ ] New test fixture `tests/fixtures/optimization/param-i64-promotion.ts` (quicksort)
- [ ] All existing tests pass
- [ ] Self-hosting verification passes