### PR TITLE
fix(http): 3-arg httpServe accepted; wsBroadcast/wsSend usable without wsHandler

### DIFF
--- a/lib/http.ts
+++ b/lib/http.ts
@@ -46,7 +46,11 @@ export function parseCookies(cookieHeader: string): Map<string, string> {
   return result;
 }
 
-export function httpServe(port: number, handler: (req: HttpRequest) => HttpResponse): void {}
+export function httpServe(
+  port: number,
+  handler: (req: HttpRequest) => HttpResponse,
+  wsHandler?: (event: WsEvent) => string,
+): void {}
 export function wsBroadcast(message: string): void {}
 export function wsSend(connId: string, message: string): void {}
 export function parseMultipart(req: HttpRequest): MultipartPart[] {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -259,6 +259,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public usesCrypto: number = 0;
   public usesJson: number = 0;
   public usesHttpServer: number = 0;
+  public usesWsPrimitives: number = 0;
   public usesMultipart: number = 0;
   public usesRegex: number = 0;
   public usesTestRunner: number = 0;
@@ -3177,7 +3178,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       if (eventHandler) {
         irParts.push(eventHandler);
       }
-      if (wsHandler) {
+      // Emit the WS server→client primitives whenever the program either
+      // registered a wsHandler OR directly called wsBroadcast / wsSend.
+      // Previously only the former triggered emission, causing
+      // "undefined value @__ws_broadcast" at link time for push-only apps.
+      if (wsHandler || this.usesWsPrimitives) {
         irParts.push("\n");
         irParts.push(this.httpServerGen.generateWsBroadcastFunction());
         irParts.push(this.httpServerGen.generateWsSendToFunction());
@@ -4593,6 +4598,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     if (expr.args.length < 1) {
       return this.emitError("wsBroadcast() requires 1 argument: message string", expr.loc);
     }
+    // Mark that this program calls a WS primitive directly so the module
+    // finalizer emits @__ws_broadcast (previously gated behind wsHandler
+    // presence, which broke server→client push when the app didn't accept
+    // incoming WS messages).
+    this.usesWsPrimitives = 1;
     const msgValue = this.generateExpression(expr.args[0], params);
     const len = this.nextTemp();
     this.emit(`${len} = call i64 @strlen(i8* ${msgValue})`);
@@ -4604,6 +4614,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     if (expr.args.length < 2) {
       return this.emitError("wsSend() requires 2 arguments: connId, message", expr.loc);
     }
+    this.usesWsPrimitives = 1;
     const connIdValue = this.generateExpression(expr.args[0], params);
     const msgValue = this.generateExpression(expr.args[1], params);
     const len = this.nextTemp();

--- a/src/semantic/safety-checks.ts
+++ b/src/semantic/safety-checks.ts
@@ -497,8 +497,25 @@ export function checkArgumentCounts(ast: AST, sourceCode: string): void {
 
   for (let i = 0; i < ast.functions.length; i++) {
     const fn = ast.functions[i];
-    if (state.lookup(fn.name) >= 0) {
-      state.dupNames.push(fn.name);
+    const existingIdx = state.lookup(fn.name);
+    if (existingIdx >= 0) {
+      // Overload: merge min/max across all signatures so a caller passing
+      // an arg count valid for ANY signature is accepted. Previously we
+      // skipped duplicates entirely, leaving the arity constraints of the
+      // first-seen signature as authoritative — which silently broke
+      // 3-arg httpServe (only 2-arg overload's max=2 was kept). Without
+      // this, the declared 3-arg form in chadscript.d.ts was unreachable.
+      if (argHasRest(fn)) {
+        // Rest params effectively unbound upper — drop constraint entirely.
+        state.names.splice(existingIdx, 1);
+        state.mins.splice(existingIdx, 1);
+        state.maxes.splice(existingIdx, 1);
+      } else {
+        const newMin = argCountMin(fn);
+        const newMax = argCountMax(fn);
+        if (newMin < state.mins[existingIdx]) state.mins[existingIdx] = newMin;
+        if (newMax > state.maxes[existingIdx]) state.maxes[existingIdx] = newMax;
+      }
       continue;
     }
     if (argHasRest(fn)) continue;

--- a/tests/fixtures/builtins/ws-broadcast-without-handler.ts
+++ b/tests/fixtures/builtins/ws-broadcast-without-handler.ts
@@ -1,0 +1,14 @@
+// @test-skip
+// Compiles a program that calls wsBroadcast from an HTTP handler without
+// registering any wsHandler. Previously this linked-errored with
+// 'use of undefined value @__ws_broadcast' because the primitive was only
+// emitted when a wsHandler was present. Test is @test-skip because it
+// binds port 3000 — smoke-only. The regression we want is that it compiles.
+import { httpServe, wsBroadcast } from "chadscript/http";
+
+function httpHandler(req: HttpRequest): HttpResponse {
+  wsBroadcast("server push");
+  return { status: 200, body: "ok", contentType: "text/plain", headers: "", bodyLen: 0 };
+}
+
+httpServe(3000, httpHandler);


### PR DESCRIPTION
## Summary

Closes dapweb NOTES **#15** — two symptoms, one fix each, unblocks phase-4a push-first architecture.

### Symptom A — 3-arg httpServe rejected

```
error: function 'httpServe' expects at most 2 argument(s) but got 3
```

`chadscript.d.ts` declared both overloads, but `lib/http.ts` (which actually lands in `ast.functions` when imported from `chadscript/http`) only had the 2-arg signature. Added the optional `wsHandler` param so arity check sees min=2, max=3.

### Symptom B — wsBroadcast/wsSend emission gated on wsHandler

```
/tmp/dapbus.ll:4828:13: error: use of undefined value '@__ws_broadcast'
```

`generateWsBroadcastFunction` / `generateWsSendToFunction` were emitted only when a wsHandler was registered. But server→client push is a separate use case — apps that only broadcast shouldn't need to accept incoming WS messages too.

Added `usesWsPrimitives` flag, set on any `wsBroadcast`/`wsSend` call. Emit the definitions whenever either `wsHandler` OR the flag is set.

### Bonus — overload merging in safety-checks

`checkArgumentCounts` previously skipped duplicate function names entirely (treating them as ambiguous). Now merges min/max across all signatures, future-proofing the overload path for other stdlib multi-signature declarations.

## Test plan

- [x] 3-arg `httpServe(port, handler, wsHandler)` compiles + runs
- [x] `wsBroadcast` from handler without wsHandler compiles + links (new fixture `ws-broadcast-without-handler.ts`)
- [x] Existing 2-arg `httpServe` unchanged
- [ ] CI green