### PR TITLE
refactor(codegen): central ir-operand emission helpers

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -80,6 +80,7 @@ const testFiles = [
   "tests/compiler.test.ts",
   "tests/unit/symbol-table.test.ts",
   "tests/unit/type-system.test.ts",
+  "tests/unit/ir-operand.test.ts",
   "tests/network.test.ts",
   "tests/http-routes.test.ts",
   "tests/http-headers.test.ts",

--- a/src/codegen/expressions/method-calls/promise-handlers.ts
+++ b/src/codegen/expressions/method-calls/promise-handlers.ts
@@ -1,5 +1,6 @@
 import { Expression, MethodCallNode, VariableNode, ArrowFunctionNode } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
+import { userGlobalRef } from "../../infrastructure/ir-operand.js";
 
 interface ExprBase {
   type: string;
@@ -183,9 +184,9 @@ export function handlePromiseThen(
           scopeVarsTyped.names,
           scopeVarsTyped.types,
         );
-        onRejected = `@${ctx.mangleUserName(callbackName)}`;
+        onRejected = userGlobalRef(ctx, callbackName);
       } else if (callbackBase.type === "variable") {
-        onRejected = `@${ctx.mangleUserName((callback as VariableNode).name)}`;
+        onRejected = userGlobalRef(ctx, (callback as VariableNode).name);
       }
     }
   } else {
@@ -200,9 +201,9 @@ export function handlePromiseThen(
           scopeVarsTyped.names,
           scopeVarsTyped.types,
         );
-        onFulfilled = `@${ctx.mangleUserName(callbackName)}`;
+        onFulfilled = userGlobalRef(ctx, callbackName);
       } else if (callbackBase.type === "variable") {
-        onFulfilled = `@${ctx.mangleUserName((callback as VariableNode).name)}`;
+        onFulfilled = userGlobalRef(ctx, (callback as VariableNode).name);
       }
     }
     if (expr.args.length > 1) {
@@ -216,9 +217,9 @@ export function handlePromiseThen(
           scopeVarsTyped.names,
           scopeVarsTyped.types,
         );
-        onRejected = `@${ctx.mangleUserName(callbackName)}`;
+        onRejected = userGlobalRef(ctx, callbackName);
       } else if (callbackBase.type === "variable") {
-        onRejected = `@${ctx.mangleUserName((callback as VariableNode).name)}`;
+        onRejected = userGlobalRef(ctx, (callback as VariableNode).name);
       }
     }
   }
@@ -270,9 +271,9 @@ export function handlePromiseFinally(
         scopeVarsTyped.names,
         scopeVarsTyped.types,
       );
-      userCallback = `@${ctx.mangleUserName(callbackName)}`;
+      userCallback = userGlobalRef(ctx, callbackName);
     } else if (callbackBase.type === "variable") {
-      userCallback = `@${ctx.mangleUserName((callback as VariableNode).name)}`;
+      userCallback = userGlobalRef(ctx, (callback as VariableNode).name);
     }
   }
 

--- a/src/codegen/infrastructure/ir-operand.ts
+++ b/src/codegen/infrastructure/ir-operand.ts
@@ -1,0 +1,83 @@
+// Central IR-operand emission helpers.
+//
+// Codegen sites across the compiler each build raw LLVM operand strings by
+// hand: `@${mangle(name)}`, `%${temp}`, `i8* ${value}`. Scattered call sites
+// drift — some forget to mangle user names, some use the wrong sigil, some
+// stringify types inconsistently. Every concrete bug in that class (see
+// PRs #545/#547/#548/#550, ladder task #11) reduces to "one of the string
+// templates was wrong".
+//
+// This module centralizes the three primitive shapes:
+//
+//   symbolRef(name, sigil) -> "@_cs_foo"   or "%tmp"
+//   operand(type, value)   -> "type value" — the canonical bound form LLVM
+//                             expects in call args, GEP bases, phi operands, …
+//
+// For user-named globals, prefer userGlobalRef(ctx, name) which delegates to
+// the context's mangleUserName so the rule for when to prefix (_cs_) lives
+// in one place. Raw (already-formed) symbol strings stay as-is — this module
+// never double-mangles.
+
+export type SymbolSigil = "@" | "%";
+
+interface ManglerContext {
+  mangleUserName(name: string): string;
+}
+
+// Produce a correctly-sigiled reference to a symbol. `name` is the *unsigiled*
+// symbol name — do NOT pass pre-prefixed "@foo" or "%tmp".
+export function symbolRef(name: string, sigil: SymbolSigil): string {
+  if (name.length === 0) {
+    throw new Error("symbolRef: empty symbol name");
+  }
+  if (name[0] === "@" || name[0] === "%") {
+    throw new Error(`symbolRef: name already sigiled: ${name}`);
+  }
+  return `${sigil}${name}`;
+}
+
+// Produce a global reference for a *user-declared* identifier (function,
+// global variable). Uses the context's mangleUserName to pick up the _cs_
+// prefix rule. Pass the raw user identifier, not pre-mangled.
+export function userGlobalRef(ctx: ManglerContext, userName: string): string {
+  return symbolRef(ctx.mangleUserName(userName), "@");
+}
+
+// Produce a global reference for a *compiler-internal* (already-final) name
+// — e.g. "GC_malloc", "http_serve", class/method slot names that the
+// compiler constructs itself. Skips the mangler.
+export function internalGlobalRef(finalName: string): string {
+  return symbolRef(finalName, "@");
+}
+
+// Produce a bound operand "type value" — the shape LLVM expects anywhere an
+// SSA value appears with its type (call arguments, GEP indices, phi pairs,
+// select operands, …). Centralizing this lets future work check that `type`
+// is actually a valid LLVM type string without touching every call site.
+export function operand(type: string, value: string): string {
+  if (type.length === 0) {
+    throw new Error("operand: empty type string");
+  }
+  if (value.length === 0) {
+    throw new Error("operand: empty value string");
+  }
+  return `${type} ${value}`;
+}
+
+// Join parallel type/value arrays into a comma-separated argument list —
+// saves the ", " + zip boilerplate at call sites. Parallel arrays (rather
+// than an Array<[type, value]> tuple) keeps the helper Stage-0-compatible:
+// the native self-host compiler does not round-trip tuple element types
+// correctly through `for...of` destructuring.
+export function operandList(types: string[], values: string[]): string {
+  if (types.length !== values.length) {
+    throw new Error(
+      `operandList: length mismatch (types=${types.length}, values=${values.length})`,
+    );
+  }
+  const parts: string[] = [];
+  for (let i = 0; i < types.length; i++) {
+    parts.push(operand(types[i], values[i]));
+  }
+  return parts.join(", ");
+}

--- a/tests/unit/ir-operand.test.ts
+++ b/tests/unit/ir-operand.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  symbolRef,
+  userGlobalRef,
+  internalGlobalRef,
+  operand,
+  operandList,
+} from "../../src/codegen/infrastructure/ir-operand.js";
+
+const mockCtx = {
+  mangleUserName(name: string): string {
+    if (name.startsWith("__")) return name;
+    return `_cs_${name}`;
+  },
+};
+
+describe("ir-operand", () => {
+  describe("symbolRef", () => {
+    it("prefixes global symbols with @", () => {
+      assert.strictEqual(symbolRef("foo", "@"), "@foo");
+    });
+
+    it("prefixes local symbols with %", () => {
+      assert.strictEqual(symbolRef("1", "%"), "%1");
+      assert.strictEqual(symbolRef("tmp", "%"), "%tmp");
+    });
+
+    it("rejects empty names", () => {
+      assert.throws(() => symbolRef("", "@"), /empty symbol name/);
+    });
+
+    it("rejects already-sigiled names", () => {
+      assert.throws(() => symbolRef("@foo", "@"), /already sigiled/);
+      assert.throws(() => symbolRef("%tmp", "%"), /already sigiled/);
+    });
+  });
+
+  describe("userGlobalRef", () => {
+    it("mangles user names with _cs_ prefix", () => {
+      assert.strictEqual(userGlobalRef(mockCtx, "foo"), "@_cs_foo");
+    });
+
+    it("skips mangling for __-prefixed internals", () => {
+      assert.strictEqual(userGlobalRef(mockCtx, "__internal"), "@__internal");
+    });
+  });
+
+  describe("internalGlobalRef", () => {
+    it("emits without mangling", () => {
+      assert.strictEqual(internalGlobalRef("GC_malloc"), "@GC_malloc");
+      assert.strictEqual(internalGlobalRef("http_serve"), "@http_serve");
+    });
+  });
+
+  describe("operand", () => {
+    it("binds type and value", () => {
+      assert.strictEqual(operand("i8*", "%1"), "i8* %1");
+      assert.strictEqual(operand("double", "3.14"), "double 3.14");
+    });
+
+    it("rejects empty type or value", () => {
+      assert.throws(() => operand("", "%1"), /empty type string/);
+      assert.throws(() => operand("i8*", ""), /empty value string/);
+    });
+  });
+
+  describe("operandList", () => {
+    it("joins parallel type/value arrays with commas", () => {
+      assert.strictEqual(operandList(["i32", "i8*"], ["%0", "%1"]), "i32 %0, i8* %1");
+    });
+
+    it("returns empty string for empty arrays", () => {
+      assert.strictEqual(operandList([], []), "");
+    });
+
+    it("rejects length mismatch", () => {
+      assert.throws(() => operandList(["i32"], ["%0", "%1"]), /length mismatch/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `src/codegen/infrastructure/ir-operand.ts` — a small, central module for emitting LLVM operand shapes. Before today, every codegen site built operand strings by hand (`` `@${mangle(name)}` ``, `` `%${tmp}` ``, `` `${type} ${value}` ``). That scattered pattern is the root cause behind the recurring "forgot to mangle" / "wrong sigil" bug class (see PRs #545/#547/#548/#550 and ladder task #11 in the patch-ladder backlog).

Helpers introduced:

- `symbolRef(name, sigil)` — `@foo` / `%tmp`, rejects pre-sigiled and empty input
- `userGlobalRef(ctx, name)` — user-name mangled reference (delegates to `ctx.mangleUserName`)
- `internalGlobalRef(name)` — compiler-internal globals that bypass mangling
- `operand(type, value)` — the "type value" bound form LLVM expects in call args / GEP / phi / select
- `operandList(types, values)` — parallel-array zip for argument lists (parallel arrays chosen over `Array<[string,string]>` for Stage-0 compatibility — native self-host compiler round-trips tuple element types as `double`)

One demonstration migration: `src/codegen/expressions/method-calls/promise-handlers.ts` (8 ad-hoc `` `@${ctx.mangleUserName(...)}` `` template sites → `userGlobalRef(ctx, ...)`).

## Impact

- Users: no behavior change — pure refactor.
- Follow-ups: migrate remaining ~28 `` `@${ctx.mangleUserName(...)}` `` sites file by file (class.ts has 10, calls.ts has 3, etc.) in separate stage-2-gated PRs. Each migration shrinks the surface where the "wrong sigil / forgot to mangle" bug class can hide.

## Test plan

- [x] `node --test tests/unit/ir-operand.test.ts` — 12 new unit tests pass
- [x] `npm run verify` (full, stage-2 gated) — all tests + 3-stage self-hosting green
- [x] Prettier formatting clean

Part of refactor plan step 2 (task #11 in patch-ladder-refactor-backlog).