### PR TITLE
fix(parser-native): restore trailing return in bare switch case bodies (#597)

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -525,13 +525,17 @@ function transformExpression(node: TreeSitterNode): Expression {
     case "binary_expression":
       return transformBinaryExpression(node);
 
-    case "unary_expression":
-      // void expressions evaluate to undefined (not a unary op in our AST)
+    case "unary_expression": {
+      // Block-wrapped: parser-native's switch_case iteration drops the trailing
+      // return when a bare case body has [var_decl, if_no_else, return]. Wrapping
+      // the case in {} produces a single statement_block child that preserves all
+      // three statements. See #597 for the full diagnostic.
       const voidOpChild = getChild(node, 0);
       if (voidOpChild && (voidOpChild as NodeBase).type === "void") {
         return { type: "variable", name: "undefined" };
       }
       return transformUnaryExpression(node);
+    }
 
     case "update_expression":
       return transformUpdateExpression(node);
@@ -1650,7 +1654,7 @@ function transformStatement(node: TreeSitterNode): Statement | null {
       return transformSwitchStatement(node);
 
     case "statement_block":
-      return null;
+      return transformStatementBlock(node);
 
     case "empty_statement":
       return null;


### PR DESCRIPTION
## Summary
Fixes #597 — the regression that blocked all stdlib additions past 8 count. Unblocks #585 (net TCP module) and every future stdlib registration.

## User-facing effect
- Compiler now correctly compiles itself when it has 8+ \`registerStdlib()\` calls. Previously failed with a false-positive \`checkMissingReturns\` error on \`transformExpression\`.
- stdlib module count is no longer artificially capped.

## Root cause
Parser-native's switch_case iteration was silently dropping the trailing \`return\` statement when a bare case body had the shape \`[lexical_declaration, if_no_else, return]\`. Tree-sitter reports fewer \`namedChildCount\` siblings than expected for this specific pattern, so the loop at \`transformer.ts:2297\` never visits the final \`return\`. The case body ended up as \`[var_decl, if_no_else]\` — no path returns — and \`checkMissingReturns\` correctly flagged it.

Only \`case \"unary_expression\":\` at \`transformer.ts:528\` had this 3-statement bare shape in the compiler source, so it was the lone trigger. Other bare case bodies had at most 2 statements (\`[var_decl, return]\`) and weren't affected.

## Fix (two parts)

1. **\`transformStatement\` handles \`statement_block\`**: was \`return null\`, now calls \`transformStatementBlock\` to preserve the block's contents. Without this, any \`{}\`-wrapped case body would silently drop.
2. **\`case \"unary_expression\":\` body wrapped in \`{}\`**: forces tree-sitter to produce a single \`statement_block\` child, which now traverses correctly, preserving all three inner statements.

## Followup
- Deeper root cause (tree-sitter or parser-native case-body iteration dropping bare siblings) is not addressed here. Captured in #597 comments.
- #601 proposes a semantic pass to reject bare case-declarations at compile time — would prevent future regressions of this class.

## Test plan
- [x] \`npm run verify\` — full tests + 3-stage self-host green locally (with 8+ stdlibs — the repro threshold)
- [ ] CI green