### PR TITLE
fix: native compiler segfault on unknown new expression at module scope

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2159,13 +2159,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     const items = this.ast.topLevelStatements;
     const i64Eligible = findI64EligibleVariables(this.ast.topLevelStatements);
     for (let stmtIdx = 0; stmtIdx < totalCount; stmtIdx++) {
-      const stmt = items[stmtIdx] as {
-        type: string;
-        kind: string;
-        name: string;
-        value: Expression | null;
-        declaredType?: string;
-      };
+      const stmt = items[stmtIdx] as VariableDeclaration;
       if (stmt.type !== "variable_declaration") continue;
       if (stmt.value !== null) {
         const name = stmt.name;

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -1835,6 +1835,8 @@ function desugarDestructuring(
       kind: "const",
       name: tempName,
       value: rhsExpr,
+      declaredType: undefined,
+      loc: undefined,
     });
     objectRef = { type: "variable", name: tempName } as Expression;
   }
@@ -1852,6 +1854,8 @@ function desugarDestructuring(
           kind,
           name: propName,
           value: { type: "member_access", object: objectRef, property: propName } as Expression,
+          declaredType: undefined,
+          loc: undefined,
         });
       } else if (p.type === "pair_pattern") {
         const keyNode = getNamedChild(prop, 0);
@@ -1864,6 +1868,8 @@ function desugarDestructuring(
             kind,
             name: aliasName,
             value: { type: "member_access", object: objectRef, property: keyName } as Expression,
+            declaredType: undefined,
+            loc: undefined,
           });
         }
       }
@@ -1887,6 +1893,8 @@ function desugarDestructuring(
             object: objectRef,
             index: { type: "number", value: idx },
           } as Expression,
+          declaredType: undefined,
+          loc: undefined,
         });
         idx++;
       }
@@ -1920,7 +1928,7 @@ function transformVariableDeclarator(
     }
   }
 
-  return { type: "variable_declaration", kind, name, value, declaredType };
+  return { type: "variable_declaration", kind, name, value, declaredType, loc: undefined };
 }
 
 function transformReturnStatement(node: TreeSitterNode): ReturnStatement {

--- a/src/parser-ts/handlers/statements.ts
+++ b/src/parser-ts/handlers/statements.ts
@@ -155,6 +155,7 @@ function desugarObjectDestructuring(
       name: tempName,
       value: source,
       declaredType,
+      loc: undefined,
     } as VariableDeclaration);
     objectRef = { type: "variable", name: tempName } as VariableNode;
   }
@@ -175,7 +176,14 @@ function desugarObjectDestructuring(
       property: propertyName,
     };
 
-    statements.push({ type: "variable_declaration", kind, name: localName, value: memberAccess });
+    statements.push({
+      type: "variable_declaration",
+      kind,
+      name: localName,
+      value: memberAccess,
+      declaredType: undefined,
+      loc: undefined,
+    });
   }
 
   return { type: "block", statements };
@@ -212,6 +220,7 @@ function desugarArrayDestructuring(
       name: tempName,
       value: source,
       declaredType,
+      loc: undefined,
     } as VariableDeclaration);
     arrayRef = { type: "variable", name: tempName } as VariableNode;
   }
@@ -230,7 +239,14 @@ function desugarArrayDestructuring(
       index: { type: "number", value: i },
     };
 
-    statements.push({ type: "variable_declaration", kind, name: localName, value: indexAccess });
+    statements.push({
+      type: "variable_declaration",
+      kind,
+      name: localName,
+      value: indexAccess,
+      declaredType: undefined,
+      loc: undefined,
+    });
   }
 
   return { type: "block", statements };

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -531,6 +531,7 @@ export function transformVariableDeclaration(
         name: tempName,
         value: source,
         declaredType,
+        loc: undefined,
       } as VariableDeclaration);
       objectRef = { type: "variable", name: tempName } as Expression;
     }
@@ -551,7 +552,14 @@ export function transformVariableDeclaration(
         property: propertyName,
       };
 
-      statements.push({ type: "variable_declaration", kind, name: localName, value: memberAccess });
+      statements.push({
+        type: "variable_declaration",
+        kind,
+        name: localName,
+        value: memberAccess,
+        declaredType: undefined,
+        loc: undefined,
+      });
     }
 
     return { type: "block", statements };
@@ -583,6 +591,7 @@ export function transformVariableDeclaration(
         name: tempName,
         value: source,
         declaredType,
+        loc: undefined,
       } as VariableDeclaration);
       arrayRef = { type: "variable", name: tempName } as Expression;
     }
@@ -601,7 +610,14 @@ export function transformVariableDeclaration(
         index: { type: "number", value: i },
       };
 
-      statements.push({ type: "variable_declaration", kind, name: localName, value: indexAccess });
+      statements.push({
+        type: "variable_declaration",
+        kind,
+        name: localName,
+        value: indexAccess,
+        declaredType: undefined,
+        loc: undefined,
+      });
     }
 
     return { type: "block", statements };
@@ -620,7 +636,7 @@ export function transformVariableDeclaration(
     value = transformExpression(decl.initializer, checker);
   }
 
-  return { type: "variable_declaration", kind, name, value, declaredType };
+  return { type: "variable_declaration", kind, name, value, declaredType, loc: undefined };
 }
 
 function extractTypeString(typeNode: ts.TypeNode): string {

--- a/tests/fixtures/edge-cases/new-unknown-class-module-scope.ts
+++ b/tests/fixtures/edge-cases/new-unknown-class-module-scope.ts
@@ -1,0 +1,3 @@
+// @test-compile-error: cannot determine type of module-scope variable
+// @test-description: new UnknownClass() at module scope emits compile error instead of segfault
+const x = new UnknownClass();


### PR DESCRIPTION
## User impact

Before this PR, `const x = new UnknownClass()` at module scope caused the native self-hosted compiler (`.build/chad`) to segfault silently. After this PR, it emits a compile error and exits cleanly.

## Root cause

`VariableDeclaration` creation sites had inconsistent field counts across parsers:
- 4-field sites (destructuring): `{ type, kind, name, value }`
- 5-field sites (normal): `{ type, kind, name, value, declaredType }`
- 6-field sites (statements.ts): `{ type, kind, name, value, declaredType, loc }`

Per CLAUDE.md rule #3, the native compiler infers struct layouts from creation sites. Inconsistent field sets caused GEP misalignment — reading `stmt.value` returned a wrong pointer, and subsequent field accesses on the misaligned expression struct crashed.

## Fix

1. Aligned ALL `VariableDeclaration` creation sites to include all 6 fields (adding `declaredType: undefined, loc: undefined` where missing)
2. Changed the inline type assertion in `generateGlobalVariableDeclarations` to use the real `VariableDeclaration` type (per rule #5: never invent subset types for assertions)

## What this does NOT fix

- `new Date()` at module scope still segfaults — requires aligning `NewNode` creation sites, but doing so shifts the overall union struct layout and undoes the `VariableDeclaration` fix (cascading struct-layout interference)
- `instanceof` with class hierarchies still segfaults — same systemic issue
- These need a deeper fix: making the native compiler unify struct layouts from interface definitions rather than creation sites

## Test plan

- [x] `tests/fixtures/edge-cases/new-unknown-class-module-scope.ts` — new fixture
- [x] `npm run verify:quick` — all tests + stage 1 self-hosting pass