### PR TITLE
chore: remove Bun from benchmark suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,6 @@ jobs:
           clang -c -O2 -fPIC -I vendor/tree-sitter/lib/include c_bridges/treesitter-bridge.c -o build/treesitter-bridge.o
       - name: Build native chad
         run: node dist/chad-node.js build src/chad-native.ts -o .build/chad --target-cpu=x86-64
-      - name: Install Bun
-        run: curl -fsSL https://bun.sh/install | bash && echo "$HOME/.bun/bin" >> $GITHUB_PATH
       - name: Run benchmarks
         run: bash benchmarks/run-ci.sh
         timeout-minutes: 10
@@ -86,7 +84,7 @@ jobs:
               if old.returncode == 0:
                   prev = json.loads(old.stdout).get('benchmarks', {})
           except: pass
-          lines = ['### Benchmark Results (Linux x86-64)\n', '| Benchmark | C | ChadScript | Go | Node | Bun | Place |', '|---|---|---|---|---|---|---|']
+          lines = ['### Benchmark Results (Linux x86-64)\n', '| Benchmark | C | ChadScript | Go | Node | Place |', '|---|---|---|---|---|---|']
           def fmt(val_str):
               try:
                   v = float(val_str.rstrip('smsg/req'))
@@ -129,7 +127,7 @@ jobs:
                   v = r.get(lang, {}).get('label', '—')
                   return fmt(v) if v != '—' else v
               chad_str = f'**{g(\"chadscript\")}{delta(k, b)}**'
-              lines.append(f\"| {b['name']} | {g('c')} | {chad_str} | {g('go')} | {g('node')} | {g('bun')} | {rank(b)} |\")
+              lines.append(f\"| {b['name']} | {g('c')} | {chad_str} | {g('go')} | {g('node')} | {rank(b)} |\")
           if cli:
               cli_names = {'grep': 'grep', 'ripgrep': 'ripgrep', 'node': 'Node.js', 'xxd': 'xxd'}
               lines.append('')

--- a/.github/workflows/update-benchmarks.yml
+++ b/.github/workflows/update-benchmarks.yml
@@ -49,8 +49,6 @@ jobs:
           clang -c -O2 -fPIC -I vendor/tree-sitter/lib/include c_bridges/treesitter-bridge.c -o build/treesitter-bridge.o
       - name: Build native chad
         run: node dist/chad-node.js build src/chad-native.ts -o .build/chad --target-cpu=x86-64
-      - name: Install Bun
-        run: curl -fsSL https://bun.sh/install | bash && echo "$HOME/.bun/bin" >> $GITHUB_PATH
       - name: Run benchmarks
         run: bash benchmarks/run-ci.sh
         timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Hono-style API, C-level performance. One binary, no node_modules. See [`examples
 
 ## Benchmarks
 
-ChadScript compiles through LLVM, the same backend behind C and Rust — so it gets the same optimization passes. Compared against C, Go, Node.js, and Bun on Ubuntu (CI):
+ChadScript compiles through LLVM, the same backend behind C and Rust — so it gets the same optimization passes. Compared against C, Go, and Node.js on Ubuntu (CI):
 
 | Benchmark      | ChadScript | Node.js | vs Node  | C      |
 | -------------- | ---------- | ------- | -------- | ------ |
@@ -85,7 +85,7 @@ ChadScript compiles through LLVM, the same backend behind C and Rust — so it g
 | Quicksort      | **0.202s** | 0.249s  | **1.2x** | 0.170s |
 | SQLite         | **0.374s** | 0.437s  | **1.2x** | 0.314s |
 
-[Full benchmarks with Go and Bun](https://cs01.github.io/ChadScript/benchmarks) (updated on every PR)
+[Full benchmarks dashboard](https://cs01.github.io/ChadScript/benchmarks) (updated on every PR)
 
 ---
 

--- a/benchmarks/run-ci.sh
+++ b/benchmarks/run-ci.sh
@@ -116,7 +116,6 @@ echo "=== Cold Start (avg of $STARTUP_RUNS runs) ==="
 bench_startup "C" "c" /tmp/bench-startup-c
 bench_startup "ChadScript" "chadscript" /tmp/bench-startup-chad
 bench_startup "Go" "go" /tmp/bench-startup-go
-bench_startup "Bun" "bun" bun "$DIR/startup/bun.mjs"
 bench_startup "Node.js" "node" node "$DIR/startup/node.mjs"
 
 echo ""
@@ -124,77 +123,66 @@ echo "=== SQLite (100K queries) ==="
 bench_compute "sqlite" "c" "C" "Time:" /tmp/bench-sqlite-c
 bench_compute "sqlite" "chadscript" "ChadScript" "Time:" /tmp/bench-sqlite-chad
 bench_compute "sqlite" "node" "Node.js" "Time:" node --experimental-sqlite "$DIR/sqlite/node.mjs"
-bench_compute "sqlite" "bun" "Bun" "Time:" bun "$DIR/sqlite/bun.mjs"
 
 echo "=== Fibonacci (fib 42) ==="
 bench_compute "fibonacci" "c" "C" "Time:" /tmp/bench-fibonacci-c
 bench_compute "fibonacci" "chadscript" "ChadScript" "Time:" /tmp/bench-fibonacci-chad
 bench_compute "fibonacci" "go" "Go" "Time:" /tmp/bench-fibonacci-go
 bench_compute "fibonacci" "node" "Node.js" "Time:" node "$DIR/fibonacci/node.mjs"
-bench_compute "fibonacci" "bun" "Bun" "Time:" bun "$DIR/fibonacci/bun.mjs"
 
 echo "=== N-Body (50M steps) ==="
 bench_compute "nbody" "c" "C" "Time:" /tmp/bench-nbody-c
 bench_compute "nbody" "chadscript" "ChadScript" "Time:" /tmp/bench-nbody-chad
 bench_compute "nbody" "go" "Go" "Time:" /tmp/bench-nbody-go
 bench_compute "nbody" "node" "Node.js" "Time:" node "$DIR/nbody/node.mjs"
-bench_compute "nbody" "bun" "Bun" "Time:" bun "$DIR/nbody/bun.mjs"
 
 echo "=== JSON Parse/Stringify (10K objects) ==="
 bench_compute "json" "c" "C (yyjson)" "Time:" /tmp/bench-json-c
 bench_compute "json" "chadscript" "ChadScript" "Time:" /tmp/bench-json-chad
 bench_compute "json" "go" "Go" "Time:" /tmp/bench-json-go
 bench_compute "json" "node" "Node.js" "Time:" node "$DIR/json/node.mjs"
-bench_compute "json" "bun" "Bun" "Time:" bun "$DIR/json/bun.mjs"
 
 echo "=== Sieve of Eratosthenes (10M) ==="
 bench_compute "sieve" "c" "C" "Time:" /tmp/bench-sieve-c
 bench_compute "sieve" "chadscript" "ChadScript" "Time:" /tmp/bench-sieve-chad
 bench_compute "sieve" "go" "Go" "Time:" /tmp/bench-sieve-go
 bench_compute "sieve" "node" "Node.js" "Time:" node "$DIR/sieve/node.mjs"
-bench_compute "sieve" "bun" "Bun" "Time:" bun "$DIR/sieve/bun.mjs"
 
 echo "=== Monte Carlo Pi (50M samples) ==="
 bench_compute "montecarlo" "c" "C" "Time:" /tmp/bench-montecarlo-c
 bench_compute "montecarlo" "chadscript" "ChadScript" "Time:" /tmp/bench-montecarlo-chad
 bench_compute "montecarlo" "go" "Go" "Time:" /tmp/bench-montecarlo-go
 bench_compute "montecarlo" "node" "Node.js" "Time:" node "$DIR/montecarlo/node.mjs"
-bench_compute "montecarlo" "bun" "Bun" "Time:" bun "$DIR/montecarlo/bun.mjs"
 
 echo "=== Quicksort (2M doubles) ==="
 bench_compute "sorting" "c" "C" "Time:" /tmp/bench-sorting-c
 bench_compute "sorting" "chadscript" "ChadScript" "Time:" /tmp/bench-sorting-chad
 bench_compute "sorting" "go" "Go" "Time:" /tmp/bench-sorting-go
 bench_compute "sorting" "node" "Node.js" "Time:" node "$DIR/sorting/node.mjs"
-bench_compute "sorting" "bun" "Bun" "Time:" bun "$DIR/sorting/bun.mjs"
 
 echo "=== Matrix Multiply (512x512) ==="
 bench_compute "matmul" "c" "C" "Time:" /tmp/bench-matmul-c
 bench_compute "matmul" "chadscript" "ChadScript" "Time:" /tmp/bench-matmul-chad
 bench_compute "matmul" "go" "Go" "Time:" /tmp/bench-matmul-go
 bench_compute "matmul" "node" "Node.js" "Time:" node "$DIR/matmul/node.mjs"
-bench_compute "matmul" "bun" "Bun" "Time:" bun "$DIR/matmul/bun.mjs"
 
 echo "=== String Manipulation (100K strings) ==="
 bench_compute "stringops" "c" "C" "Time:" /tmp/bench-stringops-c
 bench_compute "stringops" "chadscript" "ChadScript" "Time:" /tmp/bench-stringops-chad
 bench_compute "stringops" "go" "Go" "Time:" /tmp/bench-stringops-go
 bench_compute "stringops" "node" "Node.js" "Time:" node "$DIR/stringops/node.mjs"
-bench_compute "stringops" "bun" "Bun" "Time:" bun "$DIR/stringops/bun.mjs"
 
 echo "=== Binary Trees (depth 18) ==="
 bench_compute "binarytrees" "c" "C" "Time:" /tmp/bench-binarytrees-c
 bench_compute "binarytrees" "chadscript" "ChadScript" "Time:" /tmp/bench-binarytrees-chad
 bench_compute "binarytrees" "go" "Go" "Time:" /tmp/bench-binarytrees-go
 bench_compute "binarytrees" "node" "Node.js" "Time:" node "$DIR/binarytrees/node.mjs"
-bench_compute "binarytrees" "bun" "Bun" "Time:" bun "$DIR/binarytrees/bun.mjs"
 
 echo "=== File I/O (100MB read/write) ==="
 bench_compute "fileio" "c" "C" "Time:" /tmp/bench-fileio-c
 bench_compute "fileio" "chadscript" "ChadScript" "Time:" /tmp/bench-fileio-chad
 bench_compute "fileio" "go" "Go" "Time:" /tmp/bench-fileio-go
 bench_compute "fileio" "node" "Node.js" "Time:" node "$DIR/fileio/node.mjs"
-bench_compute "fileio" "bun" "Bun" "Time:" bun "$DIR/fileio/bun.mjs"
 
 echo ""
 echo "--- Building ChadScript CLI tools ---"

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -439,7 +439,6 @@ echo ""
 bench_startup "C (clang -O2 -march=native)" "c" /tmp/bench-startup-c
 bench_startup "ChadScript" "chadscript" /tmp/bench-startup-chad
 bench_startup "Go" "go" /tmp/bench-startup-go
-bench_startup "Bun" "bun" bun "$DIR/startup/bun.mjs"
 bench_startup "Node.js" "node" node "$DIR/startup/node.mjs"
 
 echo ""
@@ -451,7 +450,6 @@ echo ""
 bench_compute "sqlite" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-sqlite-c
 bench_compute "sqlite" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-sqlite-chad
 bench_compute "sqlite" "node" "Node.js $(node --version)" "Time:" node --experimental-sqlite "$DIR/sqlite/node.mjs"
-bench_compute "sqlite" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/sqlite/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  Matrix Multiply  (512x512, double precision)"
@@ -462,7 +460,6 @@ bench_compute "matmul" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-matm
 bench_compute "matmul" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-matmul-chad
 bench_compute "matmul" "go" "Go" "Time:" /tmp/bench-matmul-go
 bench_compute "matmul" "node" "Node.js $(node --version)" "Time:" node "$DIR/matmul/node.mjs"
-bench_compute "matmul" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/matmul/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  Monte Carlo Pi  (50M samples, deterministic LCG)"
@@ -473,7 +470,6 @@ bench_compute "montecarlo" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-
 bench_compute "montecarlo" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-montecarlo-chad
 bench_compute "montecarlo" "go" "Go" "Time:" /tmp/bench-montecarlo-go
 bench_compute "montecarlo" "node" "Node.js $(node --version)" "Time:" node "$DIR/montecarlo/node.mjs"
-bench_compute "montecarlo" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/montecarlo/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  Fibonacci  (fib(42), naive recursion)"
@@ -484,7 +480,6 @@ bench_compute "fibonacci" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-f
 bench_compute "fibonacci" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-fibonacci-chad
 bench_compute "fibonacci" "go" "Go" "Time:" /tmp/bench-fibonacci-go
 bench_compute "fibonacci" "node" "Node.js $(node --version)" "Time:" node "$DIR/fibonacci/node.mjs"
-bench_compute "fibonacci" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/fibonacci/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  Sieve of Eratosthenes  (primes up to 10M)"
@@ -495,7 +490,6 @@ bench_compute "sieve" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-sieve
 bench_compute "sieve" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-sieve-chad
 bench_compute "sieve" "go" "Go" "Time:" /tmp/bench-sieve-go
 bench_compute "sieve" "node" "Node.js $(node --version)" "Time:" node "$DIR/sieve/node.mjs"
-bench_compute "sieve" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/sieve/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  Quicksort  (2M doubles, deterministic LCG)"
@@ -506,7 +500,6 @@ bench_compute "sorting" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-sor
 bench_compute "sorting" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-sorting-chad
 bench_compute "sorting" "go" "Go" "Time:" /tmp/bench-sorting-go
 bench_compute "sorting" "node" "Node.js $(node --version)" "Time:" node "$DIR/sorting/node.mjs"
-bench_compute "sorting" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/sorting/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  N-Body Simulation  (5 bodies, 25M steps)"
@@ -517,7 +510,6 @@ bench_compute "nbody" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-nbody
 bench_compute "nbody" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-nbody-chad
 bench_compute "nbody" "go" "Go" "Time:" /tmp/bench-nbody-go
 bench_compute "nbody" "node" "Node.js $(node --version)" "Time:" node "$DIR/nbody/node.mjs"
-bench_compute "nbody" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/nbody/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  String Manipulation  (100K strings)"
@@ -528,7 +520,6 @@ bench_compute "stringops" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-s
 bench_compute "stringops" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-stringops-chad
 bench_compute "stringops" "go" "Go" "Time:" /tmp/bench-stringops-go
 bench_compute "stringops" "node" "Node.js $(node --version)" "Time:" node "$DIR/stringops/node.mjs"
-bench_compute "stringops" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/stringops/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  File I/O  (write + read ~100MB)"
@@ -539,7 +530,6 @@ bench_compute "fileio" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench-file
 bench_compute "fileio" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-fileio-chad
 bench_compute "fileio" "go" "Go" "Time:" /tmp/bench-fileio-go
 bench_compute "fileio" "node" "Node.js $(node --version)" "Time:" node "$DIR/fileio/node.mjs"
-bench_compute "fileio" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/fileio/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  Binary Trees  (depth 18, GC pressure)"
@@ -550,7 +540,6 @@ bench_compute "binarytrees" "c" "C (clang -O2 -march=native)" "Time:" /tmp/bench
 bench_compute "binarytrees" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-binarytrees-chad
 bench_compute "binarytrees" "go" "Go" "Time:" /tmp/bench-binarytrees-go
 bench_compute "binarytrees" "node" "Node.js $(node --version)" "Time:" node "$DIR/binarytrees/node.mjs"
-bench_compute "binarytrees" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/binarytrees/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  JSON Parse/Stringify  (10K objects)"
@@ -561,7 +550,6 @@ bench_compute "json" "c" "C (clang -O2 -march=native, yyjson)" "Time:" /tmp/benc
 bench_compute "json" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-json-chad
 bench_compute "json" "go" "Go" "Time:" /tmp/bench-json-go
 bench_compute "json" "node" "Node.js $(node --version)" "Time:" node "$DIR/json/node.mjs"
-bench_compute "json" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/json/bun.mjs"
 
 echo "═══════════════════════════════════════════════════"
 echo "  String Search  (recursive, 'console.log' in src/)"
@@ -572,7 +560,6 @@ bench_compute "stringsearch" "c" "C (clang -O2 -march=native)" "Time:" /tmp/benc
 bench_compute "stringsearch" "chadscript" "ChadScript (native)" "Time:" /tmp/bench-stringsearch-chad
 bench_compute "stringsearch" "go" "Go" "Time:" /tmp/bench-stringsearch-go
 bench_compute "stringsearch" "node" "Node.js $(node --version)" "Time:" node "$DIR/stringsearch/node.mjs"
-bench_compute "stringsearch" "bun" "Bun $(bun --version)" "Time:" bun "$DIR/stringsearch/bun.mjs"
 bench_compute "stringsearch" "grep" "grep -r (GNU)" "Time:" bash "$DIR/stringsearch/grep.sh"
 bench_compute "stringsearch" "ripgrep" "ripgrep (rg)" "Time:" bash "$DIR/stringsearch/rg.sh"
 

--- a/docs/.vitepress/theme/BenchmarkBars.vue
+++ b/docs/.vitepress/theme/BenchmarkBars.vue
@@ -19,13 +19,12 @@ const LANG_NAMES: Record<string, string> = {
   chadscript: 'ChadScript',
   go: 'Go',
   node: 'Node.js',
-  bun: 'Bun',
   grep: 'grep',
   ripgrep: 'ripgrep',
   xxd: 'xxd',
 }
 
-const LANG_ORDER = ['c', 'chadscript', 'go', 'bun', 'node', 'grep', 'ripgrep', 'xxd']
+const LANG_ORDER = ['c', 'chadscript', 'go', 'node', 'grep', 'ripgrep', 'xxd']
 
 const benchmarks = ref<Benchmark[]>([])
 const visible = ref(false)

--- a/docs/.vitepress/theme/HeroBenchmarks.vue
+++ b/docs/.vitepress/theme/HeroBenchmarks.vue
@@ -20,7 +20,6 @@ const LANG_NAMES: Record<string, string> = {
   chadscript: 'ChadScript',
   go: 'Go',
   node: 'Node.js',
-  bun: 'Bun',
   grep: 'grep',
   ripgrep: 'ripgrep',
   xxd: 'xxd',
@@ -36,7 +35,7 @@ const activeBench = computed(() => benchmarks.value[activeIndex.value])
 const entries = computed(() => {
   const b = activeBench.value
   if (!b) return []
-  const langOrder = ['c', 'chadscript', 'go', 'bun', 'node', 'grep', 'ripgrep', 'xxd']
+  const langOrder = ['c', 'chadscript', 'go', 'node', 'grep', 'ripgrep', 'xxd']
   const known = new Set(langOrder)
   const sorted = langOrder
     .filter(k => k in b.results)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -2,7 +2,7 @@
 
 ChadScript compiles to native binaries via LLVM IR — no runtime, no JIT warmup, no cold start penalty.
 
-These benchmarks compare ChadScript against C (clang -O2), Go, Bun, and Node.js across compute, I/O, and real-world workloads.
+These benchmarks compare ChadScript against C (clang -O2), Go, and Node.js across compute, I/O, and real-world workloads.
 
 <BenchmarkBars />
 

--- a/scripts/update-benchmark-docs.js
+++ b/scripts/update-benchmark-docs.js
@@ -20,7 +20,6 @@ const langMeta = {
   c: { name: "C", color: "c" },
   chadscript: { name: "ChadScript", color: "chad", hero: true },
   go: { name: "Go", color: "go" },
-  bun: { name: "Bun", color: "bun" },
   node: { name: "Node.js", color: "node" },
 };
 
@@ -152,13 +151,11 @@ function buildMarkdownSummary(json) {
   if (b.fibonacci) {
     const cs = b.fibonacci.results.chadscript;
     const go = b.fibonacci.results.go;
-    const bun = b.fibonacci.results.bun;
     const node = b.fibonacci.results.node;
     if (cs && go) {
-      const bunRatio = bun ? (bun.value / cs.value).toFixed(0) : "?";
       const nodeRatio = node ? (node.value / cs.value).toFixed(0) : "?";
       lines.push(
-        `- **Faster than Go on recursion** \u2014 fib(42) in ${fmt(b.fibonacci, "chadscript")} vs Go\u2019s ${fmt(b.fibonacci, "go")}, ${bunRatio}x faster than Bun, ${nodeRatio}x faster than Node`,
+        `- **Faster than Go on recursion** \u2014 fib(42) in ${fmt(b.fibonacci, "chadscript")} vs Go\u2019s ${fmt(b.fibonacci, "go")}, ${nodeRatio}x faster than Node`,
       );
     }
   }
@@ -167,14 +164,12 @@ function buildMarkdownSummary(json) {
     const cs = b.startup.results.chadscript;
     const c = b.startup.results.c;
     const go = b.startup.results.go;
-    const bun = b.startup.results.bun;
     const node = b.startup.results.node;
     if (cs && c) {
       const goRatio = go ? Math.round(go.value / cs.value) : "?";
-      const bunRatio = bun ? Math.round(bun.value / cs.value) : "?";
       const nodeRatio = node ? Math.round(node.value / cs.value) : "?";
       lines.push(
-        `- **${fmt(b.startup, "chadscript")} cold start** \u2014 within ${Math.round((cs.value / c.value - 1) * 100)}% of C, ${goRatio}x faster than Go, ${bunRatio}x faster than Bun, ${nodeRatio}x faster than Node`,
+        `- **${fmt(b.startup, "chadscript")} cold start** \u2014 within ${Math.round((cs.value / c.value - 1) * 100)}% of C, ${goRatio}x faster than Go, ${nodeRatio}x faster than Node`,
       );
     }
   }
@@ -195,14 +190,12 @@ function buildMarkdownSummary(json) {
   if (b.sqlite) {
     const cs = b.sqlite.results.chadscript;
     const c = b.sqlite.results.c;
-    const bun = b.sqlite.results.bun;
     const node = b.sqlite.results.node;
     if (cs && c) {
       const pct = Math.round((c.value / cs.value) * 100);
-      const bunRatio = bun ? (bun.value / cs.value).toFixed(1) : "?";
       const nodeRatio = node ? (node.value / cs.value).toFixed(1) : "?";
       lines.push(
-        `- **Zero-overhead FFI** \u2014 calls C libraries directly, ${pct}% of C\u2019s SQLite throughput, ${bunRatio}x faster than Bun, ${nodeRatio}x faster than Node`,
+        `- **Zero-overhead FFI** \u2014 calls C libraries directly, ${pct}% of C\u2019s SQLite throughput, ${nodeRatio}x faster than Node`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Removes **Bun** from every benchmark surface. ChadScript is now measured against **C (clang -O2)**, **ChadScript**, **Go**, and **Node.js**. **Go is kept** as a meaningful anchor for "fast compiled language" — the narrative "beats Node, competes with Go, approaches C" reads cleanly with Go in the table.

### What changed from the first revision of this PR

The original commit on this branch removed both Go and Bun. That was too aggressive — Go carries real signal (static-typed, native-compiled, well-known performance baseline) and is worth keeping in the comparison. Bun on the other hand competes with Node in the same "JS runtime" category and adds noise without a distinct narrative. This revision force-pushed to remove Bun only.

## What's removed

- **`benchmarks/run-ci.sh`** — all `bench_*` lines for `bun`. No Bun builds, no Bun runs. C, ChadScript, Go, Node remain.
- **`benchmarks/run.sh`** (local dev runner) — same treatment.
- **`.github/workflows/ci.yml`** — removed the `Install Bun` step; the PR-comment table drops the `Bun` column (now `| Benchmark | C | ChadScript | Go | Node | Place |`).
- **`.github/workflows/update-benchmarks.yml`** — removed the `Install Bun` step.
- **`docs/.vitepress/theme/BenchmarkBars.vue`** — `LANG_NAMES` and `LANG_ORDER` no longer include `bun`.
- **`docs/.vitepress/theme/HeroBenchmarks.vue`** — same.
- **`docs/benchmarks.md`** — prose "against C (clang -O2), Go, Bun, and Node.js" → "against C (clang -O2), Go, and Node.js".
- **`README.md`** — prose "Compared against C, Go, Node.js, and Bun" → "Compared against C, Go, and Node.js". Footer link text "Full benchmarks with Go and Bun" → "Full benchmarks dashboard". Table columns unchanged (ChadScript / Node.js / vs Node / C).
- **`scripts/update-benchmark-docs.js`** — `langMeta.bun` removed. `buildMarkdownSummary` no longer generates "Xx faster than Bun" sentences.

## What's NOT removed

- **Go** — kept across all benchmark surfaces. Go is the comparable compiled-language baseline.
- **Benchmark source files** (`benchmarks/*/bun.mjs`, `benchmarks/*/*.go`) are left in place. Bun's source files are orphaned but harmless — they just no longer run in CI or show up in dashboards. Deleting them can be a separate cleanup PR if desired.
- **`docs/.vitepress/theme/ComparisonCards.vue`** — still has a "Node.js / Deno / Bun" positioning/marketing card. That's a separate editorial decision (comparison cards aren't benchmark results) and is left alone here.

## Diff stat

```
 .github/workflows/ci.yml                 |  6 ++----
 .github/workflows/update-benchmarks.yml  |  2 --
 README.md                                |  4 ++--
 benchmarks/run-ci.sh                     | 12 ------------
 benchmarks/run.sh                        | 13 -------------
 docs/.vitepress/theme/BenchmarkBars.vue  |  3 +--
 docs/.vitepress/theme/HeroBenchmarks.vue |  3 +--
 docs/benchmarks.md                       |  2 +-
 scripts/update-benchmark-docs.js         | 13 +++----------
 9 files changed, 10 insertions(+), 48 deletions(-)
```

## Verification

- `npm run build` — tsc passes clean on the modified sources.
- Manual grep sweep: no `\bbun\b` or `\bBun\b` remaining in any of the 9 touched files; Go references intact (23 hits in run-ci.sh, 36 in run.sh, unchanged).
- `assemble_json.py` is language-agnostic — it naturally stops emitting `bun` entries once the runners no longer produce them, and keeps emitting `go` entries.
- PR comment's markdown table now has 6 columns instead of 7.

## Expected impact

- **CI benchmark job** runs faster (no Bun install, no Bun runs).
- **Dashboard** (`cs01.github.io/ChadScript/benchmarks`) auto-refreshes on next main CI run to show only C / ChadScript / Go / Node bars.
- **PR comment table** shifts from 7-column to 6-column next time a PR runs.
- **README table** unchanged (it was already C/ChadScript/Node).

No user code or runtime behavior changes. Pure cleanup.