### PR TITLE
fix: runtime segfault when console.log prints null interface or undefined array

### DIFF
--- a/src/codegen/expressions/method-calls/console.ts
+++ b/src/codegen/expressions/method-calls/console.ts
@@ -69,6 +69,19 @@ function emitArrayPrint(
   arrayPtr: string,
   arrayType: "Array" | "StringArray" | "ObjectArray",
 ): void {
+  const arrCast = ctx.nextTemp();
+  ctx.emit(`${arrCast} = ptrtoint %${arrayType}* ${arrayPtr} to i64`);
+  const arrIsNull = ctx.emitIcmp("eq", "i64", arrCast, "0");
+  const arrNullLabel = ctx.nextLabel("arr_null");
+  const arrNonNullLabel = ctx.nextLabel("arr_nonnull");
+  ctx.emitBrCond(arrIsNull, arrNullLabel, arrNonNullLabel);
+  ctx.emitLabel(arrNullLabel);
+  const undefStr = ctx.stringGen.doCreateStringConstant("undefined");
+  emitPrintStrNoNl(ctx, useStderr, undefStr);
+  const arrDoneNullLabel = ctx.nextLabel("arr_done_null");
+  ctx.emitBr(arrDoneNullLabel);
+  ctx.emitLabel(arrNonNullLabel);
+
   const lenPtr = ctx.nextTemp();
   ctx.emit(
     `${lenPtr} = getelementptr inbounds %${arrayType}, %${arrayType}* ${arrayPtr}, i32 0, i32 1`,
@@ -164,6 +177,8 @@ function emitArrayPrint(
   ctx.emitBr(doneLabel);
 
   ctx.emitLabel(doneLabel);
+  ctx.emitBr(arrDoneNullLabel);
+  ctx.emitLabel(arrDoneNullLabel);
 }
 
 function emitMapPrint(
@@ -513,13 +528,39 @@ function emitSingleArg(
     const ifaceType =
       ctx.symbolTable.getInterfaceType(varName) || ctx.symbolTable.getRawInterfaceType(varName);
     if (ifaceType) {
+      const ptrVal = ctx.generateExpression(arg, params);
+      const isNull = ctx.emitIcmp("eq", "i8*", ptrVal, "null");
+      const nullLabel = ctx.nextLabel("console_null");
+      const nonNullLabel = ctx.nextLabel("console_nonnull");
+      const doneLabel = ctx.nextLabel("console_done");
+      ctx.emitBrCond(isNull, nullLabel, nonNullLabel);
+      ctx.emitLabel(nullLabel);
+      const nullStr = ctx.stringGen.doCreateStringConstant("null");
+      emitPrintStrNoNl(ctx, useStderr, nullStr);
+      ctx.emitBr(doneLabel);
+      ctx.emitLabel(nonNullLabel);
       const jsonStr = ctx.jsonGen.generateStringifyExpr(arg, params);
       emitPrintStrNoNl(ctx, useStderr, jsonStr);
+      ctx.emitBr(doneLabel);
+      ctx.emitLabel(doneLabel);
       return;
     }
     const cn = ctx.symbolTable.getClassName(varName);
     if (cn) {
+      const clsPtr = ctx.generateExpression(arg, params);
+      const clsIsNull = ctx.emitIcmp("eq", "i8*", clsPtr, "null");
+      const clsNullLabel = ctx.nextLabel("console_cls_null");
+      const clsNonNullLabel = ctx.nextLabel("console_cls_nonnull");
+      const clsDoneLabel = ctx.nextLabel("console_cls_done");
+      ctx.emitBrCond(clsIsNull, clsNullLabel, clsNonNullLabel);
+      ctx.emitLabel(clsNullLabel);
+      const clsNullStr = ctx.stringGen.doCreateStringConstant("null");
+      emitPrintStrNoNl(ctx, useStderr, clsNullStr);
+      ctx.emitBr(clsDoneLabel);
+      ctx.emitLabel(clsNonNullLabel);
       emitClassInstancePrint(ctx, useStderr, arg, params, cn);
+      ctx.emitBr(clsDoneLabel);
+      ctx.emitLabel(clsDoneLabel);
       return;
     }
   }

--- a/tests/fixtures/edge-cases/console-log-null-interface.ts
+++ b/tests/fixtures/edge-cases/console-log-null-interface.ts
@@ -1,0 +1,10 @@
+// @test-description: console.log on null interface value prints null instead of segfaulting
+interface Item {
+  name: string;
+}
+function f(): Item | null {
+  return null;
+}
+const y = f();
+console.log(y);
+console.log("TEST_PASSED");

--- a/tests/fixtures/edge-cases/console-log-null-map-array.ts
+++ b/tests/fixtures/edge-cases/console-log-null-map-array.ts
@@ -1,0 +1,5 @@
+// @test-description: console.log on Map.get() miss for array value prints undefined instead of segfaulting
+const m = new Map<string, number[]>();
+const v = m.get("nope");
+console.log(v);
+console.log("TEST_PASSED");


### PR DESCRIPTION
## User impact

Fixes 3 runtime segfaults in compiled binaries:

1. `console.log(x)` where `x` is a null interface value (e.g., `function f(): Item | null { return null; }`) — was SIGSEGV, now prints `null`
2. `console.log(v)` where `v` is from `Map<string, number[]>.get("missing")` — was SIGSEGV, now prints `undefined`  
3. `for (const p of people) console.log(p.name, p.tags[0])` where `people` is an interface array — was SIGSEGV, now prints correctly

## Root causes + fixes

**B1/B2 (null pointer dereference in console.log):** `emitSingleArg` serialized interface/class values via JSON stringify and `emitArrayPrint` accessed array length — both without null-checking the pointer. Fix: emit `icmp eq null` guards that print `"null"` / `"undefined"` for null pointers.

**B3 (for-of interface array member access):** `getObjectArrayInfo` didn't resolve interface metadata for simple variable iterables (`for (const p of people)`). The iterator variable `p` had `SymbolKind_Object` but no interface type, so member access (`p.name`, `p.tags[0]`) miscompiled — treating the raw struct pointer as the field value instead of GEPing into the struct. Fix: added a fallback in `getObjectArrayInfo` that resolves the interface type from `getRawInterfaceType` / `getObjectArrayElementType` and builds metadata from the AST interface definition.

## Test plan

- [x] `tests/fixtures/edge-cases/console-log-null-interface.ts`
- [x] `tests/fixtures/edge-cases/console-log-null-map-array.ts`
- [x] `tests/fixtures/edge-cases/forof-interface-array-member-access.ts`
- [x] `npm run verify:quick` — all tests + stage 1 self-hosting pass