### PR TITLE
fix(codegen): obj.fn() for fn-typed class fields + spawn i8* tracking

### DIFF
--- a/src/codegen/expressions/method-calls/class-dispatch.ts
+++ b/src/codegen/expressions/method-calls/class-dispatch.ts
@@ -21,6 +21,75 @@ export interface InterfaceDefInfo {
   properties: { name: string; type: string }[];
 }
 
+/**
+ * Invoke a function-typed class field as if it were a method: obj.f(args).
+ * Previously this shape errored with "Method f not found in class X" because
+ * method dispatch only looked at declared methods, not function-typed fields.
+ *
+ * Lowers to the same path as the `callHandler(obj.f, ...args)` builtin:
+ * load the i8* field, bitcast to a function pointer whose signature mirrors
+ * the provided arg types, then call. Integer-typed args are promoted to
+ * double to match ChadScript's (number) => ... ABI.
+ */
+export function invokeFunctionTypedField(
+  ctx: MethodCallGeneratorContext,
+  instancePtr: string,
+  className: string,
+  fieldName: string,
+  args: Expression[],
+  params: string[],
+): string {
+  const fieldInfo = ctx.classGenGetFieldInfo(className, fieldName);
+  if (!fieldInfo) {
+    return ctx.emitError(`Field ${fieldName} not found in class ${className}`);
+  }
+
+  // Load the field — the struct slot holds an i8* function pointer.
+  const fieldPtr = ctx.nextTemp();
+  ctx.emit(
+    `${fieldPtr} = getelementptr inbounds %${className}_struct, %${className}_struct* ${instancePtr}, i32 0, i32 ${fieldInfo.index}`,
+  );
+  const fnPtr = ctx.emitLoad("i8*", fieldPtr);
+
+  // Generate each arg, promote numerics to double, emit the bitcast + call.
+  const argValues: string[] = [];
+  const argTypes: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const rawVal = ctx.generateExpression(args[i], params);
+    const lt = ctx.getVariableType(rawVal);
+    let coercedVal = rawVal;
+    let paramTy: string;
+    if (lt === "i64" || lt === "i32" || lt === "i16" || lt === "i8") {
+      const promoted = ctx.nextTemp();
+      ctx.emit(`${promoted} = sitofp ${lt} ${rawVal} to double`);
+      coercedVal = promoted;
+      paramTy = "double";
+    } else if (lt === "i1") {
+      const promoted = ctx.nextTemp();
+      ctx.emit(`${promoted} = uitofp i1 ${rawVal} to double`);
+      coercedVal = promoted;
+      paramTy = "double";
+    } else if (!lt || lt.length === 0) {
+      paramTy = "i8*";
+    } else {
+      paramTy = lt;
+    }
+    argValues.push(coercedVal);
+    argTypes.push(paramTy);
+  }
+
+  const typedFn = ctx.nextTemp();
+  ctx.emit(`${typedFn} = bitcast i8* ${fnPtr} to double (${argTypes.join(", ")})*`);
+
+  const callArgsList: string[] = [];
+  for (let i = 0; i < argValues.length; i++) {
+    callArgsList.push(`${argTypes[i]} ${argValues[i]}`);
+  }
+  const result = ctx.nextTemp();
+  ctx.emit(`${result} = call double ${typedFn}(${callArgsList.join(", ")})`);
+  return result;
+}
+
 export function getInterfaceDecl(
   ctx: MethodCallGeneratorContext,
   name: string,
@@ -783,6 +852,14 @@ export function handleClassMethods(
       }
     }
     if (!resolvedClass) {
+      // No method with this name — maybe it's a function-typed FIELD being
+      // invoked directly (e.g. s.onEvent(msg) where onEvent is typed
+      // `((s: string) => void) | null`). Load the field as i8* and dispatch
+      // the same way callHandler does: bitcast using arg types, then call.
+      const fldInfo = ctx.classGenGetFieldInfo(className, method);
+      if (fldInfo && fldInfo.tsType && fldInfo.tsType.indexOf("=>") !== -1) {
+        return invokeFunctionTypedField(ctx, instancePtr, className, method, expr.args, params);
+      }
       return ctx.emitError(`Method ${method} not found in class ${className}`, expr.loc);
     }
 

--- a/src/codegen/stdlib/child-process.ts
+++ b/src/codegen/stdlib/child-process.ts
@@ -171,6 +171,10 @@ export class ChildProcessGenerator {
     this.ctx.emit(
       `${handle} = call i8* @cs_spawn(i8* ${cmdPtr}, i8** ${argsDataPtr}, i32 ${argsLen}, void (i8*)* @${stdoutFn}, void (i8*)* @${stderrFn}, void (double)* @${exitFn})`,
     );
+    // Track the return as a pointer — without this, class-field-assignment
+    // doesn't recognize the value as pointer-shape and emits a spurious
+    // `inttoptr i32 %h to i8*` which clang rejects (dapweb note #11).
+    this.ctx.setVariableType(handle, "i8*");
     return handle;
   }
 

--- a/tests/fixtures/builtins/class-fn-field-invoke.ts
+++ b/tests/fixtures/builtins/class-fn-field-invoke.ts
@@ -1,0 +1,16 @@
+// @test expectTestPassed
+// obj.fn(args) where fn is a function-typed class field (not a method) —
+// previously errored "Method ${fn} not found in class ${C}" at compile time,
+// forcing users to write `callHandler(obj.fn, ...args)` manually. Now the
+// dispatcher recognizes function-typed fields and lowers directly.
+function onNum(n: number): void {
+  if (n === 42) console.log("TEST_PASSED");
+}
+class S {
+  onEvent: ((n: number) => void) | null = null;
+}
+const s = new S();
+s.onEvent = onNum;
+if (s.onEvent !== null) {
+  s.onEvent(42);
+}

--- a/tests/fixtures/builtins/spawn-handle-to-class-field.ts
+++ b/tests/fixtures/builtins/spawn-handle-to-class-field.ts
@@ -1,0 +1,15 @@
+// @test expectTestPassed
+// Regression for dapweb note #11: spawn() returns i8* handle; storing it
+// into a `handle: string` class field previously emitted a spurious
+// `inttoptr i32 %h to i8*` because spawn's return temp had no tracked
+// LLVM type, making assignment-generator treat it as an integer RHS.
+function onOut(d: string): void {}
+function onErr(d: string): void {}
+function onExit(c: number): void {}
+class SessionState {
+  handle: string = "";
+}
+const s = new SessionState();
+s.handle = child_process.spawn("echo", ["hi"], onOut, onErr, onExit);
+runEventLoop();
+console.log("TEST_PASSED");


### PR DESCRIPTION
Two related fixes unblocking dapweb's per-session class-instance pattern.

## Fix 1 — `obj.fn(args)` for function-typed class fields (dapweb #6)

Before this PR, `s.onEvent(msg)` where `onEvent` is typed `((m: string) => void) | null` errored at compile time:

```
error: Method onEvent not found in class S
```

The method dispatcher only looked up declared methods on the class, not function-typed fields. Users were forced to write `callHandler(s.onEvent, msg)` — working but ugly and requires spelunking to discover.

Fix: when method lookup fails, check whether the class has a field with that name whose declared type contains `=>`. If so, lower to the same path as `callHandler` — load fn-ptr from field slot, bitcast with arg-type matching, call. Integer-typed args get sitofp-promoted to `double` (same logic as #547).

## Fix 2 — spawn() return tracked as i8* (dapweb #11)

`s.handle = child_process.spawn(...)` where `handle: string` wrapped the spawn return in `inttoptr i32 %h to i8*` because assignment-generator couldn't tell the RHS was already a pointer — `generateSpawn` never called `setVariableType(handle, 'i8*')`. One-line fix.

## Test plan

- [x] New fixture `tests/fixtures/builtins/class-fn-field-invoke.ts` (direct fn-field invocation)
- [x] New fixture `tests/fixtures/builtins/spawn-handle-to-class-field.ts` (spawn return → string field)
- [x] `npm test` — 0 failures locally
- [ ] CI green
