### PR TITLE
fix(codegen): propagate interface metadata on call-result field access

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -2742,6 +2742,33 @@ export class MemberAccessGenerator {
     const value = this.ctx.emitLoad(propType, fieldPtr);
     this.ctx.setVariableType(value, propType);
 
+    // Propagate interface metadata when the field is of named-interface type.
+    // Without this, subsequent chained access (e.g. `make().inner.x`) hits
+    // handleChainedInterfaceAccess with no metadata, falls back to anonymous
+    // struct access, and emits wrong types (`{ i8* }` instead of `%Inner`).
+    const propTsType = stripOptional(propField.type);
+    if (propType === "i8*") {
+      const innerIfaceDef = this.getInterfaceDecl(propTsType);
+      if (innerIfaceDef) {
+        const innerFields = this.ctx.getAllInterfaceFields(innerIfaceDef as InterfaceDeclaration);
+        const keys: string[] = [];
+        const types: string[] = [];
+        const tsTypes: string[] = [];
+        for (const f of innerFields) {
+          const ff = f as { name: string; type: string };
+          keys.push(stripOptional(ff.name));
+          types.push(tsTypeToLlvm(ff.type));
+          tsTypes.push(ff.type);
+        }
+        this.ctx.setJsonObjectMetadata(value, {
+          keys,
+          types,
+          tsTypes,
+          interfaceType: propTsType,
+        });
+      }
+    }
+
     return value;
   }
 

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -132,7 +132,53 @@ export class TypeInference {
     if (!baseType) return null;
     const enriched = this.enrichResolvedType(baseType);
     this.populateArrayStorage(enriched, expr);
+    if (process.env.CHAD_TRACE_RESOLVE) {
+      this.traceResolve(expr, enriched);
+    }
     return enriched;
+  }
+
+  private traceMap: Map<object, ResolvedType[]> = new Map();
+  private traceResolve(expr: Expression, rt: ResolvedType): void {
+    if (!expr || typeof expr !== "object") return;
+    const key = expr as unknown as object;
+    const prev = this.traceMap.get(key) || [];
+    prev.push(rt);
+    this.traceMap.set(key, prev);
+    if (prev.length >= 2) {
+      const first = prev[0];
+      const last = prev[prev.length - 1];
+      const diff =
+        first.base !== last.base ||
+        first.arrayDepth !== last.arrayDepth ||
+        first.sourceKind !== last.sourceKind ||
+        first.elementInterface !== last.elementInterface ||
+        first.arrayStorage !== last.arrayStorage;
+      if (diff) {
+        const eAny = expr as unknown as { type?: string; name?: string; property?: string };
+        console.error(
+          "[RESOLVE-DIVERGE] n=" +
+            prev.length +
+            " expr.type=" +
+            eAny.type +
+            " name/prop=" +
+            (eAny.name || eAny.property || "") +
+            " first={base:" +
+            first.base +
+            ",kind:" +
+            first.sourceKind +
+            ",elem:" +
+            first.elementInterface +
+            "} last={base:" +
+            last.base +
+            ",kind:" +
+            last.sourceKind +
+            ",elem:" +
+            last.elementInterface +
+            "}",
+        );
+      }
+    }
   }
 
   private enrichResolvedType(rt: ResolvedType): ResolvedType {

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -132,53 +132,7 @@ export class TypeInference {
     if (!baseType) return null;
     const enriched = this.enrichResolvedType(baseType);
     this.populateArrayStorage(enriched, expr);
-    if (process.env.CHAD_TRACE_RESOLVE) {
-      this.traceResolve(expr, enriched);
-    }
     return enriched;
-  }
-
-  private traceMap: Map<object, ResolvedType[]> = new Map();
-  private traceResolve(expr: Expression, rt: ResolvedType): void {
-    if (!expr || typeof expr !== "object") return;
-    const key = expr as unknown as object;
-    const prev = this.traceMap.get(key) || [];
-    prev.push(rt);
-    this.traceMap.set(key, prev);
-    if (prev.length >= 2) {
-      const first = prev[0];
-      const last = prev[prev.length - 1];
-      const diff =
-        first.base !== last.base ||
-        first.arrayDepth !== last.arrayDepth ||
-        first.sourceKind !== last.sourceKind ||
-        first.elementInterface !== last.elementInterface ||
-        first.arrayStorage !== last.arrayStorage;
-      if (diff) {
-        const eAny = expr as unknown as { type?: string; name?: string; property?: string };
-        console.error(
-          "[RESOLVE-DIVERGE] n=" +
-            prev.length +
-            " expr.type=" +
-            eAny.type +
-            " name/prop=" +
-            (eAny.name || eAny.property || "") +
-            " first={base:" +
-            first.base +
-            ",kind:" +
-            first.sourceKind +
-            ",elem:" +
-            first.elementInterface +
-            "} last={base:" +
-            last.base +
-            ",kind:" +
-            last.sourceKind +
-            ",elem:" +
-            last.elementInterface +
-            "}",
-        );
-      }
-    }
   }
 
   private enrichResolvedType(rt: ResolvedType): ResolvedType {


### PR DESCRIPTION
## Summary
Fixes silently-wrong and segfaulting behavior for chained access on function results — e.g. \`make().inner.x\` where \`make()\` returns an interface and \`.inner\` is also an interface type.

## The bug
When a function returning an interface had its result immediately chained through, the second level of access emitted wrong LLVM IR:

- \`const o = make(); o.inner.x\` — worked (uses named \`%Outer\` / \`%Inner\` struct types)
- \`make().inner.x\` inline — broken (fell through to anonymous \`{ i8*, i8* }\` / \`{ i8* }\`, read every field as \`i8*\`)

With the field actually being a \`number\` (double), the anonymous struct treated it as a pointer and passed the raw double bits to printf's \`%s\` format → segfault on some inputs, silent wrong output on others.

## Fix
\`handleCallResultPropertyAccess\` now attaches JSON-object interface metadata to its loaded result when the field's TS type is a named interface. Subsequent \`handleChainedInterfaceAccess\` finds the metadata and uses the correct named struct layout.

## Test plan
- [x] \`npm run verify\` green (all tests + stage 1 + stage 2)
- [x] Fuzz corpus: g03 silent-wrong → TEST_PASSED
- [x] Zero regressions across \`/tmp/fuzz3\` and \`/tmp/fuzz4\` fresh adversarial corpora