### PR TITLE
fix(type-inference): canonical indexed-object-array path fires only for depth-1 arrays

### DIFF
--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -382,12 +382,13 @@ export class ArrayAllocator {
     const indexExpr = expr as IndexAccessNode;
     if (!indexExpr.object) return null;
 
-    // Canonical path (P2): delegate to TypeInference.resolveExpressionTypeRich.
-    // Fires when the object resolves to an array of an interface/class whose
-    // fields we know. Legacy fallback below still handles shapes the canonical
-    // resolver doesn't yet cover (P3 widens coverage).
+    // Canonical path: only fires when indexing once yields a scalar
+    // interface/class element (depth-1 array of interface). For depth>1
+    // (e.g. `P[][]` indexed once → `P[]`) we must NOT classify the result
+    // as an indexed-object-array element; fall through so the normal
+    // nested-array allocation is used instead.
     const rich = this.ctx.resolveExpressionTypeRich(indexExpr.object);
-    if (rich && rich.arrayDepth > 0 && rich.fields) {
+    if (rich && rich.arrayDepth === 1 && rich.fields) {
       return { keys: rich.fields.keys, types: rich.fields.types, tsTypes: rich.fields.tsTypes };
     }
 


### PR DESCRIPTION
## Summary

P2's canonical \`getIndexedObjectArrayType\` returned element interface fields for **any** \`arrayDepth>0\`. That made \`P[][]\` indexed once (\`grid[1]\`) get classified as a scalar-interface element — but the result is still an array (\`P[]\`). Downstream object-array-element allocation then routed the variable to dynamic-object-access IR, which rejected numeric indices with:

\`\`\`
error: Dynamic object property access requires a string key, got: i64
\`\`\`

Canonical now only fires when indexing yields a scalar — \`arrayDepth === 1\`. Nested-array shapes fall through to the normal array-of-array alloc path.

## Impact for users

Compiles nested-interface-array patterns that were rejected with a misleading dynamic-access error:

\`\`\`typescript
const grid: P[][] = [[{ v: 1 }], [{ v: 2 }, { v: 3 }]];
const inner = grid[1];  // used to fail to compile
\`\`\`

## Test plan

- [x] \`npm run verify\` green (stage 2)
- [x] \`tests/self-hosting.test.ts\` green (fixture suite)
- [x] Fuzz corpus: 12/21 unchanged (no regression)
- [x] Nested \`P[][]\` indexed once now compiles (was hard compile error)