### PR TITLE
auto-rebuild stale native compiler in test runner

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -50,8 +50,14 @@ if (missingVendor.length > 0) {
 }
 
 const chad = path.join(projectRoot, ".build", "chad");
-if (!fs.existsSync(chad)) {
-  console.log("Native compiler missing, building .build/chad...");
+const chadMtime = fs.existsSync(chad) ? fs.statSync(chad).mtimeMs : 0;
+const distMtimeForChad = fs.existsSync(distEntry) ? fs.statSync(distEntry).mtimeMs : 0;
+if (!chadMtime || distMtimeForChad > chadMtime) {
+  console.log(
+    chadMtime
+      ? "Native compiler is stale, rebuilding .build/chad..."
+      : "Native compiler missing, building .build/chad...",
+  );
   try {
     execSync("node dist/chad-node.js build src/chad-native.ts -o .build/chad", {
       cwd: projectRoot,


### PR DESCRIPTION
## Summary
- Fixes mysterious test failures after source changes by detecting when `.build/chad` is older than `dist/` and auto-rebuilding it
- Previously the test runner only checked if `.build/chad` exists, not whether it's current — a stale native compiler silently produces wrong codegen, causing tests to fail with confusing errors (wrong truthiness, SIGSEGVs, missing features)

## Test plan
- [x] `npm run verify:quick` passes
- [x] Verified: when `dist/` is newer than `.build/chad`, test runner prints "Native compiler is stale, rebuilding" and rebuilds before running tests