### PR TITLE
refactor(codegen): delete dead resolveExpressionType public passthrough on LLVMGenerator

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -4243,10 +4243,6 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     return this.typeInference.isArrayExpression(expr);
   }
 
-  public resolveExpressionType(expr: Expression): ResolvedType | null {
-    return this.typeInference.resolveExpressionType(expr);
-  }
-
   public resolveExpressionTypeRich(expr: Expression): ResolvedType | null {
     return this.typeInference.resolveExpressionTypeRich(expr);
   }


### PR DESCRIPTION
## Summary
- Deletes the `public resolveExpressionType(expr)` passthrough on `LLVMGenerator` (was `llvm-generator.ts:4246-4248`). After #594 migrated the last external consumer (member.ts), this method had zero callers.
- `resolveExpressionTypeRich` passthrough stays — it's the `TypeAnnotatorSink` method the pre-codegen annotator calls to fill the `typeOf` cache.

## User-facing effect
- No behavior change. Shrinks the LLVMGenerator public API surface. One fewer way to bypass the canonical `typeOf()` lookup.

## Part of Phase-E convergence
- Umbrella issue: #595.

## Test plan
- [x] `npm run verify` — full tests + 3-stage self-host green locally
- [ ] CI green