### PR TITLE
fix(runtime): line-buffer stdout/stderr so console.log flushes promptly

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -1176,6 +1176,15 @@ export class FunctionGenerator {
 
     ir += "  store i32 %argc, i32* @__argc\n";
     ir += "  store i8** %argv, i8*** @__argv\n";
+    // Line-buffer stdout/stderr so prints flush per line even when the
+    // program is long-running (libuv event loop, servers) or has stdout
+    // redirected to a pipe/file. Otherwise libc full-buffers non-TTY
+    // streams and console.log appears silent until exit — especially
+    // painful for programs pinned in uv_run forever. _IOLBF = 1.
+    ir += "  %__so_lb = load i8*, i8** @stdout\n";
+    ir += "  %__so_lb_r = call i32 @setvbuf(i8* %__so_lb, i8* null, i32 1, i64 0)\n";
+    ir += "  %__se_lb = load i8*, i8** @stderr\n";
+    ir += "  %__se_lb_r = call i32 @setvbuf(i8* %__se_lb, i8* null, i32 1, i64 0)\n";
     ir += "  call void @cs_load_dotenv()\n";
 
     if (outputStr.length > 0) {

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -134,6 +134,11 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
 
   ir += "declare i32 @printf(i8*, ...)\n";
   ir += "declare i32 @fprintf(i8*, i8*, ...)\n";
+  // setvbuf: line-buffer stdout/stderr in main so prints flush per line
+  // when the program is long-running (e.g. pinned in uv_run) or has its
+  // stdout redirected to a pipe / file. Without this, libc defaults to
+  // full buffering on non-TTY streams and console.log is silent until exit.
+  ir += "declare i32 @setvbuf(i8*, i8*, i32, i64)\n";
   const isMac =
     config && config.targetOS ? config.targetOS === "darwin" : process.platform === "darwin";
   if (isMac) {

--- a/tests/fixtures/builtins/stdout-line-buffered.ts
+++ b/tests/fixtures/builtins/stdout-line-buffered.ts
@@ -1,0 +1,12 @@
+// @test expectTestPassed
+// Regression for dapweb NOTES #13: with stdout redirected to a pipe/file
+// and the program pinned inside a long event loop, console.log output was
+// silently buffered (full-buffering on non-TTY) and never appeared until
+// exit. Main now calls setvbuf(..., _IOLBF, 0) on stdout and stderr so
+// each newline-terminated print flushes promptly.
+//
+// The fixture itself just exits fast, so the test harness only verifies
+// that setvbuf doesn't break anything. The real behavior is visible when
+// piping: `./bin > out &; sleep 1; wc -c out` — should show bytes
+// immediately, not only after the child exits.
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

Fixes dapweb NOTES #13 'runtime silence'. Programs that pin inside `uv_run` (HTTP servers, DAP adapter drivers, spawn multiplexers) appeared to emit no `console.log` output when their stdout was redirected — because libc full-buffers non-TTY streams and the buffer only flushed at exit, which never came.

## Evidence

Minimal repro on main:

```ts
console.log("=== start ===");
child_process.spawn("sleep", ["2"], onOut, onErr, onExit);
runEventLoop();
```

```
$ ./repro > out &
$ wc -c out     # during execution
  0 out
$ wait          # program exits
$ wc -c out
  14 out        # bytes appear only at exit
```

Zero bytes during execution, 14 bytes after. Classic full-buffering on redirected stdout.

## Fix

`main` now calls `setvbuf(stdout, NULL, _IOLBF, 0)` and the same for stderr before any user code runs. Matches Node.js default. Negligible cost — two setvbuf calls once at startup.

After this PR, same repro:
```
$ wc -c out     # during execution
  14 out        # flushes per newline
```

## Test plan

- [x] Added `tests/fixtures/builtins/stdout-line-buffered.ts` as a canary (verifies setvbuf doesn't break anything)
- [x] Manual repro confirms bytes now appear during execution with stdout redirected
- [ ] CI green

## Why the smoke test looked like a compiler bug

dapweb's investigation narrowed it to 'smoke.ts-specific, not console.log / spawn / uv_run in isolation.' The confound was that each isolated repro program is fast enough that exit flushes the buffer — so the symptom only manifests in long-running programs under redirected stdout. Classic stdio-buffering trap, not a ChadScript-specific bug, but it was Chadscript's responsibility to configure the defaults sanely.