### PR TITLE
fix(imports): 'import * as ns' namespace dispatch ns.fn() works

### DIFF
--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -711,6 +711,25 @@ export class MethodCallGenerator {
             imp.source.startsWith("./") ||
             imp.source.startsWith("../") ||
             imp.source.startsWith("/");
+
+          // Namespace import dispatch: `import * as lib from "./x.js"; lib.foo()`
+          // Parser stores the specifier as the literal string "* as <local>".
+          // ChadScript merges imported files' functions into a flat AST, so
+          // `foo` is already in ast.functions — we just need to rewrite the
+          // method_call into a plain call to emit the direct invocation
+          // (dapweb NOTES #17).
+          if (isRelative && imp.specifiers) {
+            const nsPrefix = `* as ${varName}`;
+            if (imp.specifiers.indexOf(nsPrefix) !== -1) {
+              const flatCall = {
+                type: "call",
+                name: method,
+                args: expr.args,
+                loc: expr.loc,
+              } as unknown as Expression;
+              return this.ctx.generateExpression(flatCall, params);
+            }
+          }
           if (!isRelative && imp.specifiers && imp.specifiers.indexOf(varName) !== -1) {
             return this.ctx.emitError(
               `'${varName}.${method}()' — module '${imp.source}' is not supported by ChadScript`,

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -545,6 +545,35 @@ export class TypeInference {
     const method = expr.method;
     const objBase = expr.object as ExprBase;
 
+    // Namespace-import dispatch: `lib.fn()` when lib is `import * as lib`
+    // resolves to the imported function's return type. The actual codegen
+    // rewrite happens in method-calls.ts (dapweb NOTES #17); here we just
+    // make sure variable-allocator classifies the result correctly when it
+    // runs before codegen sees the rewrite.
+    if (objBase.type === "variable") {
+      const varName = (expr.object as VariableNode).name;
+      const ast = this.ctx.getAst();
+      if (ast && ast.imports) {
+        for (let ii = 0; ii < ast.imports.length; ii++) {
+          const imp = ast.imports[ii];
+          if (!imp || !imp.specifiers) continue;
+          const isRelative =
+            imp.source.startsWith("./") ||
+            imp.source.startsWith("../") ||
+            imp.source.startsWith("/");
+          if (isRelative && imp.specifiers.indexOf(`* as ${varName}`) !== -1) {
+            // Look up the function as if it were called directly.
+            const fakeCall = {
+              type: "call",
+              name: method,
+              args: expr.args,
+            } as unknown as Expression;
+            return this.resolveExpressionType(fakeCall);
+          }
+        }
+      }
+    }
+
     if (
       method === "trim" ||
       method === "toLowerCase" ||

--- a/tests/fixtures/builtins/ns-import-dispatch-lib.ts
+++ b/tests/fixtures/builtins/ns-import-dispatch-lib.ts
@@ -1,0 +1,9 @@
+// @test-skip
+// Helper module for ns-import-dispatch.ts — not a standalone fixture.
+export function greet(): string {
+  return "hello";
+}
+
+export function double(n: number): number {
+  return n * 2;
+}

--- a/tests/fixtures/builtins/ns-import-dispatch.ts
+++ b/tests/fixtures/builtins/ns-import-dispatch.ts
@@ -1,0 +1,12 @@
+// @test expectTestPassed
+// Regression for dapweb NOTES #17: `import * as ns` + `ns.fn()` dispatch
+// was rejected with "Method 'fn' on 'ns' is not supported." Namespace
+// imports from relative modules should lower to direct calls — the
+// imported functions are already merged into the flat AST.
+import * as lib from "./ns-import-dispatch-lib.js";
+
+const s = lib.greet();
+const n = lib.double(21);
+if (s === "hello" && n === 42) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
Closes dapweb NOTES **#17**.

## Symptom

```ts
import * as lib from "./lib.js";
lib.sayHi();   // error: Method 'sayHi' on 'lib' is not supported.
```

Every `lib.foo(...)` call — even on purely synchronous helpers — hit the generic 'unsupported method' fallback. Named imports were fine, but `import * as` is idiomatic TS for grouping.

## Fix

ChadScript merges imported files into one flat AST (per CLAUDE.md Module System), so `foo` is already in `ast.functions` when you do `import * as lib`. The dispatcher just needs to recognize the pattern.

**Two coordinated changes:**

1. **`method-calls.ts`**: when the method's object is a variable matching a namespace-import specifier of a relative module (`* as ns`), rewrite the `method_call` into a plain `call` to the method name and re-dispatch. Works for sync + async + any return type.

2. **`type-inference.ts resolveMethodCallType`**: same detection there — variable-allocator runs before codegen sees the rewrite, so without this `const s = lib.greet()` allocated `s` as `double` even though `greet` returns `string`, triggering a store type-mismatch.

## Test plan

- [x] New fixtures: `ns-import-dispatch-lib.ts` (helper) + `ns-import-dispatch.ts` (exercises string + number return)
- [x] Named imports still work (existing tests untouched)
- [x] Relative-module namespace imports now dispatch correctly
- [x] Non-relative (stdlib) module namespace imports still error clearly (e.g. `import * as fs from 'fs'; fs.foo()` — unchanged behavior)
- [ ] CI green