### PR TITLE
add total build time to -v output, harden dispatchNamedObject

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -436,6 +436,7 @@ export class MethodCallGenerator {
       default:
         return null;
     }
+    return null;
   }
 
   private handleYamlParse(expr: MethodCallNode, params: string[]): string {

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -430,6 +430,7 @@ export function parseFileToAST(inputFile: string): string {
 }
 
 export function compileNative(inputFile: string, outputFile: string): void {
+  const phaseStart = Date.now();
   const execDir = path.dirname(path.resolve(process.argv0));
   const installedLibDir = execDir + "/lib";
   const isInstalled = fs.existsSync(installedLibDir + "/libgc.a");
@@ -939,7 +940,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
 
   fs.unlinkSync(objFile);
   if (verbose) {
-    console.log("Compiled: " + outputFile);
+    console.log("Compiled: " + outputFile + " in " + (Date.now() - phaseStart) + "ms");
   }
 }
 


### PR DESCRIPTION
## Summary

- `chad build -v foo.ts` now appends \` in Xms\` to the existing \`Compiled: ...\` line. Cheap way to see total build time without reaching for the shell's \`time\`. No change at default verbosity.
- One-line workaround in \`MethodCallGenerator.dispatchNamedObject\` to harden it against a pre-existing native-compiler false positive in \`checkMissingReturns\`. Needed because any edit to \`compileNative\`'s body shifts AST layout enough to trip the false positive on that function — same class of bug we've hit before on \`transformExpression\`. The extra trailing \`return null;\` after the switch-with-default short-circuits \`mrAllReturn\` on the first reverse-iteration step and makes the function immune to future layout shifts.

## Why the two changes ship together

They're not logically coupled, but they're operationally coupled: landing the timing change alone reliably trips the \`dispatchNamedObject\` false positive. Verified by bisection — even a 2-line timing edit is enough.

## Test plan

- [x] \`npm run verify:quick\` passes locally (tsc + Stage 0 build + Stage 1 self-build + Stage 1 smoke + unit tests)
- [x] \`chad build foo.ts\` — no behavior change
- [x] \`chad build foo.ts -v\` — \`Compiled: foo in 26621ms\` appears
- [ ] CI green

## Root cause note

The underlying \`checkMissingReturns\` / \`mrAllReturn\` codegen bug is documented in memory (\`native-missing-returns-false-positive.md\`) for future sessions. This PR is a workaround for that specific function, not a fix for the root cause. The real fix lives in \`src/semantic/safety-checks.ts\` \`mrAllReturn\` and is a separate effort.