### PR TITLE
fix(codegen): optional-chain NaN sentinel retires silent-wrong for number fields

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -617,7 +617,10 @@ export class MemberAccessGenerator {
     this.ctx.setCurrentLabel(nullLabel);
     let nullValue: string;
     if (accessType === "double") {
-      nullValue = "0.0";
+      // Quiet NaN sentinel for undefined — `??` in convertToNonNullish treats
+      // NaN as nullish via fcmp ord. Legitimate arithmetic NaN also surfaces
+      // as undefined (acceptable tradeoff; see optional-chain-undefined-sentinel.md).
+      nullValue = "0x7FF8000000000000";
     } else if (accessType === "i1") {
       nullValue = "false";
     } else if (accessType === "i32") {

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -196,12 +196,16 @@ export class ControlFlowGenerator {
   }
 
   private convertToNonNullish(value: string, valueType: string): string {
-    if (
-      valueType === "i1" ||
-      valueType === "double" ||
-      valueType === "i32" ||
-      valueType === "i64"
-    ) {
+    if (valueType === "double") {
+      // NaN sentinel = undefined. fcmp ord returns true when both operands
+      // are non-NaN (i.e., value is defined). Pairs with the NaN short-circuit
+      // in generateOptionalChain — see optional-chain-undefined-sentinel.md.
+      const temp = this.nextTemp();
+      this.emit(`${temp} = fcmp ord double ${value}, ${value}`);
+      this.ctx.setVariableType(temp, "i1");
+      return temp;
+    }
+    if (valueType === "i1" || valueType === "i32" || valueType === "i64") {
       const condBool = this.ctx.emitIcmp("eq", "i32", "1", "1");
       return condBool;
     }

--- a/tests/fixtures/edge-cases/optional-chain-nan-sentinel.ts
+++ b/tests/fixtures/edge-cases/optional-chain-nan-sentinel.ts
@@ -1,0 +1,13 @@
+interface C {
+  val: number;
+}
+interface B {
+  c?: C;
+}
+interface A {
+  b?: B;
+}
+const a2: A = {};
+const r = a2?.b?.c?.val ?? -1;
+if (r === -1) console.log("TEST_PASSED");
+else console.log("TEST_FAILED got " + r);


### PR DESCRIPTION
## Summary

Retires the last known silent-wrong class from the Apr 18 rearchitect snapshot. `a?.b?.c?.val ?? -1` now returns `-1` when any link is null, instead of silently returning `0`.

## User impact

Before: `const v = maybe?.nested?.count ?? -1` would return `0` not `-1` when `maybe` was null. Anyone relying on `??` as a "use this default if missing" guard for numeric fields was hitting wrong results silently. This fuzz-caught class was g05/g07/g18/h05/h07/h09 (6 programs).

After: `??` fallback correctly fires. Ported tests pass. Stage 2 self-host clean.

## How

Two coordinated changes:

1. `generateOptionalChain` short-circuit for `double` fields now emits quiet-NaN bit pattern (`0x7FF8000000000000`) instead of `0.0`.
2. `convertToNonNullish` for `double` now emits `fcmp ord v, v` — NaN fails the ordered check → treated as nullish → `??` fires.

Tradeoff: legitimate arithmetic NaN (0/0, sqrt(-1)) also triggers `??` fallback. Acceptable — few non-math programs produce NaN, and "NaN is undefined" is a defensible reading.

## Test plan
- [x] New fixture `tests/fixtures/edge-cases/optional-chain-nan-sentinel.ts`
- [x] `npm run verify` passes (full stage 2 self-host)
- [x] Manual repro of g07 returns -1
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)