### PR TITLE
fix float-literal typing: 0.0 as double not integer, fixes matmul and nbody correctness

### DIFF
--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -17,6 +17,7 @@ export interface NumberNode {
   type: "number";
   value: number;
   loc?: SourceLocation;
+  isFloat?: boolean;
 }
 
 export interface StringNode {

--- a/src/codegen/expressions/expression-dispatch.ts
+++ b/src/codegen/expressions/expression-dispatch.ts
@@ -50,7 +50,8 @@ export function dispatchPrimitiveLiteral(
   _params: string[],
 ): string | null {
   if (expr.type === "number") {
-    return ctx.literalGen.generateNumber((expr as NumberNode).value);
+    const numNode = expr as NumberNode;
+    return ctx.literalGen.generateNumber(numNode.value, numNode.isFloat);
   }
   if (expr.type === "boolean") {
     return ctx.literalGen.generateBoolean((expr as BooleanNode).value);

--- a/src/codegen/expressions/literals.ts
+++ b/src/codegen/expressions/literals.ts
@@ -66,10 +66,12 @@ export class LiteralExpressionGenerator {
 
   /**
    * Generate number literal
-   * Converts integers to double via sitofp for consistency with JavaScript semantics
+   * Converts integers to double via sitofp for consistency with JavaScript semantics.
+   * isFloat is set by the parser when the literal was written with `.` or an exponent
+   * (`0.0`, `1.5`, `3e10`) — such literals must stay double even if the value is mathematically integral.
    */
-  generateNumber(value: number): string {
-    const isInteger = value % 1 === 0;
+  generateNumber(value: number, isFloat?: boolean): string {
+    const isInteger = isFloat !== true && value % 1 === 0;
 
     if (isInteger && value >= -9007199254740991 && value <= 9007199254740991) {
       const temp = this.ctx.nextTemp();

--- a/src/codegen/expressions/operators/binary.ts
+++ b/src/codegen/expressions/operators/binary.ts
@@ -178,7 +178,7 @@ export class BinaryExpressionGenerator {
   private isKnownInteger(expr: Expression): boolean {
     const exprTyped = expr as NumberNode;
     if (exprTyped.type === "number" && typeof exprTyped.value === "number") {
-      return Number.isInteger(exprTyped.value);
+      return exprTyped.isFloat !== true && Number.isInteger(exprTyped.value);
     }
     return false;
   }

--- a/src/codegen/infrastructure/integer-analysis.ts
+++ b/src/codegen/infrastructure/integer-analysis.ts
@@ -42,7 +42,9 @@ class IntegerAnalyzer {
 
   private isIntegerLiteral(val: Expression): boolean {
     if (val.type !== "number") return false;
-    return (val as NumberNode).value % 1 === 0;
+    const num = val as NumberNode;
+    if (num.isFloat === true) return false;
+    return num.value % 1 === 0;
   }
 
   private isIntegerExpressionForCandidacy(val: Expression): boolean {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2120,7 +2120,12 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     i64Eligible: string[],
   ): { llvmType: string; value: string } | null {
     if (stmt.kind !== "const" || stmt.value === null) return null;
-    const val = stmt.value as { type: string; value?: number | string | boolean };
+    const val = stmt.value as {
+      type: string;
+      value?: number | string | boolean;
+      loc?: SourceLocation;
+      isFloat?: boolean;
+    };
     if (val.type === "number" && typeof val.value === "number") {
       let isI64 = false;
       for (let ei = 0; ei < i64Eligible.length; ei++) {
@@ -2129,7 +2134,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           break;
         }
       }
-      if (isI64 && val.value % 1 === 0) {
+      if (isI64 && val.value % 1 === 0 && val.isFloat !== true) {
         return { llvmType: "i64", value: String(Math.trunc(val.value)) };
       }
       const s = String(val.value);

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -33,6 +33,7 @@ import {
   TopLevelItem,
   FunctionParameter,
   StringNode,
+  NumberNode,
   BinaryNode,
   UnaryNode,
   CallNode,
@@ -495,7 +496,7 @@ function handleExportStatement(node: TreeSitterNode, ast: AST): void {
 function transformExpression(node: TreeSitterNode): Expression {
   switch (node.type) {
     case "number":
-      return { type: "number", value: parseFloat(node.text) };
+      return transformNumberNode(node);
 
     case "string":
       return transformStringNode(node);
@@ -759,6 +760,13 @@ function transformTypeAssertion(node: TreeSitterNode): TypeAssertionNode {
     expression,
     assertedType,
   };
+}
+
+function transformNumberNode(node: TreeSitterNode): NumberNode {
+  const numText = node.text;
+  const isFloat =
+    numText.indexOf(".") !== -1 || numText.indexOf("e") !== -1 || numText.indexOf("E") !== -1;
+  return { type: "number", value: parseFloat(numText), loc: undefined, isFloat };
 }
 
 function transformStringNode(node: TreeSitterNode): StringNode {

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -157,7 +157,10 @@ export function transformExpressionStatement(
 }
 
 function transformNumericLiteral(node: ts.NumericLiteral): NumberNode {
-  return { type: "number", value: parseFloat(node.text), loc: getLoc(node) };
+  const rawText = node.getText();
+  const isFloat =
+    rawText.indexOf(".") !== -1 || rawText.indexOf("e") !== -1 || rawText.indexOf("E") !== -1;
+  return { type: "number", value: parseFloat(node.text), loc: getLoc(node), isFloat };
 }
 
 function transformStringLiteral(node: ts.StringLiteral): StringNode {


### PR DESCRIPTION
## Summary

Numeric literals written with a decimal point or exponent (`0.0`, `1.5`, `3e10`) were being classified as integer literals by the narrowing analyzer. The check used `value % 1 === 0`, which returns true for mathematically-integer values regardless of source form — so `0.0` (value `0`) was indistinguishable from `0`.

For a function-scoped `let sum = 0.0`, this caused `sum` to be allocated as `i64` instead of `double`. The inner loop of a numeric accumulator then emitted:

```llvm
%loaded  = load i64, i64* %sum
%as_d    = sitofp i64 %loaded to double
%updated = fadd double %as_d, %product
%back    = fptosi double %updated to i64  ; TRUNCATES fractional part
store i64 %back, i64* %sum
```

every iteration, which simultaneously (a) silently truncated the fractional part of every partial result and (b) blocked loop vectorization of the reduction (loop-carried dep through the fptosi).

### Minimal repro

```ts
function sumFloats(): number {
  let s = 0.0;
  let i = 0;
  while (i < 10) { s = s + 0.1; i = i + 1; }
  return s;
}
console.log(sumFloats());
```

Before: `0`  
After:  `1` (well, `0.9999999999999999`, as expected from binary float representation of 0.1)

Explicit `let s: number = 0.0` was also incorrectly narrowed — the annotation was ignored.

## Fix

Added an optional `isFloat?: boolean` field to `NumberNode`, set at parse time based on the presence of `.` / `e` / `E` in the literal's raw source text. The two parsers (TS-based and tree-sitter-based native) populate the flag; four narrowing/codegen sites gate integer classification on `isFloat !== true`.

**Files:**
- `src/ast/types.ts` — `NumberNode.isFloat?: boolean`
- `src/parser-ts/handlers/expressions.ts` — `transformNumericLiteral` sets `isFloat` from `node.getText()`
- `src/parser-native/transformer.ts` — new `transformNumberNode` helper, stays self-hosting-compatible (no Set, no for...of, no regex — plain `indexOf` on `.`, `e`, `E`)
- `src/codegen/infrastructure/integer-analysis.ts` — `isIntegerLiteral` gates on `isFloat !== true`
- `src/codegen/llvm-generator.ts` — i64 literal emission path gates on `isFloat !== true`
- `src/codegen/expressions/operators/binary.ts` — `isKnownInteger` gates on `isFloat !== true`
- `src/codegen/expressions/literals.ts` — `generateNumber` now takes `isFloat` param
- `src/codegen/expressions/expression-dispatch.ts` — threads `isFloat` through to `generateNumber`

## Correctness fixes

Both of these were silent bugs that produced compiling, running, wrong output:

**matmul** (`benchmarks/matmul/chadscript.ts`)
- Before: ` Check:    44634215`
- After:  ` Check:    44634424.32`

The 512×512 matmul inner loop's `sum += a[row*N+k] * b[k*N+col]` was losing the `.32` fractional tail 512 times per cell, accumulated error ~209.

**nbody** (`benchmarks/nbody/chadscript.ts`)
- Before: ` Energy:   0` (both before and after the 25M-step simulation)
- After:  ` Energy:   -0.169065129117806` (initial) / ` Energy:   -0.169046651628287` (after 25M steps)

The `energy()` function starts with `let e = 0.0` and accumulates kinetic + potential terms. Before this fix, `e` was typed `i64` and every fadd result was truncated to `0` through fptosi. The benchmark was emitting zero for both the initial and final energy, effectively measuring nothing. Energy conservation after the fix is ~0.00002, consistent with a 25M-step double-precision leapfrog integrator.

## Measurements

Apple Silicon M-series, macOS ARM64, best of 5 runs, both sides built from the same worktree with identical linked libraries (vendor/bdwgc/libgc.a, c_bridges/*.o) — only the compiler source differs.

| bench        | baseline   | fix        | delta       |
|--------------|-----------:|-----------:|:------------|
| **matmul**   |   **834 ms** | **108 ms** | **-87%, 7.7× faster** |
| fibonacci    |     792 ms |     797 ms | ~tie (+0.6%)        |
| sieve        |      11 ms |      12 ms | ~tie                |
| sorting      |     136 ms |     135 ms | ~tie                |
| montecarlo   |     266 ms |     266 ms | tie                 |
| nbody        |     817 ms |     819 ms | ~tie                |
| binarytrees  |     615 ms |     614 ms | tie                 |

matmul is the only substantial speedup — the fptosi/sitofp round-trip removal unlocks LLVM's NEON vectorizer on the inner reduction. The other benchmarks are unchanged because their hot loops don't involve a function-scoped float accumulator.

## Tests

- `npm test` — **774/774 pass, 0 failures, 37 suites.**
- No test had to be updated. The narrowing change is strict-additive: literals that used to be classified integer are still classified integer (because they have no `.` / `e` / `E`), and only literals written with `.` or exponent are newly classified as float.

## IR check

Pre-fix IR for the `sumFloats` loop:
```llvm
%s.addr.0 = alloca i64
store i64 0, i64* %s.addr.0
...
%loaded   = load i64, i64* %s.addr.0
%as_d     = sitofp i64 %loaded to double
%updated  = fadd nnan ninf nsz arcp contract reassoc afn double %as_d, 0x3FB999999999999A
%back     = fptosi double %updated to i64
store i64 %back, i64* %s.addr.0
```

Post-fix:
```llvm
%s.addr.0 = alloca double
store double 0.0, double* %s.addr.0
...
%loaded   = load double, double* %s.addr.0
%updated  = fadd nnan ninf nsz arcp contract reassoc afn double %loaded, 0x3FB999999999999A
store double %updated, double* %s.addr.0
```

No more round-trip through i64. The loop body is now a pure-double reduction, and LLVM's LoopVectorizer can reorder the accumulator (the fast-math `reassoc` flag is already present).

## Risk

Low. The change is strict-additive at the classification level (new `isFloat === true` short-circuits the existing "is integer?" check, never widens integer to float). Parser changes stay self-hosting-compatible. 774/774 tests pass with no updates.