### PR TITLE
fix(type-inference): Map.keys()/values() return type on class-instance field

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -855,6 +855,36 @@ export class TypeInference {
           }
         }
       }
+      // Class-instance Map field: e.g. `s.pending.keys()` where
+      // `s: S` and `S.pending: Map<string, V>`. Without this branch the
+      // result defaults to `number` and downstream `.length` errors with
+      // ".length is not available on type 'number'".
+      if (objBase.type === "member_access") {
+        const memExpr = expr.object as MemberAccessNode;
+        const memObjBase = memExpr.object as ExprBase;
+        if (memObjBase.type === "variable") {
+          const instName = (memExpr.object as VariableNode).name;
+          const classInfo = this.st.getClassInfo(instName);
+          if (classInfo && this.ctx.typeResolver) {
+            const fieldInfo = this.ctx.typeResolver.getClassFieldInfo(
+              classInfo.className,
+              memExpr.property,
+            );
+            if (fieldInfo && fieldInfo.tsType && fieldInfo.tsType.startsWith("Map<")) {
+              // Parse "Map<K, V>" — key is between the first '<' and first ','.
+              const lt = fieldInfo.tsType.indexOf("<");
+              const comma = fieldInfo.tsType.indexOf(",");
+              if (lt !== -1 && comma !== -1) {
+                const keyType = fieldInfo.tsType.slice(lt + 1, comma).trim();
+                if (method === "keys" && keyType === "string") {
+                  return this.ctx.typeContext.getArrayType("string");
+                }
+                return this.ctx.typeContext.getArrayType("number");
+              }
+            }
+          }
+        }
+      }
     }
 
     if (method === "values" || method === "entries") {

--- a/tests/fixtures/builtins/class-field-map-keys.ts
+++ b/tests/fixtures/builtins/class-field-map-keys.ts
@@ -1,0 +1,21 @@
+// @test expectTestPassed
+// Previously `s.pending.keys()` on a class-field Map lost return-type
+// tracking and the result defaulted to `number`, making `.length` and
+// for-of iteration fail with '.length is not available on type number'.
+interface Req {
+  seq: number;
+}
+class S {
+  pending: Map<string, Req> = new Map();
+}
+const s = new S();
+s.pending.set("1", { seq: 1 });
+s.pending.set("2", { seq: 2 });
+const ks = s.pending.keys();
+let count = 0;
+for (const k of ks) {
+  count = count + 1;
+}
+if (ks.length === 2 && count === 2) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Summary

dapweb NOTES #7 partial: iterating keys of a class-field Map.

```ts
class S { pending: Map<string, Req> = new Map(); }
const s = new S();
s.pending.set(...);
const ks = s.pending.keys();   // before: ks was typed number
for (const k of ks) { ... }    // before: '.length is not available on type number'
```

The type inference pass knew `<local-var>.keys()` returned `string[]` / `number[]`, but didn't match `<class-instance>.<map-field>.keys()` — result defaulted to `number`.

## Fix

Extended the keys/values branch in `inferMethodCallReturnType` to handle the member-access object shape: look up the variable as a class instance, find the field info, parse `Map<K, V>` from the tsType, return the appropriate array type.

## Test plan

- [x] New fixture: `tests/fixtures/builtins/class-field-map-keys.ts` exercises both `.length` and `for...of`
- [ ] CI green
