### PR TITLE
enable ast type-annotator pass (phase-e step 5, pr1)

### DIFF
--- a/src/codegen/infrastructure/base-generator.ts
+++ b/src/codegen/infrastructure/base-generator.ts
@@ -74,8 +74,13 @@ export class BaseGenerator {
   // Named variables use SymbolTable instead
   public variableTypes: Map<string, string>;
 
-  // Expression type cache - maps expressions to their resolved types
-  public expressionTypes: Map<Expression, ResolvedType>;
+  // Expression type cache — parallel arrays keyed by AST expression identity.
+  // Parallel arrays (not Map<object,V>) because native self-hosted Map lacks
+  // pointer-identity hashing (see native-map-object-key-unsupported.md).
+  // Populated once by the pre-codegen annotator pass; NOT cleared on reset()
+  // because AST lives for the whole compilation.
+  public expressionTypeNodes: Expression[];
+  public expressionTypeValues: ResolvedType[];
 
   // Actual class type tracking - when an interface-typed variable holds a class instance,
   // this maps the variable/register to its actual concrete class name for correct struct access
@@ -104,7 +109,8 @@ export class BaseGenerator {
     this.globalStrings = [];
     this.symbolTable = new SymbolTable();
     this.variableTypes = new Map();
-    this.expressionTypes = new Map();
+    this.expressionTypeNodes = [];
+    this.expressionTypeValues = [];
     this.actualClassTypes = new Map();
   }
 
@@ -128,7 +134,9 @@ export class BaseGenerator {
     this.currentFunctionReturnType = "double";
     this.symbolTable.clearLocals();
     this.variableTypes.clear();
-    this.expressionTypes.clear();
+    // expressionTypeNodes/Values are intentionally NOT cleared — they're
+    // populated once per compilation by the annotator and indexed by AST
+    // node identity, which is stable across function boundaries.
     this.actualClassTypes.clear();
     this.currentDebugLocId = -1;
   }
@@ -609,14 +617,19 @@ export class BaseGenerator {
   }
 
   /**
-   * Get cached type for an expression
+   * Get cached type for an expression (parallel-array linear scan).
    */
   getExpressionType(expr: Expression): ResolvedType | undefined {
-    return this.expressionTypes.get(expr);
+    const nodes = this.expressionTypeNodes;
+    for (let i = 0; i < nodes.length; i++) {
+      if (nodes[i] === expr) return this.expressionTypeValues[i];
+    }
+    return undefined;
   }
 
   /**
-   * Cache type for an expression
+   * Cache type for an expression. O(N) dedup scan — callers that know the
+   * expression is fresh (the annotator) should use appendExpressionType.
    */
   setExpressionType(expr: Expression, type: ResolvedType): void {
     if (type.base === "unknown") {
@@ -624,7 +637,25 @@ export class BaseGenerator {
         `Cannot cache 'unknown' type for expression of type '${expr.type}'. Type resolution failed.`,
       );
     }
-    this.expressionTypes.set(expr, type);
+    const nodes = this.expressionTypeNodes;
+    for (let i = 0; i < nodes.length; i++) {
+      if (nodes[i] === expr) {
+        this.expressionTypeValues[i] = type;
+        return;
+      }
+    }
+    this.expressionTypeNodes.push(expr);
+    this.expressionTypeValues.push(type);
+  }
+
+  /**
+   * Fast append — skips dedup. Use only when caller guarantees the
+   * expression hasn't been annotated yet (the AST annotator walks each
+   * node exactly once in post-order).
+   */
+  appendExpressionType(expr: Expression, type: ResolvedType): void {
+    this.expressionTypeNodes.push(expr);
+    this.expressionTypeValues.push(type);
   }
 
   /**

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -638,10 +638,12 @@ export interface IGeneratorContext {
   readonly actualClassTypes: Map<string, string>;
 
   /**
-   * Expression type cache - maps expressions to their resolved types
-   * Caches type inference results to avoid repeated computation
+   * Expression type cache — parallel arrays keyed by AST expression identity.
+   * Native Map<object,V> segfaults, so we scan linearly. Populated by the
+   * pre-codegen annotator pass; codegen reads via typeOf/getExpressionType.
    */
-  readonly expressionTypes: Map<Expression, ResolvedType>;
+  readonly expressionTypeNodes: Expression[];
+  readonly expressionTypeValues: ResolvedType[];
 
   /**
    * Get or compute the type of an expression
@@ -650,9 +652,21 @@ export interface IGeneratorContext {
   getExpressionType(expr: Expression): ResolvedType | undefined;
 
   /**
-   * Cache an expression's type for future lookups
+   * Cache an expression's type for future lookups.
    */
   setExpressionType(expr: Expression, type: ResolvedType): void;
+
+  /**
+   * Fast-append variant for the annotator — skips dedup scan.
+   */
+  appendExpressionType(expr: Expression, type: ResolvedType): void;
+
+  /**
+   * Canonical type lookup for any expression. Codegen MUST prefer typeOf()
+   * over re-deriving types from LLVM value names. Returns null for
+   * expressions whose types couldn't be resolved (treat as "unknown").
+   */
+  typeOf(expr: Expression): ResolvedType | null;
 
   setActualClassType(name: string, className: string): void;
 
@@ -1064,7 +1078,8 @@ export class MockGeneratorContext implements IGeneratorContext {
   public variableTypes: Map<string, string>;
   public actualClassTypes: Map<string, string>;
   public jsonObjectMetadata: Map<string, JsonObjectMeta>;
-  public expressionTypes: Map<Expression, ResolvedType>;
+  public expressionTypeNodes: Expression[];
+  public expressionTypeValues: ResolvedType[];
   public globalStrings: string[] = [];
   public currentFunctionReturnType: string = "double";
   public currentFunctionTsReturnType: string | undefined = undefined;
@@ -1110,7 +1125,8 @@ export class MockGeneratorContext implements IGeneratorContext {
     this.variableTypes = new Map();
     this.actualClassTypes = new Map();
     this.jsonObjectMetadata = new Map();
-    this.expressionTypes = new Map();
+    this.expressionTypeNodes = [];
+    this.expressionTypeValues = [];
   }
 
   getClassesCount(): number {
@@ -1135,11 +1151,36 @@ export class MockGeneratorContext implements IGeneratorContext {
   emitWarning(_message: string, _loc?: SourceLocation, _suggestion?: string): void {}
 
   getExpressionType(expr: Expression): ResolvedType | undefined {
-    return this.expressionTypes.get(expr);
+    const nodes = this.expressionTypeNodes;
+    for (let i = 0; i < nodes.length; i++) {
+      if (nodes[i] === expr) return this.expressionTypeValues[i];
+    }
+    return undefined;
   }
 
   setExpressionType(expr: Expression, type: ResolvedType): void {
-    this.expressionTypes.set(expr, type);
+    const nodes = this.expressionTypeNodes;
+    for (let i = 0; i < nodes.length; i++) {
+      if (nodes[i] === expr) {
+        this.expressionTypeValues[i] = type;
+        return;
+      }
+    }
+    this.expressionTypeNodes.push(expr);
+    this.expressionTypeValues.push(type);
+  }
+
+  appendExpressionType(expr: Expression, type: ResolvedType): void {
+    this.expressionTypeNodes.push(expr);
+    this.expressionTypeValues.push(type);
+  }
+
+  typeOf(expr: Expression): ResolvedType | null {
+    const nodes = this.expressionTypeNodes;
+    for (let i = 0; i < nodes.length; i++) {
+      if (nodes[i] === expr) return this.expressionTypeValues[i];
+    }
+    return null;
   }
 
   setActualClassType(name: string, className: string): void {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -156,6 +156,7 @@ import { checkUnionTypes } from "../semantic/union-type-checker.js";
 import { checkArraysOfFunctions } from "../semantic/array-of-function-checker.js";
 import { markIntSpecializedFunctions } from "./infrastructure/int-specialization-detector.js";
 import { checkTypeAssertions } from "../semantic/type-assertion-checker.js";
+import { annotateTypes } from "../semantic/type-annotator.js";
 import { checkUninitializedFields } from "../semantic/uninitialized-field-checker.js";
 import { analyzeEscapes } from "../semantic/escape-analysis.js";
 // binary-type-checker.ts: original top-level-only checker kept for reference; deep version is in safety-checks.ts
@@ -1769,6 +1770,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   // early partial answers don't lock out later authoritative ones.
   typeOf(expr: Expression): ResolvedType | null {
     if (!expr || typeof expr !== "object") return null;
+    // Prefer the pre-populated annotator cache (parallel arrays in
+    // BaseGenerator). Fall back to on-demand resolution for expressions
+    // that the annotator skipped (unknown base or types that only resolve
+    // mid-codegen once the symbol table is refined).
+    const nodes = this.expressionTypeNodes;
+    for (let i = 0; i < nodes.length; i++) {
+      if (nodes[i] === expr) return this.expressionTypeValues[i];
+    }
     return this.typeInference.resolveExpressionTypeRich(expr);
   }
 
@@ -3020,6 +3029,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     checkAsyncAwait(this.ast, this.sourceCode);
     this.stackEligibleVars = analyzeEscapes(this.ast);
     markIntSpecializedFunctions(this.ast);
+    // Pre-codegen type annotation — populate typeOf() cache for every
+    // expression in the AST. Codegen consumers migrate to typeOf() in
+    // follow-up PRs; this first PR is purely additive (populates the cache,
+    // no reads yet). Skips expressions with unknown/missing base.
+    annotateTypes(this.ast, this);
 
     const irParts: string[] = [];
 

--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -1,0 +1,253 @@
+// AST type annotator — populates the expression-type cache BEFORE codegen
+// runs. Replaces scattered, lazy re-derivation of types at each codegen site
+// with a single up-front pass.
+//
+// Design intent: make `ctx.typeOf(expr)` a pure lookup. Codegen never asks
+// TypeInference directly; this pass fills the table so codegen reads and
+// emits LLVM, nothing more.
+//
+// Starts small — annotates the expression kinds where typeOf is currently
+// consumed. Expands as more codegen sites migrate to typeOf.
+
+import type {
+  AST,
+  Expression,
+  Statement,
+  BlockStatement,
+  VariableDeclaration,
+  AssignmentStatement,
+  IfStatement,
+  WhileStatement,
+  DoWhileStatement,
+  ForStatement,
+  ForOfStatement,
+  TryStatement,
+  SwitchStatement,
+  ReturnStatement,
+  ThrowStatement,
+  ArrowFunctionNode,
+  MethodCallNode,
+  CallNode,
+  MemberAccessNode,
+  IndexAccessNode,
+  BinaryNode,
+  UnaryNode,
+  ConditionalExpressionNode,
+  AwaitExpressionNode,
+  ObjectNode,
+  ObjectProperty,
+  ArrayNode,
+  MapEntry,
+  MapNode,
+  SetNode,
+  SpreadElementNode,
+  TemplateLiteralNode,
+  TypeAssertionNode,
+  NewNode,
+  MemberAccessAssignmentNode,
+  IndexAccessAssignmentNode,
+} from "../ast/types.js";
+import type { ResolvedType } from "../codegen/infrastructure/type-system.js";
+
+// The annotator speaks to codegen through a narrow interface so this pass
+// can be unit-tested against a mock, and so the concrete LLVMGenerator can
+// evolve without breaking this file.
+export interface TypeAnnotatorSink {
+  resolveExpressionTypeRich(expr: Expression): ResolvedType | null;
+  appendExpressionType(expr: Expression, type: ResolvedType): void;
+}
+
+export function annotateTypes(ast: AST, sink: TypeAnnotatorSink): void {
+  const walker = new TypeAnnotator(sink);
+  walker.walkAST(ast);
+}
+
+class TypeAnnotator {
+  private sink: TypeAnnotatorSink;
+
+  constructor(sink: TypeAnnotatorSink) {
+    this.sink = sink;
+  }
+
+  walkAST(ast: AST): void {
+    if (ast.topLevelItems && ast.topLevelItems.length > 0) {
+      this.walkStmts(ast.topLevelItems as Statement[]);
+    }
+    for (let i = 0; i < ast.functions.length; i++) {
+      this.walkBlock(ast.functions[i].body);
+    }
+    for (let i = 0; i < ast.classes.length; i++) {
+      const cls = ast.classes[i];
+      for (let j = 0; j < cls.methods.length; j++) {
+        this.walkBlock(cls.methods[j].body);
+      }
+    }
+  }
+
+  private walkStmts(stmts: Statement[]): void {
+    for (let i = 0; i < stmts.length; i++) {
+      this.walkStmt(stmts[i]);
+    }
+  }
+
+  private walkBlock(block: BlockStatement): void {
+    this.walkStmts(block.statements);
+  }
+
+  private walkStmt(stmt: Statement): void {
+    const s = stmt as { type: string };
+    const t = s.type;
+    if (t === "variable_declaration") {
+      const decl = stmt as VariableDeclaration;
+      if (decl.value) this.visitExpr(decl.value as Expression);
+    } else if (t === "assignment") {
+      const a = stmt as AssignmentStatement;
+      this.visitExpr(a.value);
+    } else if (t === "if") {
+      const i = stmt as IfStatement;
+      this.visitExpr(i.condition);
+      this.walkBlock(i.thenBlock);
+      if (i.elseBlock) this.walkBlock(i.elseBlock);
+    } else if (t === "while") {
+      const w = stmt as WhileStatement;
+      this.visitExpr(w.condition);
+      this.walkBlock(w.body);
+    } else if (t === "do_while") {
+      const dw = stmt as DoWhileStatement;
+      this.walkBlock(dw.body);
+      this.visitExpr(dw.condition);
+    } else if (t === "for") {
+      const f = stmt as ForStatement;
+      if (f.init) this.walkStmt(f.init as Statement);
+      if (f.condition) this.visitExpr(f.condition as Expression);
+      this.walkBlock(f.body);
+      if (f.update) this.visitExpr(f.update as Expression);
+    } else if (t === "for_of") {
+      const fo = stmt as ForOfStatement;
+      this.visitExpr(fo.iterable);
+      this.walkBlock(fo.body);
+    } else if (t === "try") {
+      const tr = stmt as TryStatement;
+      this.walkBlock(tr.tryBlock);
+      if (tr.catchBody) this.walkBlock(tr.catchBody);
+      if (tr.finallyBlock) this.walkBlock(tr.finallyBlock);
+    } else if (t === "switch") {
+      const sw = stmt as SwitchStatement;
+      this.visitExpr(sw.discriminant);
+      for (let ci = 0; ci < sw.cases.length; ci++) {
+        const c = sw.cases[ci];
+        if (c.test) this.visitExpr(c.test as Expression);
+        this.walkStmts(c.consequent);
+      }
+    } else if (t === "return") {
+      const r = stmt as ReturnStatement;
+      if (r.value) this.visitExpr(r.value as Expression);
+    } else if (t === "throw") {
+      const th = stmt as ThrowStatement;
+      this.visitExpr(th.argument);
+    } else if (t === "block") {
+      this.walkBlock(stmt as BlockStatement);
+    } else if (t !== "break" && t !== "continue") {
+      this.visitExpr(stmt as Expression);
+    }
+  }
+
+  // Post-order: annotate children first so parent resolvers see already-
+  // cached sub-expression types.
+  private visitExpr(expr: Expression): void {
+    if (!expr) return;
+    const e = expr as { type: string };
+    const t = e.type;
+
+    if (t === "binary") {
+      const b = expr as BinaryNode;
+      this.visitExpr(b.left);
+      this.visitExpr(b.right);
+    } else if (t === "unary") {
+      const u = expr as UnaryNode;
+      this.visitExpr(u.operand);
+    } else if (t === "call") {
+      const c = expr as CallNode;
+      for (let i = 0; i < c.args.length; i++) this.visitExpr(c.args[i]);
+    } else if (t === "method_call") {
+      const mc = expr as MethodCallNode;
+      this.visitExpr(mc.object);
+      for (let i = 0; i < mc.args.length; i++) this.visitExpr(mc.args[i]);
+    } else if (t === "member_access") {
+      const ma = expr as MemberAccessNode;
+      this.visitExpr(ma.object);
+    } else if (t === "index_access") {
+      const ia = expr as IndexAccessNode;
+      this.visitExpr(ia.object);
+      this.visitExpr(ia.index);
+    } else if (t === "array") {
+      const ar = expr as ArrayNode;
+      for (let i = 0; i < ar.elements.length; i++) this.visitExpr(ar.elements[i]);
+    } else if (t === "object") {
+      const ob = expr as ObjectNode;
+      for (let i = 0; i < ob.properties.length; i++) {
+        const prop = ob.properties[i] as ObjectProperty;
+        this.visitExpr(prop.value);
+      }
+    } else if (t === "conditional") {
+      const co = expr as ConditionalExpressionNode;
+      this.visitExpr(co.condition);
+      this.visitExpr(co.consequent);
+      this.visitExpr(co.alternate);
+    } else if (t === "await") {
+      const aw = expr as AwaitExpressionNode;
+      this.visitExpr(aw.argument);
+    } else if (t === "new") {
+      const n = expr as NewNode;
+      for (let i = 0; i < n.args.length; i++) this.visitExpr(n.args[i]);
+    } else if (t === "arrow_function") {
+      const af = expr as ArrowFunctionNode;
+      const body = af.body as { type: string };
+      if (body.type === "block") {
+        this.walkBlock(af.body as BlockStatement);
+      } else {
+        this.visitExpr(af.body as Expression);
+      }
+    } else if (t === "template_literal") {
+      const tl = expr as TemplateLiteralNode;
+      for (let i = 0; i < tl.parts.length; i++) {
+        const part = tl.parts[i];
+        const pt = part as { type: string };
+        if (pt.type) this.visitExpr(part as Expression);
+      }
+    } else if (t === "spread_element") {
+      const se = expr as SpreadElementNode;
+      this.visitExpr(se.argument);
+    } else if (t === "member_access_assignment") {
+      const maa = expr as MemberAccessAssignmentNode;
+      this.visitExpr(maa.object);
+      this.visitExpr(maa.value);
+    } else if (t === "index_access_assignment") {
+      const iaa = expr as IndexAccessAssignmentNode;
+      this.visitExpr(iaa.object);
+      this.visitExpr(iaa.index);
+      this.visitExpr(iaa.value);
+    } else if (t === "map") {
+      const m = expr as MapNode;
+      for (let i = 0; i < m.entries.length; i++) {
+        const entry = m.entries[i] as MapEntry;
+        this.visitExpr(entry.key);
+        this.visitExpr(entry.value);
+      }
+    } else if (t === "set") {
+      const s = expr as SetNode;
+      for (let i = 0; i < s.values.length; i++) this.visitExpr(s.values[i]);
+    } else if (t === "type_assertion") {
+      const ta = expr as TypeAssertionNode;
+      this.visitExpr(ta.expression);
+    }
+
+    // After recursion, annotate this expression. Skip unknown-base and
+    // missing sourceKind — they represent resolver gaps, not authoritative
+    // info. typeOf's fallback still covers them on demand.
+    const resolved = this.sink.resolveExpressionTypeRich(expr);
+    if (resolved && resolved.base && resolved.base !== "unknown") {
+      this.sink.appendExpressionType(expr, resolved);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Enables the pre-codegen AST type-annotator pass introduced (but disabled) in the phase-e scaffolding. The annotator walks every expression in the AST once, resolves its type via the memoized `TypeInference.resolveExpressionTypeRich`, and stores the result in an expression-keyed cache. Codegen consumers can now read canonical types via `ctx.typeOf(expr)` instead of re-deriving from stringly-typed LLVM value names.

This PR is **purely additive**: it populates the cache. No codegen consumer reads from it yet. Consumer migrations land in follow-up PRs, one site at a time.

## Why users benefit

Foundations work that retires whole classes of silent-wrong bugs. Today different codegen sites disagree about an expression's type because each re-derives it from whatever happens to be in scope; the annotator makes type info authoritative and shared.

## Key changes

- `src/semantic/type-annotator.ts` — new file. Post-order walker over the full AST, calls `sink.resolveExpressionTypeRich` then `sink.appendExpressionType`. Skips expressions with `unknown` base (resolver gaps remain on-demand for now).
- `BaseGenerator`/`IGeneratorContext` — replaced `expressionTypes: Map<Expression, ResolvedType>` with parallel arrays `expressionTypeNodes` / `expressionTypeValues`. Native self-hosted Map lacks pointer-identity hashing (segfaults — see `native-map-object-key-unsupported.md`); linear-scan is mandatory until that's fixed.
- `expressionType*` arrays are NOT cleared in `reset()` — they're keyed by AST identity which outlives per-function state.
- New `appendExpressionType` fast-path skips dedup for the annotator, which guarantees each node is visited once.
- `typeOf()` now reads the parallel-array cache first, falls back to on-demand resolution for unknown/missing-base expressions.

## Test plan

- [x] `npm run verify` (full, stage 2 included) green locally.
- [x] Stage 0 / 1 / 2 self-hosting all pass. Stage 2 is the byte-exact oracle — proves the annotator doesn't perturb codegen output.

## Follow-ups (not in this PR)

- Migrate one codegen consumer from `getVariableType(valueName)` to `typeOf(expr)` to prove the pattern.
- Expand migrations incrementally; each prior CLAUDE.md rule about stringly-typed side-channels retires as a consumer moves over.