### PR TITLE
feat(semantic): inject null defaults for missing optional fields

### DIFF
--- a/src/semantic/interface-layout-normalizer.ts
+++ b/src/semantic/interface-layout-normalizer.ts
@@ -554,7 +554,7 @@ export class InterfaceLayoutNormalizer {
 // Flipping these on requires first making `getObjectMetadata` (and its
 // consumers) canonical-layout-aware.
 const REORDER_ENABLED = true;
-const INJECT_DEFAULTS_ENABLED = false;
+const INJECT_DEFAULTS_ENABLED = true;
 
 const NORM_VARIABLE_DECL = true;
 const NORM_TYPE_ASSERTION = true;


### PR DESCRIPTION
## Summary
- Flips \`INJECT_DEFAULTS_ENABLED\` in the interface-layout-normalizer from \`false\` to \`true\`.
- When an object literal is typed against an interface, missing optional fields now get explicit \`null\` / \`0\` / \`false\` slots in declaration order.

## Why this matters
Before: \`{value: 2}\` typed as \`Tree {value, left?, right?}\` only allocated 8 bytes (\`value\`). At runtime, \`.left\` access did GEP at offset 8 — which read past the struct into garbage memory → segfault. Recursive interfaces like tree/linked-list where most sites only set a subset of optional fields were silently broken.

After: the struct is always the full declared size, missing optionals are explicit nulls. GEP reads a real slot. Recursive \`Tree\`/\`LinkedList\` patterns work.

## Test plan
- [x] \`npm run verify\` green (stage 0/1/2 + all tests)
- [x] g12 recursive Tree fuzz case: segfault → TEST_PASSED