### PR TITLE
refactor(codegen): Phase B — single source of truth for array storage strategy

### DIFF
--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -68,6 +68,7 @@ export interface ArrayAllocatorContext {
   emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
   getAst(): AST | undefined;
   resolveExpressionTypeRich(expr: Expression): ResolvedType | null;
+  getArrayStorageStrategy(expr: Expression): "inlined" | "pointer";
 }
 
 export class ArrayAllocator {
@@ -173,20 +174,16 @@ export class ArrayAllocator {
           elementTypes: typeInfo.types,
           elementTsTypes: typeInfo.tsTypes,
         });
-        // Contiguous layout is only correct when the RHS is an ARRAY LITERAL
-        // that the compiler packs inline. Derived arrays (e.g. `g[1]` where
-        // g is P[][], or a method return) inherit pointer-based storage, so
-        // marking them contiguous causes the indexer to compute byte offsets
-        // into raw memory instead of loading element pointers.
-        const stmtValueBase = stmt.value as ExprBase | undefined;
-        const isArrayLiteral = stmtValueBase !== undefined && stmtValueBase.type === "array";
-        let isAllDouble = isArrayLiteral && typeInfo.types.length > 0;
-        for (let ti = 0; ti < typeInfo.types.length && isAllDouble; ti++) {
-          if (typeInfo.types[ti] !== "double") {
-            isAllDouble = false;
-          }
-        }
-        if (isAllDouble) {
+        // Phase B: consult the canonical resolver's arrayStorage strategy
+        // as the single source of truth. The helper returns "inlined" only
+        // for array-literal RHS whose element fields are all double; derived
+        // arrays (indexing, method returns, function results) return
+        // "pointer" so we correctly skip the contiguous marking. Supersedes
+        // the ad-hoc "isArrayLiteral + all-double" check introduced in #529.
+        const storage = stmt.value
+          ? this.ctx.getArrayStorageStrategy(stmt.value)
+          : ("pointer" as const);
+        if (storage === "inlined") {
           const stride = typeInfo.types.length * 8;
           this.ctx.symbolTable.markContiguousObjectArray(stmt.name, typeInfo.types.length);
           this.ctx.symbolTable.setPendingContiguousStride(stride);

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -160,8 +160,7 @@ export class TypeInference {
   // interface has fields that are all "double". Anything else — including
   // derived arrays from indexing, method returns, function returns, variables
   // whose source is a derived array — is "pointer". This matches what the
-  // codegen actually lays out today; Phase B makes consumers read this
-  // instead of the per-var markContiguousObjectArray table.
+  // codegen actually lays out today.
   private populateArrayStorage(rich: ResolvedType, expr: Expression): void {
     if (rich.arrayDepth === 0) return;
     rich.arrayStorage = this.deriveArrayStorage(rich, expr);
@@ -177,6 +176,16 @@ export class TypeInference {
       if (types[i] !== "double") return "pointer";
     }
     return "inlined";
+  }
+
+  // Phase B: public single source of truth for array storage strategy.
+  // All code that needs to decide "is this array inlined-contiguous or
+  // pointer-based" should call this helper — never recompute ad hoc.
+  // Returns "pointer" when the expression has no resolvable array type.
+  public getArrayStorageStrategy(expr: Expression): ArrayStorageStrategy {
+    const rich = this.resolveExpressionTypeRich(expr);
+    if (!rich || rich.arrayDepth === 0) return "pointer";
+    return rich.arrayStorage || "pointer";
   }
 
   private classifySourceKind(base: string): ResolvedTypeSourceKind {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -4036,6 +4036,10 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     return this.typeInference.resolveExpressionTypeRich(expr);
   }
 
+  public getArrayStorageStrategy(expr: Expression): "inlined" | "pointer" {
+    return this.typeInference.getArrayStorageStrategy(expr);
+  }
+
   public isObjectArrayExpression(expr: Expression): boolean {
     return this.typeInference.isObjectArrayExpression(expr);
   }


### PR DESCRIPTION
## Summary

**Phase B of 5-axis rearchitect.** See \`memory/rearchitect-plan.md\`.

Adds \`TypeInference.getArrayStorageStrategy(expr)\` — ONE function that decides whether an ObjectArray is inlined-contiguous (stride byte-math indexing) or pointer-based (load-each-slot indexing). Forward through \`LLVMGenerator\` to \`ArrayAllocator\`, which now calls the helper instead of its own ad-hoc "is literal + all double?" recomputation.

## Why this matters for users

Every site that decides "is this array laid out contiguously?" used to do it independently — the ad-hoc check in #529 fixed ONE site; new operations (method returns, function results, etc.) kept being at risk of the same class of bug. With Phase B landed, whoever wants to know the storage strategy calls one helper. Future shapes (canonical enrichment for \`.map\`, \`.filter\`, etc.) feed into the same channel and propagate automatically.

## Test plan

- [x] \`npm run verify\` green (stage 2)
- [x] \`tests/self-hosting.test.ts\` green (fixture suite)
- [x] Fuzz corpus: **14/21 → 15/21** (f12_sort now passes)