### PR TITLE
fix: three codegen/parser/ffi bugs (#587, #589, #591)

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1170,6 +1170,20 @@ export class CallExpressionGenerator {
       return coerced;
     }
 
+    // FFI null-string coercion: `declare function f(): string` returning NULL
+    // from C should round-trip to TS as the empty string so `result === ""`
+    // works reliably. Only applied to user-declared extern functions (not
+    // internal runtime calls, which rely on NULL sentinels internally).
+    if (returnType === "i8*" && func && func.declare) {
+      const emptyStr = this.ctx.stringGen.doCreateStringConstant("");
+      const isNull = this.ctx.nextTemp();
+      this.ctx.emit(`${isNull} = icmp eq i8* ${temp}, null`);
+      const coerced = this.ctx.nextTemp();
+      this.ctx.emit(`${coerced} = select i1 ${isNull}, i8* ${emptyStr}, i8* ${temp}`);
+      this.ctx.setVariableType(coerced, "i8*");
+      return coerced;
+    }
+
     return temp;
   }
 

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -419,6 +419,9 @@ export class AssignmentGenerator {
     value: string,
     memberAccessValue: MemberAccessAssignmentNode,
   ): void {
+    if (value.startsWith("__lambda_")) {
+      value = `@${value}`;
+    }
     if (fiTsType) {
       const enumResult = this.isEnumType(fiTsType);
       if (enumResult) {

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -435,7 +435,8 @@ function transformCallExpression(
     };
   } else if (
     ts.isCallExpression(node.expression) ||
-    ts.isParenthesizedExpression(node.expression)
+    ts.isParenthesizedExpression(node.expression) ||
+    ts.isElementAccessExpression(node.expression)
   ) {
     const callee = transformExpression(node.expression, checker);
     return {

--- a/tests/fixtures/classes/class-arrow-field-in-ctor.ts
+++ b/tests/fixtures/classes/class-arrow-field-in-ctor.ts
@@ -1,0 +1,12 @@
+// @test-description: issue #587 — arrow literal assigned to class field inside ctor body
+class Foo {
+  cb: (x: number) => number;
+  constructor() {
+    this.cb = (x) => x * 2;
+  }
+}
+
+const f = new Foo();
+if (f.cb(21) === 42) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/edge-cases/call-element-access-callee.ts
+++ b/tests/fixtures/edge-cases/call-element-access-callee.ts
@@ -1,0 +1,12 @@
+// @test-description: issue #589 — parser accepts arr[i](args) as a call expression (ElementAccessExpression callee)
+// @test-compile-error: Immediately invoked function expressions
+function doubler(x: number): number {
+  return x * 2;
+}
+function plusOne(x: number): number {
+  return x + 1;
+}
+
+const fns = [doubler, plusOne];
+const a = fns[0](10);
+console.log(a);

--- a/tests/fixtures/edge-cases/ffi-null-string-to-empty.ts
+++ b/tests/fixtures/edge-cases/ffi-null-string-to-empty.ts
@@ -1,0 +1,9 @@
+// @test-description: issue #591 — NULL char* from FFI round-trips to TS as empty string
+declare function getenv(name: string): string;
+
+const v = getenv("__CHADSCRIPT_TEST_VAR_THAT_DOES_NOT_EXIST_91237__");
+if (v === "") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: got " + v);
+}


### PR DESCRIPTION
## Summary

Three independent fixes, one commit each:

- **#587** (`459665de` → `02aecec1` pre-rebase) — `fix(codegen)`: arrow literal assigned to a class field inside the ctor body was emitting `store i8* __lambda_N, i8** %X` (missing `@` sigil). Clang rejected. Fix normalizes raw `__lambda_N` operands to `@__lambda_N` at the single class-field store site in `storeFieldValueDirect`. **1 file, +3 LOC** (`src/codegen/infrastructure/assignment-generator.ts`).
- **#589** (`887c76fc` → `9fcf31a8` pre-rebase) — `fix(parser)`: `CallExpression` visitor now accepts `ElementAccessExpression` as a callee alongside `CallExpression`/`ParenthesizedExpression`. Unblocks parsing `arr[i](args)` dispatch-table shapes (codegen still needs function-pointer array indirect-call support to run end-to-end; that's tracked separately — the parser no longer rejects the shape). **1 file, +1/-1 LOC** (`src/parser-ts/handlers/expressions.ts`).
- **#591** (`d50c5199` → `25693fe1` pre-rebase) — `fix(ffi)`: `declare function` returning a `char*` now round-trips NULL as the empty string. Added a `select i1 (icmp eq ptr null), empty_str, result` coercion at the FFI call return for declare-function i8* returns, so `if (someBridge() === "")` works without per-bridge `_is_*` probes. **1 file, +12 LOC** (`src/codegen/expressions/calls.ts`).

## Before / After

### #587
```ts
class Foo {
  cb: (x: number) => number;
  constructor() { this.cb = (x) => x * 2; }
}
```
- Before: `store i8* __lambda_0, i8** %5` → clang `error: expected value token`
- After: `store i8* @__lambda_0, i8** %5` → compiles and calls correctly.

### #589
```ts
const fns = [doubler, plusOne];
const a = fns[0](10);
```
- Before: parser throws `Unsupported call expression: ElementAccessExpression`.
- After: parser lowers to a `method_call` with `method: ""` just like existing paren/IIFE-callee shapes; downstream semantic layer now returns the real "IIFE not supported" error, making the function-array codegen gap visible and addressable as a separate follow-up.

### #591
```ts
declare function getenv(name: string): string;
const v = getenv("__DOES_NOT_EXIST__");
if (v === "") { /* ok — was unreachable before */ }
```
- Before: NULL `char*` fell into the null-vs-string branch of the `===` strcmp lowering and produced `false` (bothNull was false because `""` is a real string).
- After: NULL is coerced to the interned empty string at the FFI return, so `v === ""` is true.

## Test files added
- `tests/fixtures/classes/class-arrow-field-in-ctor.ts` (#587)
- `tests/fixtures/edge-cases/call-element-access-callee.ts` (#589 — compile-error fixture asserting the parser now reaches the IIFE semantic error)
- `tests/fixtures/edge-cases/ffi-null-string-to-empty.ts` (#591)

## Verify

Full `npm run verify` passed on this branch before opening the PR:
- Stage 0: native compiler built, smoke test passed
- Stage 1 self-host: built + smoke test passed
- Stage 2 self-host: built + smoke test passed (bit-exact oracle)
- All fixture tests passed

## Test plan
- [ ] CI green on `npm run verify`
- [ ] CI green on `npm test` (fixture suite picks up the three new tests)
- [ ] Self-host stages 1 + 2 still produce bit-exact binaries