### PR TITLE
refactor(codegen): SemaTable — first step of Sema/codegen extraction

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -157,6 +157,7 @@ import { checkArraysOfFunctions } from "../semantic/array-of-function-checker.js
 import { markIntSpecializedFunctions } from "./infrastructure/int-specialization-detector.js";
 import { checkTypeAssertions } from "../semantic/type-assertion-checker.js";
 import { annotateTypes } from "../semantic/type-annotator.js";
+import { SemaTable } from "../semantic/sema-table.js";
 import { checkUninitializedFields } from "../semantic/uninitialized-field-checker.js";
 import { analyzeEscapes } from "../semantic/escape-analysis.js";
 // binary-type-checker.ts: original top-level-only checker kept for reference; deep version is in safety-checks.ts
@@ -1458,6 +1459,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public trampolineEmitter!: TrampolineEmitter;
   public usesTrampolines: number = 0;
   public usesTimers: number = 0;
+  // Sema table: pure-AST class + interface catalog built pre-codegen.
+  // Consumers (esp. TypeInference) can query `isClass(name)` / `isInterface(name)`
+  // etc. without touching mid-codegen SymbolTable state. Empty until
+  // generateParts() runs; migration of call sites happens in follow-up PRs.
+  public semaTable: SemaTable | null = null;
 
   constructor(ast: AST, typeChecker: TypeChecker | null, options: LLVMGeneratorOptions) {
     super();
@@ -3029,6 +3035,10 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     checkAsyncAwait(this.ast, this.sourceCode);
     this.stackEligibleVars = analyzeEscapes(this.ast);
     markIntSpecializedFunctions(this.ast);
+    // Build pure-AST class + interface catalog so downstream queries
+    // don't need mid-codegen SymbolTable state. Populated once, read-only
+    // thereafter. First consumers migrate in follow-up PRs.
+    this.semaTable = new SemaTable(this.ast);
     // Pre-codegen type annotation — populate typeOf() cache for every
     // expression in the AST. Codegen consumers migrate to typeOf() in
     // follow-up PRs; this first PR is purely additive (populates the cache,

--- a/src/semantic/sema-table.ts
+++ b/src/semantic/sema-table.ts
@@ -1,0 +1,57 @@
+// Sema table: pure-AST symbol catalog built pre-codegen. Captures all
+// class + interface names/declarations from the AST so consumers can
+// answer "is this name a class?" / "get this interface's declaration"
+// without touching codegen-time symbol-table state.
+//
+// This is the first step of extracting Sema as its own pass (refactor
+// plan step 6). TypeInference used to read this same data through
+// `this.st.isClass(name)` etc., but SymbolTable is populated DURING
+// codegen — the annotator running pre-codegen saw stale/empty data.
+// SemaTable is built once from the AST and is authoritative for these
+// queries.
+
+import type { AST, ClassNode, InterfaceDeclaration } from "../ast/types.js";
+
+export class SemaTable {
+  private classNames: string[] = [];
+  private classByName: Map<string, ClassNode> = new Map();
+  private interfaceNames: string[] = [];
+  private interfaceByName: Map<string, InterfaceDeclaration> = new Map();
+
+  constructor(ast: AST) {
+    if (ast.classes) {
+      for (let i = 0; i < ast.classes.length; i++) {
+        const c = ast.classes[i];
+        if (c && c.name) {
+          this.classNames.push(c.name);
+          this.classByName.set(c.name, c);
+        }
+      }
+    }
+    if (ast.interfaces) {
+      for (let i = 0; i < ast.interfaces.length; i++) {
+        const ifc = ast.interfaces[i];
+        if (ifc && ifc.name) {
+          this.interfaceNames.push(ifc.name);
+          this.interfaceByName.set(ifc.name, ifc);
+        }
+      }
+    }
+  }
+
+  isClass(name: string): boolean {
+    return this.classByName.has(name);
+  }
+
+  getClass(name: string): ClassNode | undefined {
+    return this.classByName.get(name);
+  }
+
+  isInterface(name: string): boolean {
+    return this.interfaceByName.has(name);
+  }
+
+  getInterface(name: string): InterfaceDeclaration | undefined {
+    return this.interfaceByName.get(name);
+  }
+}


### PR DESCRIPTION
Step 6 Phase 1 of the refactor plan. Pure infrastructure — no consumer migrations yet.

**What it adds:**
- `src/semantic/sema-table.ts` (47 LOC): a minimal pre-codegen class + interface catalog built directly from the AST (`ast.classes[]` / `ast.interfaces[]`). Immutable after construction.
- Wire it in `LLVMGenerator.generateParts`: `this.semaTable = new SemaTable(this.ast)` alongside the other semantic passes.
- Field pinned at end of the class (rule #5).

**Why:**
Today, `TypeInference` queries `this.st.isClass(name)` / `getClassName(name)` / `getInterfaceType(name)` against `SymbolTable`, which is populated DURING codegen. The pre-codegen annotator sees empty/stale state on these queries for some code paths. `SemaTable` is authoritative for class/interface names because they live in the AST from parse time.

**What's next (not in this PR):**
Follow-up PRs migrate the ~50 call sites in `TypeInference` + friends from `this.st.isClass(...)` to `ctx.semaTable.isClass(...)`. That removes the last major drift surface in the annotator and lets us eventually enforce "codegen must never resolve types live — always read annotations".

**Footprint:**
- +47 LOC new file
- +7 LOC in llvm-generator.ts
- 0 call sites migrated
- Stage 2 verify clean locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)