### PR TITLE
refactor(codegen): migrate array-allocator to typeof() (phase-e step 5, pr2)

### DIFF
--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -67,7 +67,7 @@ export interface ArrayAllocatorContext {
   readonly symbolTable: SymbolTable;
   emitError(message: string, loc?: SourceLocation, suggestion?: string): never;
   getAst(): AST | undefined;
-  resolveExpressionTypeRich(expr: Expression): ResolvedType | null;
+  typeOf(expr: Expression): ResolvedType | null;
   getArrayStorageStrategy(expr: Expression): "inlined" | "pointer";
 }
 
@@ -391,7 +391,7 @@ export class ArrayAllocator {
     // as an indexed-object-array element — the result is still an array,
     // not an element. Short-circuit null so no legacy branch misclassifies
     // it as element-info either.
-    const rich = this.ctx.resolveExpressionTypeRich(indexExpr.object);
+    const rich = this.ctx.typeOf(indexExpr.object);
     if (rich && rich.arrayDepth === 1 && rich.fields) {
       return { keys: rich.fields.keys, types: rich.fields.types, tsTypes: rich.fields.tsTypes };
     }


### PR DESCRIPTION
## Why this matters for users

Part of Phase E's type-resolver consolidation. Each migrated site is one less place where two codegen paths can disagree about an expression's type and silently produce wrong native code. No user-visible behavior change in this PR — it's a mechanical swap that routes a query through the annotator's pre-populated cache.

## Change

`ArrayAllocator.buildInterfaceElementInfo` formerly called `ctx.resolveExpressionTypeRich(expr)` directly. Now calls `ctx.typeOf(expr)` — same semantics (returns `ResolvedType | null`), but hits the annotator cache first, only falling through to `resolveExpressionTypeRich` for expressions the annotator skipped (unknown-base).

Interface `ArrayAllocatorContext` updated accordingly.

## Verification

Full `npm run verify` (tests + stage 2 self-host) green locally.

## Scope

One call site. First consumer migration following the Step-5 annotator landing in #573. More migrations land in subsequent PRs.