### PR TITLE
fix(codegen): .size property on class-instance Map/Set field

### DIFF
--- a/src/codegen/expressions/access/property-handlers.ts
+++ b/src/codegen/expressions/access/property-handlers.ts
@@ -427,8 +427,18 @@ export function handleSizeProperty(
   if (exprObjType === "member_access") {
     const innerAccess = expr.object as MemberAccessNode;
     const innerObjBase = innerAccess.object as ExprBase;
-    const classNameForLookup = ctx.getCurrentClassName();
-    if (innerObjBase.type === "this" && classNameForLookup) {
+    // Resolve the class that owns the field: either `this.X` (own class) or
+    // `<var>.X` where var is a class instance. Both share the same sizing
+    // logic below — previously only `this.X` worked.
+    let classNameForLookup: string | null = null;
+    if (innerObjBase.type === "this") {
+      classNameForLookup = ctx.getCurrentClassName();
+    } else if (innerObjBase.type === "variable") {
+      const varName = (innerAccess.object as VariableNode).name;
+      const classInfo = ctx.symbolTable.getClassInfo(varName);
+      if (classInfo) classNameForLookup = classInfo.className;
+    }
+    if (classNameForLookup) {
       const fieldInfo = ctx.classGenGetFieldInfo(classNameForLookup, innerAccess.property);
       if (fieldInfo && fieldInfo.tsType) {
         const isMap =

--- a/tests/fixtures/builtins/class-field-map-size.ts
+++ b/tests/fixtures/builtins/class-field-map-size.ts
@@ -1,0 +1,15 @@
+// @test expectTestPassed
+// Regression: `s.m.size` / `s.s.size` on a class-instance Map/Set field
+// previously segfaulted because the `.size` property handler only wired
+// up `this.X.size` access. PR #546 fixed method dispatch for the same
+// shape but missed the size-property path.
+class Container {
+  m: Map<string, number> = new Map();
+}
+const c = new Container();
+c.m.set("a", 1);
+c.m.set("b", 2);
+let ok = c.m.size === 2;
+c.m.clear();
+ok = ok && c.m.size === 0;
+if (ok) console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary

The `.size` property handler only looked up the class via `getCurrentClassName()` — correct for `this.X.size` but wrong for `<var>.X.size` where var is a class instance. The latter **segfaulted** (no handler matched, fell through to something that read a bad pointer).

## Fix

In the member-access branch of `handleMapAndSetSize`, resolve `classNameForLookup` from either `this` (current class) OR the variable's `ClassInfo`. Matches the symmetry PR #546 did for Map method dispatch and PR #552 did for keys/values return types.

## Why this was a hole

The `class-field Map API` surface now completes:

| Op | this.X | other.X |
|---|---|---|
| set/get/has/delete | #546 | #546 |
| clear | already worked | already worked |
| keys/values | #552 | #552 |
| **size** | #552 (via same handler) | **THIS PR** |

## Test plan

- [x] New fixture `tests/fixtures/builtins/class-field-map-size.ts` covers size + clear on class-instance Map field
- [x] Local tests green
- [ ] CI green
