### PR TITLE
fix release workflow: use softprops/action-gh-release for latest tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,22 +584,15 @@ jobs:
         with:
           path: artifacts
 
-      - name: Delete old latest release
-        run: gh release delete latest --yes --cleanup-tag 2>/dev/null || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-
-      - name: Create latest release
-        run: |
-          gh release create latest \
-            --title "Latest Build" \
-            --notes "Automated release from ${GITHUB_REF_NAME} branch. Download native binaries and target SDKs below." \
-            --latest \
-            artifacts/**/*.tar.gz
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
+      - name: Publish latest release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: Latest Build
+          body: Automated release from main branch. Download native binaries and target SDKs below.
+          files: artifacts/**/*.tar.gz
+          make_latest: "true"
+          target_commitish: ${{ github.sha }}
 
   tagged-release:
     needs: [build-linux-glibc, build-macos, test-artifact]


### PR DESCRIPTION
## Summary

The \`install.sh\` download URL returned 404 after PR #497 merged because the \`latest\` release ended up stuck in **draft** state with its tag disconnected from any commit (URL was \`/releases/tag/untagged-aae38c13828ddbf9ef52\`). Manually re-published it to unblock users.

Root cause: the \`release\` job's two-step "delete old release with \`--cleanup-tag\`, then create new release" pattern has a race condition. If the tag cleanup hasn't propagated by the time \`gh release create latest\` runs, the new release is created in a partial state — no tag attachment, ends up as draft. The \`|| true\` on the delete step hid any signal that this happened, so the job still reported success.

## Fix

Replace the two-step delete/create with a single \`softprops/action-gh-release@v2\` step. The action talks to the GitHub Releases API directly and handles the create-or-update-by-tag flow atomically — no race window. The \`tagged-release\` job in the same file already uses this action, so this brings both release paths in sync.

- Drops 20 lines, adds 9.
- Explicit \`tag_name: latest\`, \`make_latest: "true"\`, and \`target_commitish: \${{ github.sha }}\` so the tag always attaches to the commit that triggered the workflow.

## What users see

- \`curl -fsSL https://raw.githubusercontent.com/cs01/ChadScript/main/install.sh | sh\` stops failing with a 404 on the next merge to main.
- No change for tagged releases (\`v*\`) — that job was already using softprops and is untouched.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, check that the \`release\` job on main produces a published (non-draft) release at \`/releases/tag/latest\` with all four tar.gz assets
- [ ] \`curl -sI https://github.com/cs01/ChadScript/releases/download/latest/chadscript-macos-arm64.tar.gz\` returns 302 after the next main merge