### PR TITLE
refactor(type-inference): P3b — member.ts delegates to canonical + revert #521 workaround

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -33,6 +33,7 @@ import {
   parseMapTypeString,
   canonicalTypeToLlvm,
 } from "../../infrastructure/type-system.js";
+import type { ResolvedType } from "../../infrastructure/type-system.js";
 import type {
   IStringGenerator,
   IMapGenerator,
@@ -203,6 +204,7 @@ export interface MemberAccessGeneratorContext {
   classGenIsStaticField(className: string, fieldName: string): boolean;
   classGenGetStaticFieldType(className: string, fieldName: string): string;
   mangleUserName(name: string): string;
+  resolveExpressionTypeRich(expr: Expression): ResolvedType | null;
 }
 
 export type MemberAccessHandlerFn = (
@@ -2221,6 +2223,16 @@ export class MemberAccessGenerator {
   private getObjectArrayElementInfo(
     arrayExpr: Expression,
   ): { keys: string[]; types: string[]; tsTypes: string[] } | null {
+    // Canonical path (P3b): delegate to TypeInference.resolveExpressionTypeRich.
+    // Fires when the object resolves to an array of an interface/class whose
+    // fields we know — covers method-chain and call returns that the legacy
+    // branches below partially miss. Legacy branches remain for shapes not yet
+    // covered by the canonical resolver.
+    const rich = this.ctx.resolveExpressionTypeRich(arrayExpr);
+    if (rich && rich.arrayDepth > 0 && rich.fields) {
+      return { keys: rich.fields.keys, types: rich.fields.types, tsTypes: rich.fields.tsTypes };
+    }
+
     if (arrayExpr.type === "member_access") {
       const memberAccess = arrayExpr as MemberAccessNode;
       const memberAccessObjBase = memberAccess.object as ExprBase;

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -332,9 +332,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
   public emitError(message: string, loc?: SourceLocation, suggestion?: string): never {
     this.diagnostics.error(message, loc, suggestion);
-    const errs = this.diagnostics.getErrors();
-    const last = errs[errs.length - 1];
-    const output = this.diagnostics.formatDiagnostic(last);
+    const output = this.diagnostics.formatDiagnostic(
+      this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1],
+    );
     process.stderr.write(output);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Second consumer migration (plan P3b, after #525 P2).

- \`MemberAccessGenerator.getObjectArrayElementInfo\` now consults canonical \`resolveExpressionTypeRich\` first; legacy branches remain as fallback for shapes canonical doesn't yet enrich.
- With canonical covering indexed-object-array element-field access, **PR #521's \`emitError\` intermediate-variable workaround is reverted** — the chained \`method_call()[method_call().length - 1]\` form now compiles correctly under the native compiler. Confirmed: \`tests/fixtures/edge-cases/new-date-module-scope.ts\` still prints the expected diagnostic instead of segfaulting.

## Impact for users

Eliminates a whole chained-expression category of native-compiler segfaults that used to hide behind a mechanical workaround. The underlying type-propagation fix now lives in one place instead of being papered over at call sites.

## Test plan

- [x] \`npm run verify\` green (stage 2 self-hosting)
- [x] \`node --import tsx --test tests/self-hosting.test.ts\` green (stage1 + stage2 fixture suite — the gap that bit us in #526)
- [x] Fuzz corpus /tmp/fuzz2/f*.ts: 12 pass, no regression
- [x] \`new-date-module-scope.ts\` no longer relies on the #521 workaround