### PR TITLE
use strchr for single-char indexOf, fix colors import type mismatch

### DIFF
--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -9,6 +9,7 @@ import {
   ArrayNode,
   ObjectNode,
   ObjectProperty,
+  CallNode,
   MethodCallNode,
   BinaryNode,
   VariableNode,
@@ -82,6 +83,7 @@ export class SemanticAnalyzer {
   private currentFunction: string = "";
   private diagnosticEngine: DiagnosticEngine;
   private suppressWarnings: boolean = false;
+  private functionReturnTypes: Map<string, string> = new Map();
 
   constructor(ast: AST) {
     this.ast = ast;
@@ -162,6 +164,13 @@ export class SemanticAnalyzer {
     // The native compiler can't handle iface.fields[i].name or iface.methods[i].name
     // (array-of-objects field access pattern) during self-hosting. The variable
     // declaration and class field checks below still catch most unsafe unions.
+
+    for (let _fri = 0; _fri < this.ast.functions.length; _fri++) {
+      const fn = this.ast.functions[_fri];
+      if (fn.name && fn.returnType) {
+        this.functionReturnTypes.set(fn.name, fn.returnType);
+      }
+    }
 
     for (let _si = 0; _si < this.ast.topLevelStatements.length; _si++) {
       const stmt = this.ast.topLevelStatements[_si];
@@ -849,8 +858,16 @@ export class SemanticAnalyzer {
       };
     }
 
+    if (e.type === "call") {
+      const callExpr = expr as CallNode;
+      const retType = this.functionReturnTypes.get(callExpr.name);
+      if (retType === "string") return STRING_SYMBOL;
+      if (retType === "number") return NUMBER_SYMBOL;
+      if (retType === "boolean") return { name: "", type: "boolean", llvmType: "double" };
+      return { name: "", type: "unknown", llvmType: "double" };
+    }
+
     if (
-      e.type === "call" ||
       e.type === "new" ||
       e.type === "index_access" ||
       e.type === "arrow_function" ||

--- a/src/codegen/expressions/method-calls/string-methods.ts
+++ b/src/codegen/expressions/method-calls/string-methods.ts
@@ -4,6 +4,7 @@ import {
   MemberAccessNode,
   VariableNode,
   RegexNode,
+  StringNode,
 } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
 
@@ -309,7 +310,20 @@ export function handleIndexOf(
     return ctx.emitError(`indexOf() expects 1 or 2 arguments, got ${expr.args.length}`, expr.loc);
   }
 
-  const substring = ctx.generateExpression(expr.args[0], params);
+  const searchArg = expr.args[0];
+  const isSingleChar = searchArg.type === "string" && (searchArg as StringNode).value.length === 1;
+
+  if (isSingleChar) {
+    const charCode = (searchArg as StringNode).value.charCodeAt(0);
+    if (expr.args.length === 2) {
+      const fromIndexDouble = ctx.generateExpression(expr.args[1], params);
+      const fromIndex = convertToI32(ctx, fromIndexDouble);
+      return ctx.stringGen.doGenerateIndexOfCharFrom(strPtr, charCode, fromIndex);
+    }
+    return ctx.stringGen.doGenerateIndexOfChar(strPtr, charCode);
+  }
+
+  const substring = ctx.generateExpression(searchArg, params);
 
   if (expr.args.length === 2) {
     const fromIndexDouble = ctx.generateExpression(expr.args[1], params);

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -91,7 +91,9 @@ export interface IStringGenerator {
   doGenerateToUpperCase(strPtr: string): string;
   doGenerateToLowerCase(strPtr: string): string;
   doGenerateIndexOf(strPtr: string, substring: string): string;
+  doGenerateIndexOfChar(strPtr: string, charCode: number): string;
   doGenerateIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string;
+  doGenerateIndexOfCharFrom(strPtr: string, charCode: number, fromIndex: string): string;
   doGenerateLastIndexOf(strPtr: string, substring: string): string;
   doGenerateLastIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string;
   doGenerateIncludes(strPtr: string, substring: string): string;
@@ -1725,7 +1727,10 @@ export class MockGeneratorContext implements IGeneratorContext {
     doGenerateToUpperCase: (_strPtr: string): string => "%0",
     doGenerateToLowerCase: (_strPtr: string): string => "%0",
     doGenerateIndexOf: (_strPtr: string, _substring: string): string => "%0",
+    doGenerateIndexOfChar: (_strPtr: string, _charCode: number): string => "%0",
     doGenerateIndexOfFrom: (_strPtr: string, _substring: string, _fromIndex: string): string =>
+      "%0",
+    doGenerateIndexOfCharFrom: (_strPtr: string, _charCode: number, _fromIndex: string): string =>
       "%0",
     doGenerateLastIndexOf: (_strPtr: string, _substring: string): string => "%0",
     doGenerateLastIndexOfFrom: (_strPtr: string, _substring: string, _fromIndex: string): string =>

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -49,6 +49,7 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "declare i64 @strtol(i8*, i8**, i32)\n";
   ir += "declare double @strtod(i8*, i8**)\n";
   ir += "declare i8* @strstr(i8*, i8*)\n";
+  ir += "declare i8* @strchr(i8*, i32)\n";
   ir += "declare i8* @strrchr(i8*, i32)\n";
   ir += "declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)\n";
   ir += "declare void @llvm.memmove.p0i8.p0i8.i64(i8*, i8*, i64, i1)\n";

--- a/src/codegen/types/collections/string.ts
+++ b/src/codegen/types/collections/string.ts
@@ -27,7 +27,9 @@ import {
   generateStringAt,
   generateCharCodeAt,
   generateIndexOf,
+  generateIndexOfChar,
   generateIndexOfFrom,
+  generateIndexOfCharFrom,
   generateLastIndexOf,
   generateLastIndexOfFrom,
   generateIncludes,
@@ -140,8 +142,16 @@ export class StringGenerator implements IStringGenerator {
     return generateIndexOf(this.ctx, strPtr, substring);
   }
 
+  doGenerateIndexOfChar(strPtr: string, charCode: number): string {
+    return generateIndexOfChar(this.ctx, strPtr, charCode);
+  }
+
   doGenerateIndexOfFrom(strPtr: string, substring: string, fromIndex: string): string {
     return generateIndexOfFrom(this.ctx, strPtr, substring, fromIndex);
+  }
+
+  doGenerateIndexOfCharFrom(strPtr: string, charCode: number, fromIndex: string): string {
+    return generateIndexOfCharFrom(this.ctx, strPtr, charCode, fromIndex);
   }
 
   doGenerateLastIndexOf(strPtr: string, substring: string): string {

--- a/src/codegen/types/collections/string/search.ts
+++ b/src/codegen/types/collections/string/search.ts
@@ -154,6 +154,108 @@ export function generateCharCodeAt(ctx: IGeneratorContext, strPtr: string, index
   return result;
 }
 
+export function generateIndexOfChar(
+  ctx: IGeneratorContext,
+  strPtr: string,
+  charCode: number,
+): string {
+  const foundPtr = ctx.emitCall("i8*", "@strchr", `i8* ${strPtr}, i32 ${charCode}`);
+
+  const isNull = ctx.emitIcmp("eq", "i8*", foundPtr, "null");
+
+  const notFoundLabel = ctx.nextLabel("indexof_notfound");
+  const foundLabel = ctx.nextLabel("indexof_found");
+  const endLabel = ctx.nextLabel("indexof_end");
+
+  ctx.emitBrCond(isNull, notFoundLabel, foundLabel);
+
+  ctx.emitLabel(notFoundLabel);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(foundLabel);
+  const strPtrInt = ctx.nextTemp();
+  ctx.emit(`${strPtrInt} = ptrtoint i8* ${strPtr} to i64`);
+  const foundPtrInt = ctx.nextTemp();
+  ctx.emit(`${foundPtrInt} = ptrtoint i8* ${foundPtr} to i64`);
+  const indexI64 = ctx.nextTemp();
+  ctx.emit(`${indexI64} = sub i64 ${foundPtrInt}, ${strPtrInt}`);
+  const indexI32 = ctx.nextTemp();
+  ctx.emit(`${indexI32} = trunc i64 ${indexI64} to i32`);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(endLabel);
+  const resultI32 = ctx.nextTemp();
+  ctx.emit(`${resultI32} = phi i32 [ -1, %${notFoundLabel} ], [ ${indexI32}, %${foundLabel} ]`);
+
+  const result = ctx.nextTemp();
+  ctx.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  ctx.setVariableType(result, "double");
+
+  return result;
+}
+
+export function generateIndexOfCharFrom(
+  ctx: IGeneratorContext,
+  strPtr: string,
+  charCode: number,
+  fromIndex: string,
+): string {
+  const strLen = ctx.emitCall("i64", "@strlen", `i8* ${strPtr}`);
+  const strLenI32 = ctx.nextTemp();
+  ctx.emit(`${strLenI32} = trunc i64 ${strLen} to i32`);
+
+  const isNeg = ctx.emitIcmp("slt", "i32", fromIndex, "0");
+  const clamped0 = ctx.nextTemp();
+  ctx.emit(`${clamped0} = select i1 ${isNeg}, i32 0, i32 ${fromIndex}`);
+  const pastEnd = ctx.emitIcmp("sge", "i32", clamped0, strLenI32);
+
+  const searchLabel = ctx.nextLabel("indexof_from_search");
+  const pastEndLabel = ctx.nextLabel("indexof_from_pastend");
+  const endLabel = ctx.nextLabel("indexof_from_end");
+  ctx.emitBrCond(pastEnd, pastEndLabel, searchLabel);
+
+  ctx.emitLabel(pastEndLabel);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(searchLabel);
+  const offsetI64 = ctx.nextTemp();
+  ctx.emit(`${offsetI64} = zext i32 ${clamped0} to i64`);
+  const offsetPtr = ctx.nextTemp();
+  ctx.emit(`${offsetPtr} = getelementptr inbounds i8, i8* ${strPtr}, i64 ${offsetI64}`);
+  const foundPtr = ctx.emitCall("i8*", "@strchr", `i8* ${offsetPtr}, i32 ${charCode}`);
+  const isNull = ctx.emitIcmp("eq", "i8*", foundPtr, "null");
+
+  const notFoundLabel = ctx.nextLabel("indexof_from_notfound");
+  const foundLabel = ctx.nextLabel("indexof_from_found");
+  ctx.emitBrCond(isNull, notFoundLabel, foundLabel);
+
+  ctx.emitLabel(notFoundLabel);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(foundLabel);
+  const strPtrInt = ctx.nextTemp();
+  ctx.emit(`${strPtrInt} = ptrtoint i8* ${strPtr} to i64`);
+  const foundPtrInt = ctx.nextTemp();
+  ctx.emit(`${foundPtrInt} = ptrtoint i8* ${foundPtr} to i64`);
+  const indexI64 = ctx.nextTemp();
+  ctx.emit(`${indexI64} = sub i64 ${foundPtrInt}, ${strPtrInt}`);
+  const indexI32 = ctx.nextTemp();
+  ctx.emit(`${indexI32} = trunc i64 ${indexI64} to i32`);
+  ctx.emitBr(endLabel);
+
+  ctx.emitLabel(endLabel);
+  const resultI32 = ctx.nextTemp();
+  ctx.emit(
+    `${resultI32} = phi i32 [ -1, %${pastEndLabel} ], [ -1, %${notFoundLabel} ], [ ${indexI32}, %${foundLabel} ]`,
+  );
+
+  const result = ctx.nextTemp();
+  ctx.emit(`${result} = sitofp i32 ${resultI32} to double`);
+  ctx.setVariableType(result, "double");
+
+  return result;
+}
+
 export function generateIndexOf(ctx: IGeneratorContext, strPtr: string, substring: string): string {
   const foundPtr = ctx.emitCall("i8*", "@strstr", `i8* ${strPtr}, i8* ${substring}`);
 

--- a/tests/fixtures/stdlib/colors-number-concat.ts
+++ b/tests/fixtures/stdlib/colors-number-concat.ts
@@ -1,0 +1,11 @@
+import { magenta, cyan } from "chadscript/colors";
+
+function searchFile(): void {
+  const count = 42;
+  let output = "";
+  output = magenta("file") + cyan(":") + count;
+  console.log(output);
+}
+
+searchFile();
+console.log("TEST_PASSED");

--- a/tests/fixtures/strings/string-indexof-char.ts
+++ b/tests/fixtures/strings/string-indexof-char.ts
@@ -1,0 +1,64 @@
+const str = "hello world";
+
+const idx1 = str.indexOf("o");
+if (idx1 !== 4) {
+  console.log("FAIL: indexOf single char expected 4, got " + idx1);
+  process.exit(1);
+}
+
+const idx2 = str.indexOf("o", 5);
+if (idx2 !== 7) {
+  console.log("FAIL: indexOf single char from 5 expected 7, got " + idx2);
+  process.exit(1);
+}
+
+const idx3 = str.indexOf("z");
+if (idx3 !== -1) {
+  console.log("FAIL: indexOf single char not found expected -1, got " + idx3);
+  process.exit(1);
+}
+
+const idx4 = str.indexOf("\n");
+if (idx4 !== -1) {
+  console.log("FAIL: indexOf newline expected -1, got " + idx4);
+  process.exit(1);
+}
+
+const withNewline = "line1\nline2";
+const idx5 = withNewline.indexOf("\n");
+if (idx5 !== 5) {
+  console.log("FAIL: indexOf newline expected 5, got " + idx5);
+  process.exit(1);
+}
+
+const idx6 = withNewline.indexOf("\n", 6);
+if (idx6 !== -1) {
+  console.log("FAIL: indexOf newline from 6 expected -1, got " + idx6);
+  process.exit(1);
+}
+
+const idx7 = str.indexOf("h");
+if (idx7 !== 0) {
+  console.log("FAIL: indexOf first char expected 0, got " + idx7);
+  process.exit(1);
+}
+
+const idx8 = str.indexOf("d");
+if (idx8 !== 10) {
+  console.log("FAIL: indexOf last char expected 10, got " + idx8);
+  process.exit(1);
+}
+
+const idx9 = str.indexOf("o", -1);
+if (idx9 !== 4) {
+  console.log("FAIL: indexOf from negative expected 4, got " + idx9);
+  process.exit(1);
+}
+
+const idx10 = str.indexOf("o", 100);
+if (idx10 !== -1) {
+  console.log("FAIL: indexOf from past end expected -1, got " + idx10);
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

Two compiler fixes:

- **strchr for single-char indexOf** — `str.indexOf("\n", pos)` now uses `strchr` instead of `strstr` when the search string is a single character. `strchr` is significantly faster for scanning large buffers (e.g., line-by-line file processing). Detected at codegen time when the argument is a string literal of length 1.

- **Fix colors import type mismatch** — importing from `chadscript/colors` and using the result in string concat with numbers (`magenta("file") + ":" + count`) caused "Type mismatch: Cannot assign number to string". The semantic analyzer now tracks function return types from imported modules so call expressions resolve correctly in type inference.

## Test plan

- [x] 766 tests pass
- [x] New test: `string-indexof-char.ts` (10 cases for strchr path)
- [x] New test: `colors-number-concat.ts` (colors + number concat)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)