### PR TITLE
cgrep: 5x faster recursive grep by skipping split in count mode

### DIFF
--- a/examples/cli-tools/cgrep.ts
+++ b/examples/cli-tools/cgrep.ts
@@ -89,9 +89,48 @@ function highlightLine(line: string): string {
   return result;
 }
 
+function countMatchesRaw(content: string): number {
+  let haystack = content;
+  if (ignoreCase) {
+    haystack = content.toLowerCase();
+  }
+  let matchCount = 0;
+  let pos = 0;
+  while (pos < haystack.length) {
+    const idx = haystack.indexOf(searchPattern, pos);
+    if (idx === -1) {
+      break;
+    }
+    matchCount = matchCount + 1;
+    const nlIdx = haystack.indexOf("\n", idx);
+    if (nlIdx === -1) {
+      break;
+    }
+    pos = nlIdx + 1;
+  }
+  return matchCount;
+}
+
 function searchFile(filePath: string, showPrefix: boolean): void {
   const content = fs.readFileSync(filePath);
   if (content.length === 0) {
+    return;
+  }
+
+  if (countOnly && !invertMatch) {
+    const matchCount = countMatchesRaw(content);
+    if (showPrefix) {
+      if (noColor) {
+        console.log(filePath + ":" + matchCount);
+      } else {
+        console.log(
+          colorMagenta + filePath + colorReset + colorCyan + ":" + colorReset + matchCount,
+        );
+      }
+    } else {
+      console.log(matchCount);
+    }
+    totalMatches = totalMatches + matchCount;
     return;
   }
 


### PR DESCRIPTION
## Summary

- **4x faster than GNU grep** in count-only mode (`-c`) — was 5x slower
- Skip `content.split("\n")` entirely when counting matches — search raw file content with `indexOf` and skip to next line on match
- `split("\n")` was 76% of runtime (158ms of 208ms) across 1400 files / 808K lines

Before: 0.153s (CI), 0.187s (local)
After: ~0.037s (local), beating GNU grep at 0.154s

No behavior change — output matches GNU grep exactly (verified with sorted diff).

## Test plan

- [x] Output matches GNU grep on 1400 files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)