### PR TITLE
fix(codegen): callHandler honors arg types instead of hardcoded i8*

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -52,18 +52,52 @@ export class CallExpressionGenerator {
     }
 
     if (expr.name === "callHandler") {
+      // callHandler(fnPtr, ...args) — invoke a raw function pointer stored
+      // as i8* (typically an object's function-typed field). Previously the
+      // bitcast and call used a fixed `double(i8*, i8*, ...)*` shape, which
+      // only worked when every arg was actually a pointer. For numeric /
+      // boolean args that emitted broken IR (passing i64/double as i8*).
+      //
+      // Current strategy: generate each arg first, inspect its LLVM type,
+      // and mirror that type in both the bitcast signature and the call
+      // site. Assumes the function's declared signature matches the types
+      // the user is passing — which it must, or the TS would not typecheck.
       const fnPtr = this.ctx.generateExpression(expr.args[0], params);
-      const typedFn = this.ctx.nextTemp();
-      const numCallArgs = expr.args.length - 1;
-      const argTypeList: string[] = [];
-      for (let ti = 0; ti < numCallArgs; ti++) {
-        argTypeList.push("i8*");
-      }
-      this.ctx.emit(`${typedFn} = bitcast i8* ${fnPtr} to double (${argTypeList.join(", ")})*`);
-      const callArgsList: string[] = [];
+      const argValues: string[] = [];
+      const argTypes: string[] = [];
       for (let ai = 1; ai < expr.args.length; ai++) {
-        const argVal = this.ctx.generateExpression(expr.args[ai], params);
-        callArgsList.push(`i8* ${argVal}`);
+        const rawArgVal = this.ctx.generateExpression(expr.args[ai], params);
+        const lt = this.ctx.getVariableType(rawArgVal);
+        // ChadScript's 'number' is double in function signatures. Promote
+        // integer-typed values (int literals, i64 from integer specialization)
+        // to double so the call ABI matches a (number) => ... function.
+        let coercedVal = rawArgVal;
+        let paramTy: string;
+        if (lt === "i64" || lt === "i32" || lt === "i16" || lt === "i8") {
+          const promoted = this.ctx.nextTemp();
+          this.ctx.emit(`${promoted} = sitofp ${lt} ${rawArgVal} to double`);
+          coercedVal = promoted;
+          paramTy = "double";
+        } else if (lt === "i1") {
+          const promoted = this.ctx.nextTemp();
+          this.ctx.emit(`${promoted} = uitofp i1 ${rawArgVal} to double`);
+          coercedVal = promoted;
+          paramTy = "double";
+        } else if (!lt || lt.length === 0) {
+          paramTy = "i8*";
+        } else {
+          paramTy = lt;
+        }
+        argValues.push(coercedVal);
+        argTypes.push(paramTy);
+      }
+
+      const typedFn = this.ctx.nextTemp();
+      this.ctx.emit(`${typedFn} = bitcast i8* ${fnPtr} to double (${argTypes.join(", ")})*`);
+
+      const callArgsList: string[] = [];
+      for (let i = 0; i < argValues.length; i++) {
+        callArgsList.push(`${argTypes[i]} ${argValues[i]}`);
       }
       const callResult = this.ctx.nextTemp();
       this.ctx.emit(`${callResult} = call double ${typedFn}(${callArgsList.join(", ")})`);

--- a/tests/fixtures/builtins/callhandler-number-arg.ts
+++ b/tests/fixtures/builtins/callhandler-number-arg.ts
@@ -1,0 +1,13 @@
+// @test expectTestPassed
+// Regression for callHandler with non-string args: before the fix, the
+// bitcast used a fixed double(i8*, i8*, ...)* shape and numeric args were
+// passed as raw i64 where an i8* was expected — clang rejected the IR.
+function onNum(n: number): void {
+  if (n === 42) console.log("TEST_PASSED");
+}
+class S {
+  f: ((n: number) => void) | null = null;
+}
+const s = new S();
+s.f = onNum;
+if (s.f !== null) callHandler(s.f, 42);


### PR DESCRIPTION
## Summary

Unblocks dapweb NOTES #10. `callHandler(fnPtr, ...args)` previously emitted invalid IR for any non-pointer arg:

```llvm
%11 = bitcast i8* %10 to double (i8*)*
%13 = call double %11(i8* %12)  ; passing i64 to i8* — clang rejects
```

The bitcast shape was hardcoded to `double(i8*, i8*, ...)*`. Worked for string-arg handlers; broke the moment a handler took a number or boolean.

### Fix

Each arg's LLVM type now drives both the bitcast signature and the call site. Integer-typed args (`i64`/`i32`/`i16`/`i8`) get sitofp-promoted to `double` to match ChadScript's `(number) => ...` ABI; `i1` booleans get uitofp-promoted. Arg types with an unknown LLVM type fall back to `i8*` (existing behavior for pointer handlers).

### Test plan

- [x] New fixture `tests/fixtures/builtins/callhandler-number-arg.ts` — a class with a fn-field of shape `((n: number) => void)` invoked via callHandler with an integer literal
- [x] Manually verified multi-arg signatures `(number, string) => void` emit correct bitcast
- [x] `npm test` — 0 failures
- [ ] CI green
