### PR TITLE
simplify benchmarks page, let results speak for themselves

### DIFF
--- a/docs/.vitepress/theme/BenchmarkBars.vue
+++ b/docs/.vitepress/theme/BenchmarkBars.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted } from 'vue'
 
 interface BenchResult {
   value: number
@@ -12,7 +12,6 @@ interface Benchmark {
   metric: string
   lower_is_better: boolean
   results: Record<string, BenchResult>
-  place?: number
 }
 
 const LANG_NAMES: Record<string, string> = {
@@ -53,24 +52,9 @@ function sortEntries(b: Benchmark) {
       val: formatted,
       pct: Math.max(3, Math.round((s.value / maxVal) * 100)),
       hero: s.key === 'chadscript',
-      rank: sorted.findIndex(e => e.key === s.key) + 1,
     }
   })
 }
-
-const groups = computed(() => {
-  const wins: Benchmark[] = []
-  const podium: Benchmark[] = []
-  const rest: Benchmark[] = []
-  for (const b of benchmarks.value) {
-    const entries = sortEntries(b)
-    const csRank = entries.find(e => e.hero)?.rank ?? 99
-    if (csRank === 1) wins.push(b)
-    else if (csRank <= 3) podium.push(b)
-    else rest.push(b)
-  }
-  return { wins, podium, rest }
-})
 
 onMounted(async () => {
   try {
@@ -81,8 +65,8 @@ onMounted(async () => {
     all.sort((a, b) => {
       const aEntries = sortEntries(a)
       const bEntries = sortEntries(b)
-      const aRank = aEntries.find(e => e.hero)?.rank ?? 99
-      const bRank = bEntries.find(e => e.hero)?.rank ?? 99
+      const aRank = aEntries.findIndex(e => e.hero)
+      const bRank = bEntries.findIndex(e => e.hero)
       return aRank - bRank
     })
     benchmarks.value = all
@@ -95,97 +79,27 @@ onMounted(async () => {
 
 <template>
   <div class="bench-page" :class="{ visible }">
-    <div class="bench-summary" v-if="benchmarks.length">
-      <div class="stat">
-        <span class="stat-num">{{ groups.wins.length }}</span>
-        <span class="stat-label">1st place</span>
-      </div>
-      <div class="stat">
-        <span class="stat-num">{{ groups.wins.length + groups.podium.length }}</span>
-        <span class="stat-label">Top 3</span>
-      </div>
-      <div class="stat">
-        <span class="stat-num">{{ benchmarks.length }}</span>
-        <span class="stat-label">Total</span>
+    <div class="bench-grid">
+      <div v-for="b in benchmarks" :key="b.name" class="bench-card">
+        <div class="card-header">
+          <span class="card-title">{{ b.name }}</span>
+        </div>
+        <div class="card-desc">{{ b.desc }}</div>
+        <div class="card-rows">
+          <div v-for="e in sortEntries(b)" :key="e.name" class="card-row">
+            <div class="card-label" :class="{ hero: e.hero }">{{ e.name }}</div>
+            <div class="card-track">
+              <div
+                class="card-bar"
+                :class="{ hero: e.hero }"
+                :style="{ width: e.pct + '%' }"
+              ></div>
+            </div>
+            <div class="card-val" :class="{ hero: e.hero }">{{ e.val }}</div>
+          </div>
+        </div>
       </div>
     </div>
-
-    <template v-if="groups.wins.length">
-      <h2 class="group-title gold">1st Place</h2>
-      <div class="bench-grid">
-        <div v-for="b in groups.wins" :key="b.name" class="bench-card gold">
-          <div class="card-header">
-            <span class="card-title">{{ b.name }}</span>
-            <span class="card-badge gold">1st</span>
-          </div>
-          <div class="card-desc">{{ b.desc }}</div>
-          <div class="card-rows">
-            <div v-for="(e, i) in sortEntries(b)" :key="e.name" class="card-row">
-              <div class="card-label" :class="{ hero: e.hero }">{{ e.name }}</div>
-              <div class="card-track">
-                <div
-                  class="card-bar"
-                  :class="{ hero: e.hero }"
-                  :style="{ width: e.pct + '%' }"
-                ></div>
-              </div>
-              <div class="card-val" :class="{ hero: e.hero }">{{ e.val }}</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </template>
-
-    <template v-if="groups.podium.length">
-      <h2 class="group-title silver">Top 3</h2>
-      <div class="bench-grid">
-        <div v-for="b in groups.podium" :key="b.name" class="bench-card">
-          <div class="card-header">
-            <span class="card-title">{{ b.name }}</span>
-            <span class="card-badge">Top 3</span>
-          </div>
-          <div class="card-desc">{{ b.desc }}</div>
-          <div class="card-rows">
-            <div v-for="(e, i) in sortEntries(b)" :key="e.name" class="card-row">
-              <div class="card-label" :class="{ hero: e.hero }">{{ e.name }}</div>
-              <div class="card-track">
-                <div
-                  class="card-bar"
-                  :class="{ hero: e.hero }"
-                  :style="{ width: e.pct + '%' }"
-                ></div>
-              </div>
-              <div class="card-val" :class="{ hero: e.hero }">{{ e.val }}</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </template>
-
-    <template v-if="groups.rest.length">
-      <h2 class="group-title">All Results</h2>
-      <div class="bench-grid">
-        <div v-for="b in groups.rest" :key="b.name" class="bench-card muted">
-          <div class="card-header">
-            <span class="card-title">{{ b.name }}</span>
-          </div>
-          <div class="card-desc">{{ b.desc }}</div>
-          <div class="card-rows">
-            <div v-for="(e, i) in sortEntries(b)" :key="e.name" class="card-row">
-              <div class="card-label" :class="{ hero: e.hero }">{{ e.name }}</div>
-              <div class="card-track">
-                <div
-                  class="card-bar"
-                  :class="{ hero: e.hero }"
-                  :style="{ width: e.pct + '%' }"
-                ></div>
-              </div>
-              <div class="card-val" :class="{ hero: e.hero }">{{ e.val }}</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </template>
   </div>
 </template>
 
@@ -199,52 +113,6 @@ onMounted(async () => {
 .bench-page.visible {
   opacity: 1;
   transform: translateY(0);
-}
-
-.bench-summary {
-  display: flex;
-  gap: 32px;
-  justify-content: center;
-  margin-bottom: 32px;
-  padding: 20px;
-  border-radius: 12px;
-  background: var(--vp-c-bg-soft);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.stat {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-}
-
-.stat-num {
-  font-size: 2rem;
-  font-weight: 800;
-  color: var(--vp-c-brand-1);
-  line-height: 1;
-}
-
-.stat-label {
-  font-size: 0.8rem;
-  color: var(--vp-c-text-3);
-  font-weight: 500;
-}
-
-.group-title {
-  font-size: 1.1rem;
-  font-weight: 700;
-  margin: 28px 0 12px;
-  color: var(--vp-c-text-2);
-}
-
-.group-title.gold {
-  color: var(--vp-c-brand-1);
-}
-
-.group-title.silver {
-  color: var(--vp-c-text-1);
 }
 
 .bench-grid {
@@ -265,22 +133,7 @@ onMounted(async () => {
   border-color: rgba(255, 255, 255, 0.12);
 }
 
-.bench-card.gold {
-  border-color: rgba(255, 200, 50, 0.2);
-}
-
-.bench-card.gold:hover {
-  border-color: rgba(255, 200, 50, 0.35);
-}
-
-.bench-card.muted {
-  opacity: 0.8;
-}
-
 .card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   margin-bottom: 2px;
 }
 
@@ -288,20 +141,6 @@ onMounted(async () => {
   font-size: 0.88rem;
   font-weight: 700;
   color: var(--vp-c-text-1);
-}
-
-.card-badge {
-  font-size: 0.68rem;
-  font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--vp-c-text-2);
-}
-
-.card-badge.gold {
-  background: rgba(255, 200, 50, 0.12);
-  color: var(--vp-c-brand-1);
 }
 
 .card-desc {
@@ -373,9 +212,6 @@ onMounted(async () => {
 @media (max-width: 480px) {
   .bench-grid {
     grid-template-columns: 1fr;
-  }
-  .bench-summary {
-    gap: 20px;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- Remove the "1st place / Top 3 / Total" summary stats bar
- Remove group headings (1st Place, Top 3, All Results)
- Remove badges (1st, Top 3) from individual cards
- Remove gold/muted card styling
- Just a clean flat grid of benchmark cards sorted by ChadScript's rank

## Test plan
- [ ] Verify benchmarks page shows a flat grid with no grouping or badges