### PR TITLE
refactor(codegen): migrate map-allocator to typeOf()

### DIFF
--- a/src/codegen/infrastructure/map-allocator.ts
+++ b/src/codegen/infrastructure/map-allocator.ts
@@ -63,7 +63,7 @@ export interface MapAllocatorContext {
     metadata: SymbolMetadata,
   ): void;
   generateExpression(expr: Expression, params: string[]): string;
-  resolveExpressionType(expr: Expression): ResolvedType | null;
+  typeOf(expr: Expression): ResolvedType | null;
   setCurrentDeclaredMapType(type: string | undefined): void;
   setCurrentDeclaredSetType(type: string | undefined): void;
   getCurrentClassName(): string | null;
@@ -105,7 +105,7 @@ export class MapAllocator {
       stmt.value.type !== "new" &&
       stmt.value.type !== "map"
     ) {
-      const resolved = this.ctx.resolveExpressionType(stmt.value);
+      const resolved = this.ctx.typeOf(stmt.value);
       if (resolved && resolved.base.startsWith("Map<")) {
         mapTypeInfoResult = this.parseMapType(resolved.base);
       }
@@ -276,7 +276,7 @@ export class MapAllocator {
       stmt.value.type !== "new" &&
       stmt.value.type !== "set"
     ) {
-      const resolved = this.ctx.resolveExpressionType(stmt.value);
+      const resolved = this.ctx.typeOf(stmt.value);
       if (resolved && resolved.base.startsWith("Set<")) {
         setTypeInfoResult = this.parseSetType(resolved.base);
       }


### PR DESCRIPTION
## Summary
- Migrates 2 `this.ctx.resolveExpressionType(stmt.value)` call sites in `map-allocator.ts` (Map type inference at line 108, Set type inference at line 279) to the canonical `this.ctx.typeOf(stmt.value)`.
- Same pattern as PR #575 (array-allocator), #576 (class-allocator), #583 (llvm-generator). Hits the annotator cache first, falls through to the resolver for context-dependent types.
- Widens `MapAllocatorContext` interface to expose `typeOf` instead of `resolveExpressionType`.

## User-facing effect
- No behavior change. Continues Phase-E "typed AST" convergence — every codegen site reads types through one canonical lookup. Eliminates "two codegen sites asked the resolver at different times and got different answers" silent-wrong bugs for Map/Set allocation.

## Test plan
- [x] `npm run verify` — full tests + 3-stage self-host green locally
- [ ] CI green