### PR TITLE
fix(errors): 'any' param error message points at idiomatic workaround

### DIFF
--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -264,7 +264,13 @@ export function canonicalTypeToLlvm(
   if (mode === "param") {
     if (tsType === "any" || tsType === "unknown") {
       console.error(
-        "error: parameter type '" + tsType + "' is not allowed — add explicit type annotations",
+        "error: parameter type '" +
+          tsType +
+          "' is not allowed — add explicit type annotations. " +
+          "For polymorphic payloads, the idiomatic pattern is to pass a JSON " +
+          "string and let the callee parse with JSON.parse<T>(...) on a " +
+          "discriminant (e.g. a 'kind' or 'event' field). Alternatively use " +
+          "'object' for a generic interface-pointer parameter.",
       );
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

Small but high-leverage UX fix for dapweb NOTES #5. The compiler correctly rejects `any` / `unknown` as parameter types (no concrete LLVM shape at ABI boundaries), but the old error message —

```
error: parameter type 'any' is not allowed — add explicit type annotations
```

— didn't say *what* the explicit annotation should be. dapweb hit this, lost time, landed on 'pass a JSON string + parse on discriminant.' That's the actually-idiomatic pattern for polymorphic payloads (DAP messages, webhook bodies, variant dispatchers), and the compiler should have told them.

## Change

Error text now says:

```
error: parameter type 'any' is not allowed — add explicit type annotations.
For polymorphic payloads, the idiomatic pattern is to pass a JSON string
and let the callee parse with JSON.parse<T>(...) on a discriminant (e.g.
a 'kind' or 'event' field). Alternatively use 'object' for a generic
interface-pointer parameter.
```

## Why not allow `any`?

Tried; allowing `any → i8*` breaks caller-side for non-pointer args (numbers passed as i64 to i8*-typed params, clang rejects). A real solution requires ABI coercion at every call site — substantial change for marginal benefit given the JSON-discriminant pattern already works.

## Test plan

Error-only change; no new compiles succeed or fail — only the wording changes.