### PR TITLE
feat(stdin): add process.stdin.readLine() + declare process.stdin in d.ts

### DIFF
--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -61,6 +61,19 @@ declare namespace process {
   namespace stderr {
     function write(str: string): void;
   }
+  namespace stdin {
+    // Reads the entire rest of stdin to EOF and returns it as a string.
+    // Good for filter-shaped tools (`cat | tool`) and one-shot pipes.
+    function read(): string;
+    // Reads a single line from stdin (blocking). Strips the trailing \n
+    // (and preceding \r for CRLF). Returns "" on EOF — callers that need
+    // to distinguish "empty line" from "EOF" should tag their protocol
+    // accordingly (MCP / JSON-RPC lines are never empty).
+    //
+    // Intended for line-oriented protocols: MCP stdio server, JSON-RPC,
+    // LSP, simple REPLs.
+    function readLine(): string;
+  }
 }
 
 // ============================================================================

--- a/src/codegen/expressions/method-calls.ts
+++ b/src/codegen/expressions/method-calls.ts
@@ -514,7 +514,7 @@ export class MethodCallGenerator {
     }
 
     if (isProcessStdinRead(expr)) {
-      return handleProcessStdinRead(this.ctx);
+      return handleProcessStdinRead(this.ctx, expr);
     }
 
     // Handle Math.* methods (delegated to MathGenerator)

--- a/src/codegen/expressions/method-calls/process.ts
+++ b/src/codegen/expressions/method-calls/process.ts
@@ -98,7 +98,7 @@ export function handleProcessSyscallI32(ctx: MethodCallGeneratorContext, funcNam
 }
 
 export function isProcessStdinRead(expr: MethodCallNode): boolean {
-  if (expr.method !== "read") return false;
+  if (expr.method !== "read" && expr.method !== "readLine") return false;
   const objBase = expr.object as ExprBase;
   if (objBase.type !== "member_access") return false;
   const memberAccess = expr.object as MemberAccessNode;
@@ -108,9 +108,18 @@ export function isProcessStdinRead(expr: MethodCallNode): boolean {
   return varNode.name === "process" && memberAccess.property === "stdin";
 }
 
-export function handleProcessStdinRead(ctx: MethodCallGeneratorContext): string {
+export function handleProcessStdinRead(
+  ctx: MethodCallGeneratorContext,
+  expr?: MethodCallNode,
+): string {
   const result = ctx.nextTemp();
-  ctx.emit(`${result} = call i8* @__process_stdin_read()`);
+  // `process.stdin.readLine()` → @__process_stdin_readline (fgets-based,
+  // strips trailing \n / \r\n, returns "" on EOF). `process.stdin.read()`
+  // → @__process_stdin_read (reads entire stream to EOF). Distinguish via
+  // method name — both are stdin reads but different granularity.
+  const isReadLine = expr !== undefined && expr.method === "readLine";
+  const fn = isReadLine ? "@__process_stdin_readline" : "@__process_stdin_read";
+  ctx.emit(`${result} = call i8* ${fn}()`);
   ctx.setVariableType(result, "i8*");
   return result;
 }

--- a/src/codegen/infrastructure/llvm-declarations.ts
+++ b/src/codegen/infrastructure/llvm-declarations.ts
@@ -186,6 +186,7 @@ export function getLLVMDeclarations(config?: DeclConfig): string {
   ir += "declare i32 @fclose(i8*)\n";
   ir += "declare i64 @fread(i8*, i64, i64, i8*)\n";
   ir += "declare i64 @fwrite(i8*, i64, i64, i8*)\n";
+  ir += "declare i8* @fgets(i8*, i32, i8*)\n";
   ir += "declare i32 @fseek(i8*, i64, i32)\n";
   ir += "declare i64 @ftell(i8*)\n";
   ir += "declare i32 @unlink(i8*)\n";

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -3060,6 +3060,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     irParts.push(this.fsGen.generateReaddirSyncHelper());
     irParts.push(this.fsGen.generateStatSyncHelper());
     irParts.push(this.fsGen.generateStdinReadHelper());
+    irParts.push(this.fsGen.generateStdinReadLineHelper());
     irParts.push(this.pathGen.generateNormalizeHelper());
     irParts.push(this.pathGen.generateRelativeHelper());
     irParts.push(this.pathGen.generateParseHelper());

--- a/src/codegen/stdlib/fs.ts
+++ b/src/codegen/stdlib/fs.ts
@@ -850,4 +850,78 @@ export class FilesystemGenerator {
     ir += "}\n\n";
     return ir;
   }
+
+  /**
+   * `process.stdin.readLine()` — blocking single-line read from stdin.
+   * Returns the line WITHOUT the trailing newline. Returns an empty string
+   * on EOF. Required for MCP stdio servers, JSON-RPC loops, REPLs.
+   *
+   * Implementation: fgets into a grow-as-needed GC buffer. Strips the
+   * trailing \n (and optional \r). On fgets returning NULL (EOF with no
+   * bytes read) returns the empty string.
+   */
+  generateStdinReadLineHelper(): string {
+    let ir = "";
+    ir += "define i8* @__process_stdin_readline() {\n";
+    ir += "entry:\n";
+    ir += "  %stdin_fp = load i8*, i8** @stdin\n";
+    ir += "  %init_cap = add i64 0, 256\n";
+    ir += "  %init_buf = call i8* @GC_malloc_atomic(i64 256)\n";
+    ir += "  ; zero first byte so subsequent strlen works even if fgets returns null\n";
+    ir += "  store i8 0, i8* %init_buf\n";
+    ir += "  br label %loop\n";
+    ir += "\n";
+    ir += "loop:\n";
+    ir += "  %buf = phi i8* [ %init_buf, %entry ], [ %grown_buf, %grow ]\n";
+    ir += "  %cap = phi i64 [ %init_cap, %entry ], [ %new_cap, %grow ]\n";
+    ir += "  %len = phi i64 [ 0, %entry ], [ %total_len, %grow ]\n";
+    ir += "  %remain = sub i64 %cap, %len\n";
+    ir += "  %remain_i32 = trunc i64 %remain to i32\n";
+    ir += "  %write_ptr = getelementptr inbounds i8, i8* %buf, i64 %len\n";
+    ir += "  %fgets_ret = call i8* @fgets(i8* %write_ptr, i32 %remain_i32, i8* %stdin_fp)\n";
+    ir += "  %fgets_null = icmp eq i8* %fgets_ret, null\n";
+    ir += "  br i1 %fgets_null, label %done_eof, label %check_newline\n";
+    ir += "\n";
+    ir += "check_newline:\n";
+    ir += "  %chunk_len = call i64 @strlen(i8* %write_ptr)\n";
+    ir += "  %total_len = add i64 %len, %chunk_len\n";
+    ir += "  ; If the last byte is '\\n', we got a complete line.\n";
+    ir += "  %last_idx = sub i64 %total_len, 1\n";
+    ir += "  %last_ptr = getelementptr inbounds i8, i8* %buf, i64 %last_idx\n";
+    ir += "  %last_byte = load i8, i8* %last_ptr\n";
+    ir += "  %is_newline = icmp eq i8 %last_byte, 10\n";
+    ir += "  br i1 %is_newline, label %strip_newline, label %grow\n";
+    ir += "\n";
+    ir += "grow:\n";
+    ir += "  %new_cap = mul i64 %cap, 2\n";
+    ir += "  %grown_buf = call i8* @GC_realloc(i8* %buf, i64 %new_cap)\n";
+    ir += "  br label %loop\n";
+    ir += "\n";
+    ir += "strip_newline:\n";
+    ir += "  store i8 0, i8* %last_ptr\n";
+    ir += "  ; Also strip preceding \\r if present (CRLF line ending).\n";
+    ir += "  %after_strip_len = sub i64 %total_len, 1\n";
+    ir += "  %has_prev = icmp ugt i64 %after_strip_len, 0\n";
+    ir += "  br i1 %has_prev, label %check_cr, label %done_line\n";
+    ir += "\n";
+    ir += "check_cr:\n";
+    ir += "  %cr_idx = sub i64 %after_strip_len, 1\n";
+    ir += "  %cr_ptr = getelementptr inbounds i8, i8* %buf, i64 %cr_idx\n";
+    ir += "  %cr_byte = load i8, i8* %cr_ptr\n";
+    ir += "  %is_cr = icmp eq i8 %cr_byte, 13\n";
+    ir += "  br i1 %is_cr, label %strip_cr, label %done_line\n";
+    ir += "\n";
+    ir += "strip_cr:\n";
+    ir += "  store i8 0, i8* %cr_ptr\n";
+    ir += "  br label %done_line\n";
+    ir += "\n";
+    ir += "done_line:\n";
+    ir += "  ret i8* %buf\n";
+    ir += "\n";
+    ir += "done_eof:\n";
+    ir += "  ; On EOF with zero bytes read, return empty string.\n";
+    ir += "  ret i8* %init_buf\n";
+    ir += "}\n\n";
+    return ir;
+  }
 }

--- a/tests/fixtures/builtins/process-stdin-readline.ts
+++ b/tests/fixtures/builtins/process-stdin-readline.ts
@@ -1,0 +1,14 @@
+// @test-skip
+// Fixture for dapweb NOTES #22: process.stdin.readLine() for MCP / JSON-RPC
+// stdio servers. @test-skip because the test harness doesn't feed stdin to
+// fixtures; manual verify pattern is:
+//   echo -e "hello\nworld\nfoo" | ./bin
+// expected output:
+//   got: hello
+//   got: world
+//   got: foo
+while (true) {
+  const line = process.stdin.readLine();
+  if (line === "") break;
+  console.log("got: " + line);
+}


### PR DESCRIPTION
Closes dapweb NOTES **#22** — MCP stdio server blocker.

## What was missing

`chadscript.d.ts` never exposed `process.stdin` at all. The read-to-EOF helper (`@__process_stdin_read`) existed internally but had no type declaration, and no line-oriented read for protocols like MCP / JSON-RPC / LSP that frame messages by newline.

dapbus's `mcp` subcommand couldn't receive JSON-RPC messages from agents — ~280 lines of dispatch logic sat unreachable behind a missing primitive.

## Added

```ts
declare namespace process {
  namespace stdin {
    function read(): string;       // existing helper, now declared
    function readLine(): string;   // new
  }
}
```

`readLine()` uses `fgets` + grow-as-needed GC buffer; strips trailing `\n` (and preceding `\r` for CRLF). Returns `""` on EOF.

For line-oriented protocols where empty lines are never valid (MCP, JSON-RPC, LSP), the simple `while (readLine() !== "") {...}` pattern works. Protocols that need to distinguish empty-line from EOF should tag their own framing.

## Unblocks dapbus mcp:

```ts
while (true) {
  const line = process.stdin.readLine();
  if (line === "") break;
  process.stdout.write(handleLine(line) + "\n");
}
```

## Test plan

- [x] Manual verify: `echo -e "hello\nworld\nfoo" | ./bin` emits three `got: ...` lines and exits cleanly.
- [x] Fixture (`@test-skip`) in `tests/fixtures/builtins/process-stdin-readline.ts` documents the shape.
- [ ] CI green