### PR TITLE
fix(codegen): module-level let can initialize from a top-level fn reference

### DIFF
--- a/src/analysis/semantic-analyzer.ts
+++ b/src/analysis/semantic-analyzer.ts
@@ -170,6 +170,12 @@ export class SemanticAnalyzer {
       if (fn.name && fn.returnType) {
         this.functionReturnTypes.set(fn.name, fn.returnType);
       }
+      // Hoist function symbols so module-level `let`/`const` initializers
+      // can reference them regardless of source order — matches JS/TS hoist
+      // semantics for top-level `function` declarations.
+      if (fn.name && !this.symbols.get(fn.name)) {
+        this.symbols.set(fn.name, { name: fn.name, type: "object", llvmType: "i8*" });
+      }
     }
 
     for (let _si = 0; _si < this.ast.topLevelStatements.length; _si++) {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -897,6 +897,21 @@ export class CallExpressionGenerator {
       return this.generateClosureCall(expr, params);
     }
 
+    // If expr.name isn't a declared top-level function but IS a bound
+    // variable, treat it as a function-pointer call: load the i8*, bitcast
+    // with arg-type-matching signature, and call indirectly. This is the
+    // same lowering pattern as callHandler / obj.fn(args) and unblocks
+    //   function cb(...) { ... }
+    //   let hook: (...) => void = cb;
+    //   hook(args);  // ← used to emit `call @_cs_hook` (no such symbol)
+    const astFuncLookup = this.getFunctionFromAST(expr.name);
+    if (!astFuncLookup) {
+      const allocaReg = this.ctx.symbolTable.getAlloca(expr.name);
+      if (allocaReg) {
+        return this.generateFunctionPointerCall(expr, params, allocaReg);
+      }
+    }
+
     const resolvedFuncName = this.ctx.resolveImportAlias(expr.name);
     let returnType = "double";
     let paramTypes: string[] = [];
@@ -1107,6 +1122,52 @@ export class CallExpressionGenerator {
     }
 
     return temp;
+  }
+
+  /**
+   * Call a function pointer stored in a variable — e.g. `let cb = namedFn; cb(args)`.
+   * Mirrors the callHandler lowering: load the i8* from the variable's
+   * alloca, bitcast to a function signature whose parameter types are
+   * inferred from the arg values (with integer → double promotion for
+   * ChadScript's number ABI), and call indirectly.
+   */
+  private generateFunctionPointerCall(expr: CallNode, params: string[], allocaReg: string): string {
+    const fnPtr = this.ctx.emitLoad("i8*", allocaReg);
+    const argValues: string[] = [];
+    const argTypes: string[] = [];
+    for (let i = 0; i < expr.args.length; i++) {
+      const rawVal = this.ctx.generateExpression(expr.args[i], params);
+      const lt = this.ctx.getVariableType(rawVal);
+      let coercedVal = rawVal;
+      let paramTy: string;
+      if (lt === "i64" || lt === "i32" || lt === "i16" || lt === "i8") {
+        const promoted = this.ctx.nextTemp();
+        this.ctx.emit(`${promoted} = sitofp ${lt} ${rawVal} to double`);
+        coercedVal = promoted;
+        paramTy = "double";
+      } else if (lt === "i1") {
+        const promoted = this.ctx.nextTemp();
+        this.ctx.emit(`${promoted} = uitofp i1 ${rawVal} to double`);
+        coercedVal = promoted;
+        paramTy = "double";
+      } else if (!lt || lt.length === 0) {
+        paramTy = "i8*";
+      } else {
+        paramTy = lt;
+      }
+      argValues.push(coercedVal);
+      argTypes.push(paramTy);
+    }
+
+    const typedFn = this.ctx.nextTemp();
+    this.ctx.emit(`${typedFn} = bitcast i8* ${fnPtr} to double (${argTypes.join(", ")})*`);
+    const callArgsList: string[] = [];
+    for (let i = 0; i < argValues.length; i++) {
+      callArgsList.push(`${argTypes[i]} ${argValues[i]}`);
+    }
+    const result = this.ctx.nextTemp();
+    this.ctx.emit(`${result} = call double ${typedFn}(${callArgsList.join(", ")})`);
+    return result;
   }
 
   private generateClosureCall(expr: CallNode, params: string[]): string {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2152,6 +2152,22 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         this.emitError(genericErr);
       }
     }
+    // Function reference RHS — `let cb = namedFn` where namedFn is a
+    // top-level function. Must be classified BEFORE the generic type-infer
+    // path below because resolveExpressionType doesn't know function names
+    // are values; it falls through to number/i64. We'd then emit
+    //   store i64 @_cs_fn, i64* @cb
+    // which clang rejects ("global variable reference must have pointer
+    // type"). Allocate as i8* so the store uses pointer shape. (dapweb #2)
+    if (exprNodeType === "variable") {
+      const vn = value as VariableNode;
+      const funcLen = this.ast.functions.length;
+      for (let fi = 0; fi < funcLen; fi++) {
+        if (this.ast.functions[fi].name === vn.name) {
+          return { llvmType: "i8*", kind: SymbolKind_Object, defaultValue: "null" };
+        }
+      }
+    }
     if (
       exprNodeType === "number" ||
       exprNodeType === "boolean" ||

--- a/tests/fixtures/builtins/fn-ref-let-init.ts
+++ b/tests/fixtures/builtins/fn-ref-let-init.ts
@@ -1,0 +1,11 @@
+// @test expectTestPassed
+// Regression for dapweb #2: module-level `let x = namedFn` where namedFn is
+// a top-level function declared anywhere in the file. Previously errored
+// "Reference to undeclared variable 'namedFn'" because the symbol table
+// was populated in source order, missing forward function declarations.
+// Also exercises calling through the resulting function-pointer variable.
+function defaultOnEvent(msg: string): void {
+  if (msg === "hello") console.log("TEST_PASSED");
+}
+let onEvent: (msg: string) => void = defaultOnEvent;
+onEvent("hello");


### PR DESCRIPTION
## Summary

Unblocks dapweb NOTES #2: the 'default no-op handler' pattern.

```ts
function defaultOnEvent(msg: string): void { /* no-op */ }
let onEvent: (msg: string) => void = defaultOnEvent;
onEvent("hi");
```

Before this PR, each of the three lines broke in turn.

## Three coordinated fixes

1. **Semantic hoist** (`src/analysis/semantic-analyzer.ts`). Module-level vars were analyzed before functions, so `defaultOnEvent` wasn't in the symbol table when the initializer resolved. Top-level function names are now hoisted into the symbol table prior to module-var analysis.

2. **Classification** (`src/codegen/llvm-generator.ts`). With the hoist, the slot was classified as `number` (fallback path) and the store emitted `store i64 @_cs_defaultOnEvent, i64* @onEvent` — clang rejected. `classifyGlobalCatchAll` now detects a `variable` RHS whose name matches a top-level function and allocates an `i8*` slot with `SymbolKind_Object`.

3. **Indirect call** (`src/codegen/expressions/calls.ts`). `onEvent("hi")` was still being compiled as a direct call to `@_cs_onEvent` — no such symbol. `generateGenericCall` now falls back to an indirect-call path when `expr.name` has no function AST entry but does have an alloca: load `i8*`, bitcast with arg-type matching, call. Mirrors the callHandler lowering from PR #547 and the obj.fn() lowering from PR #548.

## Test plan

- [x] `tests/fixtures/builtins/fn-ref-let-init.ts` covers all three layers
- [x] `npm test` locally — 0 failures
- [ ] CI green

## Related

Part of the 'same-disease' identifier-leak series (#545, #547, #548, #546, #549). A central identifier-emission helper is the epic-level refactor (task #11), but each specific user-observable bug is worth its own narrow fix first.