### PR TITLE
fix(native): emitError chained method call caused segv on every compile error

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -332,9 +332,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
   public emitError(message: string, loc?: SourceLocation, suggestion?: string): never {
     this.diagnostics.error(message, loc, suggestion);
-    const output = this.diagnostics.formatDiagnostic(
-      this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1],
-    );
+    const errs = this.diagnostics.getErrors();
+    const last = errs[errs.length - 1];
+    const output = this.diagnostics.formatDiagnostic(last);
     process.stderr.write(output);
     process.exit(1);
   }

--- a/tests/fixtures/edge-cases/new-date-module-scope.ts
+++ b/tests/fixtures/edge-cases/new-date-module-scope.ts
@@ -1,0 +1,3 @@
+// @test-compile-error: cannot determine type of module-scope variable
+// @test-description: new Date() at module scope emits clean compile error instead of segfault
+const d = new Date();

--- a/tests/fixtures/edge-cases/new-date-zero-module-scope.ts
+++ b/tests/fixtures/edge-cases/new-date-zero-module-scope.ts
@@ -1,0 +1,3 @@
+// @test-compile-error: cannot determine type of module-scope variable
+// @test-description: new Date(0) at module scope emits clean compile error instead of segfault
+const d = new Date(0);


### PR DESCRIPTION
## User impact

The native self-hosted compiler (\`.build/chad\`) segfaulted instead of printing any compile error whose upstream code path ran through \`emitError\`. Concretely: fuzz A2-A5 repros (\`new Date()\` at module scope, \`instanceof\` with class hierarchy, \`typeof d.getTime()\`, etc.) all crashed with no output. Users saw a silent SIGSEGV where they should have seen a diagnostic.

After this PR, every one of those inputs prints the clean error the Node compiler already prints:

\`\`\`
error: cannot determine type of module-scope variable 'd' (expression type: new). Move the declaration inside a function, or add a type annotation
\`\`\`

## Root cause

\`emitError\` in \`src/codegen/llvm-generator.ts\` built the output via a chained expression:

\`\`\`typescript
this.diagnostics.formatDiagnostic(
  this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1],
)
\`\`\`

This is \`method_call()[method_call().length - 1]\` — an index access into the result of a method call. The native compiler's codegen for this pattern does not propagate the result's \`elementInterfaceName\` through, so the indexed element is handed to \`formatDiagnostic\` as a bare \`i8*\` pointing to memory the reader treats as a \`%Diagnostic\` struct with a different layout than what was stored. Subsequent \`diag.message\` GEP loads garbage; \`strlen\` on the garbage pointer crashes.

Confirmed under lldb: backtrace lands in \`strlen\` called from \`formatDiagnostic + 260\` (the \`bold(": " + diag.message)\` expression), with x1 holding ANSI-escape byte values instead of a string pointer. Debug prints before and after the intermediate-variable refactor prove the fix: with intermediates, \`severity\` reads \`0\` and \`message\` reads the correct string; without, severity reads \`9.48606e-322\` (garbage) and the message read segfaults.

## Change

- \`src/codegen/llvm-generator.ts\` — \`emitError\` extracts \`getErrors()\` result and the last diagnostic into intermediate variables before passing to \`formatDiagnostic\`. Functionally identical; mechanically avoids the chained-index codegen bug.
- \`tests/fixtures/edge-cases/new-date-module-scope.ts\`, \`tests/fixtures/edge-cases/new-date-zero-module-scope.ts\` — regression fixtures using \`@test-compile-error\` annotation. They used to segv; now they emit the expected diagnostic.

## Follow-up

The underlying codegen bug (method-call-result indexed access loses element interface type) is still present and worth fixing at the root in \`access/member.ts\` / \`handleIndexAccessPropertyAccess\`. This PR is the targeted workaround to immediately unblock A2-A5. Filed as future work.

## Test plan
- [x] \`npm run verify\` green (tests + stage 1 + stage 2)
- [x] /tmp/chad_fuzz/c29_date, c36_date_basic, c37_date_zero, c38_date_typeof, c62_instanceof — all now emit clean compile errors (no segfault)
- [x] Two regression fixtures added to \`tests/fixtures/edge-cases/\`