### PR TITLE
perf: 2.5x faster string split on single-char separators

### DIFF
--- a/c_bridges/string-ops-bridge.c
+++ b/c_bridges/string-ops-bridge.c
@@ -79,13 +79,26 @@ StringArray *cs_str_split(const char *src, size_t src_len,
     }
 
     int32_t part_count = 1;
-    size_t pos = 0;
-    while (pos + sep_len <= src_len) {
-        if (memcmp(src + pos, sep, sep_len) == 0) {
+    if (sep_len == 1) {
+        // Fast path: single-char separator uses SIMD memchr
+        const char c = sep[0];
+        const char *p = src;
+        const char *end = src + src_len;
+        while (p < end) {
+            const char *hit = (const char *)memchr(p, c, (size_t)(end - p));
+            if (!hit) break;
             part_count++;
-            pos += sep_len;
-        } else {
-            pos++;
+            p = hit + 1;
+        }
+    } else {
+        size_t pos = 0;
+        while (pos + sep_len <= src_len) {
+            if (memcmp(src + pos, sep, sep_len) == 0) {
+                part_count++;
+                pos += sep_len;
+            } else {
+                pos++;
+            }
         }
     }
 
@@ -99,10 +112,15 @@ StringArray *cs_str_split(const char *src, size_t src_len,
 
     int32_t idx = 0;
     size_t start = 0;
-    pos = 0;
-    while (pos + sep_len <= src_len) {
-        if (memcmp(src + pos, sep, sep_len) == 0) {
-            size_t plen = pos - start;
+    if (sep_len == 1) {
+        // Fast path: single-char separator uses SIMD memchr
+        const char c = sep[0];
+        const char *p = src;
+        const char *end = src + src_len;
+        while (p < end) {
+            const char *hit = (const char *)memchr(p, c, (size_t)(end - p));
+            if (!hit) break;
+            size_t plen = (size_t)(hit - (src + start));
             char *s = pool + pool_off;
             memcpy(s, src + start, plen);
             s[plen] = '\0';
@@ -110,10 +128,26 @@ StringArray *cs_str_split(const char *src, size_t src_len,
             data[idx] = s;
             lens[idx] = (int32_t)plen;
             idx++;
-            start = pos + sep_len;
-            pos = start;
-        } else {
-            pos++;
+            start = (size_t)(hit - src) + 1;
+            p = hit + 1;
+        }
+    } else {
+        size_t pos = 0;
+        while (pos + sep_len <= src_len) {
+            if (memcmp(src + pos, sep, sep_len) == 0) {
+                size_t plen = pos - start;
+                char *s = pool + pool_off;
+                memcpy(s, src + start, plen);
+                s[plen] = '\0';
+                pool_off += plen + 1;
+                data[idx] = s;
+                lens[idx] = (int32_t)plen;
+                idx++;
+                start = pos + sep_len;
+                pos = start;
+            } else {
+                pos++;
+            }
         }
     }
     size_t plen = src_len - start;


### PR DESCRIPTION
## User-visible impact

`"text".split("\n")`, `.split(",")`, `.split(" ")` — the most common split patterns — are now roughly **2.5x faster**. Any ChadScript program that parses line-based or delimited data (log readers, CSV loaders, tokenizers, grep-style tools) gets the speedup for free.

### Measured on the string search benchmark (recursively grep `console.log` in `src/`)

| binary             | before    | after    |
| ------------------ | --------- | -------- |
| chad               | ~21 ms    | ~8.5 ms  |
| C baseline         | ~7 ms     | ~7 ms    |

Chad now runs within ~20% of a hand-written C implementation of the same benchmark. Instruction count drops from 267M to 101M; cycles from 91M to 37M.

## Root cause

`cs_str_split` (the C bridge backing `String.prototype.split`) walked the source buffer one byte at a time and called `memcmp(src + pos, sep, 1)` on every byte when the separator was a single character. That's a PLT-stub call per byte, and `memcmp` with `n=1` never reaches its SIMD fast path. For a typical 2-3 KB source file that's thousands of stub calls per split — profiling the old benchmark showed ~80% of total time in `cs_str_split` → `_platform_memcmp`.

## Fix

Added a `sep_len == 1` fast path that uses `memchr` instead. `memchr` is a libc SIMD primitive that scans whole cache lines at once (NEON on arm64, AVX2 on glibc x86_64), so finding the next separator in a long string costs ~1 cycle per 16 bytes instead of a full function call per byte. Both passes of `cs_str_split` (counting parts, then filling them) take the fast path.

Multi-char separators are unchanged.

## Test plan

- [x] `npm run verify:quick` — all tests + stage 1 self-hosting pass
- [x] String search benchmark improves from 21 ms to ~8.5 ms
- [x] String ops benchmark (also uses single-char split) runs clean at ~13 ms
- [ ] CI green