### PR TITLE
refactor(type-resolver): P3a — delete dead resolveIndexedAccessType

### DIFF
--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -746,39 +746,6 @@ export class TypeResolver {
     return valueType;
   }
 
-  resolveIndexedAccessType(expr: IndexAccessNode): ObjectMetadata | null {
-    const exprObjBase = expr.object as ExprBase;
-    if (exprObjBase.type !== "member_access") return null;
-
-    const memberAccess = expr.object as MemberAccessNode;
-    const propertyName = memberAccess.property;
-
-    let objectInfo:
-      | { ptr: string; keys: string[]; types: string[]; tsTypes?: string[] }
-      | undefined;
-
-    const memberAccessObjBase = memberAccess.object as ExprBase;
-    if (memberAccessObjBase.type === "variable") {
-      const varName = (memberAccess.object as VariableNode).name;
-      objectInfo = this.ctx.symbolTable.getObjectInfo(varName);
-    }
-
-    if (!objectInfo) return null;
-
-    const propIndex = objectInfo.keys.indexOf(propertyName);
-    if (propIndex === -1) return null;
-
-    const tsTypesArr = objectInfo.tsTypes as string[];
-    const propTsType = tsTypesArr[propIndex];
-    if (!propTsType) return null;
-
-    const arrayParsed = parseArrayTypeString(propTsType);
-    if (!arrayParsed) return null;
-
-    const elementType = arrayParsed.elementType;
-    return this.getInterfaceMetadata(elementType);
-  }
-
   detectTypeGuard(condition: Expression): TypeGuardInfo | null {
     if (!condition) return null;
     if (condition.type !== "binary") return null;


### PR DESCRIPTION
## Summary

`TypeResolver.resolveIndexedAccessType` has zero callers across the repo. Removing it reduces the surface area of the type-resolution unification (plan P3a, after #525).

## Impact for users

None — dead code removal. Same compiler output, smaller resolver footprint.

## Test plan

- [x] `npm run verify` green (stage 2 self-hosting + tests)
- [x] Repo-wide grep confirms no callers