### PR TITLE
fix(codegen): method-call indexed access loses interface type (root cause for A2-A5 segvs)

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -166,6 +166,7 @@ export interface MemberAccessGeneratorContext {
   ): { keys: string[]; types: string[]; tsTypes: string[] } | null;
   getInterfaceFieldType(interfaceName: string, fieldName: string): string | null;
   getMethodReturnType(className: string, methodName: string): string | null;
+  resolveImportAlias(localName: string): string;
   isEnumType(name: string): boolean;
   getEnumMemberValue(enumName: string, memberName: string): number;
   getEnumMemberStringValue(enumName: string, memberName: string): string | null;
@@ -2334,6 +2335,50 @@ export class MemberAccessGenerator {
         const interfaceInfo = this.getInterfaceInfo(elemType);
         if (interfaceInfo) {
           return interfaceInfo;
+        }
+      }
+    }
+    if (arrayExpr.type === "method_call") {
+      const mc = arrayExpr as MethodCallNode;
+      const mcObjBase = mc.object as { type: string };
+      let className: string | null = null;
+      if (mcObjBase.type === "variable") {
+        const mcVar = mc.object as VariableNode;
+        const concrete = this.ctx.symbolTable.getConcreteClass(mcVar.name);
+        if (concrete) {
+          className = concrete;
+        } else {
+          const classInfo = this.ctx.symbolTable.getClassInfo(mcVar.name);
+          if (classInfo) className = classInfo.className;
+        }
+      } else if (mcObjBase.type === "this") {
+        className = this.ctx.getCurrentClassName();
+      }
+      if (className) {
+        const retType = this.ctx.getMethodReturnType(className, mc.method);
+        if (retType && retType.endsWith("[]")) {
+          const elemType = retType.slice(0, -2);
+          const interfaceInfo = this.getInterfaceInfo(elemType);
+          if (interfaceInfo) return interfaceInfo;
+        }
+      }
+    }
+    if (arrayExpr.type === "call") {
+      const ce = arrayExpr as CallNode;
+      const fnName = this.ctx.resolveImportAlias(ce.name);
+      const ast = this.ctx.getAst();
+      if (ast) {
+        for (let fi = 0; fi < ast.functions.length; fi++) {
+          const fn = ast.functions[fi] as FunctionNode;
+          if (fn && fn.name === fnName && fn.returnType) {
+            const rt = fn.returnType;
+            if (rt.endsWith("[]")) {
+              const elemType = rt.slice(0, -2);
+              const interfaceInfo = this.getInterfaceInfo(elemType);
+              if (interfaceInfo) return interfaceInfo;
+            }
+            break;
+          }
         }
       }
     }

--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -520,6 +520,12 @@ export class ArrayAllocator {
     }
     if (e.type === "variable") {
       const varName = (expr as VariableNode).name;
+      if (this.ctx.symbolTable.isClass(varName)) {
+        const classInfo = this.ctx.symbolTable.getClassInfo(varName);
+        if (classInfo) return classInfo.className;
+      }
+      const concrete = this.ctx.symbolTable.getConcreteClass(varName);
+      if (concrete) return concrete;
       const objMeta = this.ctx.symbolTable.getObjectMetadata(varName);
       if (objMeta && objMeta.tsTypes) {
         return this.ctx.symbolTable.getType(varName) || null;

--- a/tests/fixtures/interfaces/method-call-indexed-access-chained.ts
+++ b/tests/fixtures/interfaces/method-call-indexed-access-chained.ts
@@ -1,0 +1,25 @@
+interface Thing {
+  name: string;
+  value: number;
+}
+
+class Store {
+  items: Thing[] = [];
+  push(t: Thing): void {
+    this.items.push(t);
+  }
+  all(): Thing[] {
+    return this.items;
+  }
+}
+
+function main(): void {
+  const s = new Store();
+  s.push({ name: "a", value: 1 });
+  s.push({ name: "b", value: 2 });
+  if (s.all()[s.all().length - 1].name === "b") {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();

--- a/tests/fixtures/interfaces/method-call-indexed-access.ts
+++ b/tests/fixtures/interfaces/method-call-indexed-access.ts
@@ -1,0 +1,26 @@
+interface Thing {
+  name: string;
+  value: number;
+}
+
+class Store {
+  items: Thing[] = [];
+  push(t: Thing): void {
+    this.items.push(t);
+  }
+  all(): Thing[] {
+    return this.items;
+  }
+}
+
+function main(): void {
+  const s = new Store();
+  s.push({ name: "a", value: 1 });
+  s.push({ name: "b", value: 2 });
+  const last = s.all()[s.all().length - 1];
+  if (last.name === "b" && last.value === 2) {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## User impact

\`obj.method()[i]\` and \`fn()[i]\` expressions now correctly type the result as the declared element interface. Previously the result was an untyped \`i8*\` with no struct-layout metadata, so:

- \`const x = obj.method()[i]; x.name\` read garbage memory instead of the name field
- \`obj.method()[i].prop\` chained form read garbage
- \`formatDiagnostic(errors.getErrors()[errors.getErrors().length - 1])\` — the actual real-world trigger in the self-hosted compiler — segfaulted because \`strlen\` was called on misaligned struct bytes

This is the **root cause** for the A2-A5 fuzz segvs that PR #521 patched with intermediate-variable workarounds.

## Change

\`src/codegen/infrastructure/array-allocator.ts\` — \`resolveMemberAccessObjectType\` for variable expressions: in addition to \`getObjectMetadata\` and \`getParameterTypeFromAST\`, now checks \`symbolTable.isClass(varName)\` (returns class name for \`new X()\` instances) and \`getConcreteClass(varName)\` (returns class for otherwise-resolved variables). Lets the existing \`getMethodCallReturnType\` path resolve \`s.all()\` → \`Thing[]\` when \`s\` is \`const s = new Store()\`.

\`src/codegen/expressions/access/member.ts\` — \`getObjectArrayElementInfo\` now handles \`method_call\` and \`call\` array expressions, using \`getMethodReturnType\` and AST function lookup. Covers the \`arr.method()[i].prop\` chained form.

Two regression fixtures added.

## Why this matters

CLAUDE.md's note \"ObjectArray element access loses type info: arr[i] returns i8*, must use \`as NamedType\` to get correct GEP\" can be softened: when the static type is known (variable declared as \`Thing[]\`, or returned from a method declared as \`Thing[]\`), the compiler now tracks it automatically.

## Follow-up

Once this lands, PR #521's \`emitError\` intermediate-variable workaround can be reverted to the original concise chained form.

## Test plan
- [x] \`npm run verify\` green (tests + stage 1 + stage 2)
- [x] fixture \`method-call-indexed-access.ts\` — const-binding form
- [x] fixture \`method-call-indexed-access-chained.ts\` — chained form