### PR TITLE
add llvm.assume bounds hints, full fast-math flags on all fp ops

### DIFF
--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -201,6 +201,9 @@ export class IndexAccessGenerator {
     this.ctx.emit(`call void @__cs_bounds_fail(i32 ${index}, i32 ${len})`);
     this.ctx.emit(`unreachable`);
     this.ctx.emit(`${okLabel}:`);
+    const inBounds = this.ctx.nextTemp();
+    this.ctx.emit(`${inBounds} = icmp ult i32 ${index}, ${len}`);
+    this.ctx.emit(`call void @llvm.assume(i1 ${inBounds})`);
   }
 
   private generateStringArrayIndex(expr: IndexAccessNode, params: string[]): string {

--- a/src/codegen/expressions/operators/binary.ts
+++ b/src/codegen/expressions/operators/binary.ts
@@ -88,12 +88,12 @@ export class BinaryExpressionGenerator {
     const leftValue = this.ctx.generateExpression(left, params);
     const rightValue = this.ctx.generateExpression(right, params);
 
-    // Arithmetic operators (floating-point)
+    // Arithmetic operators (floating-point) — fast-math flags enable LLVM optimizations
     const arithMap: { [key: string]: string } = {
-      "+": "fadd nsz arcp contract reassoc afn",
-      "-": "fsub nsz arcp contract reassoc afn",
-      "*": "fmul nsz arcp contract reassoc afn",
-      "/": "fdiv nsz arcp contract reassoc afn",
+      "+": "fadd nnan ninf nsz arcp contract reassoc afn",
+      "-": "fsub nnan ninf nsz arcp contract reassoc afn",
+      "*": "fmul nnan ninf nsz arcp contract reassoc afn",
+      "/": "fdiv nnan ninf nsz arcp contract reassoc afn",
     };
 
     // Bitwise operators (need to convert double -> i64 -> operate -> double)

--- a/src/codegen/infrastructure/ir-builders.ts
+++ b/src/codegen/infrastructure/ir-builders.ts
@@ -25,30 +25,32 @@ export function emitMul(ctx: EmitContext, type: string, lhs: string, rhs: string
   return temp;
 }
 
+const FMATH = "nnan ninf nsz arcp contract reassoc afn";
+
 export function emitFAdd(ctx: EmitContext, lhs: string, rhs: string): string {
   const temp = ctx.nextTemp();
-  ctx.emit(`${temp} = fadd double ${lhs}, ${rhs}`);
+  ctx.emit(`${temp} = fadd ${FMATH} double ${lhs}, ${rhs}`);
   ctx.setVariableType(temp, "double");
   return temp;
 }
 
 export function emitFSub(ctx: EmitContext, lhs: string, rhs: string): string {
   const temp = ctx.nextTemp();
-  ctx.emit(`${temp} = fsub double ${lhs}, ${rhs}`);
+  ctx.emit(`${temp} = fsub ${FMATH} double ${lhs}, ${rhs}`);
   ctx.setVariableType(temp, "double");
   return temp;
 }
 
 export function emitFMul(ctx: EmitContext, lhs: string, rhs: string): string {
   const temp = ctx.nextTemp();
-  ctx.emit(`${temp} = fmul double ${lhs}, ${rhs}`);
+  ctx.emit(`${temp} = fmul ${FMATH} double ${lhs}, ${rhs}`);
   ctx.setVariableType(temp, "double");
   return temp;
 }
 
 export function emitFDiv(ctx: EmitContext, lhs: string, rhs: string): string {
   const temp = ctx.nextTemp();
-  ctx.emit(`${temp} = fdiv double ${lhs}, ${rhs}`);
+  ctx.emit(`${temp} = fdiv ${FMATH} double ${lhs}, ${rhs}`);
   ctx.setVariableType(temp, "double");
   return temp;
 }
@@ -62,14 +64,14 @@ export function emitSRem(ctx: EmitContext, type: string, lhs: string, rhs: strin
 
 export function emitFRem(ctx: EmitContext, lhs: string, rhs: string): string {
   const temp = ctx.nextTemp();
-  ctx.emit(`${temp} = frem double ${lhs}, ${rhs}`);
+  ctx.emit(`${temp} = frem ${FMATH} double ${lhs}, ${rhs}`);
   ctx.setVariableType(temp, "double");
   return temp;
 }
 
 export function emitFNeg(ctx: EmitContext, value: string): string {
   const temp = ctx.nextTemp();
-  ctx.emit(`${temp} = fneg double ${value}`);
+  ctx.emit(`${temp} = fneg ${FMATH} double ${value}`);
   ctx.setVariableType(temp, "double");
   return temp;
 }

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -51,6 +51,7 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "declare i8* @strstr(i8*, i8*)\n";
   ir += "declare i8* @strchr(i8*, i32)\n";
   ir += "declare i8* @strrchr(i8*, i32)\n";
+  ir += "declare void @llvm.assume(i1)\n";
   ir += "declare void @llvm.memcpy.p0i8.p0i8.i64(i8*, i8*, i64, i1)\n";
   ir += "declare void @llvm.memmove.p0i8.p0i8.i64(i8*, i8*, i64, i1)\n";
   ir += "declare void @llvm.memset.p0i8.i64(i8*, i8, i64, i1)\n";


### PR DESCRIPTION
## Summary
- **`@llvm.assume` after bounds checks** — after a successful bounds check, emit `call void @llvm.assume(i1 %in_bounds)` to explicitly tell LLVM's optimizer that the index is valid. Zero runtime cost (assume generates no machine code). Enables SCEV to potentially eliminate redundant bounds checks in loops with monotonic access patterns.
- **Full fast-math flags on all floating-point operations** — add `nnan ninf` to the existing `nsz arcp contract reassoc afn` flags on `fadd`, `fsub`, `fmul`, `fdiv`, `frem`, `fneg`. This tells LLVM it can assume no NaN/Infinity values, enabling more aggressive loop transforms and FP optimizations.
- **IR builder consistency** — the `emitFAdd`/`emitFSub`/`emitFMul`/`emitFDiv`/`emitFRem`/`emitFNeg` builder functions now emit the same fast-math flags as the binary operator codegen path.

These are foundational optimizations that give LLVM's optimizer more information to work with. They don't produce measurable speedups on current benchmarks alone, but they're prerequisites for future optimizations (loop bounds check elimination, auto-vectorization) and ensure consistent optimization across all FP code paths.

## Test plan
- [x] `npm run verify:quick` passes (tests + self-hosting Stage 1)
- [x] All existing tests pass unchanged (fast-math and assume are purely optimizer hints)