### PR TITLE
fix(json): JSON.parse<T> with 'any'-typed field stores raw JSON substring

### DIFF
--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -498,6 +498,35 @@ export class JsonGenerator {
           lines.push("  store double %value_" + fieldIndex + ", double* %field_ptr_" + fieldIndex);
           lines.push("  br label %" + nextLabel);
           lines.push("");
+        } else if (fieldType === "any" || fieldType === "unknown") {
+          // `any`/`unknown` field — serialize the JSON value back to its raw
+          // source-text representation and store as a string (i8*). User can
+          // re-parse with JSON.parse<SpecificShape>(field) once they know
+          // the concrete shape from a sibling discriminant (DAP `command`,
+          // JSON-RPC `method`, etc.). This is the most useful semantics for
+          // polymorphic payloads — matches how dapweb's extractField walker
+          // was manually recovering these fields. (dapweb NOTES #12)
+          lines.push("field_" + fieldIndex + "_extract:");
+          lines.push(
+            "  %value_" +
+              fieldIndex +
+              " = call i8* @csyyjson_val_write(i8* %item_" +
+              fieldIndex +
+              ")",
+          );
+          lines.push(
+            "  %field_ptr_" +
+              fieldIndex +
+              " = getelementptr inbounds %" +
+              typeName +
+              ", %" +
+              typeName +
+              "* %struct_ptr, i32 0, i32 " +
+              fieldIndex,
+          );
+          lines.push("  store i8* %value_" + fieldIndex + ", i8** %field_ptr_" + fieldIndex);
+          lines.push("  br label %" + nextLabel);
+          lines.push("");
         } else if (fieldType === "number[]" || fieldType === "string[]") {
           // Array-of-primitive field. Materialize a %Array* / %StringArray*
           // into the field slot from the already-parsed JSON array at %item_N.

--- a/tests/fixtures/builtins/json-parse-any-field.ts
+++ b/tests/fixtures/builtins/json-parse-any-field.ts
@@ -1,0 +1,23 @@
+// @test expectTestPassed
+// Regression for dapweb NOTES #12: JSON.parse<T> where T has an `any`-typed
+// field previously emitted broken IR (`@parse_json_any`). Now the parser
+// stores the raw JSON source-text of the value as an i8* string, enabling
+// the "discriminant dispatch" pattern common in DAP / JSON-RPC / webhook
+// routers: peek at a sibling field, then re-parse the polymorphic payload.
+interface Envelope {
+  command: string;
+  body: any;
+}
+interface LaunchArgs {
+  program: string;
+  args: string[];
+}
+const e = JSON.parse<Envelope>(
+  '{"command":"launch","body":{"program":"/bin/ls","args":["-la","/tmp"]}}',
+);
+let ok = e.command === "launch";
+const args = JSON.parse<LaunchArgs>(e.body);
+ok = ok && args.program === "/bin/ls";
+ok = ok && args.args.length === 2;
+ok = ok && args.args[0] === "-la" && args.args[1] === "/tmp";
+if (ok) console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

Closes dapweb NOTES #12. `any`-typed fields inside a JSON.parse<T> interface previously emitted `@parse_json_any` — broken IR with 'use of undefined type named any'. Now the parser serializes the JSON value's source text back to a string via `csyyjson_val_write` and stores it in the struct slot as `i8*`.

## Why this is useful, not a hack

This is exactly the semantics for polymorphic payload dispatch (DAP, JSON-RPC, webhooks):

```ts
interface Envelope { command: string; body: any; }
const e = JSON.parse<Envelope>(rawWire);
switch (e.command) {
  case "launch": {
    const args = JSON.parse<LaunchArgs>(e.body);  // re-parse raw substring
    runLaunch(args);
    break;
  }
  case "setBreakpoints": {
    const args = JSON.parse<SetBreakpointsArgs>(e.body);
    ...
  }
}
```

dapweb was doing this manually with an `extractField()` walker — now it's native, zero boilerplate.

## Scope note

`any` remains rejected as a parameter type (#5 behavior unchanged). This PR only addresses the interface-field case, where the field type maps to `i8*` anyway — the parser was just missing the generation branch.

## Test plan

- [x] New fixture `tests/fixtures/builtins/json-parse-any-field.ts` covers full envelope-dispatch pattern
- [ ] CI green