### PR TITLE
feat(codegen): getObjectMetadata accepts optional target interface

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -180,7 +180,7 @@ export interface MemberAccessGeneratorContext {
   getVariableAlloca(name: string): string | undefined;
   emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
   emitWarning(message: string, loc?: SourceLocation, suggestion?: string): void;
-  getObjectMetadata(obj: ObjectNode): ObjectMetadata;
+  getObjectMetadata(obj: ObjectNode, targetInterface?: string): ObjectMetadata;
   classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   classGenGetFieldType(className: string, fieldName: string): string | null;
   classGenGetFieldTsType(className: string, fieldName: string): string | null;

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -161,7 +161,10 @@ export interface VariableAllocatorContext {
   getMethodCallInterfaceReturn(expr: Expression): string | null;
   getMethodCallArrayReturn(expr: Expression): string | null;
   getJSONParseInterface(expr: Expression): string | null;
-  getObjectMetadata(objExpr: ObjectNode): { keys: string[]; types: string[] };
+  getObjectMetadata(
+    objExpr: ObjectNode,
+    targetInterface?: string,
+  ): { keys: string[]; types: string[] };
   emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
   emitWarning(message: string, loc?: SourceLocation, suggestion?: string): void;
   getAst(): AST | undefined;

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -1283,10 +1283,57 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     return info.fields[fieldIndex].llvmType;
   }
 
-  // Helper: Extract object literal metadata (public for context pattern access)
-  public getObjectMetadata(objExpr: ObjectNode): { keys: string[]; types: string[] } {
+  // Helper: Extract object literal metadata (public for context pattern access).
+  // When `targetInterface` names a known interface, emit keys/types in the
+  // interface's DECLARATION order — this matches the canonical struct layout
+  // that generateInterfaceObject emits, so variable metadata and actual struct
+  // GEP indices agree. Without a target, returns source-order (legacy).
+  //
+  // The canonical-order path is INLINED here rather than a separate helper
+  // method to avoid shifting LLVMGenerator's method count — the native
+  // compiler has positional class-method dispatch (see memory
+  // `native-method-deletion-breaks-vtable.md`).
+  public getObjectMetadata(
+    objExpr: ObjectNode,
+    targetInterface?: string,
+  ): { keys: string[]; types: string[] } {
     if (!objExpr || objExpr.type !== "object") {
       return { keys: [], types: [] };
+    }
+
+    // Canonical-order path when a known interface is provided.
+    if (
+      targetInterface &&
+      this.interfaceStructGen &&
+      this.interfaceStructGen.hasInterface(targetInterface)
+    ) {
+      const info = this.interfaceStructGen.getInterfaceStruct(targetInterface);
+      if (info) {
+        const kOut: string[] = [];
+        const tOut: string[] = [];
+        const covered: string[] = [];
+        for (let fi = 0; fi < info.fields.length; fi++) {
+          const f = info.fields[fi] as { name: string; llvmType: string };
+          kOut.push(f.name);
+          tOut.push(f.llvmType);
+          covered.push(f.name);
+        }
+        if (objExpr.properties) {
+          for (let pi = 0; pi < objExpr.properties.length; pi++) {
+            const p = objExpr.properties[pi] as ObjectProperty;
+            if (!p) continue;
+            if (covered.indexOf(p.key) !== -1) continue;
+            kOut.push(p.key);
+            // Fallback: infer extra-key type inline. i8* is the safe default
+            // because most runtime values are pointers.
+            let t = "i8*";
+            const pvt = (p.value as { type: string }).type;
+            if (pvt === "number" || pvt === "boolean" || pvt === "unary") t = "double";
+            tOut.push(t);
+          }
+        }
+        return { keys: kOut, types: tOut };
+      }
     }
 
     const keys: string[] = [];
@@ -2479,7 +2526,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           llvmType = "i8*";
           kind = SymbolKind_Object;
           defaultValue = "null";
-          const objMeta = this.getObjectMetadata(stmt.value as ObjectNode);
+          // Pass declaredType so metadata keys/types come out in canonical
+          // interface declaration order when stmt.declaredType is a known
+          // interface. Keeps variable metadata aligned with the struct layout
+          // generateInterfaceObject emits.
+          const objMeta = this.getObjectMetadata(stmt.value as ObjectNode, stmt.declaredType);
           if (objMeta && objMeta.keys.length > 0) {
             const interfaceName = stmt.declaredType || undefined;
             ir += `@${name} = global ${llvmType} ${defaultValue}` + "\n";


### PR DESCRIPTION
## Summary

Adds optional \`targetInterface\` param to \`LLVMGenerator.getObjectMetadata\`. When provided and the interface is registered, returns \`{keys, types}\` in the interface's declared field order instead of the object literal's source order. This matches the struct layout that \`generateInterfaceObject\` emits — so when a \`const x: I = {...}\` literal is stored, the variable's metadata and the actual struct GEP indices agree.

Migrates one caller: the module-scope \`isObject\` branch in \`generateTopLevelDeclarations\`, which already has \`stmt.declaredType\` in hand. Other callers unchanged — they opt in per site.

Source-order behavior preserved when no target is passed. Strictly additive.

## Impact for users

Unblocks the object-literal codegen audit that's been waiting on a way to get canonical-order metadata at a call site. Downstream: members accessed via variable metadata on a module-scope \`const x: I = {...}\` now read the same GEP indices the struct was laid out with, eliminating a class of "added optional field in middle and stage 2 broke" bugs for that specific shape.

## Test plan

- [x] \`npm run verify\` green (self-hosting)
- [x] \`tests/self-hosting.test.ts\` green (fixture suite)
- [x] Fuzz corpus unchanged at 18/21