### PR TITLE
fix(codegen): nested interface-array indexing — derived arrays + interface element types

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -2223,13 +2223,12 @@ export class MemberAccessGenerator {
   private getObjectArrayElementInfo(
     arrayExpr: Expression,
   ): { keys: string[]; types: string[]; tsTypes: string[] } | null {
-    // Canonical path (P3b): delegate to TypeInference.resolveExpressionTypeRich.
-    // Fires when the object resolves to an array of an interface/class whose
-    // fields we know — covers method-chain and call returns that the legacy
-    // branches below partially miss. Legacy branches remain for shapes not yet
-    // covered by the canonical resolver.
+    // Canonical path: only fires when the INDEX will yield a scalar
+    // interface/class element — i.e. the object is a depth-1 array. For
+    // depth>1 (e.g. `P[][]` indexed once → `P[]`) the result is still an
+    // array and the indexed-object-array element-info is not appropriate.
     const rich = this.ctx.resolveExpressionTypeRich(arrayExpr);
-    if (rich && rich.arrayDepth > 0 && rich.fields) {
+    if (rich && rich.arrayDepth === 1 && rich.fields) {
       return { keys: rich.fields.keys, types: rich.fields.types, tsTypes: rich.fields.tsTypes };
     }
 

--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -173,11 +173,17 @@ export class ArrayAllocator {
           elementTypes: typeInfo.types,
           elementTsTypes: typeInfo.tsTypes,
         });
-        let isAllDouble = typeInfo.types.length > 0;
-        for (let ti = 0; ti < typeInfo.types.length; ti++) {
+        // Contiguous layout is only correct when the RHS is an ARRAY LITERAL
+        // that the compiler packs inline. Derived arrays (e.g. `g[1]` where
+        // g is P[][], or a method return) inherit pointer-based storage, so
+        // marking them contiguous causes the indexer to compute byte offsets
+        // into raw memory instead of loading element pointers.
+        const stmtValueBase = stmt.value as ExprBase | undefined;
+        const isArrayLiteral = stmtValueBase !== undefined && stmtValueBase.type === "array";
+        let isAllDouble = isArrayLiteral && typeInfo.types.length > 0;
+        for (let ti = 0; ti < typeInfo.types.length && isAllDouble; ti++) {
           if (typeInfo.types[ti] !== "double") {
             isAllDouble = false;
-            break;
           }
         }
         if (isAllDouble) {
@@ -385,11 +391,15 @@ export class ArrayAllocator {
     // Canonical path: only fires when indexing once yields a scalar
     // interface/class element (depth-1 array of interface). For depth>1
     // (e.g. `P[][]` indexed once → `P[]`) we must NOT classify the result
-    // as an indexed-object-array element; fall through so the normal
-    // nested-array allocation is used instead.
+    // as an indexed-object-array element — the result is still an array,
+    // not an element. Short-circuit null so no legacy branch misclassifies
+    // it as element-info either.
     const rich = this.ctx.resolveExpressionTypeRich(indexExpr.object);
     if (rich && rich.arrayDepth === 1 && rich.fields) {
       return { keys: rich.fields.keys, types: rich.fields.types, tsTypes: rich.fields.tsTypes };
+    }
+    if (rich && rich.arrayDepth > 1) {
+      return null;
     }
 
     const idxObjBase = indexExpr.object as ExprBase;

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -411,7 +411,9 @@ export class TypeInference {
           !isPrimitive &&
           this.ctx.classGen !== null &&
           this.ctx.classGen.getClassFields(objResolved.base).length > 0;
-        if (isPrimitive || isClass) {
+        const isInterface =
+          !isPrimitive && !isClass && this.getInterface(objResolved.base) !== null;
+        if (isPrimitive || isClass || isInterface) {
           if (objResolved.arrayDepth > 1) {
             return createResolvedType(
               objResolved.base,


### PR DESCRIPTION
## Summary

Two paired fixes for nested interface-array segfaults:

1. **\`resolveExpressionType\` on \`index_access\` now handles interface element types.** Previously only primitive/class elements resolved; interface arrays fell through to \`null\`, cascading into bad downstream classification. \`g[1]\` of type \`P[][]\` now correctly resolves to \`P[]\`.

2. **\`allocateObjectArray\` only marks contiguous-layout when RHS is an array LITERAL.** Derived arrays (from indexing into nested types, method returns, etc.) inherit pointer-based \`ObjectArray\` storage, but the old code marked them contiguous whenever all element fields were \`double\`. The indexer then computed raw byte offsets into memory instead of loading element pointers — reading garbage doubles where interface field values should be.

## Impact for users

Code like this was silently reading garbage:

\`\`\`typescript
interface P { v: number; }
const g: P[][] = [[{ v: 1 }], [{ v: 2 }]];
const inner = g[1];
inner[0].v  // used to read ~2e-314 (pointer-bits-as-float); now reads 2
\`\`\`

This is a whole class of segfault / wrong-value bugs in nested interface arrays.

## Test plan

- [x] \`npm run verify\` green (stage 2)
- [x] \`tests/self-hosting.test.ts\` green (full fixture suite)
- [x] Fuzz corpus: **12/21 → 14/21** (f04 nested_array, f20 index_indexed now green)