### PR TITLE
feat(child_process): bidirectional stdin for spawn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,23 @@ Pattern:
 Existing bridges: `regex-bridge.c`, `yyjson-bridge.c`, `os-bridge.c`, `child-process-bridge.c`,
 `child-process-spawn.c`, `lws-bridge.c`, `treesitter-bridge.c`.
 
+### child_process.spawn — bidirectional stdio
+
+`child_process.spawn()` returns an opaque handle (`i8*`) for long-lived children with
+interactive stdio (DAP adapters, REPL subprocesses, etc.):
+
+```ts
+const h = child_process.spawn("lldb-dap", [], onStdout, onStderr, onExit);
+child_process.writeStdin(h, "Content-Length: 42\r\n\r\n{...}");
+child_process.endStdin(h);      // sends EOF
+child_process.kill(h, 15);      // optional signum, default SIGTERM
+```
+
+Handle lifecycle is refcounted in `child-process-spawn.c` (proc + 3 pipes each hold a ref;
+freed when all closed). `onExit` fires once after stdout/stderr/proc all close; stdin close
+doesn't gate exit (user controls it). Writes after child exit, `kill` after exit, and
+`writeStdin`/`endStdin` on null handles are all no-ops — never crash.
+
 ## Codegen Quick Rules
 
 1. **Hoist allocas to entry block** — never in conditional branches

--- a/c_bridges/child-process-spawn.c
+++ b/c_bridges/child-process-spawn.c
@@ -1,8 +1,8 @@
 // child-process-spawn.c — Async child process spawning via libuv.
-// Uses uv_spawn with piped stdout/stderr and streaming callbacks.
-// Conditionally linked only when the program uses child_process.spawn().
-// Separated from child-process-bridge.c to avoid libuv link dependency for
-// programs that only use sync operations (or don't use child_process at all).
+// Bidirectional: piped stdin (parent writes) + piped stdout/stderr (parent reads)
+// + streaming callbacks. Conditionally linked only when the program uses
+// child_process.spawn(). Separated from child-process-bridge.c to avoid libuv
+// link dependency for programs that only use sync operations.
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,62 +12,80 @@
 extern void *GC_malloc(size_t);
 extern void *GC_malloc_atomic(size_t);
 extern void *GC_malloc_uncollectable(size_t);
+extern void GC_free(void *);
 
-// Callback typedefs matching ChadScript function signatures
 typedef void (*cs_data_cb)(const char *data);
 typedef void (*cs_exit_cb)(double exit_status);
 
-// Context for an async spawn — holds callbacks, exit status, and completion tracking.
-// The user's onExit fires only when ALL conditions are met:
-//   1. Both pipes have closed (all stdout/stderr data delivered)
-//   2. The process exit callback has fired (exit status known)
-// Either event can happen first, so we track both with a countdown.
+// SpawnHandle — opaque handle returned by cs_spawn. Lifetime managed by refcount.
+// Each outstanding libuv handle (proc, stdin_pipe, stdout_pipe, stderr_pipe) holds
+// one ref; backing memory is freed when refcount hits 0.
+// on_exit fires exactly once, gated by exit_fired, after proc+stdout+stderr close.
+// Stdin close does NOT gate exit (user controls stdin lifetime).
 typedef struct {
     cs_data_cb on_stdout;
     cs_data_cb on_stderr;
     cs_exit_cb on_exit;
+    uv_process_t *proc;
+    uv_pipe_t *stdin_pipe;
+    uv_pipe_t *stdout_pipe;
+    uv_pipe_t *stderr_pipe;
     double exit_status;
-    int completions_remaining; // starts at 3 (stdout pipe + stderr pipe + exit cb)
-} SpawnContext;
+    int refcount;              // outstanding libuv handles referencing this ctx
+    int completions_remaining; // stdout close + stderr close + proc close
+    int exit_fired;            // 1 once on_exit has been called
+    int stdin_closed;          // 1 once stdin_pipe has been closed
+} SpawnHandle;
 
-// uv alloc callback — allocate temp read buffer
+static void handle_unref(SpawnHandle *h) {
+    h->refcount--;
+    if (h->refcount <= 0) {
+        if (h->proc) GC_free(h->proc);
+        if (h->stdin_pipe) GC_free(h->stdin_pipe);
+        if (h->stdout_pipe) GC_free(h->stdout_pipe);
+        if (h->stderr_pipe) GC_free(h->stderr_pipe);
+    }
+}
+
+static void spawn_maybe_fire_exit(SpawnHandle *h) {
+    if (h->completions_remaining <= 0 && !h->exit_fired) {
+        h->exit_fired = 1;
+        if (h->on_exit) h->on_exit(h->exit_status);
+    }
+}
+
 static void spawn_alloc_cb(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) {
     (void)handle;
     buf->base = (char *)malloc(suggested_size);
     buf->len = suggested_size;
 }
 
-// Helper: check if all completions are done (pipes closed + exit received), fire onExit
-static void spawn_maybe_fire_exit(SpawnContext *ctx) {
-    if (ctx->completions_remaining <= 0 && ctx->on_exit) {
-        ctx->on_exit(ctx->exit_status);
-    }
+// Close cb for stdout/stderr: gates exit + releases ref.
+static void spawn_rpipe_close_cb(uv_handle_t *handle) {
+    SpawnHandle *h = (SpawnHandle *)uv_handle_get_data(handle);
+    h->completions_remaining--;
+    spawn_maybe_fire_exit(h);
+    handle_unref(h);
 }
 
-// Called when a pipe handle is closed
-static void spawn_pipe_close_cb(uv_handle_t *handle) {
-    SpawnContext *ctx = (SpawnContext *)uv_handle_get_data(handle);
-    ctx->completions_remaining--;
-    spawn_maybe_fire_exit(ctx);
+// Close cb for stdin: does not gate exit (user-controlled), just releases ref.
+static void spawn_stdin_close_cb(uv_handle_t *handle) {
+    SpawnHandle *h = (SpawnHandle *)uv_handle_get_data(handle);
+    handle_unref(h);
 }
 
-// Helper: copy read data to GC string and invoke user callback
 static void spawn_read_cb_impl(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf, int is_stdout) {
-    SpawnContext *ctx = (SpawnContext *)uv_handle_get_data((uv_handle_t *)stream);
+    SpawnHandle *h = (SpawnHandle *)uv_handle_get_data((uv_handle_t *)stream);
     if (nread > 0) {
         char *data = (char *)GC_malloc_atomic((size_t)nread + 1);
         memcpy(data, buf->base, (size_t)nread);
         data[nread] = '\0';
-        if (is_stdout && ctx->on_stdout) {
-            ctx->on_stdout(data);
-        } else if (!is_stdout && ctx->on_stderr) {
-            ctx->on_stderr(data);
-        }
+        if (is_stdout && h->on_stdout) h->on_stdout(data);
+        else if (!is_stdout && h->on_stderr) h->on_stderr(data);
     }
     if (buf->base) free(buf->base);
     if (nread < 0) {
-        // EOF or error — close this pipe (triggers spawn_pipe_close_cb)
-        uv_close((uv_handle_t *)stream, spawn_pipe_close_cb);
+        uv_close((uv_handle_t *)stream, spawn_rpipe_close_cb);
     }
 }
 
@@ -79,50 +97,60 @@ static void spawn_stderr_read_cb(uv_stream_t *stream, ssize_t nread, const uv_bu
     spawn_read_cb_impl(stream, nread, buf, 0);
 }
 
-// Process exit callback — store exit status, close process handle, check if all done.
 static void spawn_proc_close_cb(uv_handle_t *handle) {
-    SpawnContext *ctx = (SpawnContext *)uv_handle_get_data(handle);
-    ctx->completions_remaining--;
-    spawn_maybe_fire_exit(ctx);
+    SpawnHandle *h = (SpawnHandle *)uv_handle_get_data(handle);
+    h->completions_remaining--;
+    spawn_maybe_fire_exit(h);
+    handle_unref(h);
 }
 
 static void spawn_exit_cb(uv_process_t *proc, int64_t exit_status, int term_signal) {
     (void)term_signal;
-    SpawnContext *ctx = (SpawnContext *)uv_handle_get_data((uv_handle_t *)proc);
-    ctx->exit_status = (double)exit_status;
-    // Close process handle; its close callback decrements completions_remaining
+    SpawnHandle *h = (SpawnHandle *)uv_handle_get_data((uv_handle_t *)proc);
+    h->exit_status = (double)exit_status;
+    // Force-close stdin if user never called endStdin — otherwise its ref leaks.
+    if (!h->stdin_closed && h->stdin_pipe) {
+        h->stdin_closed = 1;
+        uv_close((uv_handle_t *)h->stdin_pipe, spawn_stdin_close_cb);
+    }
     uv_close((uv_handle_t *)proc, spawn_proc_close_cb);
 }
 
-// cs_spawn: spawn a child process with piped stdout/stderr and streaming callbacks.
-// When argc == 0: shell mode (runs through /bin/sh -c command)
-// When argc > 0: direct exec mode with args array
-// Callbacks are invoked on the main event loop thread as data arrives.
-void cs_spawn(const char *command, const char **args, int argc,
-              cs_data_cb on_stdout, cs_data_cb on_stderr, cs_exit_cb on_exit) {
+// cs_spawn: spawn a child with bidirectional piped stdio + streaming callbacks.
+// Returns an opaque handle usable with cs_spawn_write/end_stdin/kill; NULL on
+// failure (on_exit is invoked with -1 before returning).
+void *cs_spawn(const char *command, const char **args, int argc,
+               cs_data_cb on_stdout, cs_data_cb on_stderr, cs_exit_cb on_exit) {
     uv_loop_t *loop = uv_default_loop();
 
-    // Allocate handles with GC_malloc_uncollectable — libuv stores internal pointers
-    // in these structs that the GC can't trace, so they must not be collected
     uv_process_t *proc = (uv_process_t *)GC_malloc_uncollectable(sizeof(uv_process_t));
+    uv_pipe_t *stdin_pipe = (uv_pipe_t *)GC_malloc_uncollectable(sizeof(uv_pipe_t));
     uv_pipe_t *stdout_pipe = (uv_pipe_t *)GC_malloc_uncollectable(sizeof(uv_pipe_t));
     uv_pipe_t *stderr_pipe = (uv_pipe_t *)GC_malloc_uncollectable(sizeof(uv_pipe_t));
 
+    uv_pipe_init(loop, stdin_pipe, 0);
     uv_pipe_init(loop, stdout_pipe, 0);
     uv_pipe_init(loop, stderr_pipe, 0);
 
-    SpawnContext *ctx = (SpawnContext *)GC_malloc(sizeof(SpawnContext));
-    ctx->on_stdout = on_stdout;
-    ctx->on_stderr = on_stderr;
-    ctx->on_exit = on_exit;
-    ctx->exit_status = -1.0;
-    ctx->completions_remaining = 3; // stdout pipe close + stderr pipe close + exit callback
+    SpawnHandle *h = (SpawnHandle *)GC_malloc(sizeof(SpawnHandle));
+    h->on_stdout = on_stdout;
+    h->on_stderr = on_stderr;
+    h->on_exit = on_exit;
+    h->proc = proc;
+    h->stdin_pipe = stdin_pipe;
+    h->stdout_pipe = stdout_pipe;
+    h->stderr_pipe = stderr_pipe;
+    h->exit_status = -1.0;
+    h->refcount = 4; // proc + stdin + stdout + stderr
+    h->completions_remaining = 3; // stdout + stderr + proc (stdin excluded)
+    h->exit_fired = 0;
+    h->stdin_closed = 0;
 
-    uv_handle_set_data((uv_handle_t *)proc, ctx);
-    uv_handle_set_data((uv_handle_t *)stdout_pipe, ctx);
-    uv_handle_set_data((uv_handle_t *)stderr_pipe, ctx);
+    uv_handle_set_data((uv_handle_t *)proc, h);
+    uv_handle_set_data((uv_handle_t *)stdin_pipe, h);
+    uv_handle_set_data((uv_handle_t *)stdout_pipe, h);
+    uv_handle_set_data((uv_handle_t *)stderr_pipe, h);
 
-    // Build args array
     char **argv;
     const char *file;
     if (argc == 0) {
@@ -135,17 +163,16 @@ void cs_spawn(const char *command, const char **args, int argc,
     } else {
         argv = (char **)malloc((size_t)(argc + 2) * sizeof(char *));
         argv[0] = (char *)command;
-        for (int i = 0; i < argc; i++) {
-            argv[i + 1] = (char *)args[i];
-        }
+        for (int i = 0; i < argc; i++) argv[i + 1] = (char *)args[i];
         argv[argc + 1] = NULL;
         file = command;
     }
 
-    // Configure stdio: stdin=ignore, stdout=pipe, stderr=pipe
-    // UV_WRITABLE_PIPE = child can write to this fd (parent reads from it)
+    // stdio[0]: parent→child, READABLE from child's POV (child reads it)
+    // stdio[1,2]: child→parent, WRITABLE from child's POV (child writes to them)
     uv_stdio_container_t child_stdio[3];
-    child_stdio[0].flags = UV_IGNORE;
+    child_stdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
+    child_stdio[0].data.stream = (uv_stream_t *)stdin_pipe;
     child_stdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
     child_stdio[1].data.stream = (uv_stream_t *)stdout_pipe;
     child_stdio[2].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
@@ -165,9 +192,66 @@ void cs_spawn(const char *command, const char **args, int argc,
     if (r != 0) {
         fprintf(stderr, "cs_spawn: uv_spawn failed: %s\n", uv_strerror(r));
         if (on_exit) on_exit(-1.0);
-        return;
+        GC_free(proc);
+        GC_free(stdin_pipe);
+        GC_free(stdout_pipe);
+        GC_free(stderr_pipe);
+        return NULL;
     }
 
     uv_read_start((uv_stream_t *)stdout_pipe, spawn_alloc_cb, spawn_stdout_read_cb);
     uv_read_start((uv_stream_t *)stderr_pipe, spawn_alloc_cb, spawn_stderr_read_cb);
+    return h;
+}
+
+// Write-request context — holds the copied buffer until libuv has flushed.
+typedef struct {
+    uv_write_t req;
+    char *data;
+} cs_write_req_t;
+
+static void cs_spawn_write_cb(uv_write_t *req, int status) {
+    (void)status;
+    cs_write_req_t *wr = (cs_write_req_t *)req;
+    free(wr->data);
+    free(wr);
+}
+
+// cs_spawn_write: queue a write to child's stdin. Fire-and-forget.
+// No-op if handle is NULL or stdin already closed.
+void cs_spawn_write(void *handle, const char *data) {
+    if (!handle || !data) return;
+    SpawnHandle *h = (SpawnHandle *)handle;
+    if (h->stdin_closed || !h->stdin_pipe) return;
+
+    size_t len = strlen(data);
+    cs_write_req_t *wr = (cs_write_req_t *)malloc(sizeof(cs_write_req_t));
+    wr->data = (char *)malloc(len);
+    memcpy(wr->data, data, len);
+    uv_buf_t buf = uv_buf_init(wr->data, (unsigned int)len);
+    int r = uv_write(&wr->req, (uv_stream_t *)h->stdin_pipe, &buf, 1, cs_spawn_write_cb);
+    if (r != 0) {
+        fprintf(stderr, "cs_spawn_write: uv_write failed: %s\n", uv_strerror(r));
+        free(wr->data);
+        free(wr);
+    }
+}
+
+// cs_spawn_end_stdin: close child's stdin (sends EOF). Idempotent.
+void cs_spawn_end_stdin(void *handle) {
+    if (!handle) return;
+    SpawnHandle *h = (SpawnHandle *)handle;
+    if (h->stdin_closed || !h->stdin_pipe) return;
+    h->stdin_closed = 1;
+    uv_close((uv_handle_t *)h->stdin_pipe, spawn_stdin_close_cb);
+}
+
+// cs_spawn_kill: send signal to child. signum=0 defaults to SIGTERM (15).
+// No-op if process already exited.
+void cs_spawn_kill(void *handle, int signum) {
+    if (!handle) return;
+    SpawnHandle *h = (SpawnHandle *)handle;
+    if (h->exit_fired || !h->proc) return;
+    if (signum == 0) signum = 15;
+    uv_process_kill(h->proc, signum);
 }

--- a/src/codegen/expressions/method-calls/named-object-dispatch.ts
+++ b/src/codegen/expressions/method-calls/named-object-dispatch.ts
@@ -168,6 +168,9 @@ export function handleChildProcessMethod(
   if (method === "exec") return ctx.childProcessGen.generateExec(expr, params);
   if (method === "spawn") return ctx.childProcessGen.generateSpawn(expr, params);
   if (method === "spawnSync") return ctx.childProcessGen.generateSpawnSync(expr, params);
+  if (method === "writeStdin") return ctx.childProcessGen.generateWriteStdin(expr, params);
+  if (method === "endStdin") return ctx.childProcessGen.generateEndStdin(expr, params);
+  if (method === "kill") return ctx.childProcessGen.generateKill(expr, params);
   return null;
 }
 

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -225,6 +225,9 @@ export interface IChildProcessGenerator {
   generateSpawnSync(expr: MethodCallNode, params: string[]): string;
   generateExec(expr: MethodCallNode, params: string[]): string;
   generateSpawn(expr: MethodCallNode, params: string[]): string;
+  generateWriteStdin(expr: MethodCallNode, params: string[]): string;
+  generateEndStdin(expr: MethodCallNode, params: string[]): string;
+  generateKill(expr: MethodCallNode, params: string[]): string;
 }
 
 export interface IEmbedGenerator {
@@ -2084,6 +2087,9 @@ export class MockGeneratorContext implements IGeneratorContext {
     generateSpawnSync: (_expr: MethodCallNode, _params: string[]): string => "%mock_spawnsync",
     generateExec: (_expr: MethodCallNode, _params: string[]): string => "%mock_exec",
     generateSpawn: (_expr: MethodCallNode, _params: string[]): string => "%mock_spawn",
+    generateWriteStdin: (_expr: MethodCallNode, _params: string[]): string => "null",
+    generateEndStdin: (_expr: MethodCallNode, _params: string[]): string => "null",
+    generateKill: (_expr: MethodCallNode, _params: string[]): string => "null",
   };
   arrayGen: IArrayGenerator = {
     generateArrayLiteral: (_expr: ArrayNode, _params: string[]): string => "%mock_array_literal",

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -92,8 +92,12 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "declare void @cs_exec_passthrough(i8*)\n";
   ir += "declare i8* @cs_execSync(i8*)\n";
   ir += "declare i8* @cs_spawnSync(i8*, i8**, i32)\n";
-  // cs_spawn: async spawn with streaming callbacks (stdout_cb, stderr_cb, exit_cb)
-  ir += "declare void @cs_spawn(i8*, i8**, i32, void (i8*)*, void (i8*)*, void (double)*)\n";
+  // cs_spawn: async spawn with streaming callbacks (stdout_cb, stderr_cb, exit_cb).
+  // Returns opaque handle (i8*) for writeStdin/endStdin/kill; NULL on failure.
+  ir += "declare i8* @cs_spawn(i8*, i8**, i32, void (i8*)*, void (i8*)*, void (double)*)\n";
+  ir += "declare void @cs_spawn_write(i8*, i8*)\n";
+  ir += "declare void @cs_spawn_end_stdin(i8*)\n";
+  ir += "declare void @cs_spawn_kill(i8*, i32)\n";
   ir += "\n";
 
   // base64 bridge — Buffer.from(str, 'base64') → %Uint8Array*; btoa/atob → i8*

--- a/src/codegen/stdlib/child-process.ts
+++ b/src/codegen/stdlib/child-process.ts
@@ -18,7 +18,7 @@ export class ChildProcessGenerator {
     if (exprObjBase.type !== "variable") return false;
     const varNode = expr.object as VariableNode;
     if (varNode.name !== "child_process" && varNode.name !== "cp") return false;
-    const supported = ["execSync", "spawnSync", "exec", "spawn"];
+    const supported = ["execSync", "spawnSync", "exec", "spawn", "writeStdin", "endStdin", "kill"];
     return supported.indexOf(expr.method) !== -1;
   }
 
@@ -167,11 +167,63 @@ export class ChildProcessGenerator {
     const stderrFn = this.ctx.mangleUserName((expr.args[cbStartIdx + 1] as VariableNode).name);
     const exitFn = this.ctx.mangleUserName((expr.args[cbStartIdx + 2] as VariableNode).name);
 
+    const handle = this.ctx.nextTemp();
     this.ctx.emit(
-      `call void @cs_spawn(i8* ${cmdPtr}, i8** ${argsDataPtr}, i32 ${argsLen}, void (i8*)* @${stdoutFn}, void (i8*)* @${stderrFn}, void (double)* @${exitFn})`,
+      `${handle} = call i8* @cs_spawn(i8* ${cmdPtr}, i8** ${argsDataPtr}, i32 ${argsLen}, void (i8*)* @${stdoutFn}, void (i8*)* @${stderrFn}, void (double)* @${exitFn})`,
     );
+    return handle;
+  }
 
-    // spawn() doesn't return a value — it's fire-and-forget
+  /**
+   * child_process.writeStdin(handle, data) — queue a write to child's stdin.
+   * Fire-and-forget. No-op if handle is null or stdin already closed.
+   */
+  generateWriteStdin(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length < 2) {
+      return this.ctx.emitError("writeStdin() requires 2 arguments (handle, data)", expr.loc);
+    }
+    this.ctx.setUsesChildProcess(true);
+    this.ctx.setUsesSpawn(true);
+    const handlePtr = this.ctx.generateExpression(expr.args[0], params);
+    const dataPtr = this.ctx.generateExpression(expr.args[1], params);
+    this.ctx.emit(`call void @cs_spawn_write(i8* ${handlePtr}, i8* ${dataPtr})`);
+    return "null";
+  }
+
+  /**
+   * child_process.endStdin(handle) — close child's stdin (EOF). Idempotent.
+   */
+  generateEndStdin(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("endStdin() requires 1 argument (handle)", expr.loc);
+    }
+    this.ctx.setUsesChildProcess(true);
+    this.ctx.setUsesSpawn(true);
+    const handlePtr = this.ctx.generateExpression(expr.args[0], params);
+    this.ctx.emit(`call void @cs_spawn_end_stdin(i8* ${handlePtr})`);
+    return "null";
+  }
+
+  /**
+   * child_process.kill(handle, signum?) — send signal to child (default SIGTERM).
+   * No-op if process already exited.
+   */
+  generateKill(expr: MethodCallNode, params: string[]): string {
+    if (expr.args.length < 1) {
+      return this.ctx.emitError("kill() requires at least 1 argument (handle)", expr.loc);
+    }
+    this.ctx.setUsesChildProcess(true);
+    this.ctx.setUsesSpawn(true);
+    const handlePtr = this.ctx.generateExpression(expr.args[0], params);
+    let signum = "i32 0";
+    if (expr.args.length >= 2) {
+      const sigVal = this.ctx.generateExpression(expr.args[1], params);
+      const sigDbl = this.ctx.ensureDouble(sigVal);
+      const sigInt = this.ctx.nextTemp();
+      this.ctx.emit(`${sigInt} = fptosi double ${sigDbl} to i32`);
+      signum = `i32 ${sigInt}`;
+    }
+    this.ctx.emit(`call void @cs_spawn_kill(i8* ${handlePtr}, ${signum})`);
     return "null";
   }
 }

--- a/tests/fixtures/builtins/cp-spawn-kill.ts
+++ b/tests/fixtures/builtins/cp-spawn-kill.ts
@@ -1,0 +1,16 @@
+// @test expectTestPassed
+let handle: string = "";
+
+function onStdout(data: string): void {}
+function onStderr(data: string): void {}
+
+function onExit(code: number): void {
+  // killed by signal → non-zero exit (libuv reports signal in term_signal;
+  // we only forward exit_status here, which for signal-killed procs is typically 0
+  // or the signal number depending on OS). Just assert onExit fires.
+  console.log("TEST_PASSED");
+}
+
+handle = child_process.spawn("sleep", ["30"], onStdout, onStderr, onExit);
+child_process.kill(handle, 15);
+runEventLoop();

--- a/tests/fixtures/builtins/cp-spawn-stdin.ts
+++ b/tests/fixtures/builtins/cp-spawn-stdin.ts
@@ -1,0 +1,22 @@
+// @test expectTestPassed
+let collected = "";
+let handle: string = "";
+
+function onStdout(data: string): void {
+  collected = collected + data;
+}
+
+function onStderr(data: string): void {}
+
+function onExit(code: number): void {
+  if (collected === "hello world\n" && code === 0) {
+    console.log("TEST_PASSED");
+  } else {
+    console.log("FAIL: collected='" + collected + "' code=" + code);
+  }
+}
+
+handle = child_process.spawn("cat", [], onStdout, onStderr, onExit);
+child_process.writeStdin(handle, "hello world\n");
+child_process.endStdin(handle);
+runEventLoop();


### PR DESCRIPTION
## Summary

Unblocks ChadScript as a runtime for long-lived interactive subprocesses — DAP debug
adapters, REPLs, JSON-RPC servers — where you need to keep talking to the child after
spawning it. Before this PR, `child_process.spawn()` was fire-and-forget with stdin
hardcoded to `UV_IGNORE`.

### New user-facing API

```ts
const handle = child_process.spawn("lldb-dap", [], onStdout, onStderr, onExit);
child_process.writeStdin(handle, 'Content-Length: 42\r\n\r\n{"seq":1,...}');
child_process.endStdin(handle);         // sends EOF
child_process.kill(handle, 15);         // optional signum, default SIGTERM
```

- `spawn()` now returns an opaque handle (`i8*`) instead of void. Existing 4/5-arg
  callback signatures are unchanged, so existing code that ignores the return value
  (see `tests/fixtures/builtins/cp-spawn.ts`) keeps working.
- `writeStdin` / `endStdin` / `kill` on `null` handle, closed stdin, or exited process
  are no-ops — never crash. This matters for async races where the child exits before
  your next write queues.

### Lifecycle

`SpawnHandle` is refcounted: proc + stdin + stdout + stderr each hold a ref, freed
when all close. `onExit` fires exactly once (guarded by `exit_fired`) after
stdout/stderr/proc have all closed; stdin close does NOT gate exit because the user
controls when to end stdin. If the child exits before the user calls `endStdin`, the
exit callback force-closes stdin so its ref doesn't leak.

### Files

- `c_bridges/child-process-spawn.c` — rewritten with stdin pipe + refcounted handle
  + `cs_spawn_write` / `cs_spawn_end_stdin` / `cs_spawn_kill`
- `src/codegen/stdlib/child-process.ts` — `generateSpawn` returns the handle;
  new `generateWriteStdin` / `generateEndStdin` / `generateKill`
- `src/codegen/expressions/method-calls/named-object-dispatch.ts` — dispatch wiring
- `src/codegen/infrastructure/llvm-declarations.ts` — extern decls
- `src/codegen/infrastructure/generator-context.ts` — interface + mock updates
- `CLAUDE.md` — documents the new API + lifecycle guarantees
- `tests/fixtures/builtins/cp-spawn-stdin.ts` — cat echo roundtrip
- `tests/fixtures/builtins/cp-spawn-kill.ts` — kill long-sleep child

### Test plan

- [x] `node dist/chad-node.js build tests/fixtures/builtins/cp-spawn-stdin.ts` → TEST_PASSED
- [x] `node dist/chad-node.js build tests/fixtures/builtins/cp-spawn-kill.ts` → TEST_PASSED
- [x] Existing `cp-spawn.ts` still passes (return-value change is backward-compatible)
- [x] `npm test` — 0 failures (112s, full suite)
- [ ] CI green across linux + macos