### PR TITLE
feat: rustc-style --version with git commit and build date

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chadscript",
-  "version": "0.2.0-beta",
+  "version": "0.3.0-beta",
   "description": "A JavaScript to native code compiler using LLVM",
   "type": "module",
   "main": "dist/chad-node.js",

--- a/scripts/gen-version.js
+++ b/scripts/gen-version.js
@@ -1,3 +1,18 @@
 import { readFileSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
+
 const pkg = JSON.parse(readFileSync("package.json", "utf8"));
-writeFileSync("src/version.ts", `export const VERSION = "${pkg.version}";\n`);
+
+let gitCommit = "unknown";
+try {
+  gitCommit = execSync("git rev-parse --short HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+    .toString()
+    .trim();
+} catch {
+  // not a git checkout (e.g., building from a release tarball)
+}
+
+const buildDate = new Date().toISOString().slice(0, 10);
+const fullVersion = `${pkg.version}-${gitCommit}-${buildDate}`;
+
+writeFileSync("src/version.ts", `export const VERSION = "${fullVersion}";\n`);


### PR DESCRIPTION
## Summary

Makes `chad --version` useful for bug reports — prints git commit and build date embedded in the version string, rustc-style as a single hyphenated token:

```
$ chad --version
chad 0.3.0-beta-437cdd99-2026-04-14
```

Previously `chad 0.2.0-beta`, which tells you nothing about which build someone is actually running.

Also bumps version `0.2.0-beta` → `0.3.0-beta`.

## How it works

`scripts/gen-version.js` (the existing `prebuild` hook) now shells out to `git rev-parse --short HEAD` and bakes a single `VERSION` constant of the form `<semver>-<sha>-<date>` into `src/version.ts`. If git isn't available (e.g., building from a release tarball), the sha falls back to `"unknown"`.

Kept the single `VERSION` export — zero touches to `src/*.ts`, just content changes in the generated `src/version.ts`.

## Test plan

- [x] `node dist/chad-node.js --version` → `chad 0.3.0-beta-<sha>-<date>`
- [x] `./.build/chad --version` (native compiler) → same
- [x] `npm run verify` passes — full tests + stage 0/1/2 self-hosting