### PR TITLE
docs(d.ts): clarify process.argv convention (starts at user args, not binary path)

### DIFF
--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -27,6 +27,12 @@ declare namespace console {
 // ============================================================================
 
 declare namespace process {
+  // ChadScript convention differs from Node:
+  //   - argv[0] is the FIRST USER ARG (not the binary path or script name)
+  //   - argv0 (separate field) holds the binary path
+  // If you're porting a Node-shaped CLI loop, drop `.slice(2)` — ChadScript
+  // already starts at user args. For any non-trivial parsing, prefer the
+  // ArgumentParser class from `chadscript/argparse`.
   const argv: string[];
   const argv0: string;
   const platform: string;


### PR DESCRIPTION
Closes dapweb NOTES docs-gap #1.

ChadScript's `process.argv[0]` is the first user arg, not the binary path like Node. The binary path lives in `process.argv0` (separate field, note missing bracket). Easy to miss when porting a Node-shaped CLI loop — parser happily consumes `--port` as positional because it sits at `argv[0]` where people expect the binary path.

Added a four-line comment next to the declaration so IDE hover picks it up, plus a nudge toward `ArgumentParser` from `chadscript/argparse` for non-trivial parsing.

No behavior change.