### PR TITLE
refactor(codegen): drop redundant resolveExpressionType fallback in variable-allocator

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -148,7 +148,6 @@ export interface VariableAllocatorContext {
     metadata: SymbolMetadata,
   ): void;
   generateExpression(expr: Expression, params: string[]): string;
-  resolveExpressionType(expr: Expression): ResolvedType | null;
   getObjectArrayElementType(expr: Expression): string | null;
   isJSONParseExpression(expr: Expression): boolean;
   getVariableType(name: string): string | undefined;
@@ -740,12 +739,10 @@ export class VariableAllocator {
 
     const stmtDeclaredType: string = stmt.declaredType || "";
     const strippedDeclType = stripNullable(stmtDeclaredType);
-    // Prefer the annotator-populated cache via typeOf when available; fall
-    // through to the resolver for expressions the annotator skipped.
-    let resolved = this.ctx.typeOf(stmtValue);
-    if (resolved === null) {
-      resolved = this.ctx.resolveExpressionType(stmtValue);
-    }
+    // typeOf hits the annotator-populated cache first, then falls through to
+    // the Rich resolver for expressions the annotator skipped — no extra
+    // fallback needed, since Rich wraps the base resolver internally.
+    const resolved = this.ctx.typeOf(stmtValue);
     const nodeType = (stmtValue as ExprBase).type;
 
     let isString: boolean;


### PR DESCRIPTION
## Summary
- Removes a dead fallback in `variable-allocator.ts:745-748` where `typeOf()` returning null was followed by a second call to `resolveExpressionType()`. That second call was always null too, because `typeOf` already wraps `resolveExpressionTypeRich`, which wraps the base `resolveExpressionType` — if the base is null, rich is null, so typeOf is null.
- Drops `resolveExpressionType` from the `VariableAllocatorContext` interface entirely — last consumer removed, API surface shrinks.

## User-facing effect
- No behavior change. One less redundant resolver call per variable declaration.
- Tightens the Phase-E convergence: `VariableAllocatorContext` is now strictly a `typeOf`-only consumer, so future callers can't accidentally bypass the annotator cache.

## Test plan
- [x] `npm run verify` — full tests + 3-stage self-host green locally
- [ ] CI green