### PR TITLE
refactor(type-system): Phase A — add arrayStorage field on ResolvedType

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -33,7 +33,12 @@ import {
   createResolvedType,
   tsTypeToLlvm,
 } from "./type-system.js";
-import type { ResolvedType, ResolvedTypeSourceKind, ResolvedTypeFields } from "./type-system.js";
+import type {
+  ResolvedType,
+  ResolvedTypeSourceKind,
+  ResolvedTypeFields,
+  ArrayStorageStrategy,
+} from "./type-system.js";
 import type { TypeContext } from "./type-context.js";
 
 interface ExprBase {
@@ -125,7 +130,9 @@ export class TypeInference {
   resolveExpressionTypeRich(expr: Expression): ResolvedType | null {
     const baseType = this.resolveExpressionType(expr);
     if (!baseType) return null;
-    return this.enrichResolvedType(baseType);
+    const enriched = this.enrichResolvedType(baseType);
+    this.populateArrayStorage(enriched, expr);
+    return enriched;
   }
 
   private enrichResolvedType(rt: ResolvedType): ResolvedType {
@@ -146,6 +153,30 @@ export class TypeInference {
     const fields = this.computeFieldsForType(rich);
     if (fields) rich.fields = fields;
     return rich;
+  }
+
+  // Phase A: derive array storage strategy. Only populated for arrayDepth > 0.
+  // Rule: "inlined" only when the expression is an array LITERAL whose element
+  // interface has fields that are all "double". Anything else — including
+  // derived arrays from indexing, method returns, function returns, variables
+  // whose source is a derived array — is "pointer". This matches what the
+  // codegen actually lays out today; Phase B makes consumers read this
+  // instead of the per-var markContiguousObjectArray table.
+  private populateArrayStorage(rich: ResolvedType, expr: Expression): void {
+    if (rich.arrayDepth === 0) return;
+    rich.arrayStorage = this.deriveArrayStorage(rich, expr);
+  }
+
+  private deriveArrayStorage(rich: ResolvedType, expr: Expression): ArrayStorageStrategy {
+    const e = expr as ExprBase;
+    if (!e || e.type !== "array") return "pointer";
+    if (!rich.fields) return "pointer";
+    const types = rich.fields.types;
+    if (types.length === 0) return "pointer";
+    for (let i = 0; i < types.length; i++) {
+      if (types[i] !== "double") return "pointer";
+    }
+    return "inlined";
   }
 
   private classifySourceKind(base: string): ResolvedTypeSourceKind {

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -31,6 +31,16 @@ export type ResolvedTypeSourceKind =
   | "union"
   | "unknown";
 
+// Array storage strategy — single source of truth for ObjectArray element layout.
+// Phase A (rearchitect) adds this field additively; consumers still read the legacy
+// `markContiguousObjectArray` table for now. Phase B retires that table.
+//   "inlined" — packed struct-of-doubles in contiguous bytes (array literal of
+//               interface whose fields are all `double`). Indexer uses stride math.
+//   "pointer" — ObjectArray of i8* element pointers (derived arrays from indexing,
+//               method returns, function results, etc.). Indexer bitcasts data to
+//               i8** and loads each slot.
+export type ArrayStorageStrategy = "inlined" | "pointer";
+
 export interface ResolvedType {
   base: string;
   qualifiers: TypeQualifiers;
@@ -45,6 +55,7 @@ export interface ResolvedType {
   sourceKind?: ResolvedTypeSourceKind;
   members?: ResolvedType[]; // reserved for P3 union-type propagation; unpopulated in P1
   fields?: ResolvedTypeFields;
+  arrayStorage?: ArrayStorageStrategy; // Phase A: populated when arrayDepth > 0
 }
 
 // Keys/types/tsTypes triple used by object-array element access and object-literal codegen.


### PR DESCRIPTION
## Summary

**Phase A of 5-axis rearchitect.** See `memory/rearchitect-plan.md` for the master program.

Introduces \`ArrayStorageStrategy = "inlined" | "pointer"\` and adds \`ResolvedType.arrayStorage\`. Populated by \`TypeInference.resolveExpressionTypeRich\` when \`arrayDepth > 0\`:

- \`"inlined"\` — array literal whose element interface has fields all \`double\`
- \`"pointer"\` — everything else (derived arrays from indexing/method returns/etc.)

**Additive.** No consumer switches. Phase B will retire \`SymbolTable.markContiguousObjectArray\` and its per-variable tracking in favor of reading this single source of truth.

## Why this matters for users

Each operation that produces an array (indexing, \`.filter\`, \`.slice\`, \`.map\`, function return) today independently decides storage strategy — and every time one gets it wrong you get a segfault or garbage read (most recently fixed ad-hoc in #529). Phase B eliminates that whole class of bug by making storage strategy inherent to the type, not a per-variable flag.

## Test plan

- [x] \`npm run verify\` green (stage 2)
- [x] \`tests/self-hosting.test.ts\` green (fixture suite)
- [x] Fuzz corpus: 12/21 unchanged — this phase is pure plumbing, Phase B moves the counter