### PR TITLE
fix(codegen): await userAsyncFn(): Promise<Response> allocates correct struct

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1341,6 +1341,36 @@ export class VariableAllocator {
     this.ctx.emit(`store %Promise* ${promisePtr}, %Promise** ${allocaReg}`);
   }
 
+  /**
+   * For `await userAsyncFn()`, look up the function in the AST and extract
+   * the inner type from its declared `Promise<T>` return. Returns the LLVM
+   * type + SymbolKind pair to allocate, or null if the return type doesn't
+   * map to a known struct pointer (in which case the caller falls through
+   * to its existing i8* default).
+   *
+   * Currently handles: Response. Extend here when other opaque interface
+   * returns start showing up in user code.
+   */
+  private tryUnwrapAsyncCallReturnType(
+    fnName: string,
+  ): { llvmType: string; symbolKind: number } | null {
+    const ast = this.ctx.getAst();
+    if (!ast || !ast.functions) return null;
+    for (let i = 0; i < ast.functions.length; i++) {
+      const fn = ast.functions[i];
+      if (fn.name !== fnName || !fn.async || !fn.returnType) continue;
+      // returnType shape is "Promise<Foo>" — strip the wrapper.
+      const rt = fn.returnType;
+      if (!rt.startsWith("Promise<") || !rt.endsWith(">")) return null;
+      const inner = rt.slice("Promise<".length, rt.length - 1).trim();
+      if (inner === "Response") {
+        return { llvmType: "%__FetchResponse*", symbolKind: SymbolKind_Object };
+      }
+      return null;
+    }
+    return null;
+  }
+
   private allocateAwaitResult(stmt: VariableDeclaration, params: string[]): void {
     const awaitExpr = stmt.value as AwaitExpressionNode;
     const inner = awaitExpr.argument as ExprBase;
@@ -1436,6 +1466,25 @@ export class VariableAllocator {
         this.ctx.emit(`${allocaReg} = alloca %__FetchResponse*`);
         const value = this.ctx.generateExpression(stmt.value!, params);
         this.ctx.emit(`store %__FetchResponse* ${value}, %__FetchResponse** ${allocaReg}`);
+        return;
+      }
+      // await <userAsyncFn>() — unwrap Promise<T> from the function's
+      // declared return type and allocate based on T. Previously this
+      // branch only handled built-in async (fetch), so user-defined
+      // `async function httpGet(): Promise<Response>` fell through to the
+      // i8* fallback and the Response struct pointer got corrupted
+      // (dapweb NOTES #20).
+      const asyncReturnUnwrap = this.tryUnwrapAsyncCallReturnType(callNode.name);
+      if (asyncReturnUnwrap) {
+        const { llvmType, symbolKind } = asyncReturnUnwrap;
+        const allocaReg = this.ctx.nextAllocaReg(stmt.name);
+        this.ctx.defineVariable(stmt.name, allocaReg, llvmType, symbolKind, "local");
+        this.ctx.emit(`${allocaReg} = alloca ${llvmType}`);
+        const value = this.ctx.generateExpression(stmt.value!, params);
+        // value from @__Promise_await is i8*; bitcast to the struct pointer.
+        const cast = this.ctx.nextTemp();
+        this.ctx.emit(`${cast} = bitcast i8* ${value} to ${llvmType}`);
+        this.ctx.emit(`store ${llvmType} ${cast}, ${llvmType}* ${allocaReg}`);
         return;
       }
     }

--- a/tests/fixtures/builtins/async-user-fn-response-return.ts
+++ b/tests/fixtures/builtins/async-user-fn-response-return.ts
@@ -1,0 +1,17 @@
+// @test-skip
+// Fixture for dapweb NOTES #20: async function returning Promise<Response>
+// was coerced to i8*/string at the await site, corrupting the struct
+// pointer. This skipped-at-test-time because it would need a live HTTP
+// server to exercise .status/.text(). The regression the fix closes is
+// the compile failure + IR type-mismatch — verified manually.
+async function httpGet(url: string): Promise<Response> {
+  return await fetch(url);
+}
+
+async function main(): Promise<void> {
+  const r = await httpGet("http://localhost:65432/noexist");
+  console.log("status=" + r.status);
+}
+
+main();
+runEventLoop();


### PR DESCRIPTION
Closes dapweb NOTES **#20** — sibling of #18/#19 on the await-return side.

## Symptom

```ts
async function httpGet(url: string): Promise<Response> { return await fetch(url); }
const r = await httpGet(url);
console.log(r.status);   // → garbage
r.text();                // → 1-byte string (status code byte surviving as scalar)
```

Direct `const r = await fetch(url)` worked because the allocator had a special case for `fetch`. Wrapping `fetch` in a trivial async wrapper fell through to the `i8*`/`SymbolKind_String` fallback in `allocateAwaitResult` — the Response struct pointer got treated as a string, GEPs read from wrong offsets.

## Fix

Before the i8* fallback, try to unwrap the awaited user-fn's declared `Promise<T>` return type and allocate based on T. Currently handles T = `Response`. Extend the helper (`tryUnwrapAsyncCallReturnType`) when other opaque interface returns surface.

## Architectural note

This is the Nth branch in the `allocateAwaitResult` ladder (after Promise.all, Promise.allSettled, fs.readdir, fs.stat, child_process.exec, fetch, declaredType === Response). Tracked as refactor epic task #35 — the right fix is `typeInference.resolveAwaitedType(expr)` returning a `ResolvedType` that variable-allocator maps uniformly, killing the ladder. Not doing that today because dapweb is mid-ship and self-hosting risk is real.

## Test plan

- [x] New fixture `tests/fixtures/builtins/async-user-fn-response-return.ts` (@test-skip because it'd need a live HTTP server to exercise `.status`/`.text()`; the regression the fix closes is the IR corruption, verified manually)
- [x] Direct `await fetch` still works (unchanged path)
- [ ] CI green