### PR TITLE
fix(codegen): async funcs resolve per-param types (don't coerce to double)

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -967,16 +967,27 @@ export class CallExpressionGenerator {
       }
     }
 
-    if (funcResult && func.async) {
+    const funcIsAsync = funcResult ? func.async === true : false;
+    if (funcIsAsync) {
       returnType = "%Promise*";
       this.ctx.setUsesPromises(true);
-    } else if (funcResult && func.paramTypes && func.paramTypes.length > 0) {
-      const normalizedReturnType = func.returnType ? stripNullable(func.returnType) : "";
-      if (normalizedReturnType) {
-        returnType = mapReturnTypeToLLVM(
-          normalizedReturnType,
-          this.ctx.isEnumType(normalizedReturnType),
-        );
+      // Fall through so async funcs with declared paramTypes also get
+      // correct arg type resolution. Previously this branch was exclusive
+      // with the paramTypes-population branch below, so async calls like
+      // `await fwd("abc", 42)` emitted every arg as the default double —
+      // string args ended up passed as i64 through strlen/puts and crashed.
+    }
+    if (funcResult && func.paramTypes && func.paramTypes.length > 0) {
+      // For async funcs the returnType is already %Promise* — don't overwrite
+      // it. Only non-async funcs should resolve returnType from func.returnType.
+      if (!funcIsAsync) {
+        const normalizedReturnType = func.returnType ? stripNullable(func.returnType) : "";
+        if (normalizedReturnType) {
+          returnType = mapReturnTypeToLLVM(
+            normalizedReturnType,
+            this.ctx.isEnumType(normalizedReturnType),
+          );
+        }
       }
       for (let i = 0; i < func.paramTypes.length; i++) {
         const p = func.paramTypes[i] as string;

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -170,7 +170,14 @@ export class FunctionGenerator {
       }
       returnType = "%Promise*";
       this.ctx.setCurrentFunctionReturnType("%Promise*");
-    } else if (hasParamTypes && paramTypesLen > 0) {
+      // Fall through: the param-type-population block below now runs for
+      // async functions too. Previously it was gated with `else if` which
+      // meant async funcs with mixed-type params (e.g. `(id: string, n: number)`)
+      // defaulted every param to double via the fallback at line ~261,
+      // producing IR that typed string args as double and crashed in
+      // downstream strlen/puts calls (dapweb note: async mixed-type args).
+    }
+    if (hasParamTypes && paramTypesLen > 0) {
       const entryTypes: string[] = [];
       const entryNames: string[] = [];
       for (let i = 0; i < funcParams.length; i++) {

--- a/tests/fixtures/builtins/async-mixed-arg-types.ts
+++ b/tests/fixtures/builtins/async-mixed-arg-types.ts
@@ -1,0 +1,18 @@
+// @test expectTestPassed
+// Regression: async functions with mixed-type parameters (string + number,
+// string + object, etc.) emitted IR that typed every arg as `double`
+// because the param-type-resolution branch in function-generator.ts and
+// calls.ts was `else if` of the async branch — async funcs skipped param
+// resolution entirely. A string arg ended up passed as i64, crashing
+// downstream strlen/puts.
+async function send(id: string, seq: number, body: string): Promise<string> {
+  return id + "|" + seq + "|" + body;
+}
+
+async function main(): Promise<void> {
+  const r = await send("req-1", 42, "hello");
+  if (r === "req-1|42|hello") console.log("TEST_PASSED");
+  else console.log("FAIL: " + r);
+}
+main();
+runEventLoop();


### PR DESCRIPTION
Closes dapweb NOTES **#18** (blocker for CLI client) and **#19**.

## Root cause

Both `function-generator.ts` and `calls.ts` had:

```ts
if (funcIsAsync) {
  returnType = '%Promise*';
} else if (hasParamTypes) {
  // ← resolve paramTypes here
}
```

The async branch set the return type and **exclusively skipped** the param-type resolution. Async funcs fell through to a fallback loop that pushes `double` for every param.

## Symptoms

**#18** (blocker): async function with mixed string+number+array params received every arg as `double` at the call site. A string arg got passed as `i64` to `strlen` → IR type mismatch / segfault.

**#19**: module-level `dispatch();` on an async fn emitted spurious double args because the caller built paramTypes from the fallback rather than `func.paramTypes`.

## Fix

Restructure both sites so async sets `returnType` first, then **falls through** to the param-type resolution block. Guard the `returnType` write inside that block so async's `%Promise*` isn't overwritten.

## Verified

```ts
async function send(id: string, seq: number, body: string): Promise<string> {
  return id + '|' + seq + '|' + body;
}
async function main() {
  const r = await send('req-1', 42, 'hello');   // 'req-1|42|hello'
}

async function dispatch(): Promise<void> { ... }
dispatch();   // no spurious double args
```

## Test plan

- [x] New fixture `tests/fixtures/builtins/async-mixed-arg-types.ts`
- [x] Local full test suite running now
- [ ] CI green