### PR TITLE
fix(parser-native): unblock stdlib expansion by avoiding bare case-decl pattern (#597)

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -526,12 +526,7 @@ function transformExpression(node: TreeSitterNode): Expression {
       return transformBinaryExpression(node);
 
     case "unary_expression":
-      // void expressions evaluate to undefined (not a unary op in our AST)
-      const voidOpChild = getChild(node, 0);
-      if (voidOpChild && (voidOpChild as NodeBase).type === "void") {
-        return { type: "variable", name: "undefined" };
-      }
-      return transformUnaryExpression(node);
+      return transformUnaryExpressionOrVoid(node);
 
     case "update_expression":
       return transformUpdateExpression(node);
@@ -614,6 +609,18 @@ function transformExpression(node: TreeSitterNode): Expression {
     default:
       return { type: "variable", name: "undefined" };
   }
+}
+
+// Extracted to a helper so the "unary_expression" switch case in
+// transformExpression is a single-statement body — avoiding parser-native's
+// tree-sitter iteration dropping the trailing return when a bare case body has
+// [var_decl, if_no_else, return]. See #597 for diagnostic.
+function transformUnaryExpressionOrVoid(node: TreeSitterNode): Expression {
+  const voidOpChild = getChild(node, 0);
+  if (voidOpChild && (voidOpChild as NodeBase).type === "void") {
+    return { type: "variable", name: "undefined" };
+  }
+  return transformUnaryExpression(node);
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
Fixes #597 — the regression that blocked stdlib additions past 8 count. Unblocks #585 (net TCP module) and future stdlib expansion.

## User-facing effect
- Compiler now correctly compiles itself with 8+ \`registerStdlib()\` calls. No more false-positive \`checkMissingReturns\` error on \`transformExpression\`.
- Stdlib module count no longer artificially capped.

## Root cause (narrow observation)
Parser-native's switch_case iteration was producing a case body missing the trailing \`return\` for \`case \"unary_expression\":\`. The source body was:

\`\`\`ts
case \"unary_expression\":
  const voidOpChild = getChild(node, 0);
  if (voidOpChild && (voidOpChild as NodeBase).type === \"void\") {
    return { type: \"variable\", name: \"undefined\" };
  }
  return transformUnaryExpression(node);
\`\`\`

Tree-sitter reports \`namedChildCount=3\` for this case clause (value + const + if), so parser-native iterates 3 children and the final \`return\` is never added to \`caseStatements\`. Downstream \`checkMissingReturns\` correctly flagged the resulting \`[var_decl, if_no_else]\` sequence as \"does not return on all paths\".

**Why tree-sitter reports 3 instead of 4 is not yet root-caused** — could be grammar greed in \`if_statement\`'s consequence production, or a named/anonymous node classification quirk. That is a separate investigation tracked as a followup in #597.

## Fix (not a workaround, but avoids the trigger)
Extract the case body into a helper function \`transformUnaryExpressionOrVoid\`. The switch case becomes a single-statement body that can't trip the bare-case-decl pattern:

\`\`\`ts
case \"unary_expression\":
  return transformUnaryExpressionOrVoid(node);
\`\`\`

Why this approach over the rejected alternatives:
- **Block-wrap \`{ ... }\`** — led to 138 native-test regressions (global \`statement_block\` handler too broad) and stage 1 segfault (scoped inline handler hit native-compiler fragility in the new iteration path).
- **Fix parser-native's iteration** — requires understanding the tree-sitter grammar quirk; that investigation is unbounded and will re-cross today's 20+min verify cycles. Deferred to a followup that can do dedicated LLDB + tree-sitter-inspector work.

The helper extraction is one-line-shift in behavior (same logic, different call site), preserves all existing parser paths, and the full self-host suite passes.

## Test plan
- [x] \`npm run verify\` — full 3-stage self-host + all tests green locally
- [ ] CI green