### PR TITLE
fix(codegen): array literals with object elements flow to ObjectArray (not StringArray)

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -1625,6 +1625,17 @@ export class TypeInference {
 
   isObjectArrayExpression(expr: Expression): boolean {
     const e = expr as ExprBase;
+    if (e.type === "array") {
+      // Array literal: classify by first element. Object literals / new-expressions
+      // yield ObjectArray element storage (each slot is i8* to a struct).
+      const arrExpr = expr as ArrayNode;
+      if (arrExpr.elements && arrExpr.elements.length > 0) {
+        const firstBase = arrExpr.elements[0] as ExprBase;
+        if (firstBase && (firstBase.type === "object" || firstBase.type === "new")) {
+          return true;
+        }
+      }
+    }
     if (e.type === "binary") {
       const binExpr = expr as BinaryNode;
       if (binExpr.op === "||" || binExpr.op === "??") {

--- a/src/codegen/types/collections/array/literal.ts
+++ b/src/codegen/types/collections/array/literal.ts
@@ -49,9 +49,16 @@ export function generateArrayLiteral(
   }
   let firstElemValue: string | null = null;
   if (length > 0 && !isStringArray) {
+    // Object literal elements are i8* pointers to struct allocations — they must
+    // flow to ObjectArray, not StringArray. Detect BEFORE generating the element
+    // so the i8*-fallback below doesn't misclassify as string.
+    const firstElemAstType = (arrExpr.elements[0] as { type: string }).type;
+    if (firstElemAstType === "object" || firstElemAstType === "new") {
+      isPointerArray = true;
+    }
     firstElemValue = gen.generateExpression(arrExpr.elements[0], params);
     const firstElemType = gen.getVariableType(firstElemValue);
-    if (firstElemType === "i8*") {
+    if (!isPointerArray && firstElemType === "i8*") {
       isStringArray = true;
     } else if (firstElemType && firstElemType !== "double" && firstElemType.indexOf("*") !== -1) {
       isPointerArray = true;


### PR DESCRIPTION
## Summary

Two paired fixes for \`[{k:\"a\"},{k:\"b\"}][1]\` compile failure:

1. **Array literal generator**: first-element i8* pointer used to classify the literal as \`StringArray\`. Object literals and \`new\` expressions also return i8* but should flow to \`ObjectArray\` (each slot is a pointer to a heap struct). Detect the AST type of the first element before the i8*-fallback.

2. **Index dispatcher**: \`isObjectArrayExpression\` now recognizes array literals with object/new elements. Previously, literal indexing fell through to \`isArrayExpression\` (numeric) and emitted \`%Array*\` cast + double load on what was actually an ObjectArray — clang type-checked and rejected the store.

## Impact for users

Inline array-literal indexing with object elements now compiles correctly. Patterns like:

\`\`\`typescript
const x = [{ k: \"a\" }, { k: \"b\" }][1] as P;
x.k  // now works; was clang error before
\`\`\`

## Test plan

- [x] \`npm run verify\` green (stage 2)
- [x] \`tests/self-hosting.test.ts\` green (fixture suite)
- [x] Fuzz corpus: **17/21 → 18/21** (f03 array_literal_indexed now passes)