### PR TITLE
refactor(codegen): migrate class-allocator to typeof() (phase-e step 5, pr1)

### DIFF
--- a/src/codegen/infrastructure/class-allocator.ts
+++ b/src/codegen/infrastructure/class-allocator.ts
@@ -39,6 +39,7 @@ export interface ClassAllocatorContext {
   ): void;
   generateExpression(expr: Expression, params: string[]): string;
   resolveExpressionType(expr: Expression): ResolvedType | null;
+  typeOf(expr: Expression): ResolvedType | null;
   getVariableType(name: string): string | undefined;
   resolveImportAlias(localName: string): string;
   getAst(): AST | undefined;
@@ -89,7 +90,7 @@ export class ClassAllocator {
       const srcMeta = this.ctx.symbolTable.getClassMetadata(srcName);
       className = srcMeta ? srcMeta.className : "Unknown";
     } else if (valueBase.type === "ternary") {
-      const resolved = stmt.value ? this.ctx.resolveExpressionType(stmt.value) : null;
+      const resolved = stmt.value ? this.ctx.typeOf(stmt.value) : null;
       if (resolved && this.interfaceAlloc.isKnownClass(resolved.base)) {
         className = resolved.base;
       } else {


### PR DESCRIPTION
## Summary
- Swaps `ctx.resolveExpressionType(stmt.value)` for `ctx.typeOf(stmt.value)` in the class-allocator ternary branch.
- Routes through the pre-populated annotator cache first, falling through to the memoized resolver only for expression shapes the annotator skipped.

## User impact
- No behavior change. Slightly faster class allocation on ternary initializers that the annotator already typed.

## Test plan
- [x] `npm run verify` (full, stage 2 included) green locally.