### PR TITLE
docs(d.ts): declare spawn/writeStdin/endStdin/kill/exec ambients

### DIFF
--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -158,10 +158,29 @@ declare namespace sqlite {
 
 declare namespace child_process {
   function execSync(command: string): string;
+  function exec(command: string): Promise<{ stdout: string; stderr: string; status: number }>;
   function spawnSync(
     command: string,
     args?: string[],
   ): { stdout: string; stderr: string; status: number };
+  // spawn returns an opaque handle (i8*) usable with writeStdin/endStdin/kill.
+  // Callbacks must be named function references (compiler constraint).
+  function spawn(
+    command: string,
+    args: string[],
+    onStdout: (data: string) => void,
+    onStderr: (data: string) => void,
+    onExit: (code: number) => void,
+  ): string;
+  function spawn(
+    command: string,
+    onStdout: (data: string) => void,
+    onStderr: (data: string) => void,
+    onExit: (code: number) => void,
+  ): string;
+  function writeStdin(handle: string, data: string): void;
+  function endStdin(handle: string): void;
+  function kill(handle: string, signum?: number): void;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The compiler bakes these APIs in codegen (PR #542 and earlier), but chadscript.d.ts didn't declare them — so editor tooling couldn't offer completion or type-check calls. Purely additive, no codegen change.

- Adds `exec`, `spawn` (4-arg and 5-arg overloads), `writeStdin`, `endStdin`, `kill` to the `child_process` namespace.
- Notes the named-function-reference constraint on spawn callbacks inline.

## Test plan

- [x] ambients-only change — no runtime effect
- [ ] CI green
