### PR TITLE
fix(codegen): propagate declared interface type through call/new/method args

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -866,6 +866,7 @@ export class CallExpressionGenerator {
     const resolvedFuncName = this.ctx.resolveImportAlias(expr.name);
     let returnType = "double";
     let paramTypes: string[] = [];
+    const paramTsTypes: string[] = [];
 
     const funcResult = this.getFunctionFromAST(expr.name);
     const func = funcResult as FunctionNode;
@@ -903,6 +904,7 @@ export class CallExpressionGenerator {
             this.ctx.interfaceStructGenHasInterface(stripNullable(p)),
           ),
         );
+        paramTsTypes.push(stripNullable(p));
       }
       // Integer-specialized callee: every double param/return becomes i64.
       // The existing FFI coercion paths in this loop already handle paramType
@@ -935,6 +937,7 @@ export class CallExpressionGenerator {
                 false,
               ),
             );
+            paramTsTypes.push(stripNullable(pType));
           }
         } else if (funcNode.paramTypes) {
           for (let i = 0; i < funcNode.paramTypes.length; i++) {
@@ -943,6 +946,7 @@ export class CallExpressionGenerator {
             paramTypes.push(
               mapParamTypeToLLVM(t, paramName, this.ctx.isEnumType(stripNullable(t)), false),
             );
+            paramTsTypes.push(stripNullable(t));
           }
         }
         if (funcNode.intSpecialized) {
@@ -967,7 +971,21 @@ export class CallExpressionGenerator {
     for (let i = 0; i < loopLimit; i++) {
       if (i < expr.args.length) {
         const paramType = paramTypes[i] || "double";
+        const argExpr = expr.args[i] as { type: string };
+        let savedDeclaredIface: string | undefined = undefined;
+        let wrappedDeclaredIface = false;
+        if (argExpr.type === "object" && i < paramTsTypes.length) {
+          const tsParamType = paramTsTypes[i];
+          if (tsParamType && this.ctx.interfaceStructGenHasInterface(tsParamType)) {
+            savedDeclaredIface = this.ctx.getCurrentDeclaredInterfaceType();
+            this.ctx.setCurrentDeclaredInterfaceType(tsParamType);
+            wrappedDeclaredIface = true;
+          }
+        }
         const result = this.ctx.generateExpression(expr.args[i], params);
+        if (wrappedDeclaredIface) {
+          this.ctx.setCurrentDeclaredInterfaceType(savedDeclaredIface);
+        }
         const resultType = this.ctx.getVariableType(result);
         if (paramType === "double" && resultType === "i8*") {
           argsList.push(`double 0.0`);

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -1160,7 +1160,21 @@ export class ClassGenerator {
     for (let ai = 0; ai < ctorLoopLimit; ai++) {
       if (ai < args.length) {
         const arg = args[ai];
+        const argBase = arg as { type: string };
+        let savedDeclaredIface: string | undefined = undefined;
+        let wrappedDeclaredIface = false;
+        if (argBase.type === "object" && ai < paramTypes.length) {
+          const tsParamType = paramTypes[ai];
+          if (tsParamType && this.ctx.interfaceStructGenHasInterface(tsParamType)) {
+            savedDeclaredIface = this.ctx.getCurrentDeclaredInterfaceType();
+            this.ctx.setCurrentDeclaredInterfaceType(tsParamType);
+            wrappedDeclaredIface = true;
+          }
+        }
         const val = this.ctx.generateExpression(arg, params);
+        if (wrappedDeclaredIface) {
+          this.ctx.setCurrentDeclaredInterfaceType(savedDeclaredIface);
+        }
         const argType = ai < paramLLVMTypes.length ? paramLLVMTypes[ai] : "double";
         if (argType === "double") {
           argParts.push(argType + " " + this.ctx.ensureDouble(val));
@@ -1257,9 +1271,22 @@ export class ClassGenerator {
           methodName === "json" &&
           className === "Context" &&
           !this.ctx.isStringExpression(arg);
+        let savedDeclaredIfaceM: string | undefined = undefined;
+        let wrappedDeclaredIfaceM = false;
+        if (argTyped.type === "object" && ai < paramTypes.length && !autoSerialize) {
+          const tsParamTypeM = paramTypes[ai];
+          if (tsParamTypeM && this.ctx.interfaceStructGenHasInterface(tsParamTypeM)) {
+            savedDeclaredIfaceM = this.ctx.getCurrentDeclaredInterfaceType();
+            this.ctx.setCurrentDeclaredInterfaceType(tsParamTypeM);
+            wrappedDeclaredIfaceM = true;
+          }
+        }
         const val = autoSerialize
           ? this.ctx.jsonGen.generateStringifyExpr(arg, params)
           : this.ctx.generateExpression(arg, params);
+        if (wrappedDeclaredIfaceM) {
+          this.ctx.setCurrentDeclaredInterfaceType(savedDeclaredIfaceM);
+        }
         this.ctx.setExpectedCallbackParamType(null);
 
         let argType = "double";

--- a/tests/fixtures/interfaces/call-arg-literal-scrambled-order.ts
+++ b/tests/fixtures/interfaces/call-arg-literal-scrambled-order.ts
@@ -1,0 +1,17 @@
+interface Config {
+  name: string;
+  port: number;
+  host: string;
+}
+
+function boot(cfg: Config): void {
+  if (cfg.name === "n1" && cfg.host === "h1" && cfg.port === 99) {
+    console.log("TEST_PASSED");
+  }
+}
+
+function main(): void {
+  boot({ host: "h1", port: 99, name: "n1" });
+}
+
+main();

--- a/tests/fixtures/interfaces/class-arg-literal-scrambled-order.ts
+++ b/tests/fixtures/interfaces/class-arg-literal-scrambled-order.ts
@@ -1,0 +1,26 @@
+interface Point {
+  x: number;
+  y: number;
+}
+
+class Vec {
+  dx: number;
+  dy: number;
+  constructor(p: Point) {
+    this.dx = p.x;
+    this.dy = p.y;
+  }
+  dot(other: Point): number {
+    return this.dx * other.x + this.dy * other.y;
+  }
+}
+
+function main(): void {
+  const v = new Vec({ y: 3, x: 4 });
+  const r = v.dot({ y: 10, x: 5 });
+  if (v.dx === 4 && v.dy === 3 && r === 4 * 5 + 3 * 10) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## User impact

Object literals passed as function arguments, constructor arguments, or method arguments now get the correct struct layout when their property order differs from the parameter's interface declaration. Previously they fell through to an anonymous inline struct based on literal property order, producing wrong GEP indices on the callee side — the classic cause of latent native-compiler segfaults per CLAUDE.md rule #3.

## Change

- `src/codegen/expressions/calls.ts` (`generateGenericCall`): capture TS param types alongside LLVM types; before `generateExpression` on an object-literal arg, look up the parameter's TS type and, if it names a known interface, wrap `setCurrentDeclaredInterfaceType` save/restore around the call. This routes the literal through `generateInterfaceObject` (canonical declared layout) instead of `generateInlineObject` (literal-order layout).
- `src/codegen/types/objects/class.ts` (`generateNewExpression`, `generateMethodCall`): same pattern for constructor args and instance-method args.

No changes to built-in/FFI call paths. No effect when the arg is not an object literal or the param is not a known interface. Save/restore preserves any outer declared-interface context.

## Why this matters

Self-hosting has many AST-construction sites where the same interface is built with different property orders — `{ type, op, left, right }` in one spot, `{ op, type, right, left }` in another. Without contextual type propagation, each site bakes in its own layout, and any consumer that GEPs the wrong index segfaults. This is part of a phased effort (P3 of 6) to unify every interface to its declared layout.

## Test plan
- [x] fixture: `tests/fixtures/interfaces/call-arg-literal-scrambled-order.ts` — free function taking typed interface, caller scrambles property order
- [x] fixture: `tests/fixtures/interfaces/class-arg-literal-scrambled-order.ts` — exercises both `new Vec({...})` (constructor arg) and `v.dot({...})` (method arg)
- [x] `npm run verify` green (tests + stage 1 + stage 2)
- [x] depends on #518 (P2); merge #518 first, this will rebase cleanly

## Stack

This PR stacks on #518. Rebase-and-merge order: #518 → #519.