### PR TITLE
fix(codegen): @-prefix function refs when used as first-class values

### DIFF
--- a/src/codegen/expressions/variables.ts
+++ b/src/codegen/expressions/variables.ts
@@ -187,7 +187,8 @@ export class VariableExpressionGenerator {
     for (let fi = 0; fi < funcCount; fi++) {
       const funcName = this.ctx.getAstFunctionNameAt(fi);
       if (funcName === name) {
-        return "_cs_" + name;
+        // Function symbols used as first-class values need the @ sigil.
+        return "@_cs_" + name;
       }
     }
 

--- a/tests/fixtures/builtins/fn-ref-as-arg.ts
+++ b/tests/fixtures/builtins/fn-ref-as-arg.ts
@@ -1,0 +1,13 @@
+// @test expectTestPassed
+function handler(msg: string): void {
+  console.log("handler got: " + msg);
+}
+
+function registerAndCall(h: (m: string) => void, s: string): void {
+  // h(s) is call-through-param — separate bug, avoid for this fixture.
+  // Just verify we can pass-by-reference without broken IR.
+  console.log("registered");
+}
+
+registerAndCall(handler, "hi");
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

Unblocks handler-registration / pub-sub patterns. Before this PR, passing a named function as an argument (`register(myHandler)`, `someBuiltin(cb)`) emitted invalid LLVM IR because the function symbol was referenced without the `@` sigil. Clang failed with `expected value token`.

### Root cause

`variables.ts:190` — when a variable reference resolves to a top-level function name, the handler returned `"_cs_" + name` (no `@`). LLVM requires the `@` sigil for function symbols when used as values (only the callee position in `call` lets you omit it via shorthand).

### Fix

One-line change: return `"@_cs_" + name` instead of `"_cs_" + name`. Callsites that explicitly consume this for a `call` instruction already strip/handle the sigil; passing it through as a value now works naturally.

### What this unblocks

From the dapweb NOTES-for-chadscript.md file (#9a, marked **Blocker**):

```ts
function onEvt(e: string, b: string): void { ... }
setEventHandler(onEvt);  // ← was: 'expected value token'. now: compiles.
```

### What this does NOT fix

The related bug of calling **through** a function-typed parameter (`h(args)` where `h: (a, b) => void` is a parameter) still emits wrong IR. That's a separate codegen path (indirect call) and gets its own PR.

### Test plan

- [x] New fixture: `tests/fixtures/builtins/fn-ref-as-arg.ts` passes
- [x] `npm test` — 0 failures locally
- [ ] CI green across linux + macos
