### PR TITLE
weather app: responsive fixes, better sun arc, footer update

### DIFF
--- a/examples/apps/weather/public/app.js
+++ b/examples/apps/weather/public/app.js
@@ -150,7 +150,7 @@ function setWeatherBg(forecast, isDaytime) {
   } else if (f.indexOf("fog") !== -1 || f.indexOf("haze") !== -1) {
     bg = "linear-gradient(180deg, #6b7b8d 0%, #4a5568 40%, #2d3748 100%)";
   } else {
-    bg = "linear-gradient(180deg, #3a7bd5 0%, #1a5276 40%, #0f2b44 100%)";
+    bg = "linear-gradient(180deg, #4a8fe7 0%, #3a7bd5 35%, #2a6cb5 65%, #1a5276 100%)";
     showFlare = isDaytime;
   }
   document.body.style.background = bg;
@@ -592,9 +592,11 @@ function render(city, forecast, hourlyData, grid, timeZone) {
     "Golden hour: " + fmtTimeInTz(goldenRise, timeZone) + ", " + fmtTimeInTz(goldenSet, timeZone),
     "Declination: " + sunTimes.declination.toFixed(1) + "\u00B0",
   ];
+  var riseX = sunPt(riseFrac).x;
+  var setX = sunPt(setFrac).x;
   var arcSvg =
     '<div class="sun-arc-wrap">' +
-    '<svg viewBox="0 0 100 48" class="sun-arc">' +
+    '<svg viewBox="0 0 100 38" class="sun-arc">' +
     '<path d="' +
     fullD +
     '" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="1.5"/>' +
@@ -606,6 +608,20 @@ function render(city, forecast, hourlyData, grid, timeZone) {
     '" x2="95" y2="' +
     horizY +
     '" stroke="rgba(255,255,255,0.2)" stroke-width="0.5"/>' +
+    '<text x="' +
+    riseX.toFixed(1) +
+    '" y="' +
+    (horizY + 7) +
+    '" text-anchor="middle" fill="rgba(255,255,255,0.4)" font-size="3.5">' +
+    fmtTimeInTz(sunTimes.sunrise, timeZone) +
+    "</text>" +
+    '<text x="' +
+    setX.toFixed(1) +
+    '" y="' +
+    (horizY + 7) +
+    '" text-anchor="middle" fill="rgba(255,255,255,0.4)" font-size="3.5">' +
+    fmtTimeInTz(sunTimes.sunset, timeZone) +
+    "</text>" +
     '<circle class="sun-dot" cx="' +
     sp.x.toFixed(1) +
     '" cy="' +
@@ -789,6 +805,8 @@ locateBtn.addEventListener("click", function () {
     function (pos) {
       var lat = pos.coords.latitude.toFixed(4);
       var lon = pos.coords.longitude.toFixed(4);
+      history.replaceState(null, "", "?q=current+location");
+      zipInput.value = "";
       fetchWeather(lat, lon, null);
     },
     function (err) {
@@ -808,7 +826,9 @@ locateBtn.addEventListener("click", function () {
 
 var params = new URLSearchParams(window.location.search);
 var urlQuery = params.get("q") || params.get("zip");
-if (urlQuery) {
+if (urlQuery && urlQuery.replace(/\+/g, " ").trim().toLowerCase() === "current location") {
+  locateBtn.click();
+} else if (urlQuery) {
   zipInput.value = urlQuery;
   geocodeAndFetch(urlQuery);
 } else {

--- a/examples/apps/weather/public/index.html
+++ b/examples/apps/weather/public/index.html
@@ -32,8 +32,9 @@
       <div class="dashboard" id="dashboard"></div>
       <div class="powered-by">
         Built with
-        <a href="https://github.com/cs01/ChadScript" target="_blank">ChadScript</a> &mdash; data
-        from <a href="https://www.weather.gov" target="_blank">weather.gov</a>
+        <a href="https://github.com/cs01/ChadScript" target="_blank">ChadScript</a>
+        &mdash;
+        <a href="https://chadsmith.dev" target="_blank">chadsmith.dev</a>
       </div>
     </div>
     <script src="app.js"></script>

--- a/examples/apps/weather/public/style.css
+++ b/examples/apps/weather/public/style.css
@@ -9,7 +9,8 @@ body {
   background: linear-gradient(180deg, #1a3a5c 0%, #0f1f3d 40%, #0a1628 100%);
   color: #fff;
   min-height: 100vh;
-  padding: 1.5rem 1rem;
+  min-height: 100dvh;
+  padding: 1.5rem 1rem 2rem;
   position: relative;
   overflow-x: hidden;
 }
@@ -567,19 +568,22 @@ body {
 
 .powered-by {
   text-align: center;
-  padding: 1.5rem 0 0.5rem;
-  font-size: 0.7rem;
-  opacity: 0.4;
+  padding: 2rem 0 1rem;
+  font-size: 1.1rem;
+  font-weight: 500;
+  opacity: 0.6;
+  letter-spacing: 0.02em;
 }
 
 .powered-by a {
   color: #fff;
   text-decoration: none;
-  opacity: 0.8;
+  font-weight: 700;
 }
 
 .powered-by a:hover {
   opacity: 1;
+  text-decoration: underline;
 }
 
 @media (max-width: 700px) {
@@ -590,7 +594,7 @@ body {
 
 @media (max-width: 600px) {
   body {
-    padding: 1rem 0.75rem;
+    padding: 1rem 0.5rem 2.5rem;
   }
   .hero-city {
     font-size: 1.5rem;
@@ -608,8 +612,29 @@ body {
     width: 45px;
     font-size: 0.8rem;
   }
+  .dashboard {
+    grid-template-columns: repeat(2, 1fr);
+  }
   .dash-value {
     font-size: 1.5rem;
+  }
+  .wind-compass {
+    width: 100px;
+    height: 100px;
+  }
+  .search-bar input {
+    width: 180px;
+    font-size: 0.95rem;
+    padding: 0.75rem 0.8rem;
+  }
+  .search-bar button {
+    padding: 0.6rem 1rem;
+    font-size: 0.85rem;
+  }
+  .daily-low,
+  .daily-high {
+    width: 30px;
+    font-size: 0.8rem;
   }
 }
 
@@ -623,5 +648,15 @@ body {
   }
   .dash-card {
     padding: 0.75rem;
+  }
+  .wind-compass {
+    width: 80px;
+    height: 80px;
+  }
+  .search-bar input {
+    width: 140px;
+  }
+  .sun-time {
+    font-size: 1.4rem;
   }
 }


### PR DESCRIPTION
## Summary
- Mobile responsive: dashboard goes 2-col earlier, wind compass/search input scale down, bottom content no longer cut off
- Sun arc now shows sunrise/sunset times as labels on the horizon line
- Sunny gradient stays brighter blue instead of going near-black at bottom
- Geolocation sets `?q=current+location` in URL so it works as a shareable link
- Footer: bigger/bolder ChadScript branding, added chadsmith.dev link, removed weather.gov text

🤖 Generated with [Claude Code](https://claude.com/claude-code)