### PR TITLE
refactor(codegen): migrate 4 llvm-generator resolveExpressionType sites to typeOf()

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2221,7 +2221,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       exprNodeType === "index_access" ||
       exprNodeType === "member_access"
     ) {
-      const resolved = value ? this.typeInference.resolveExpressionType(value) : null;
+      const resolved = value ? this.typeOf(value) : null;
       if (resolved) {
         if (resolved.base === "string") {
           return { llvmType: "i8*", kind: SymbolKind_String, defaultValue: "null" };
@@ -2355,7 +2355,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
         }
 
-        const resolved = this.typeInference.resolveExpressionType(stmt.value);
+        const resolved = this.typeOf(stmt.value);
         let resolvedBase = "";
         let resolvedDepth = 0;
         if (resolved) {
@@ -2744,7 +2744,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             }
           }
           if (!isStringSet && stmt.value) {
-            const resolved = this.typeInference.resolveExpressionType(stmt.value);
+            const resolved = this.typeOf(stmt.value);
             if (resolved && resolved.base === "Set<string>") {
               isStringSet = true;
             }
@@ -2900,7 +2900,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         if (stmt.declaredType) {
           this.symbolTable.setResolvedType(name, parseTypeString(stmt.declaredType));
         } else if (stmt.value) {
-          const resolved = this.typeInference.resolveExpressionType(stmt.value);
+          const resolved = this.typeOf(stmt.value);
           if (resolved) {
             this.symbolTable.setResolvedType(name, resolved);
           }


### PR DESCRIPTION
## Summary
- Migrates remaining 4 `this.typeInference.resolveExpressionType(expr)` call sites in `llvm-generator.ts` (global-var allocator paths at lines 2218, 2352, 2741, 2897) to the canonical `this.typeOf(expr)`.
- Same pattern as PR #575 (array-allocator) and #576 (class-allocator) — hits the annotator cache first, falls through to the resolver for context-dependent types.
- Unblocked by PR #580 which shrunk the annotator cache to truly-static types only.

## User-facing effect
- No behavior change. Type answers are now consistent across codegen: one source of truth (`typeOf`) instead of direct resolver calls that might disagree with the cache.
- Continues the Phase-E "typed AST" convergence — eliminates the "two codegen sites ask at different moments and get different answers" class of silent-wrong bugs.

## Test plan
- [x] `npm run verify` — full tests + 3-stage self-host (stage 2 native oracle) green locally
- [ ] CI green