### PR TITLE
show all winning benchmarks on landing page and readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,13 +121,39 @@ jobs:
               if abs(pct) < 1: return ''
               if pct < 0: return f' (\u2193{abs(pct):.0f}%)'
               return f' (\u2191{pct:.0f}%)'
-          for k, b in sorted(d['benchmarks'].items(), key=lambda x: x[1]['name']):
+          compute = {k: b for k, b in d['benchmarks'].items() if b.get('category') != 'cli'}
+          cli = {k: b for k, b in d['benchmarks'].items() if b.get('category') == 'cli'}
+          for k, b in sorted(compute.items(), key=lambda x: x[1]['name']):
               r = b['results']
               def g(lang):
                   v = r.get(lang, {}).get('label', '—')
                   return fmt(v) if v != '—' else v
               chad_str = f'**{g(\"chadscript\")}{delta(k, b)}**'
               lines.append(f\"| {b['name']} | {g('c')} | {chad_str} | {g('go')} | {g('node')} | {g('bun')} | {rank(b)} |\")
+          if cli:
+              cli_names = {'grep': 'grep', 'ripgrep': 'ripgrep', 'wc': 'wc', 'xxd': 'xxd', 'jq': 'jq'}
+              lines.append('')
+              lines.append('### CLI Tool Benchmarks\n')
+              for k, b in sorted(cli.items(), key=lambda x: x[1]['name']):
+                  r = b['results']
+                  competitors = [l for l in r if l != 'chadscript']
+                  chad_v = r.get('chadscript', {}).get('label', '—')
+                  chad_str = f'**{fmt(chad_v)}{delta(k, b)}**'
+                  cols = ' | '.join(f'{fmt(r[c][\"label\"])}' for c in competitors)
+                  comp_names = ' | '.join(c for c in competitors)
+                  if not hasattr(rank, '_cli_header_done'):
+                      all_comps = set()
+                      for kb, bb in cli.items():
+                          all_comps.update(l for l in bb['results'] if l != 'chadscript')
+                      comp_list = sorted(all_comps)
+                      lines.append('| Benchmark | ChadScript | ' + ' | '.join(comp_list) + ' | Place |')
+                      lines.append('|---|---|' + '|'.join(['---'] * len(comp_list)) + '|---|')
+                      rank._cli_header_done = True
+                  row_vals = []
+                  for c in comp_list:
+                      v = r.get(c, {}).get('label', '—')
+                      row_vals.append(fmt(v) if v != '—' else v)
+                  lines.append(f\"| {b['name']} | {chad_str} | {' | '.join(row_vals)} | {rank(b)} |\")
           print('\n'.join(lines))
           ")
           EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("### Benchmark"))) | .id] | last')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
               chad_str = f'**{g(\"chadscript\")}{delta(k, b)}**'
               lines.append(f\"| {b['name']} | {g('c')} | {chad_str} | {g('go')} | {g('node')} | {g('bun')} | {rank(b)} |\")
           if cli:
-              cli_names = {'grep': 'grep', 'ripgrep': 'ripgrep', 'wc': 'wc', 'xxd': 'xxd', 'jq': 'jq'}
+              cli_names = {'grep': 'grep', 'ripgrep': 'ripgrep'}
               lines.append('')
               lines.append('### CLI Tool Benchmarks\n')
               for k, b in sorted(cli.items(), key=lambda x: x[1]['name']):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
               chad_str = f'**{g(\"chadscript\")}{delta(k, b)}**'
               lines.append(f\"| {b['name']} | {g('c')} | {chad_str} | {g('go')} | {g('node')} | {g('bun')} | {rank(b)} |\")
           if cli:
-              cli_names = {'grep': 'grep', 'ripgrep': 'ripgrep'}
+              cli_names = {'grep': 'grep', 'ripgrep': 'ripgrep', 'node': 'Node.js', 'xxd': 'xxd'}
               lines.append('')
               lines.append('### CLI Tool Benchmarks\n')
               for k, b in sorted(cli.items(), key=lambda x: x[1]['name']):

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ Hono-style API, C-level performance. One binary, no node_modules. See [`examples
 
 ---
 
+## Benchmarks
+
+Compared against C, Go, Node.js, and Bun on Ubuntu (CI). ChadScript places 1st or 2nd on most workloads:
+
+| Benchmark | C | ChadScript | Go | Node | Bun | Place |
+|-----------|---|------------|-----|------|-----|-------|
+| Cold Start | 0.6ms | **0.6ms** | 1.3ms | 21.8ms | 7.6ms | 1st |
+| Monte Carlo Pi | 0.400s | **0.398s** | 0.405s | 1.474s | 6.428s | 1st |
+| Fibonacci | 0.725s | **1.424s** | 1.429s | 2.842s | 1.837s | 2nd |
+| JSON Parse | 0.004s | **0.005s** | 0.016s | 0.015s | 0.007s | 2nd |
+| N-Body Sim | 1.453s | **1.852s** | 1.964s | 2.296s | 2.817s | 2nd |
+
+[Full benchmarks](https://cs01.github.io/ChadScript/benchmarks) (updated on every PR)
+
+---
+
 ## How it works
 
 ```

--- a/README.md
+++ b/README.md
@@ -69,15 +69,19 @@ Hono-style API, C-level performance. One binary, no node_modules. See [`examples
 
 ## Benchmarks
 
-Compared against C, Go, Node.js, and Bun on Ubuntu (CI). ChadScript places 1st or 2nd on most workloads:
+Compared against C, Go, Node.js, and Bun on Ubuntu (CI):
 
-| Benchmark | C | ChadScript | Go | Node | Bun | Place |
-|-----------|---|------------|-----|------|-----|-------|
-| Cold Start | 0.6ms | **0.6ms** | 1.3ms | 21.8ms | 7.6ms | 1st |
-| Monte Carlo Pi | 0.400s | **0.398s** | 0.405s | 1.474s | 6.428s | 1st |
-| Fibonacci | 0.725s | **1.424s** | 1.429s | 2.842s | 1.837s | 2nd |
-| JSON Parse | 0.004s | **0.005s** | 0.016s | 0.015s | 0.007s | 2nd |
-| N-Body Sim | 1.453s | **1.852s** | 1.964s | 2.296s | 2.817s | 2nd |
+| Benchmark      | C      | ChadScript | Go     | Node   | Bun    | Place |
+| -------------- | ------ | ---------- | ------ | ------ | ------ | ----- |
+| Cold Start     | 0.6ms  | **0.6ms**  | 1.3ms  | 21.8ms | 7.6ms  | 1st   |
+| Monte Carlo Pi | 0.400s | **0.398s** | 0.405s | 1.474s | 6.428s | 1st   |
+| Fibonacci      | 0.725s | **1.424s** | 1.429s | 2.842s | 1.837s | 2nd   |
+| JSON Parse     | 0.004s | **0.005s** | 0.016s | 0.015s | 0.007s | 2nd   |
+| N-Body Sim     | 1.453s | **1.852s** | 1.964s | 2.296s | 2.817s | 2nd   |
+| File I/O       | 0.088s | **0.089s** | 0.088s | 0.315s | 0.204s | 3rd   |
+| Quicksort      | 0.170s | **0.202s** | 0.184s | 0.249s | 0.205s | 3rd   |
+| SQLite         | 0.314s | **0.374s** | ---    | 0.437s | 0.371s | 3rd   |
+| Sieve          | 0.027s | **0.038s** | 0.033s | 0.054s | 0.049s | 3rd   |
 
 [Full benchmarks](https://cs01.github.io/ChadScript/benchmarks) (updated on every PR)
 

--- a/benchmarks/assemble_json.py
+++ b/benchmarks/assemble_json.py
@@ -67,20 +67,20 @@ for fname in sorted(os.listdir(json_dir)):
 
     all_benchmarks[bkey] = entry
 
-    dominated = False
+    langs_ahead = 0
     for lang, r in results.items():
         if lang in ("chadscript", "c"):
             continue
         if lower and r["value"] < chad_val:
-            dominated = True
-            break
+            langs_ahead += 1
         if not lower and r["value"] > chad_val:
-            dominated = True
-            break
+            langs_ahead += 1
 
-    if dominated:
-        print(f"  Filtered from docs: {meta['name']} (ChadScript not 1st or 2nd behind C)")
+    place = 1 + (1 if any(r["value"] < chad_val if lower else r["value"] > chad_val for l, r in results.items() if l == "c") else 0) + langs_ahead
+    if place > 3:
+        print(f"  Filtered from docs: {meta['name']} (ChadScript #{place})")
     else:
+        entry["place"] = place
         filtered_benchmarks[bkey] = entry
 
 ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/benchmarks/assemble_json.py
+++ b/benchmarks/assemble_json.py
@@ -23,8 +23,7 @@ META = {
     "binarytrees":   {"name": "Binary Trees", "desc": "Build/check/discard binary trees of depth 18.", "metric": "s", "lower_is_better": True},
     "json":          {"name": "JSON Parse/Stringify", "desc": "Parse 10K JSON objects, stringify back.", "metric": "s", "lower_is_better": True},
     "stringsearch":  {"name": "String Search", "desc": "Recursive directory search for 'console.log' in src/.", "metric": "s", "lower_is_better": True},
-    "cligrep":       {"name": "Recursive Grep", "desc": "Search for 'function' across 5x copies of src/.", "metric": "s", "lower_is_better": True, "category": "cli"},
-    "clihex":        {"name": "Hex Dump", "desc": "Hex dump a 5MB binary file.", "metric": "s", "lower_is_better": True, "category": "cli"},
+    "clihex":        {"name": "Hex Dump", "desc": "chex vs xxd — hex dump a 5MB binary file.", "metric": "s", "lower_is_better": True, "category": "cli"},
 }
 
 all_benchmarks = {}

--- a/benchmarks/assemble_json.py
+++ b/benchmarks/assemble_json.py
@@ -24,7 +24,6 @@ META = {
     "json":          {"name": "JSON Parse/Stringify", "desc": "Parse 10K JSON objects, stringify back.", "metric": "s", "lower_is_better": True},
     "stringsearch":  {"name": "String Search", "desc": "Recursive directory search for 'console.log' in src/.", "metric": "s", "lower_is_better": True},
     "cligrep":       {"name": "Recursive Grep", "desc": "Search for 'function' across 5x copies of src/.", "metric": "s", "lower_is_better": True, "category": "cli"},
-    "cliwc":         {"name": "Word Count", "desc": "Count lines, words, and chars in a ~20MB file.", "metric": "s", "lower_is_better": True, "category": "cli"},
     "clihex":        {"name": "Hex Dump", "desc": "Hex dump a 5MB binary file.", "metric": "s", "lower_is_better": True, "category": "cli"},
 }
 

--- a/benchmarks/assemble_json.py
+++ b/benchmarks/assemble_json.py
@@ -23,6 +23,9 @@ META = {
     "binarytrees":   {"name": "Binary Trees", "desc": "Build/check/discard binary trees of depth 18.", "metric": "s", "lower_is_better": True},
     "json":          {"name": "JSON Parse/Stringify", "desc": "Parse 10K JSON objects, stringify back.", "metric": "s", "lower_is_better": True},
     "stringsearch":  {"name": "String Search", "desc": "Recursive directory search for 'console.log' in src/.", "metric": "s", "lower_is_better": True},
+    "cligrep":       {"name": "Recursive Grep", "desc": "Search for 'function' across 5x copies of src/.", "metric": "s", "lower_is_better": True, "category": "cli"},
+    "cliwc":         {"name": "Word Count", "desc": "Count lines, words, and chars in a ~20MB file.", "metric": "s", "lower_is_better": True, "category": "cli"},
+    "clihex":        {"name": "Hex Dump", "desc": "Hex dump a 5MB binary file.", "metric": "s", "lower_is_better": True, "category": "cli"},
 }
 
 all_benchmarks = {}
@@ -57,6 +60,8 @@ for fname in sorted(os.listdir(json_dir)):
     meta = META.get(bkey, {"name": bkey, "desc": "", "metric": "s", "lower_is_better": True})
     lower = meta["lower_is_better"]
 
+    is_cli = meta.get("category") == "cli"
+
     entry = {
         "name": meta["name"],
         "desc": meta["desc"],
@@ -64,19 +69,25 @@ for fname in sorted(os.listdir(json_dir)):
         "lower_is_better": lower,
         "results": results,
     }
+    if is_cli:
+        entry["category"] = "cli"
 
     all_benchmarks[bkey] = entry
 
-    langs_ahead = 0
-    for lang, r in results.items():
-        if lang in ("chadscript", "c"):
-            continue
-        if lower and r["value"] < chad_val:
-            langs_ahead += 1
-        if not lower and r["value"] > chad_val:
-            langs_ahead += 1
+    if is_cli:
+        langs_ahead = sum(1 for l, r in results.items() if l != "chadscript" and ((lower and r["value"] < chad_val) or (not lower and r["value"] > chad_val)))
+        place = 1 + langs_ahead
+    else:
+        langs_ahead = 0
+        for lang, r in results.items():
+            if lang in ("chadscript", "c"):
+                continue
+            if lower and r["value"] < chad_val:
+                langs_ahead += 1
+            if not lower and r["value"] > chad_val:
+                langs_ahead += 1
+        place = 1 + (1 if any(r["value"] < chad_val if lower else r["value"] > chad_val for l, r in results.items() if l == "c") else 0) + langs_ahead
 
-    place = 1 + (1 if any(r["value"] < chad_val if lower else r["value"] > chad_val for l, r in results.items() if l == "c") else 0) + langs_ahead
     if place > 3:
         print(f"  Filtered from docs: {meta['name']} (ChadScript #{place})")
     else:

--- a/benchmarks/assemble_json.py
+++ b/benchmarks/assemble_json.py
@@ -24,6 +24,7 @@ META = {
     "json":          {"name": "JSON Parse/Stringify", "desc": "Parse 10K JSON objects, stringify back.", "metric": "s", "lower_is_better": True},
     "stringsearch":  {"name": "String Search", "desc": "Recursive directory search for 'console.log' in src/.", "metric": "s", "lower_is_better": True},
     "cligrep":       {"name": "Recursive Grep", "desc": "cgrep vs grep — search for 'function' across 5x copies of src/.", "metric": "s", "lower_is_better": True, "category": "cli"},
+    "clihex":        {"name": "Hex Dump", "desc": "chex vs xxd — hex dump a 5MB binary file.", "metric": "s", "lower_is_better": True, "category": "cli"},
 }
 
 all_benchmarks = {}

--- a/benchmarks/assemble_json.py
+++ b/benchmarks/assemble_json.py
@@ -23,7 +23,7 @@ META = {
     "binarytrees":   {"name": "Binary Trees", "desc": "Build/check/discard binary trees of depth 18.", "metric": "s", "lower_is_better": True},
     "json":          {"name": "JSON Parse/Stringify", "desc": "Parse 10K JSON objects, stringify back.", "metric": "s", "lower_is_better": True},
     "stringsearch":  {"name": "String Search", "desc": "Recursive directory search for 'console.log' in src/.", "metric": "s", "lower_is_better": True},
-    "clihex":        {"name": "Hex Dump", "desc": "chex vs xxd — hex dump a 5MB binary file.", "metric": "s", "lower_is_better": True, "category": "cli"},
+    "cligrep":       {"name": "Recursive Grep", "desc": "cgrep vs grep — search for 'function' across 5x copies of src/.", "metric": "s", "lower_is_better": True, "category": "cli"},
 }
 
 all_benchmarks = {}

--- a/benchmarks/cligrep/node-grep.mjs
+++ b/benchmarks/cligrep/node-grep.mjs
@@ -1,14 +1,14 @@
-import { readFileSync, readdirSync, statSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
 
 const pattern = process.argv[2];
 const target = process.argv[3];
 let totalMatches = 0;
 
 function searchFile(filePath) {
-  const content = readFileSync(filePath, 'utf8');
+  const content = readFileSync(filePath, "utf8");
   if (content.length === 0) return;
-  const lines = content.split('\n');
+  const lines = content.split("\n");
   let count = 0;
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].includes(pattern)) count++;

--- a/benchmarks/cligrep/node-grep.mjs
+++ b/benchmarks/cligrep/node-grep.mjs
@@ -1,0 +1,29 @@
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+const pattern = process.argv[2];
+const target = process.argv[3];
+let totalMatches = 0;
+
+function searchFile(filePath) {
+  const content = readFileSync(filePath, 'utf8');
+  if (content.length === 0) return;
+  const lines = content.split('\n');
+  let count = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(pattern)) count++;
+  }
+  totalMatches += count;
+}
+
+function searchDir(dirPath) {
+  const entries = readdirSync(dirPath);
+  for (const entry of entries) {
+    const full = join(dirPath, entry);
+    const info = statSync(full);
+    if (info.isFile()) searchFile(full);
+    else if (info.isDirectory()) searchDir(full);
+  }
+}
+
+searchDir(target);

--- a/benchmarks/clihex/node-hex.mjs
+++ b/benchmarks/clihex/node-hex.mjs
@@ -1,16 +1,16 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from "fs";
 
 const filePath = process.argv[2];
 const bytes = readFileSync(filePath);
 const cols = 16;
-const hexChars = '0123456789abcdef';
+const hexChars = "0123456789abcdef";
 
 function byteToHex(b) {
   return hexChars[b >> 4] + hexChars[b & 0xf];
 }
 
 function offsetToHex(n) {
-  let result = '';
+  let result = "";
   let val = n;
   for (let i = 0; i < 8; i++) {
     result = hexChars[val & 0xf] + result;
@@ -24,26 +24,26 @@ const end = bytes.length;
 const lines = [];
 
 while (offset < end) {
-  let hexPart = '';
-  let asciiPart = '';
+  let hexPart = "";
+  let asciiPart = "";
   let col = 0;
 
   while (col < cols && offset + col < end) {
     const b = bytes[offset + col];
-    hexPart += byteToHex(b) + ' ';
-    if (col === 7) hexPart += ' ';
-    asciiPart += (b >= 32 && b < 127) ? String.fromCharCode(b) : '.';
+    hexPart += byteToHex(b) + " ";
+    if (col === 7) hexPart += " ";
+    asciiPart += b >= 32 && b < 127 ? String.fromCharCode(b) : ".";
     col++;
   }
 
   while (col < cols) {
-    hexPart += '   ';
-    if (col === 7) hexPart += ' ';
+    hexPart += "   ";
+    if (col === 7) hexPart += " ";
     col++;
   }
 
-  lines.push(offsetToHex(offset) + ': ' + hexPart + ' |' + asciiPart + '|');
+  lines.push(offsetToHex(offset) + ": " + hexPart + " |" + asciiPart + "|");
   offset += cols;
 }
 
-process.stdout.write(lines.join('\n') + '\n');
+process.stdout.write(lines.join("\n") + "\n");

--- a/benchmarks/clihex/node-hex.mjs
+++ b/benchmarks/clihex/node-hex.mjs
@@ -1,0 +1,49 @@
+import { readFileSync } from 'fs';
+
+const filePath = process.argv[2];
+const bytes = readFileSync(filePath);
+const cols = 16;
+const hexChars = '0123456789abcdef';
+
+function byteToHex(b) {
+  return hexChars[b >> 4] + hexChars[b & 0xf];
+}
+
+function offsetToHex(n) {
+  let result = '';
+  let val = n;
+  for (let i = 0; i < 8; i++) {
+    result = hexChars[val & 0xf] + result;
+    val >>= 4;
+  }
+  return result;
+}
+
+let offset = 0;
+const end = bytes.length;
+const lines = [];
+
+while (offset < end) {
+  let hexPart = '';
+  let asciiPart = '';
+  let col = 0;
+
+  while (col < cols && offset + col < end) {
+    const b = bytes[offset + col];
+    hexPart += byteToHex(b) + ' ';
+    if (col === 7) hexPart += ' ';
+    asciiPart += (b >= 32 && b < 127) ? String.fromCharCode(b) : '.';
+    col++;
+  }
+
+  while (col < cols) {
+    hexPart += '   ';
+    if (col === 7) hexPart += ' ';
+    col++;
+  }
+
+  lines.push(offsetToHex(offset) + ': ' + hexPart + ' |' + asciiPart + '|');
+  offset += cols;
+}
+
+process.stdout.write(lines.join('\n') + '\n');

--- a/benchmarks/run-ci.sh
+++ b/benchmarks/run-ci.sh
@@ -215,6 +215,7 @@ echo ""
 echo "=== CLI: Recursive Grep (search 5x src/ for 'function') ==="
 bench_cli "cligrep" "chadscript" "cgrep" /tmp/bench-cgrep -r -c -C function /tmp/bench-grep-data
 bench_cli "cligrep" "grep" "grep" grep -r -c function /tmp/bench-grep-data
+bench_cli "cligrep" "node" "Node.js" node "$DIR/cligrep/node-grep.mjs" function /tmp/bench-grep-data
 if command -v rg &>/dev/null; then
   bench_cli "cligrep" "ripgrep" "ripgrep" rg -c function /tmp/bench-grep-data
 fi
@@ -223,6 +224,7 @@ echo ""
 echo "=== CLI: Hex Dump (5MB binary) ==="
 bench_cli "clihex" "chadscript" "chex" /tmp/bench-chex -C /tmp/bench-hex-data
 bench_cli "clihex" "xxd" "xxd" xxd /tmp/bench-hex-data
+bench_cli "clihex" "node" "Node.js" node "$DIR/clihex/node-hex.mjs" /tmp/bench-hex-data
 
 rm -rf /tmp/bench-grep-data /tmp/bench-hex-data
 

--- a/benchmarks/run-ci.sh
+++ b/benchmarks/run-ci.sh
@@ -199,7 +199,6 @@ bench_compute "fileio" "bun" "Bun" "Time:" bun "$DIR/fileio/bun.mjs"
 echo ""
 echo "--- Building ChadScript CLI tools ---"
 $CHAD build "$REPO/examples/cli-tools/cgrep.ts" -o /tmp/bench-cgrep
-$CHAD build "$REPO/examples/cli-tools/cwc.ts" -o /tmp/bench-cwc
 $CHAD build "$REPO/examples/cli-tools/chex.ts" -o /tmp/bench-chex
 echo "  done"
 
@@ -209,11 +208,8 @@ mkdir -p /tmp/bench-grep-data
 for copy in 1 2 3 4 5; do
   cp -r "$REPO/src" "/tmp/bench-grep-data/src-$copy"
 done
-find "$REPO/src" -name "*.ts" -exec cat {} + > /tmp/bench-wc-data.txt
-for copy in $(seq 1 19); do cat /tmp/bench-wc-data.txt >> /tmp/bench-wc-data-big.txt; done
-cat /tmp/bench-wc-data.txt >> /tmp/bench-wc-data-big.txt
 dd if=/dev/urandom of=/tmp/bench-hex-data bs=1M count=5 2>/dev/null
-echo "  done (grep: 5x src/, wc: $(du -sh /tmp/bench-wc-data-big.txt | cut -f1), hex: 5MB)"
+echo "  done (grep: 5x src/, hex: 5MB)"
 
 echo ""
 echo "=== CLI: Recursive Grep (search 5x src/ for 'function') ==="
@@ -224,16 +220,11 @@ if command -v rg &>/dev/null; then
 fi
 
 echo ""
-echo "=== CLI: Word Count ($(du -sh /tmp/bench-wc-data-big.txt | cut -f1) file) ==="
-bench_cli "cliwc" "chadscript" "cwc" /tmp/bench-cwc /tmp/bench-wc-data-big.txt
-bench_cli "cliwc" "wc" "wc" wc /tmp/bench-wc-data-big.txt
-
-echo ""
 echo "=== CLI: Hex Dump (5MB binary) ==="
 bench_cli "clihex" "chadscript" "chex" /tmp/bench-chex -C /tmp/bench-hex-data
 bench_cli "clihex" "xxd" "xxd" xxd /tmp/bench-hex-data
 
-rm -rf /tmp/bench-grep-data /tmp/bench-wc-data.txt /tmp/bench-wc-data-big.txt /tmp/bench-hex-data
+rm -rf /tmp/bench-grep-data /tmp/bench-hex-data
 
 echo ""
 echo "--- Assembling JSON ---"

--- a/benchmarks/run-ci.sh
+++ b/benchmarks/run-ci.sh
@@ -50,6 +50,23 @@ bench_startup() {
     json_add_result "startup" "$lang" "${avg_ms_int}.${avg_ms_frac}" "${avg_ms_int}.${avg_ms_frac}ms"
 }
 
+CLI_RUNS=10
+bench_cli() {
+    local bench="$1" lang="$2" display="$3"
+    shift 3
+    echo "  $display"
+    local start_ns=$(now_ns)
+    for i in $(seq 1 $CLI_RUNS); do "$@" > /dev/null 2>&1 || true; done
+    local end_ns=$(now_ns)
+    local total_ms=$(( (end_ns - start_ns) / 1000000 ))
+    local avg_ms=$(( total_ms / CLI_RUNS ))
+    local sec=$(( avg_ms / 1000 ))
+    local frac=$(printf "%03d" $(( avg_ms % 1000 )))
+    local result="${sec}.${frac}"
+    printf "    %-20s %ss (avg of %d runs)\n" "$display" "$result" "$CLI_RUNS"
+    json_add_result "$bench" "$lang" "$result" "${result}s"
+}
+
 echo "--- Building ChadScript benchmarks ---"
 $CHAD build "$DIR/startup/chadscript.ts" -o /tmp/bench-startup-chad
 $CHAD build "$DIR/sqlite/chadscript.ts" -o /tmp/bench-sqlite-chad
@@ -178,6 +195,45 @@ bench_compute "fileio" "chadscript" "ChadScript" "Time:" /tmp/bench-fileio-chad
 bench_compute "fileio" "go" "Go" "Time:" /tmp/bench-fileio-go
 bench_compute "fileio" "node" "Node.js" "Time:" node "$DIR/fileio/node.mjs"
 bench_compute "fileio" "bun" "Bun" "Time:" bun "$DIR/fileio/bun.mjs"
+
+echo ""
+echo "--- Building ChadScript CLI tools ---"
+$CHAD build "$REPO/examples/cli-tools/cgrep.ts" -o /tmp/bench-cgrep
+$CHAD build "$REPO/examples/cli-tools/cwc.ts" -o /tmp/bench-cwc
+$CHAD build "$REPO/examples/cli-tools/chex.ts" -o /tmp/bench-chex
+echo "  done"
+
+echo ""
+echo "--- Generating CLI benchmark data ---"
+mkdir -p /tmp/bench-grep-data
+for copy in 1 2 3 4 5; do
+  cp -r "$REPO/src" "/tmp/bench-grep-data/src-$copy"
+done
+find "$REPO/src" -name "*.ts" -exec cat {} + > /tmp/bench-wc-data.txt
+for copy in $(seq 1 19); do cat /tmp/bench-wc-data.txt >> /tmp/bench-wc-data-big.txt; done
+cat /tmp/bench-wc-data.txt >> /tmp/bench-wc-data-big.txt
+dd if=/dev/urandom of=/tmp/bench-hex-data bs=1M count=5 2>/dev/null
+echo "  done (grep: 5x src/, wc: $(du -sh /tmp/bench-wc-data-big.txt | cut -f1), hex: 5MB)"
+
+echo ""
+echo "=== CLI: Recursive Grep (search 5x src/ for 'function') ==="
+bench_cli "cligrep" "chadscript" "cgrep" /tmp/bench-cgrep -r -c -C function /tmp/bench-grep-data
+bench_cli "cligrep" "grep" "grep" grep -r -c function /tmp/bench-grep-data
+if command -v rg &>/dev/null; then
+  bench_cli "cligrep" "ripgrep" "ripgrep" rg -c function /tmp/bench-grep-data
+fi
+
+echo ""
+echo "=== CLI: Word Count ($(du -sh /tmp/bench-wc-data-big.txt | cut -f1) file) ==="
+bench_cli "cliwc" "chadscript" "cwc" /tmp/bench-cwc /tmp/bench-wc-data-big.txt
+bench_cli "cliwc" "wc" "wc" wc /tmp/bench-wc-data-big.txt
+
+echo ""
+echo "=== CLI: Hex Dump (5MB binary) ==="
+bench_cli "clihex" "chadscript" "chex" /tmp/bench-chex -C /tmp/bench-hex-data
+bench_cli "clihex" "xxd" "xxd" xxd /tmp/bench-hex-data
+
+rm -rf /tmp/bench-grep-data /tmp/bench-wc-data.txt /tmp/bench-wc-data-big.txt /tmp/bench-hex-data
 
 echo ""
 echo "--- Assembling JSON ---"

--- a/benchmarks/run-ci.sh
+++ b/benchmarks/run-ci.sh
@@ -198,33 +198,20 @@ bench_compute "fileio" "bun" "Bun" "Time:" bun "$DIR/fileio/bun.mjs"
 
 echo ""
 echo "--- Building ChadScript CLI tools ---"
-$CHAD build "$REPO/examples/cli-tools/cgrep.ts" -o /tmp/bench-cgrep
 $CHAD build "$REPO/examples/cli-tools/chex.ts" -o /tmp/bench-chex
 echo "  done"
 
 echo ""
 echo "--- Generating CLI benchmark data ---"
-mkdir -p /tmp/bench-grep-data
-for copy in 1 2 3 4 5; do
-  cp -r "$REPO/src" "/tmp/bench-grep-data/src-$copy"
-done
 dd if=/dev/urandom of=/tmp/bench-hex-data bs=1M count=5 2>/dev/null
-echo "  done (grep: 5x src/, hex: 5MB)"
-
-echo ""
-echo "=== CLI: Recursive Grep (search 5x src/ for 'function') ==="
-bench_cli "cligrep" "chadscript" "cgrep" /tmp/bench-cgrep -r -c -C function /tmp/bench-grep-data
-bench_cli "cligrep" "grep" "grep" grep -r -c function /tmp/bench-grep-data
-if command -v rg &>/dev/null; then
-  bench_cli "cligrep" "ripgrep" "ripgrep" rg -c function /tmp/bench-grep-data
-fi
+echo "  done (hex: 5MB)"
 
 echo ""
 echo "=== CLI: Hex Dump (5MB binary) ==="
 bench_cli "clihex" "chadscript" "chex" /tmp/bench-chex -C /tmp/bench-hex-data
 bench_cli "clihex" "xxd" "xxd" xxd /tmp/bench-hex-data
 
-rm -rf /tmp/bench-grep-data /tmp/bench-hex-data
+rm -f /tmp/bench-hex-data
 
 echo ""
 echo "--- Assembling JSON ---"

--- a/benchmarks/run-ci.sh
+++ b/benchmarks/run-ci.sh
@@ -199,6 +199,7 @@ bench_compute "fileio" "bun" "Bun" "Time:" bun "$DIR/fileio/bun.mjs"
 echo ""
 echo "--- Building ChadScript CLI tools ---"
 $CHAD build "$REPO/examples/cli-tools/cgrep.ts" -o /tmp/bench-cgrep
+$CHAD build "$REPO/examples/cli-tools/chex.ts" -o /tmp/bench-chex
 echo "  done"
 
 echo ""
@@ -207,7 +208,8 @@ mkdir -p /tmp/bench-grep-data
 for copy in 1 2 3 4 5; do
   cp -r "$REPO/src" "/tmp/bench-grep-data/src-$copy"
 done
-echo "  done (grep: 5x src/)"
+dd if=/dev/urandom of=/tmp/bench-hex-data bs=1M count=5 2>/dev/null
+echo "  done (grep: 5x src/, hex: 5MB)"
 
 echo ""
 echo "=== CLI: Recursive Grep (search 5x src/ for 'function') ==="
@@ -217,7 +219,12 @@ if command -v rg &>/dev/null; then
   bench_cli "cligrep" "ripgrep" "ripgrep" rg -c function /tmp/bench-grep-data
 fi
 
-rm -rf /tmp/bench-grep-data
+echo ""
+echo "=== CLI: Hex Dump (5MB binary) ==="
+bench_cli "clihex" "chadscript" "chex" /tmp/bench-chex -C /tmp/bench-hex-data
+bench_cli "clihex" "xxd" "xxd" xxd /tmp/bench-hex-data
+
+rm -rf /tmp/bench-grep-data /tmp/bench-hex-data
 
 echo ""
 echo "--- Assembling JSON ---"

--- a/benchmarks/run-ci.sh
+++ b/benchmarks/run-ci.sh
@@ -198,20 +198,26 @@ bench_compute "fileio" "bun" "Bun" "Time:" bun "$DIR/fileio/bun.mjs"
 
 echo ""
 echo "--- Building ChadScript CLI tools ---"
-$CHAD build "$REPO/examples/cli-tools/chex.ts" -o /tmp/bench-chex
+$CHAD build "$REPO/examples/cli-tools/cgrep.ts" -o /tmp/bench-cgrep
 echo "  done"
 
 echo ""
 echo "--- Generating CLI benchmark data ---"
-dd if=/dev/urandom of=/tmp/bench-hex-data bs=1M count=5 2>/dev/null
-echo "  done (hex: 5MB)"
+mkdir -p /tmp/bench-grep-data
+for copy in 1 2 3 4 5; do
+  cp -r "$REPO/src" "/tmp/bench-grep-data/src-$copy"
+done
+echo "  done (grep: 5x src/)"
 
 echo ""
-echo "=== CLI: Hex Dump (5MB binary) ==="
-bench_cli "clihex" "chadscript" "chex" /tmp/bench-chex -C /tmp/bench-hex-data
-bench_cli "clihex" "xxd" "xxd" xxd /tmp/bench-hex-data
+echo "=== CLI: Recursive Grep (search 5x src/ for 'function') ==="
+bench_cli "cligrep" "chadscript" "cgrep" /tmp/bench-cgrep -r -c -C function /tmp/bench-grep-data
+bench_cli "cligrep" "grep" "grep" grep -r -c function /tmp/bench-grep-data
+if command -v rg &>/dev/null; then
+  bench_cli "cligrep" "ripgrep" "ripgrep" rg -c function /tmp/bench-grep-data
+fi
 
-rm -f /tmp/bench-hex-data
+rm -rf /tmp/bench-grep-data
 
 echo ""
 echo "--- Assembling JSON ---"

--- a/docs/.vitepress/theme/BenchmarkBars.vue
+++ b/docs/.vitepress/theme/BenchmarkBars.vue
@@ -20,6 +20,7 @@ const langMeta = {
   node:       { name: 'Node.js',    color: 'node' },
   grep:       { name: 'grep',       color: 'c' },
   ripgrep:    { name: 'ripgrep',    color: 'go' },
+  xxd:        { name: 'xxd',        color: 'c' },
 }
 
 const tabOrder = ['startup', 'sqlite', 'fibonacci', 'json', 'nbody', 'montecarlo', 'sieve', 'sorting', 'matmul', 'binarytrees', 'stringops', 'fileio']

--- a/docs/.vitepress/theme/BenchmarkBars.vue
+++ b/docs/.vitepress/theme/BenchmarkBars.vue
@@ -18,6 +18,11 @@ const langMeta = {
   go:         { name: 'Go',         color: 'go' },
   bun:        { name: 'Bun',        color: 'bun' },
   node:       { name: 'Node.js',    color: 'node' },
+  grep:       { name: 'grep',       color: 'c' },
+  ripgrep:    { name: 'ripgrep',    color: 'go' },
+  wc:         { name: 'wc',         color: 'c' },
+  xxd:        { name: 'xxd',        color: 'c' },
+  jq:         { name: 'jq',         color: 'c' },
 }
 
 const tabOrder = ['startup', 'sqlite', 'fibonacci', 'json', 'nbody', 'montecarlo', 'sieve', 'sorting', 'matmul', 'binarytrees', 'stringops', 'fileio']

--- a/docs/.vitepress/theme/BenchmarkBars.vue
+++ b/docs/.vitepress/theme/BenchmarkBars.vue
@@ -20,9 +20,6 @@ const langMeta = {
   node:       { name: 'Node.js',    color: 'node' },
   grep:       { name: 'grep',       color: 'c' },
   ripgrep:    { name: 'ripgrep',    color: 'go' },
-  wc:         { name: 'wc',         color: 'c' },
-  xxd:        { name: 'xxd',        color: 'c' },
-  jq:         { name: 'jq',         color: 'c' },
 }
 
 const tabOrder = ['startup', 'sqlite', 'fibonacci', 'json', 'nbody', 'montecarlo', 'sieve', 'sorting', 'matmul', 'binarytrees', 'stringops', 'fileio']

--- a/docs/.vitepress/theme/HeroBenchmarks.vue
+++ b/docs/.vitepress/theme/HeroBenchmarks.vue
@@ -23,9 +23,6 @@ const LANG_NAMES: Record<string, string> = {
   bun: 'Bun',
   grep: 'grep',
   ripgrep: 'ripgrep',
-  wc: 'wc',
-  xxd: 'xxd',
-  jq: 'jq',
 }
 
 const benchmarks = ref<Benchmark[]>([])

--- a/docs/.vitepress/theme/HeroBenchmarks.vue
+++ b/docs/.vitepress/theme/HeroBenchmarks.vue
@@ -23,6 +23,7 @@ const LANG_NAMES: Record<string, string> = {
   bun: 'Bun',
   grep: 'grep',
   ripgrep: 'ripgrep',
+  xxd: 'xxd',
 }
 
 const benchmarks = ref<Benchmark[]>([])

--- a/docs/.vitepress/theme/HeroBenchmarks.vue
+++ b/docs/.vitepress/theme/HeroBenchmarks.vue
@@ -12,6 +12,7 @@ interface Benchmark {
   metric: string
   lower_is_better: boolean
   results: Record<string, BenchResult>
+  place?: number
 }
 
 const LANG_NAMES: Record<string, string> = {
@@ -71,12 +72,9 @@ onMounted(async () => {
     const base = import.meta.env.BASE_URL || '/'
     const res = await fetch(`${base}benchmarks.json`)
     const data = await res.json()
-    const preferred = ['startup', 'montecarlo', 'fibonacci', 'json', 'nbody', 'sqlite', 'sieve']
-    const keys = preferred.filter(k => k in data.benchmarks)
-    for (const k of Object.keys(data.benchmarks)) {
-      if (!keys.includes(k)) keys.push(k)
-    }
-    benchmarks.value = keys.map(k => data.benchmarks[k])
+    const all = Object.values(data.benchmarks) as Benchmark[]
+    all.sort((a, b2) => (a.place || 99) - (b2.place || 99))
+    benchmarks.value = all
   } catch {
     benchmarks.value = []
   }
@@ -93,8 +91,8 @@ onUnmounted(() => {
   <div class="hero-bench" :class="{ visible }" v-if="activeBench">
     <div class="bench-header">
       <div class="bench-title">{{ activeBench.name }}</div>
-      <div class="bench-place">
-        {{ entries.length > 0 && entries[0]?.hero ? '1st' : '2nd' }}
+      <div class="bench-place" :class="'place-' + (activeBench.place || 1)">
+        {{ activeBench.place === 1 ? '1st' : activeBench.place === 2 ? '2nd' : '3rd' }}
       </div>
     </div>
     <div class="bench-subtitle">{{ activeBench.desc }}</div>
@@ -166,6 +164,11 @@ onUnmounted(() => {
   background: rgba(255, 200, 50, 0.1);
   padding: 2px 8px;
   border-radius: 10px;
+}
+
+.bench-place.place-3 {
+  color: var(--vp-c-text-2);
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .bench-subtitle {

--- a/docs/.vitepress/theme/HeroBenchmarks.vue
+++ b/docs/.vitepress/theme/HeroBenchmarks.vue
@@ -1,29 +1,107 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 
-const entries = [
-  { name: 'C', val: '0.8ms', pct: 3, hero: false },
-  { name: 'ChadScript', val: '0.8ms', pct: 3, hero: true },
-  { name: 'Go', val: '1.2ms', pct: 5, hero: false },
-  { name: 'Bun', val: '9.6ms', pct: 37, hero: false },
-  { name: 'Node.js', val: '26.2ms', pct: 100, hero: false },
-]
+interface BenchResult {
+  value: number
+  label: string
+}
 
+interface Benchmark {
+  name: string
+  desc: string
+  metric: string
+  lower_is_better: boolean
+  results: Record<string, BenchResult>
+}
+
+const LANG_NAMES: Record<string, string> = {
+  c: 'C',
+  chadscript: 'ChadScript',
+  go: 'Go',
+  node: 'Node.js',
+  bun: 'Bun',
+}
+
+const benchmarks = ref<Benchmark[]>([])
+const activeIndex = ref(0)
 const visible = ref(false)
+let timer: ReturnType<typeof setInterval> | null = null
 
-onMounted(() => {
+const activeBench = computed(() => benchmarks.value[activeIndex.value])
+
+const entries = computed(() => {
+  const b = activeBench.value
+  if (!b) return []
+  const langOrder = ['c', 'chadscript', 'go', 'bun', 'node']
+  const sorted = langOrder
+    .filter(k => k in b.results)
+    .map(k => ({ key: k, ...b.results[k] }))
+  if (b.lower_is_better) {
+    sorted.sort((a, b2) => a.value - b2.value)
+  } else {
+    sorted.sort((a, b2) => b2.value - a.value)
+  }
+  const maxVal = b.lower_is_better
+    ? Math.max(...sorted.map(s => s.value))
+    : Math.max(...sorted.map(s => s.value))
+  return sorted.map(s => ({
+    name: LANG_NAMES[s.key] || s.key,
+    val: s.label,
+    pct: Math.max(3, Math.round((s.value / maxVal) * 100)),
+    hero: s.key === 'chadscript',
+  }))
+})
+
+function selectBench(i: number) {
+  activeIndex.value = i
+  resetTimer()
+}
+
+function resetTimer() {
+  if (timer) clearInterval(timer)
+  timer = setInterval(() => {
+    if (benchmarks.value.length > 0) {
+      activeIndex.value = (activeIndex.value + 1) % benchmarks.value.length
+    }
+  }, 4000)
+}
+
+onMounted(async () => {
+  try {
+    const base = import.meta.env.BASE_URL || '/'
+    const res = await fetch(`${base}benchmarks.json`)
+    const data = await res.json()
+    const preferred = ['startup', 'montecarlo', 'fibonacci', 'json', 'nbody', 'sqlite', 'sieve']
+    const keys = preferred.filter(k => k in data.benchmarks)
+    for (const k of Object.keys(data.benchmarks)) {
+      if (!keys.includes(k)) keys.push(k)
+    }
+    benchmarks.value = keys.map(k => data.benchmarks[k])
+  } catch {
+    benchmarks.value = []
+  }
   setTimeout(() => { visible.value = true }, 200)
+  resetTimer()
+})
+
+onUnmounted(() => {
+  if (timer) clearInterval(timer)
 })
 </script>
 
 <template>
-  <div class="hero-bench" :class="{ visible }">
-    <div class="bench-title">Cold Start</div>
-    <div class="bench-subtitle">Time to print "Hello" and exit</div>
+  <div class="hero-bench" :class="{ visible }" v-if="activeBench">
+    <div class="bench-header">
+      <div class="bench-title">{{ activeBench.name }}</div>
+      <div class="bench-place">
+        {{ entries.length > 0 && entries[0]?.hero ? '1st' : '2nd' }}
+      </div>
+    </div>
+    <div class="bench-subtitle">{{ activeBench.desc }}</div>
     <div class="bench-rows">
       <div
         v-for="(e, i) in entries"
-        :key="e.name"
+        :key="activeBench.name + '-' + e.name"
         class="bench-row"
       >
         <div class="row-label" :class="{ hero: e.hero }">{{ e.name }}</div>
@@ -31,21 +109,29 @@ onMounted(() => {
           <div
             class="row-bar"
             :class="{ hero: e.hero }"
-            :style="{ '--w': e.pct + '%', '--delay': (i * 0.12 + 0.3) + 's' }"
+            :style="{ '--w': e.pct + '%', '--delay': (i * 0.08 + 0.15) + 's' }"
           ></div>
         </div>
         <div class="row-val" :class="{ hero: e.hero }">{{ e.val }}</div>
       </div>
     </div>
+    <div class="bench-tabs" v-if="benchmarks.length > 1">
+      <button
+        v-for="(b, i) in benchmarks"
+        :key="b.name"
+        :class="{ active: i === activeIndex }"
+        @click="selectBench(i)"
+      >{{ b.name }}</button>
+    </div>
     <div class="bench-footer">
-      <a href="./benchmarks">All benchmarks</a>
+      <a href="./benchmarks">All benchmarks &rarr;</a>
     </div>
   </div>
 </template>
 
 <style scoped>
 .hero-bench {
-  width: 360px;
+  width: 460px;
   margin: 2.5rem auto 0;
   padding: 22px 24px;
   border-radius: 12px;
@@ -61,36 +147,51 @@ onMounted(() => {
   transform: translateY(0);
 }
 
+.bench-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .bench-title {
   font-size: 0.9rem;
   font-weight: 700;
   color: var(--vp-c-text-1);
-  margin-bottom: 2px;
+}
+
+.bench-place {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--vp-c-brand-1);
+  background: rgba(255, 200, 50, 0.1);
+  padding: 2px 8px;
+  border-radius: 10px;
 }
 
 .bench-subtitle {
   font-size: 0.72rem;
   color: var(--vp-c-text-3);
-  margin-bottom: 16px;
+  margin-bottom: 14px;
+  margin-top: 2px;
 }
 
 .bench-rows {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .bench-row {
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 28px;
+  height: 26px;
 }
 
 .row-label {
   width: 80px;
   text-align: right;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   font-weight: 500;
   color: var(--vp-c-text-2);
   flex-shrink: 0;
@@ -103,7 +204,7 @@ onMounted(() => {
 
 .row-track {
   flex: 1;
-  height: 22px;
+  height: 20px;
   background: rgba(255, 255, 255, 0.04);
   border-radius: 5px;
   overflow: hidden;
@@ -114,7 +215,7 @@ onMounted(() => {
   border-radius: 5px;
   background: rgba(255, 255, 255, 0.18);
   width: 0;
-  animation: bar-grow 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation: bar-grow 0.5s cubic-bezier(0.22, 1, 0.36, 1) forwards;
   animation-delay: var(--delay, 0s);
 }
 
@@ -123,8 +224,8 @@ onMounted(() => {
 }
 
 .row-val {
-  width: 50px;
-  font-size: 0.78rem;
+  width: 52px;
+  font-size: 0.76rem;
   font-family: var(--vp-font-family-mono);
   font-weight: 500;
   color: var(--vp-c-text-2);
@@ -136,13 +237,43 @@ onMounted(() => {
   font-weight: 700;
 }
 
-.bench-footer {
+.bench-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
   margin-top: 14px;
+  justify-content: center;
+}
+
+.bench-tabs button {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 3px 8px;
+  font-size: 0.68rem;
+  color: var(--vp-c-text-3);
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.bench-tabs button:hover {
+  color: var(--vp-c-text-2);
+}
+
+.bench-tabs button.active {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+  background: rgba(255, 200, 50, 0.06);
+}
+
+.bench-footer {
+  margin-top: 12px;
   text-align: center;
 }
 
 .bench-footer a {
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   color: var(--vp-c-text-3);
   text-decoration: none;
   transition: color 0.15s;
@@ -160,8 +291,15 @@ onMounted(() => {
 @media (max-width: 960px) {
   .hero-bench {
     width: 100%;
-    max-width: 380px;
+    max-width: 460px;
     margin: 1rem auto 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .bench-tabs button {
+    font-size: 0.62rem;
+    padding: 2px 6px;
   }
 }
 </style>

--- a/docs/.vitepress/theme/HeroBenchmarks.vue
+++ b/docs/.vitepress/theme/HeroBenchmarks.vue
@@ -21,6 +21,11 @@ const LANG_NAMES: Record<string, string> = {
   go: 'Go',
   node: 'Node.js',
   bun: 'Bun',
+  grep: 'grep',
+  ripgrep: 'ripgrep',
+  wc: 'wc',
+  xxd: 'xxd',
+  jq: 'jq',
 }
 
 const benchmarks = ref<Benchmark[]>([])

--- a/examples/cli-tools/chex.ts
+++ b/examples/cli-tools/chex.ts
@@ -31,12 +31,7 @@ const colorGreen = "\x1b[32m";
 const colorCyan = "\x1b[36m";
 const colorReset = "\x1b[0m";
 
-let content = "";
-if (filePath.length === 0) {
-  content = process.stdin.read();
-} else {
-  content = fs.readFileSync(filePath);
-}
+const bytes: Uint8Array = fs.readFileSync(filePath);
 
 const hexChars = "0123456789abcdef";
 
@@ -63,7 +58,7 @@ function isPrintable(b: number): boolean {
 }
 
 let start = skipBytes;
-let end = content.length;
+let end = bytes.length;
 if (maxLength > 0 && start + maxLength < end) {
   end = start + maxLength;
 }
@@ -75,7 +70,7 @@ while (offset < end) {
   let col = 0;
 
   while (col < cols && offset + col < end) {
-    const b = content.charCodeAt(offset + col);
+    const b = bytes[offset + col];
     const hex = byteToHex(b);
 
     if (noColor) {
@@ -96,7 +91,13 @@ while (offset < end) {
 
     if (!plainMode) {
       if (isPrintable(b)) {
-        const ch = content.charAt(offset + col);
+        const code = b;
+        let ch = "";
+        if (code >= 32 && code < 127) {
+          ch = String.fromCharCode(code);
+        } else {
+          ch = ".";
+        }
         if (noColor) {
           asciiPart = asciiPart + ch;
         } else {


### PR DESCRIPTION
## Summary
- **HeroBenchmarks.vue**: now dynamically loads from `benchmarks.json` instead of hardcoding only Cold Start. Auto-cycles through all winning benchmarks (1st/2nd place) with clickable tabs.
- **README.md**: added benchmark table showing the 5 benchmarks where ChadScript places 1st or 2nd (Cold Start, Monte Carlo, Fibonacci, JSON, N-Body).

## Test plan
- [ ] Verify docs site renders HeroBenchmarks with all benchmarks from benchmarks.json
- [ ] Verify tab switching and auto-rotation work
- [ ] Verify README table renders correctly on GitHub