### PR TITLE
refactor(type-inference): P2 — getIndexedObjectArrayType delegates to canonical

### DIFF
--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -27,6 +27,7 @@ import {
   createObjectMetadataWithInterface,
 } from "./symbol-table.js";
 import { stripOptional, parseArrayTypeString } from "./type-system.js";
+import type { ResolvedType } from "./type-system.js";
 import type { FieldInfo } from "./type-resolver/types.js";
 import type { UnionCommonFields } from "./type-resolver/index.js";
 
@@ -66,6 +67,7 @@ export interface ArrayAllocatorContext {
   readonly symbolTable: SymbolTable;
   emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
   getAst(): AST | undefined;
+  resolveExpressionTypeRich(expr: Expression): ResolvedType | null;
 }
 
 export class ArrayAllocator {
@@ -379,6 +381,16 @@ export class ArrayAllocator {
 
     const indexExpr = expr as IndexAccessNode;
     if (!indexExpr.object) return null;
+
+    // Canonical path (P2): delegate to TypeInference.resolveExpressionTypeRich.
+    // Fires when the object resolves to an array of an interface/class whose
+    // fields we know. Legacy fallback below still handles shapes the canonical
+    // resolver doesn't yet cover (P3 widens coverage).
+    const rich = this.ctx.resolveExpressionTypeRich(indexExpr.object);
+    if (rich && rich.arrayDepth > 0 && rich.fields) {
+      return { keys: rich.fields.keys, types: rich.fields.types, tsTypes: rich.fields.tsTypes };
+    }
+
     const idxObjBase = indexExpr.object as ExprBase;
     if (!idxObjBase || !idxObjBase.type) return null;
 

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -4032,6 +4032,10 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     return this.typeInference.resolveExpressionType(expr);
   }
 
+  public resolveExpressionTypeRich(expr: Expression): ResolvedType | null {
+    return this.typeInference.resolveExpressionTypeRich(expr);
+  }
+
   public isObjectArrayExpression(expr: Expression): boolean {
     return this.typeInference.isObjectArrayExpression(expr);
   }


### PR DESCRIPTION
## Summary

First consumer migration of the type-resolution unification (plan P2, after #524 P1a).

- `ArrayAllocator.getIndexedObjectArrayType` now consults `TypeInference.resolveExpressionTypeRich` before falling through to the legacy index-specific branches.
- When the indexed object resolves to an array of a known interface/class, the canonical resolver returns the element-field keys/types/tsTypes directly; legacy code path handles remaining shapes until P3 widens coverage.
- Fuzz corpus `/tmp/fuzz2/`: 10/21 → 12/21 passing (`f04_nested_array`, `f20_index_indexed` now green).

## Impact for users

Fewer silently-wrong compiles when indexing into arrays whose element interface only the canonical resolver can track (chained method returns, nested member access into array-of-interface fields). No regressions: stage-2 self-hosting is green and existing branches are still reached when canonical returns nothing.

## Test plan

- [x] `npm run verify` (stage 2 green)
- [x] Fuzz sweep on `/tmp/fuzz2/f*.ts` — non-decreasing (10 → 12)