### PR TITLE
feat(runtime): C-ABI trampoline closure infrastructure (PR1/4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/pg-bridge.o c_bridges/compress-bridge.o c_bridges/yaml-bridge.o c_bridges/string-ops-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/trampoline-bridge.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/pg-bridge.o c_bridges/compress-bridge.o c_bridges/yaml-bridge.o c_bridges/string-ops-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -291,6 +291,7 @@ jobs:
           cp c_bridges/regex-bridge.o release/lib/
           cp c_bridges/child-process-bridge.o release/lib/
           cp c_bridges/child-process-spawn.o release/lib/
+          cp c_bridges/trampoline-bridge.o release/lib/
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
@@ -366,7 +367,7 @@ jobs:
       - name: Verify vendor libraries
         run: |
           fail=0
-          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/pg-bridge.o c_bridges/compress-bridge.o c_bridges/yaml-bridge.o c_bridges/string-ops-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
+          for lib in vendor/bdwgc/libgc.a vendor/yyjson/libyyjson.a vendor/libuv/build/libuv.a vendor/picohttpparser/picohttpparser.o c_bridges/lws-bridge.o c_bridges/multipart-bridge.o c_bridges/regex-bridge.o c_bridges/child-process-bridge.o c_bridges/child-process-spawn.o c_bridges/trampoline-bridge.o c_bridges/os-bridge.o c_bridges/strlen-cache.o c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o c_bridges/dotenv-bridge.o c_bridges/watch-bridge.o c_bridges/arena-bridge.o c_bridges/curl-bridge.o c_bridges/pg-bridge.o c_bridges/compress-bridge.o c_bridges/yaml-bridge.o c_bridges/string-ops-bridge.o c_bridges/llvm-bridge.o c_bridges/llvm-builder-bridge.o c_bridges/lld-bridge.o; do
             if [ ! -f "$lib" ]; then
               echo "MISSING: $lib"
               fail=1
@@ -436,6 +437,7 @@ jobs:
           cp c_bridges/regex-bridge.o release/lib/
           cp c_bridges/child-process-bridge.o release/lib/
           cp c_bridges/child-process-spawn.o release/lib/
+          cp c_bridges/trampoline-bridge.o release/lib/
           cp c_bridges/os-bridge.o c_bridges/strlen-cache.o release/lib/
           cp c_bridges/time-bridge.o c_bridges/base64-bridge.o c_bridges/url-bridge.o c_bridges/uri-bridge.o release/lib/
           cp c_bridges/dotenv-bridge.o release/lib/
@@ -512,6 +514,7 @@ jobs:
             regex-bridge.o \
             child-process-bridge.o \
             child-process-spawn.o \
+            trampoline-bridge.o \
             os-bridge.o \
             strlen-cache.o \
             time-bridge.o \

--- a/c_bridges/trampoline-bridge.c
+++ b/c_bridges/trampoline-bridge.c
@@ -1,0 +1,147 @@
+// trampoline-bridge.c — slot table for C-ABI trampoline closures.
+//
+// Motivation: ChadScript closures capture env by value, but many C APIs take
+// a bare function pointer with no env param (e.g. libuv timer callbacks).
+// The slot table lets the runtime stash a closure env and pass an integer
+// handle where a C callback normally expects `void*`. A per-shape trampoline
+// (emitted in LLVM IR) recovers the env via cs_tramp_get(handle) before
+// calling the user lambda.
+//
+// PR1 scope: allocator only. Trampoline emission and bridge wiring land in
+// later PRs. See §3 of the closure-CABI plan doc for design rationale.
+
+#include "trampoline-bridge.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef NDEBUG
+#include <assert.h>
+#endif
+
+extern void *GC_malloc_uncollectable(size_t);
+extern void *GC_realloc(void *, size_t);
+extern void GC_free(void *);
+
+// Single-threaded assumption (libuv event loop). A future
+// -DCS_TRAMP_MT build would need a mutex around alloc/free/growth.
+// TODO(CS_TRAMP_MT): guard these with a mutex when we support threads.
+
+#define CS_TRAMP_INITIAL_CAP 1024
+#define CS_TRAMP_MAX_CAP (1 << 20)
+
+static void **g_slots = NULL;        // env pointers (NULL = free)
+static int32_t *g_freelist = NULL;   // stack of free indices
+static int32_t g_freelist_len = 0;   // number of entries in freelist
+static int32_t g_cap = 0;            // current capacity of g_slots
+static int32_t g_next = 0;           // next fresh slot index (never reused)
+static int32_t g_live = 0;           // live-slot count (observability)
+
+// Grow g_slots to new_cap. Returns 0 on success, -1 on OOM / cap exceeded.
+// Uses GC_malloc_uncollectable so Boehm scans env pointers conservatively
+// but doesn't collect the table itself. Freelist is a plain malloc block —
+// it stores ints, no pointers to trace.
+static int cs_tramp_grow(int32_t new_cap) {
+    if (new_cap > CS_TRAMP_MAX_CAP) {
+        return -1;
+    }
+    void **new_slots;
+    if (g_slots == NULL) {
+        new_slots = (void **)GC_malloc_uncollectable((size_t)new_cap * sizeof(void *));
+        if (new_slots == NULL) return -1;
+        memset(new_slots, 0, (size_t)new_cap * sizeof(void *));
+    } else {
+        new_slots = (void **)GC_realloc(g_slots, (size_t)new_cap * sizeof(void *));
+        if (new_slots == NULL) return -1;
+        // Zero the newly-grown tail so probing a fresh slot returns NULL.
+        memset(new_slots + g_cap, 0, (size_t)(new_cap - g_cap) * sizeof(void *));
+    }
+    g_slots = new_slots;
+
+    // Freelist holds raw ints — plain realloc is fine.
+    int32_t *new_fl = (int32_t *)realloc(g_freelist, (size_t)new_cap * sizeof(int32_t));
+    if (new_fl == NULL) return -1;
+    g_freelist = new_fl;
+
+    g_cap = new_cap;
+    return 0;
+}
+
+int32_t cs_tramp_alloc(void *env) {
+    // Fast path: pop a recycled slot.
+    if (g_freelist_len > 0) {
+        int32_t h = g_freelist[--g_freelist_len];
+        g_slots[h] = env;
+        g_live++;
+        return h;
+    }
+
+    // No recycled slot — grow if we're out of fresh indices.
+    if (g_next >= g_cap) {
+        int32_t new_cap = g_cap == 0 ? CS_TRAMP_INITIAL_CAP : g_cap * 2;
+        if (new_cap > CS_TRAMP_MAX_CAP) new_cap = CS_TRAMP_MAX_CAP;
+        if (new_cap <= g_cap) {
+            // Already at hard cap.
+            return -1;
+        }
+        if (cs_tramp_grow(new_cap) != 0) {
+            return -1;
+        }
+    }
+
+    int32_t h = g_next++;
+    g_slots[h] = env;
+    g_live++;
+    return h;
+}
+
+void *cs_tramp_get(int32_t handle) {
+    if (handle < 0 || handle >= g_next) return NULL;
+    return g_slots[handle];
+}
+
+void cs_tramp_free(int32_t handle) {
+    if (handle < 0 || handle >= g_next) {
+#ifndef NDEBUG
+        // Handle out of range — almost certainly a double-free bug in the
+        // caller. Debug builds trip the assert; release silently no-ops so
+        // a stray clearTimeout() on an already-fired timer can't crash.
+        assert(0 && "cs_tramp_free: handle out of range");
+#endif
+        return;
+    }
+    if (g_slots[handle] == NULL) {
+        // Already freed — idempotent no-op.
+        return;
+    }
+    g_slots[handle] = NULL;
+    g_freelist[g_freelist_len++] = handle;
+    if (g_live > 0) g_live--;
+}
+
+int32_t cs_tramp_stats(void) {
+    return g_live;
+}
+
+// --- ChadScript-ABI wrappers ---
+// The ChadScript `number` type lowers to LLVM `double`, so `declare function`
+// calls bind through these `double`-typed shims. Codegen-generated trampoline
+// call sites will use the `int32_t` API above directly.
+double cs_tramp_alloc_d(void *env) {
+    return (double)cs_tramp_alloc(env);
+}
+
+void *cs_tramp_get_d(double handle) {
+    return cs_tramp_get((int32_t)handle);
+}
+
+void cs_tramp_free_d(double handle) {
+    cs_tramp_free((int32_t)handle);
+}
+
+double cs_tramp_stats_d(void) {
+    return (double)cs_tramp_stats();
+}

--- a/c_bridges/trampoline-bridge.h
+++ b/c_bridges/trampoline-bridge.h
@@ -1,0 +1,37 @@
+#ifndef CS_TRAMPOLINE_BRIDGE_H
+#define CS_TRAMPOLINE_BRIDGE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Allocate a slot holding `env`. Returns a non-negative handle, or -1 if
+// the slot table has hit its hard cap (1 << 20 entries).
+int32_t cs_tramp_alloc(void *env);
+
+// Read-only lookup. Returns NULL for out-of-range or freed handles.
+void *cs_tramp_get(int32_t handle);
+
+// Idempotent — safe to call twice. NULLs the slot and pushes it back
+// onto the freelist.
+void cs_tramp_free(int32_t handle);
+
+// Debug observability: returns the number of currently-live slots.
+int32_t cs_tramp_stats(void);
+
+// --- ChadScript-ABI wrappers ---
+// ChadScript `number` lowers to `double`; these shims let `declare function`
+// bindings call the slot table without ABI mismatch. Codegen-emitted internal
+// call sites use the int32 API above directly.
+double cs_tramp_alloc_d(void *env);
+void *cs_tramp_get_d(double handle);
+void cs_tramp_free_d(double handle);
+double cs_tramp_stats_d(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/scripts/build-target-sdk.sh
+++ b/scripts/build-target-sdk.sh
@@ -69,7 +69,7 @@ fi
 
 # Copy C bridge object files
 echo "  Copying bridge objects..."
-for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o arena-bridge.o curl-bridge.o pg-bridge.o compress-bridge.o yaml-bridge.o string-ops-bridge.o llvm-bridge.o llvm-builder-bridge.o lld-bridge.o; do
+for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o trampoline-bridge.o arena-bridge.o curl-bridge.o pg-bridge.o compress-bridge.o yaml-bridge.o string-ops-bridge.o llvm-bridge.o llvm-builder-bridge.o lld-bridge.o; do
   if [ -f "$C_BRIDGES_DIR/$bridge" ]; then
     cp "$C_BRIDGES_DIR/$bridge" "$SDK_DIR/bridges/"
   fi

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -451,6 +451,18 @@ else
   echo "==> child-process-spawn already built, skipping"
 fi
 
+# --- trampoline-bridge (C-ABI closure slot table) ---
+TRAMP_SRC="$C_BRIDGES_DIR/trampoline-bridge.c"
+TRAMP_OBJ="$C_BRIDGES_DIR/trampoline-bridge.o"
+TRAMP_HDR="$C_BRIDGES_DIR/trampoline-bridge.h"
+if [ ! -f "$TRAMP_OBJ" ] || [ "$TRAMP_SRC" -nt "$TRAMP_OBJ" ] || [ "$TRAMP_HDR" -nt "$TRAMP_OBJ" ]; then
+  echo "==> Building trampoline-bridge..."
+  cc -c -O2 -fPIC "$TRAMP_SRC" -o "$TRAMP_OBJ"
+  echo "  -> $TRAMP_OBJ"
+else
+  echo "==> trampoline-bridge already built, skipping"
+fi
+
 # --- tree-sitter ---
 if [ ! -f "$VENDOR_DIR/tree-sitter/libtree-sitter.a" ]; then
   echo "==> Building tree-sitter..."

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -814,6 +814,14 @@ export interface IGeneratorContext {
   } | null;
 
   /**
+   * Whether the current compilation uses C-ABI trampoline closures
+   * (slot-table bridge for callbacks that need env recovery).
+   */
+  usesTrampolines: number;
+  setUsesTrampolines(value: boolean): void;
+  getUsesTrampolines(): boolean;
+
+  /**
    * Whether the current compilation uses timers (setTimeout/setInterval)
    */
   usesTimers: number;
@@ -1053,6 +1061,7 @@ export class MockGeneratorContext implements IGeneratorContext {
   public typeChecker: TypeChecker | null = null;
   public typeResolver?: TypeResolver;
   public usesPromises: number = 0;
+  public usesTrampolines: number = 0;
   public usesTimers: number = 0;
   public usesSqlite: number = 0;
   public usesCurl: number = 0;
@@ -1257,6 +1266,12 @@ export class MockGeneratorContext implements IGeneratorContext {
     promisePtr: string;
   } | null {
     return null;
+  }
+  setUsesTrampolines(value: boolean): void {
+    this.usesTrampolines = value ? 1 : 0;
+  }
+  getUsesTrampolines(): boolean {
+    return this.usesTrampolines !== 0;
   }
   setUsesTimers(value: boolean): void {
     this.usesTimers = value ? 1 : 0;

--- a/src/codegen/infrastructure/trampoline-emitter.ts
+++ b/src/codegen/infrastructure/trampoline-emitter.ts
@@ -1,0 +1,130 @@
+// trampoline-emitter.ts — per-shape C-ABI trampoline generator.
+//
+// A trampoline takes an env pointer plus the shape's native args and forwards
+// to a user function pointer stored inside the env struct. One trampoline is
+// generated per unique LLVM callback signature; shapes are deduped by
+// canonicalized `llvmSig`.
+//
+// PR1 scope: emit standalone trampoline functions that assume env is passed
+// as the first argument. Bridges in later PRs will provide the shim that
+// recovers env from the slot table (cs_tramp_get) before calling the
+// trampoline — this file doesn't know about that yet.
+
+export interface TrampolineShape {
+  // Canonical LLVM signature string, e.g. "void(i8*)" or "void(i8*,double)".
+  // Used as the dedup key. Does NOT include the env parameter — that's
+  // implicit for every trampoline.
+  llvmSig: string;
+  // Ordered arg LLVM types for the C-ABI callback (excluding env).
+  argTypes: string[];
+  // Always "void" in PR1. Return-value closures aren't wired up yet.
+  returnType: string;
+}
+
+export class TrampolineEmitter {
+  private shapes: Map<string, TrampolineShape> = new Map();
+  private shapeIds: Map<string, string> = new Map();
+
+  // Register a shape. Idempotent by llvmSig. Returns the fully-qualified
+  // LLVM function name (e.g. `@__cs_tramp_void_i8p_double`) that bridges
+  // should point at.
+  ensureTrampoline(shape: TrampolineShape): string {
+    const existing = this.shapeIds.get(shape.llvmSig);
+    if (existing !== undefined) return existing;
+    const id = this.shapeIdFromSig(shape);
+    const name = "@__cs_tramp_" + id;
+    this.shapes.set(shape.llvmSig, shape);
+    this.shapeIds.set(shape.llvmSig, name);
+    return name;
+  }
+
+  // Emit every registered trampoline definition plus its env struct type.
+  // Call once at module end. Idempotent output — emitting twice is wasteful
+  // but not wrong.
+  emitAll(): string {
+    if (this.shapes.size === 0) return "";
+    let ir = "";
+    ir += "; --- C-ABI trampoline closures (per-shape dispatch) ---\n";
+    ir += "; TODO(PR2): trampolines currently assume env is delivered as the\n";
+    ir += ";            first arg. Future bridges will recover env via\n";
+    ir += ";            cs_tramp_get(handle) and invoke these directly.\n";
+    for (const shape of this.shapes.values()) {
+      ir += this.emitOne(shape);
+    }
+    return ir;
+  }
+
+  // Visible for tests.
+  listRegisteredNames(): string[] {
+    return Array.from(this.shapeIds.values());
+  }
+
+  // Derive a safe identifier fragment from the shape. Maps pointer `*` to
+  // `p`, commas to `_`, parens to nothing. "void(i8*,double)" -> "void_i8p_double".
+  private shapeIdFromSig(shape: TrampolineShape): string {
+    let id = shape.returnType;
+    for (const t of shape.argTypes) {
+      id += "_" + this.sanitizeType(t);
+    }
+    return id;
+  }
+
+  private sanitizeType(t: string): string {
+    let out = "";
+    for (let i = 0; i < t.length; i++) {
+      const ch = t.charAt(i);
+      if (ch === "*") out += "p";
+      else if (ch === " ") continue;
+      else if (ch === ",") out += "_";
+      else out += ch;
+    }
+    return out;
+  }
+
+  private emitOne(shape: TrampolineShape): string {
+    const id = this.shapeIdFromSig(shape);
+    const envTy = "%__TrampEnv_S_" + id;
+    const fnTy = this.userFnType(shape);
+
+    // Env struct: { user_env_ptr, user_fn_ptr }. Both are i8* / function-ptr.
+    let ir = "";
+    ir += envTy + " = type { i8*, " + fnTy + " }\n";
+    ir += "define " + shape.returnType + " @__cs_tramp_" + id + "(";
+    ir += "i8* %env";
+    for (let i = 0; i < shape.argTypes.length; i++) {
+      ir += ", " + shape.argTypes[i] + " %arg" + i.toString();
+    }
+    ir += ") {\n";
+    ir += "entry:\n";
+    ir += "  %e = bitcast i8* %env to " + envTy + "*\n";
+    ir += "  %ufp = getelementptr inbounds " + envTy + ", " + envTy + "* %e, i32 0, i32 0\n";
+    ir += "  %ue = load i8*, i8** %ufp\n";
+    ir += "  %fp = getelementptr inbounds " + envTy + ", " + envTy + "* %e, i32 0, i32 1\n";
+    ir += "  %fn = load " + fnTy + ", " + fnTy + "* %fp\n";
+    ir += "  ";
+    if (shape.returnType === "void") {
+      ir += "call void %fn(i8* %ue";
+    } else {
+      ir += "%r = call " + shape.returnType + " %fn(i8* %ue";
+    }
+    for (let i = 0; i < shape.argTypes.length; i++) {
+      ir += ", " + shape.argTypes[i] + " %arg" + i.toString();
+    }
+    ir += ")\n";
+    if (shape.returnType === "void") {
+      ir += "  ret void\n";
+    } else {
+      ir += "  ret " + shape.returnType + " %r\n";
+    }
+    ir += "}\n\n";
+    return ir;
+  }
+
+  // User function takes i8* env first, then the shape's native args.
+  private userFnType(shape: TrampolineShape): string {
+    let t = shape.returnType + " (i8*";
+    for (const a of shape.argTypes) t += ", " + a;
+    t += ")*";
+    return t;
+  }
+}

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -250,6 +250,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   private wsHandlers: string[];
   public usesTimers: number = 0;
   public usesPromises: number = 0;
+  public usesTrampolines: number = 0;
   public usesSqlite: number = 0;
   public usesCurl: number = 0;
   public usesUvHrtime: number = 0;
@@ -896,6 +897,12 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     if (this.promiseExecutorStack.length === 0) return null;
     return this.promiseExecutorStack[this.promiseExecutorStack.length - 1];
   }
+  public setUsesTrampolines(value: boolean): void {
+    this.usesTrampolines = value ? 1 : 0;
+  }
+  public getUsesTrampolines(): boolean {
+    return this.usesTrampolines !== 0;
+  }
   public setUsesTimers(value: boolean): void {
     this.usesTimers = value ? 1 : 0;
   }
@@ -1467,6 +1474,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     this.dbgBuilder = new DebugMetadataBuilder();
     this.usesTimers = 0;
     this.usesPromises = 0;
+    this.usesTrampolines = 0;
     this.usesSqlite = 0;
     this.usesCurl = 0;
     this.usesUvHrtime = 0;
@@ -3354,6 +3362,16 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       if (promiseDecls) {
         finalParts.push(this.filterDuplicateDeclarations(promiseDecls));
       }
+      finalParts.push("\n");
+    }
+
+    if (this.usesTrampolines) {
+      let trampDecls = "";
+      trampDecls += "; C-ABI trampoline slot table (trampoline-bridge.c)\n";
+      trampDecls += "declare i32 @cs_tramp_alloc(i8*)\n";
+      trampDecls += "declare i8* @cs_tramp_get(i32)\n";
+      trampDecls += "declare void @cs_tramp_free(i32)\n";
+      finalParts.push(this.filterDuplicateDeclarations(trampDecls));
       finalParts.push("\n");
     }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -469,6 +469,7 @@ export function compile(
     : "";
   const watchBridgeObj = `${bridgePath}/watch-bridge.o`;
   const arenaBridgeObj = `${bridgePath}/arena-bridge.o`;
+  const trampBridgeObj = `${bridgePath}/trampoline-bridge.o`;
   const cpSpawnObj = generator.getUsesSpawn() ? `${bridgePath}/child-process-spawn.o` : "";
   const curlBridgeObj = generator.usesCurl ? `${bridgePath}/curl-bridge.o` : "";
   const pgBridgeObj = usesPostgres ? `${bridgePath}/pg-bridge.o` : "";
@@ -637,7 +638,7 @@ export function compile(
   const userObjs = extraLinkObjs.length > 0 ? " " + extraLinkObjs.join(" ") : "";
   const userPaths = extraLinkPaths.map((p) => ` -L${p}`).join("");
   const userLibs = extraLinkLibs.map((l) => ` -l${l}`).join("");
-  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${strlenCacheObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${arenaBridgeObj} ${cpSpawnObj} ${curlBridgeObj} ${pgBridgeObj} ${compressBridgeObj} ${yamlBridgeObj} ${stringOpsBridgeObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${suppressLdWarnings}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
+  const linkCmd = `${linker} ${objFile} ${lwsBridgeObj} ${regexBridgeObj} ${cpBridgeObj} ${osBridgeObj} ${strlenCacheObj} ${timeBridgeObj} ${base64BridgeObj} ${urlBridgeObj} ${uriBridgeObj} ${dotenvBridgeObj} ${watchBridgeObj} ${arenaBridgeObj} ${trampBridgeObj} ${cpSpawnObj} ${curlBridgeObj} ${pgBridgeObj} ${compressBridgeObj} ${yamlBridgeObj} ${stringOpsBridgeObj}${extraObjs}${userObjs} -o ${outputFile}${noPie}${debugFlag}${stripFlag}${staticFlag}${crossTarget}${crossLinker}${suppressLdWarnings}${sanitizeFlags} ${linkLibs}${userPaths}${userLibs}`;
   logger.info(` ${linkCmd}`);
   const linkStdio = logger.getLevel() >= LogLevel_Verbose ? "inherit" : "pipe";
   execSync(linkCmd, { stdio: linkStdio });

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -703,6 +703,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
   const dotenvBridgeObj = fs.existsSync(dotenvBridgePath) ? dotenvBridgePath : "";
   const watchBridgeObj = effectiveBridgePath + "/watch-bridge.o";
   const arenaBridgeObj = effectiveBridgePath + "/arena-bridge.o";
+  const trampBridgeObj = effectiveBridgePath + "/trampoline-bridge.o";
   const cpSpawnObj = generator.getUsesSpawn() ? effectiveBridgePath + "/child-process-spawn.o" : "";
   const curlBridgeObj = generator.getUsesCurl() ? effectiveBridgePath + "/curl-bridge.o" : "";
   const pgBridgeObj = usesPostgres ? effectiveBridgePath + "/pg-bridge.o" : "";
@@ -764,6 +765,8 @@ export function compileNative(inputFile: string, outputFile: string): void {
     watchBridgeObj +
     " " +
     arenaBridgeObj +
+    " " +
+    trampBridgeObj +
     " " +
     cpSpawnObj +
     " " +

--- a/tests/fixtures/closures-cabi/trampoline-bridge-smoke.ts
+++ b/tests/fixtures/closures-cabi/trampoline-bridge-smoke.ts
@@ -1,0 +1,21 @@
+// @test-description: trampoline bridge alloc/get/free round-trip — PR1 wiring smoke
+// PR1: proves trampoline-bridge.o is linked and cs_tramp_alloc/get/free
+// round-trip correctly. No closures yet — PR2 wires these to cs_spawn.
+// The `_d` suffix shims wrap the int32 API for ChadScript's double-based
+// `number` ABI — codegen-emitted call sites will use the int32 entry points.
+declare function cs_tramp_alloc_d(env: string): number;
+declare function cs_tramp_get_d(handle: number): string;
+declare function cs_tramp_free_d(handle: number): void;
+
+const h = cs_tramp_alloc_d("hello");
+if (h < 0) {
+  console.log("FAIL: alloc returned " + h.toString());
+} else {
+  const got = cs_tramp_get_d(h);
+  cs_tramp_free_d(h);
+  if (got === "hello") {
+    console.log("TEST_PASSED");
+  } else {
+    console.log("FAIL: got " + got);
+  }
+}

--- a/tests/unit/trampoline-emitter.test.ts
+++ b/tests/unit/trampoline-emitter.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { TrampolineEmitter } from "../../src/codegen/infrastructure/trampoline-emitter.js";
+
+describe("TrampolineEmitter", () => {
+  it("deduplicates identical shapes", () => {
+    const e = new TrampolineEmitter();
+    const a = e.ensureTrampoline({
+      llvmSig: "void(i8*)",
+      argTypes: ["i8*"],
+      returnType: "void",
+    });
+    const b = e.ensureTrampoline({
+      llvmSig: "void(i8*)",
+      argTypes: ["i8*"],
+      returnType: "void",
+    });
+    assert.strictEqual(a, b);
+    assert.strictEqual(e.listRegisteredNames().length, 1);
+  });
+
+  it("emits distinct functions for distinct shapes", () => {
+    const e = new TrampolineEmitter();
+    const a = e.ensureTrampoline({
+      llvmSig: "void(i8*)",
+      argTypes: ["i8*"],
+      returnType: "void",
+    });
+    const b = e.ensureTrampoline({
+      llvmSig: "void(i8*,double)",
+      argTypes: ["i8*", "double"],
+      returnType: "void",
+    });
+    assert.notStrictEqual(a, b);
+    assert.strictEqual(e.listRegisteredNames().length, 2);
+  });
+
+  it("emitAll contains the registered function names", () => {
+    const e = new TrampolineEmitter();
+    const name = e.ensureTrampoline({
+      llvmSig: "void(i8*,double)",
+      argTypes: ["i8*", "double"],
+      returnType: "void",
+    });
+    const ir = e.emitAll();
+    // `name` is like "@__cs_tramp_void_i8p_double"; the `define` strips the leading @
+    const bareName = name.substring(1);
+    assert.ok(
+      ir.includes("define void @" + bareName + "("),
+      "emitAll output should contain the trampoline definition",
+    );
+    assert.ok(ir.includes("%__TrampEnv_S_void_i8p_double"), "env struct type should be emitted");
+    assert.ok(ir.includes("ret void"));
+  });
+
+  it("emitAll is empty when no shapes were registered", () => {
+    const e = new TrampolineEmitter();
+    assert.strictEqual(e.emitAll(), "");
+  });
+});


### PR DESCRIPTION
## Summary

Infrastructure-only PR — **zero user-facing surface**. Lays the groundwork for
C-ABI trampoline closures so later PRs can pass ChadScript arrows to callbacks
that take bare function pointers (libuv, timers, spawn). See §3 of the
closure-CABI plan doc for full design rationale.

- New `c_bridges/trampoline-bridge.c` — O(1) slot table for closure env pointers,
  2^20 hard cap, clean `-1` error on exhaustion, `GC_malloc_uncollectable` so
  Boehm scans env pointers conservatively without collecting the table itself.
  Debug builds trip `assert(0)` on a double-free / stray dead handle; release
  is a silent no-op (matches decision #2 in the plan).
- New `TrampolineEmitter` in `src/codegen/infrastructure/` — per-shape LLVM IR
  generator, dedups on canonical signature, returns the trampoline name so
  call sites can point at it. Carries a TODO marker for PR2 where bridges will
  recover env via `cs_tramp_get` instead of the first-arg shim.
- Feature flag plumbing (`usesTrampolines` / `getUsesTrampolines`) on both the
  real `LLVMGenerator` and `MockGeneratorContext`, mirroring `usesPromises`.
- Conditional `declare` block for `@cs_tramp_alloc/get/free` gated by the flag.
- Unconditional link of `trampoline-bridge.o` (slot table is tiny; this PR keeps
  things simple — PR2 can gate it if needed).

## Scope guardrails

- **Not wired** to `cs_spawn`, `setTimeout`, or any user-facing API. PR2 wires
  spawn; PR3 wires timers; PR4 sweeps remaining bridges.
- No changes to `closure-mutation-checker.ts`, no fat-pointer fn values, no
  heap-boxed let.

## Test plan

- [x] Unit tests for `TrampolineEmitter` (dedup, distinct shapes, emitAll output)
- [x] Integration smoke fixture (`tests/fixtures/closures-cabi/trampoline-bridge-smoke.ts`)
      that round-trips alloc/get/free to confirm the bridge is built, linked,
      and behaves — no codegen trampoline yet (that's PR2)
- [x] `npm run verify:quick` green locally
- [x] New bridge wired into all four CI copy sites + SDK + build-vendor