### PR TITLE
fix(codegen): propagate declared interface type through class-field assignment and 'as X' casts

### DIFF
--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -41,6 +41,9 @@ interface ExpressionOrchestratorContext {
   setLastTypeAssertionSourceVar(name: string | null): void;
   emitWarning(message: string, loc?: { line: number; column: number }, suggestion?: string): void;
   emitError(message: string, loc?: { line: number; column: number }, suggestion?: string): never;
+  getCurrentDeclaredInterfaceType(): string | undefined;
+  setCurrentDeclaredInterfaceType(type: string | undefined): void;
+  interfaceStructGenHasInterface(name: string): boolean;
 }
 
 /**
@@ -188,7 +191,23 @@ export class ExpressionGenerator {
       } else {
         this.ctx.setLastTypeAssertionSourceVar(null);
       }
-      return this.generate(assertExpr.expression, params);
+      const innerBase = assertExpr.expression as { type: string };
+      let savedDeclaredIface: string | undefined = undefined;
+      let wrappedDeclaredIface = false;
+      if (
+        innerBase.type === "object" &&
+        assertExpr.assertedType &&
+        this.ctx.interfaceStructGenHasInterface(assertExpr.assertedType)
+      ) {
+        savedDeclaredIface = this.ctx.getCurrentDeclaredInterfaceType();
+        this.ctx.setCurrentDeclaredInterfaceType(assertExpr.assertedType);
+        wrappedDeclaredIface = true;
+      }
+      const result = this.generate(assertExpr.expression, params);
+      if (wrappedDeclaredIface) {
+        this.ctx.setCurrentDeclaredInterfaceType(savedDeclaredIface);
+      }
+      return result;
     }
 
     return null;

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -42,6 +42,9 @@ export interface AssignmentGeneratorContext {
   setCurrentDeclaredMapType(type: string | undefined): void;
   currentDeclaredSetType: string | undefined;
   setCurrentDeclaredSetType(type: string | undefined): void;
+  getCurrentDeclaredInterfaceType(): string | undefined;
+  setCurrentDeclaredInterfaceType(type: string | undefined): void;
+  interfaceStructGenHasInterface(name: string): boolean;
   getThisPointer(): string | null;
   getCurrentClassName(): string | null;
   readonly symbolTable: SymbolTable;
@@ -268,7 +271,22 @@ export class AssignmentGenerator {
       this.ctx.setCurrentDeclaredSetType(fieldTsType);
     }
 
+    let savedDeclaredIface: string | undefined = undefined;
+    let wrappedDeclaredIface = false;
+    const rhsTyped = memberAccessValue.value as { type: string };
+    if (rhsTyped.type === "object" && fieldTsType) {
+      const strippedTs = stripNullable(fieldTsType);
+      if (this.ctx.interfaceStructGenHasInterface(strippedTs)) {
+        savedDeclaredIface = this.ctx.getCurrentDeclaredInterfaceType();
+        this.ctx.setCurrentDeclaredInterfaceType(strippedTs);
+        wrappedDeclaredIface = true;
+      }
+    }
+
     const value = this.ctx.generateExpression(memberAccessValue.value, params);
+    if (wrappedDeclaredIface) {
+      this.ctx.setCurrentDeclaredInterfaceType(savedDeclaredIface);
+    }
     this.ctx.setExpectedArrayElementType(null);
     this.ctx.setCurrentDeclaredMapType(undefined);
     this.ctx.setCurrentDeclaredSetType(undefined);

--- a/tests/fixtures/interfaces/assign-field-literal-scrambled-order.ts
+++ b/tests/fixtures/interfaces/assign-field-literal-scrambled-order.ts
@@ -1,0 +1,25 @@
+interface Conf {
+  name: string;
+  port: number;
+  host: string;
+}
+
+class Server {
+  cfg: Conf;
+  constructor() {
+    this.cfg = { name: "boot", port: 1, host: "h0" };
+  }
+  reconfigure(): void {
+    this.cfg = { port: 8080, host: "hh", name: "nn" };
+  }
+}
+
+function main(): void {
+  const s = new Server();
+  s.reconfigure();
+  if (s.cfg.name === "nn" && s.cfg.port === 8080 && s.cfg.host === "hh") {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();

--- a/tests/fixtures/interfaces/cast-literal-scrambled-order.ts
+++ b/tests/fixtures/interfaces/cast-literal-scrambled-order.ts
@@ -1,0 +1,14 @@
+interface Coord {
+  x: number;
+  y: number;
+  z: number;
+}
+
+function main(): void {
+  const p = { z: 30, y: 20, x: 10 } as Coord;
+  if (p.x === 10 && p.y === 20 && p.z === 30) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## User impact

Two more positions where object literals now get the correct struct layout regardless of property order:

1. **Class-field assignment**: `this.cfg = { port: 9, host: "x", name: "y" }` where `cfg: SomeInterface`. Previously the literal's property order baked in the struct; now the interface's declared order wins.
2. **Cast expressions**: `{ z: 30, y: 20, x: 10 } as Coord`. Previously the cast was a no-op that trusted the literal's order. Now the literal is routed through the interface's canonical layout before the cast.

## Change

- `src/codegen/infrastructure/assignment-generator.ts` (`handleClassFieldAssignment`): resolve the LHS field's TS type; if it names a known interface and the RHS is an object literal, wrap `setCurrentDeclaredInterfaceType` save/restore around the RHS expression generation. Extends the existing pattern already in place for `Map<K,V>` / `Set<T>` fields (CLAUDE.md rule #8).
- `src/codegen/expressions/orchestrator.ts` (type_assertion path): when the asserted type names a known interface and the inner expression is an object literal, wrap the same way before generating the inner expression.

Interface-type-plumbing fields (`getCurrentDeclaredInterfaceType`, `setCurrentDeclaredInterfaceType`, `interfaceStructGenHasInterface`) added to the two generator-context interfaces.

## Why this matters

Continues the struct-layout-unification effort (P4 of 6). After P2–P4, object literals in the following positions all route through `InterfaceStructGenerator`'s canonical layout: variable declarations, function/method/constructor args, return statements, class-field assignments, `as X` casts. Remaining (P5): untyped anonymous literals (alphabetical-sort fallback).

## Test plan
- [x] fixture: `tests/fixtures/interfaces/assign-field-literal-scrambled-order.ts` — reassigns a typed class field with a scrambled-order literal
- [x] fixture: `tests/fixtures/interfaces/cast-literal-scrambled-order.ts` — literal cast via \`as Iface\` with reversed field order
- [x] \`npm run verify\` green (tests + stage 1 + stage 2)