### PR TITLE
fix: native compiler segfault when closure mutation error is inside a function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chadscript",
-  "version": "0.2.0-beta",
+  "version": "0.3.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chadscript",
-      "version": "0.2.0-beta",
+      "version": "0.3.0-beta",
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",

--- a/src/semantic/closure-mutation-checker.ts
+++ b/src/semantic/closure-mutation-checker.ts
@@ -97,7 +97,11 @@ class ClosureMutationChecker {
       // Simple-name reassignment after capture is the error we're looking for.
       // Member-access assignments (obj.x = y) don't reassign the binding itself.
       if (capturedNames.indexOf(assign.name) !== -1) {
-        this.reportError(assign.name, assign.loc);
+        // NOTE: `assign.loc` is intentionally not passed here. No AssignmentStatement
+        // creation site in parser-ts/parser-native sets `loc`, so reading `assign.loc`
+        // in the native self-hosted compiler GEPs past the struct and segfaults.
+        // See the PR that introduced this comment for the full root cause.
+        this.reportError(assign.name, undefined);
       }
       this.scanExprForCaptures(assign.value, scopeVarNames, capturedNames);
     } else if (stype === "if") {

--- a/tests/fixtures/closures/closure-mutation-inside-arrow-body.ts
+++ b/tests/fixtures/closures/closure-mutation-inside-arrow-body.ts
@@ -1,0 +1,10 @@
+// @test-compile-error: variable 'x' is captured by a closure but reassigned after capture
+// @test-description: closure mutation detected when assignment is inside the arrow body itself
+function outer() {
+  let x = 0;
+  const g = () => {
+    x = 1;
+  };
+  g();
+}
+outer();

--- a/tests/fixtures/closures/closure-mutation-inside-function.ts
+++ b/tests/fixtures/closures/closure-mutation-inside-function.ts
@@ -1,0 +1,9 @@
+// @test-compile-error: variable 'x' is captured by a closure but reassigned after capture
+// @test-description: closure mutation detected inside a function body (not just top-level)
+function outer() {
+  let x = 0;
+  const g = () => x;
+  x = 1;
+  g();
+}
+outer();


### PR DESCRIPTION
## User impact

Before this PR, if you wrote a closure that mutates a captured variable **inside a function body**, the native self-hosted ChadScript compiler (`.build/chad`) would segfault silently instead of printing the "variable captured by closure but reassigned after capture" error. Node-hosted builds (`node dist/chad-node.js`) were unaffected.

After this PR, both paths correctly print the compile error.

## Repro

```ts
function outer() {
  let x = 0;
  const g = () => x;
  x = 1;
  g();
}
outer();
```

`.build/chad build m08.ts` → `exit 139` (SIGSEGV) on the old code, `exit 1` with a proper error on this PR.

The existing top-level fixture (`closure-capture-mutation-error.ts`) did not catch this because top-level `AssignmentStatement`s take a different walker path in `closure-mutation-checker.ts` than function-body ones — only the function-body path triggered the read of the crashing field.

## Root cause

`closure-mutation-checker.ts:100` called `this.reportError(assign.name, assign.loc)`. But **no** `AssignmentStatement` creation site in `parser-ts` or `parser-native` sets a `loc` field. Per the CLAUDE.md rule #3, the native compiler derives struct layouts from object-literal creation sites, so the resulting native `AssignmentStatement` struct has no slot for `loc`. Reading `assign.loc` GEPs past the end of the struct into garbage memory and segfaults inside the native `formatCompileError` pipeline — after correctly detecting the error but before it can be printed.

## Fix

Defensive one-line change in `closure-mutation-checker.ts`: pass `undefined` instead of `assign.loc` to `reportError`. The error message itself is preserved; only the optional line-number underline is lost in the native-hosted path. The node-hosted path (which never exercised the crash) is unaffected.

### Why not plumb `loc` through all `AssignmentStatement` creation sites?

I tried that first (it's the "proper" fix that would give the native path line-number info too). It triggered a deeper native-compiler bug: adding a `loc: undefined` field to some creation sites shifts the inferred struct layout in a way that breaks `mrAllReturn` in `safety-checks.ts` — the return-path walker starts misreading `stmt.type` via GEP and incorrectly flags `transformExpression` as "does not return a value on all code paths." Fixing that is a bigger native-compiler refactor (unify struct layouts from interface definitions instead of creation sites), which should be a separate PR.

## Test plan

- [x] `tests/fixtures/closures/closure-mutation-inside-function.ts` — new, captures the exact repro that used to segfault
- [x] `tests/fixtures/closures/closure-mutation-inside-arrow-body.ts` — new, captures the variant where the assignment is inside the arrow body
- [x] Existing `closure-capture-mutation-error.ts` still passes (top-level case)
- [x] `npm run verify:quick` passes (full test suite + stage 1 self-hosting)

## Followups not in this PR

1. Plumb `loc` through `AssignmentStatement` creation sites to restore line-number info in the native-hosted error output — blocked on the `mrAllReturn` struct-layout issue above.
2. The same latent bug exists for any `stmt.loc` / `ifStmt.loc` / etc. access on any statement type where no creation site sets `loc`. `codegen/statements/control-flow.ts` and `codegen/statements/for-of.ts` both read `stmt.loc` on error paths today — if any of those error paths get exercised on a native self-hosted compile, they will segfault the same way.