### PR TITLE
fix(codegen): struct layout through method-call returns + .find/.at interface elements

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -2852,6 +2852,23 @@ export class MemberAccessGenerator {
               }
             }
           }
+          // Rearchitect: consult the canonical resolver before falling back
+          // to the opaque { i8* } struct type. For method-call/call/member
+          // returns of a declared interface, this routes through the
+          // named-interface path (correct struct layout, metadata propagated
+          // for nested access). Unblocks `s.build().inner.v` chains.
+          const rich = this.ctx.resolveExpressionTypeRich(expr.object);
+          if (rich && rich.arrayDepth === 0 && rich.base) {
+            const rt = rich.base;
+            if (this.ctx.interfaceStructGen?.hasInterface(rt)) {
+              const ifaceResult = this.accessObjectPropertyWithNamedInterface(
+                innerPtr,
+                expr.property,
+                rt,
+              );
+              if (ifaceResult !== null) return ifaceResult;
+            }
+          }
           const structType = "{ i8* }";
           const typedPtr = this.ctx.nextTemp();
           this.ctx.emit(`${typedPtr} = bitcast i8* ${innerPtr} to ${structType}*`);

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -576,11 +576,15 @@ export class TypeInference {
         objResolved.arrayDepth > 0 &&
         objResolved.base !== "string" &&
         objResolved.base !== "number" &&
-        objResolved.base !== "boolean" &&
-        this.ctx.classGen !== null &&
-        this.ctx.classGen.getClassFields(objResolved.base).length > 0
+        objResolved.base !== "boolean"
       ) {
-        return this.ctx.typeContext.resolve(objResolved.base);
+        const isClass =
+          this.ctx.classGen !== null &&
+          this.ctx.classGen.getClassFields(objResolved.base).length > 0;
+        const isInterface = !isClass && this.getInterface(objResolved.base) !== null;
+        if (isClass || isInterface) {
+          return this.ctx.typeContext.resolve(objResolved.base);
+        }
       }
       return this.ctx.typeContext.stringType;
     }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2099,6 +2099,43 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         if (resolved.base === "boolean") {
           return { llvmType: "i1", kind: SymbolKind_Boolean, defaultValue: "0" };
         }
+        // Interface (non-primitive, non-array, non-class) resolved type — e.g.
+        // `arr.find(...)` on an interface array returns the element interface.
+        // Allocate as opaque i8* with interface metadata so member access later
+        // can consult the named interface's struct layout.
+        if (
+          resolved.arrayDepth === 0 &&
+          resolved.base !== "number" &&
+          resolved.base !== "void" &&
+          resolved.base !== "null" &&
+          resolved.base !== "undefined" &&
+          resolved.base !== "any" &&
+          resolved.base !== "unknown" &&
+          resolved.base !== "object" &&
+          !resolved.base.startsWith("Map") &&
+          !resolved.base.startsWith("Set") &&
+          !resolved.base.startsWith("Promise") &&
+          this.typeResolver &&
+          this.typeResolver.getInterface(resolved.base)
+        ) {
+          if (name) {
+            this.defineVariableWithMetadata(
+              name,
+              `@${name}`,
+              "i8*",
+              SymbolKind_Object,
+              "global",
+              createInterfaceMetadata(resolved.base),
+            );
+            this.symbolTable.setRawInterfaceType(name, resolved.base);
+            this.globalVariables.set(name, {
+              llvmType: "i8*",
+              kind: SymbolKind_Object,
+              initialized: false,
+            });
+          }
+          return { llvmType: "i8*", kind: SymbolKind_Object, defaultValue: "null" };
+        }
       }
       let isI64 = false;
       for (let ei = 0; ei < i64Eligible.length; ei++) {


### PR DESCRIPTION
## Summary

Two related fixes that together kill a common class of interface-array segfaults:

### 1. Member access on method-call / call / index / member returns (f17)

When property access chains off a non-variable expression returning a declared interface (\`s.build().inner\`, \`fn().field\`, \`arr[i].field\`), the dispatcher used to fall back to a hardcoded single-field struct \`{ i8* }\`. For \`Outer { inner, name }\`, that bitcast the return as a 1-field struct, accidentally read \`inner\` at index 0, but then read \`.v\` as \`i8*\` and \`ptrtoint\`'d to double — pure garbage.

Consult the canonical resolver before the fallback. If the non-variable expression returns a declared interface, route through \`accessObjectPropertyWithNamedInterface\` — correct struct type, right GEP index, right load type, AND propagates interface metadata for nested access.

### 2. \`.find\` / \`.at\` on interface arrays + module-scope allocation (f11)

\`.find(...)\` on \`P[]\` (interface) used to return \`string\` (the default), making \`found.name === \"b\"\` compile as string-char comparison (reads first two bytes of a pointer). Added the interface-array arm.

Paired with module-scope allocator fix: when a global resolves to a declared interface type (e.g. \`const found = users.find(...)\` at module scope), allocate as opaque \`i8*\` + interface metadata instead of the default \`double\`. Without this the LLVM \`store double %ptr, double* @found\` clang error surfaces.

## Impact for users

Kills two whole segfault-or-garbage-value categories: chained member access off non-variable expressions, and \`.find\`/\`.at\` results in interface arrays. \`s.build().inner.v\`, \`arr.find(...).name\` now read correct values.

## Test plan

- [x] \`npm run verify\` green (stage 2)
- [x] \`tests/self-hosting.test.ts\` green (fixture suite; \`interface-array-processing.ts\` module-scope \`.find\` still passes)
- [x] Fuzz corpus: **15/21 → 17/21** (f17 + f11 now pass)