### PR TITLE
fix(codegen): for-of over interface-typed array keeps element type

### DIFF
--- a/src/codegen/statements/for-of.ts
+++ b/src/codegen/statements/for-of.ts
@@ -982,6 +982,46 @@ export class ForOfGenerator {
       if (objArrayMeta) {
         return objArrayMeta;
       }
+      // Fallback: when the allocator stored rawInterfaceType but didn't populate
+      // ObjectArrayMetadata (happens for `const arr: Pt[] = [...]` paths where
+      // classification routed through DeclaredInterface rather than ObjectArray),
+      // synthesize the metadata from the element interface declaration. Without
+      // this fallback, for-of doesn't set interface metadata on `p`, and
+      // member-access on `p` falls through to opaque struct reads — fuzz g14.
+      const rawIface = this.ctx.symbolTable.getRawInterfaceType(varName);
+      if (rawIface && rawIface.length > 0) {
+        const elemIface = this.ctx.getInterfaceFromAST(rawIface);
+        if (elemIface) {
+          const elemIfaceTyped = elemIface as InterfaceDeclaration;
+          const allFields = this.ctx.getAllInterfaceFields(elemIfaceTyped);
+          const elementKeys: string[] = [];
+          const elementTypes: string[] = [];
+          const elementTsTypes: string[] = [];
+          for (let i = 0; i < allFields.length; i++) {
+            const fRaw = allFields[i];
+            if (!fRaw) continue;
+            const f = fRaw as InterfaceField;
+            if (!f.name || !f.type) continue;
+            elementKeys.push(f.name);
+            elementTsTypes.push(f.type);
+            if (f.type === "string") {
+              elementTypes.push("i8*");
+            } else if (f.type === "number") {
+              elementTypes.push("double");
+            } else if (f.type === "boolean") {
+              elementTypes.push("i32");
+            } else {
+              elementTypes.push("i8*");
+            }
+          }
+          return {
+            elementInterfaceName: rawIface,
+            elementKeys,
+            elementTypes,
+            elementTsTypes,
+          };
+        }
+      }
     }
 
     return null;


### PR DESCRIPTION
## User impact
Before: iterating an interface-typed array with for-of produced empty/garbage values for numeric fields:
\`\`\`ts
interface Pt { x: number; y: number }
const arr: Pt[] = [{ x: 10, y: 20 }, { x: 30, y: 40 }];
for (const p of arr) console.log(p.x, p.y);
// printed empty strings, total = 43026717184 (garbage)
\`\`\`

After: works correctly — prints 10 20 / 30 40.

## Root cause
\`const arr: Pt[]\` is classified as \`VarKind_DeclaredInterface\` and routed to \`allocateDeclaredInterface\`, which sets \`rawInterfaceType\` but doesn't populate \`objectArrayMetadata\`. \`for-of\`'s \`getObjectArrayInfo\` only checked \`objectArrayMetadata\` and returned null. The variable binding (\`p\`) got no interface metadata. Member access on \`p\` returned \`p\` itself (no field GEP), and \`console.log(p.x)\` ended up printing the raw pointer.

## Fix
\`getObjectArrayInfo\` falls back to synthesizing element metadata from the declared element interface's AST when \`objectArrayMetadata\` is absent but \`rawInterfaceType\` is present. This routes through \`generateObjectArrayForOf\` which correctly attaches interface metadata to the loop variable.

## Test plan
- [x] g14 fuzz case: silent-wrong → TEST_PASSED
- [x] \`npm run verify\` green — all tests + stage 1 + stage 2
- [x] fuzz3 corpus: 8 → 9 pass (g14 fixed, no regressions)