### PR TITLE
fix(semantic): allow async calls as bare statement (fire-and-forget)

### DIFF
--- a/src/semantic/async-await-checker.ts
+++ b/src/semantic/async-await-checker.ts
@@ -147,17 +147,24 @@ class AsyncAwaitChecker {
     } else if (stype === "block") {
       this.walkBlock(stmt as BlockStatement, insideAsync);
     } else if (stype !== "break" && stype !== "continue") {
-      this.checkExpr(stmt as Expression, insideAsync);
+      // Pass isStmtLevel=true so a bare async call as a statement
+      // (fire-and-forget) is allowed — there's no return value to misuse.
+      this.checkExpr(stmt as Expression, insideAsync, true);
     }
   }
 
-  private checkExpr(expr: Expression, insideAsync: boolean): void {
+  private checkExpr(expr: Expression, insideAsync: boolean, isStmtLevel: boolean = false): void {
     const e = expr as { type: string };
     const etype = e.type;
 
     if (etype === "call") {
       const callExpr = expr as CallNode;
-      if (!insideAsync && this.isAsyncFunc(callExpr.name)) {
+      // Disallow async-without-await UNLESS the call is the whole statement
+      // (fire-and-forget). When it's a sub-expression the Promise pointer
+      // would be used as a string / number / object and crash — that's the
+      // case we want to catch. Bare `asyncFn();` just discards the returned
+      // Promise handle, which is safe (GC'd when nobody's awaiting).
+      if (!insideAsync && !isStmtLevel && this.isAsyncFunc(callExpr.name)) {
         this.reportError(callExpr.name, callExpr.loc);
       }
       for (let i = 0; i < callExpr.args.length; i++) {

--- a/tests/fixtures/builtins/async-fire-and-forget.ts
+++ b/tests/fixtures/builtins/async-fire-and-forget.ts
@@ -1,0 +1,14 @@
+// @test expectTestPassed
+// Regression for dapweb NOTES #16: calling an async function without
+// await as a bare expression statement (fire-and-forget) used to error
+// "async function 'X()' called without await". The concern — misusing
+// the Promise pointer as a string/number — only applies when the result
+// is CONSUMED. Discarded at statement level it's a valid fire-and-forget
+// and the Promise is GC'd when no awaiters remain.
+async function later(): Promise<void> {}
+async function main(): Promise<void> {
+  later(); // ← fire-and-forget, should compile
+  console.log("TEST_PASSED");
+}
+main();
+runEventLoop();


### PR DESCRIPTION
## Summary

Closes dapweb NOTES **#16**. The async-await checker rejected every non-awaited async call with:

```
error: async function 'fwd()' called without await
```

The stated concern — 'Promise pointer used as string/object causes crash' — only applies when the **return value is consumed**. When the call is a bare statement with no consumer, the Promise is just GC'd when no one is awaiting. That's a valid fire-and-forget (register a continuation, return from the calling scope without blocking).

## Fix

Plumbed an `isStmtLevel` flag through `checkExpr`. Set true when walking expression-statements. Skip the error only when **both**:
- not inside an await chain (unchanged)
- at statement level (new)

Sub-expression uses still error correctly:

```ts
const p = fwd();          // errors — 'p' used as i8*
console.log(fwd());       // errors — Promise as string
fwd();                    // now OK — discarded, GC handles it
```

## dapweb unblock

HTTP handler (sync) can kick off an async forward without blocking the response:

```ts
function handler(req: HttpRequest): HttpResponse {
  fwdResponseAsync(req);     // fire-and-forget, GC'd
  return { status: 202, ... };
}
```

## Test plan

- [x] New fixture `tests/fixtures/builtins/async-fire-and-forget.ts`
- [x] Existing async-await negative tests still reject consumer-context misuse
- [ ] CI green