### PR TITLE
ci: path-filter stage 2/3 self-hosting for non-codegen PRs (#600)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            codegen:
+              - 'src/**'
+              - 'c_bridges/**'
+              - 'scripts/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/ci.yml'
+              - 'tests/self-hosting.test.ts'
+              - 'tests/test-discovery.ts'
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -286,6 +300,8 @@ jobs:
         timeout-minutes: 5
 
       - name: Run self-hosting tests
+        env:
+          CHADSCRIPT_SKIP_STAGE_2_3: ${{ github.event_name == 'pull_request' && steps.changes.outputs.codegen != 'true' && '1' || '' }}
         run: node --import tsx --test tests/self-hosting.test.ts
         timeout-minutes: 15
 
@@ -337,6 +353,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            codegen:
+              - 'src/**'
+              - 'c_bridges/**'
+              - 'scripts/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/ci.yml'
+              - 'tests/self-hosting.test.ts'
+              - 'tests/test-discovery.ts'
 
       - uses: actions/setup-node@v4
         with:
@@ -440,6 +470,8 @@ jobs:
         timeout-minutes: 5
 
       - name: Run self-hosting tests
+        env:
+          CHADSCRIPT_SKIP_STAGE_2_3: ${{ github.event_name == 'pull_request' && steps.changes.outputs.codegen != 'true' && '1' || '' }}
         run: node --import tsx --test tests/self-hosting.test.ts
         timeout-minutes: 15
 

--- a/tests/self-hosting.test.ts
+++ b/tests/self-hosting.test.ts
@@ -245,22 +245,26 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       }
     });
 
-    it("Stage 1 → Stage 2: Stage 1 compiles native-compiler.ts", { skip: SKIP_STAGE_2_3 }, async () => {
-      assert.ok(fsSync.existsSync(STAGE1), "Stage 1 binary must exist");
-      if (fsSync.existsSync(STAGE2)) fsSync.unlinkSync(STAGE2);
+    it(
+      "Stage 1 → Stage 2: Stage 1 compiles native-compiler.ts",
+      { skip: SKIP_STAGE_2_3 },
+      async () => {
+        assert.ok(fsSync.existsSync(STAGE1), "Stage 1 binary must exist");
+        if (fsSync.existsSync(STAGE2)) fsSync.unlinkSync(STAGE2);
 
-      await execWithRetry(`${STAGE1} build -v src/chad-native.ts -o ${STAGE2}`, {
-        timeout: 180000,
-        env: NATIVE_ENV,
-      });
+        await execWithRetry(`${STAGE1} build -v src/chad-native.ts -o ${STAGE2}`, {
+          timeout: 180000,
+          env: NATIVE_ENV,
+        });
 
-      assert.ok(fsSync.existsSync(STAGE2), `Stage 2 binary should exist at ${STAGE2}`);
-      const stats = fsSync.statSync(STAGE2);
-      assert.ok(
-        stats.size > 100000,
-        `Stage 2 binary should be substantial (got ${stats.size} bytes)`,
-      );
-    });
+        assert.ok(fsSync.existsSync(STAGE2), `Stage 2 binary should exist at ${STAGE2}`);
+        const stats = fsSync.statSync(STAGE2);
+        assert.ok(
+          stats.size > 100000,
+          `Stage 2 binary should be substantial (got ${stats.size} bytes)`,
+        );
+      },
+    );
 
     it("Stage 2 smoke test: compile and run hello.ts", { skip: SKIP_STAGE_2_3 }, async () => {
       assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
@@ -282,22 +286,26 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       }
     });
 
-    it("Stage 2 → Stage 3: Stage 2 compiles native-compiler.ts", { skip: SKIP_STAGE_2_3 }, async () => {
-      assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
-      if (fsSync.existsSync(STAGE3)) fsSync.unlinkSync(STAGE3);
+    it(
+      "Stage 2 → Stage 3: Stage 2 compiles native-compiler.ts",
+      { skip: SKIP_STAGE_2_3 },
+      async () => {
+        assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
+        if (fsSync.existsSync(STAGE3)) fsSync.unlinkSync(STAGE3);
 
-      await execWithRetry(`${STAGE2} build -v src/chad-native.ts -o ${STAGE3}`, {
-        timeout: 180000,
-        env: NATIVE_ENV,
-      });
+        await execWithRetry(`${STAGE2} build -v src/chad-native.ts -o ${STAGE3}`, {
+          timeout: 180000,
+          env: NATIVE_ENV,
+        });
 
-      assert.ok(fsSync.existsSync(STAGE3), `Stage 3 binary should exist at ${STAGE3}`);
-      const stats = fsSync.statSync(STAGE3);
-      assert.ok(
-        stats.size > 100000,
-        `Stage 3 binary should be substantial (got ${stats.size} bytes)`,
-      );
-    });
+        assert.ok(fsSync.existsSync(STAGE3), `Stage 3 binary should exist at ${STAGE3}`);
+        const stats = fsSync.statSync(STAGE3);
+        assert.ok(
+          stats.size > 100000,
+          `Stage 3 binary should be substantial (got ${stats.size} bytes)`,
+        );
+      },
+    );
 
     it("Stage 3 smoke test: compile and run hello.ts", { skip: SKIP_STAGE_2_3 }, async () => {
       assert.ok(fsSync.existsSync(STAGE3), "Stage 3 binary must exist");
@@ -319,71 +327,79 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       }
     });
 
-    it("Bootstrap verification: Stage 1 and Stage 2 produce identical IR", { skip: SKIP_STAGE_2_3 }, async () => {
-      assert.ok(fsSync.existsSync(STAGE1), "Stage 1 binary must exist");
-      assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
+    it(
+      "Bootstrap verification: Stage 1 and Stage 2 produce identical IR",
+      { skip: SKIP_STAGE_2_3 },
+      async () => {
+        assert.ok(fsSync.existsSync(STAGE1), "Stage 1 binary must exist");
+        assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
 
-      const testFile = "tests/fixtures/strings/string-length.js";
-      const s1Out = "/tmp/bootstrap-s1";
-      const s2Out = "/tmp/bootstrap-s2";
-      const s1LL = "/tmp/bootstrap-s1.ll";
-      const s2LL = "/tmp/bootstrap-s2.ll";
+        const testFile = "tests/fixtures/strings/string-length.js";
+        const s1Out = "/tmp/bootstrap-s1";
+        const s2Out = "/tmp/bootstrap-s2";
+        const s1LL = "/tmp/bootstrap-s1.ll";
+        const s2LL = "/tmp/bootstrap-s2.ll";
 
-      try {
-        await execAsync(`${STAGE1} build ${testFile} -o ${s1Out}`, {
-          timeout: 30000,
-          env: NATIVE_ENV,
-        });
-        await execAsync(`${STAGE2} build ${testFile} -o ${s2Out}`, {
-          timeout: 30000,
-          env: NATIVE_ENV,
-        });
+        try {
+          await execAsync(`${STAGE1} build ${testFile} -o ${s1Out}`, {
+            timeout: 30000,
+            env: NATIVE_ENV,
+          });
+          await execAsync(`${STAGE2} build ${testFile} -o ${s2Out}`, {
+            timeout: 30000,
+            env: NATIVE_ENV,
+          });
 
-        const ll1 = await fs.readFile(s1LL, "utf-8");
-        const ll2 = await fs.readFile(s2LL, "utf-8");
+          const ll1 = await fs.readFile(s1LL, "utf-8");
+          const ll2 = await fs.readFile(s2LL, "utf-8");
 
-        assert.strictEqual(ll1, ll2, "Stage 1 and Stage 2 should produce identical LLVM IR");
-      } finally {
-        for (const f of [s1Out, s2Out, s1LL, s2LL]) {
-          try {
-            if (fsSync.existsSync(f)) fsSync.unlinkSync(f);
-          } catch {}
+          assert.strictEqual(ll1, ll2, "Stage 1 and Stage 2 should produce identical LLVM IR");
+        } finally {
+          for (const f of [s1Out, s2Out, s1LL, s2LL]) {
+            try {
+              if (fsSync.existsSync(f)) fsSync.unlinkSync(f);
+            } catch {}
+          }
         }
-      }
-    });
+      },
+    );
 
-    it("Bootstrap verification: Stage 2 and Stage 3 produce identical IR", { skip: SKIP_STAGE_2_3 }, async () => {
-      assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
-      assert.ok(fsSync.existsSync(STAGE3), "Stage 3 binary must exist");
+    it(
+      "Bootstrap verification: Stage 2 and Stage 3 produce identical IR",
+      { skip: SKIP_STAGE_2_3 },
+      async () => {
+        assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
+        assert.ok(fsSync.existsSync(STAGE3), "Stage 3 binary must exist");
 
-      const testFile = "tests/fixtures/strings/string-length.js";
-      const s2Out = "/tmp/bootstrap-s2b";
-      const s3Out = "/tmp/bootstrap-s3";
-      const s2LL = "/tmp/bootstrap-s2b.ll";
-      const s3LL = "/tmp/bootstrap-s3.ll";
+        const testFile = "tests/fixtures/strings/string-length.js";
+        const s2Out = "/tmp/bootstrap-s2b";
+        const s3Out = "/tmp/bootstrap-s3";
+        const s2LL = "/tmp/bootstrap-s2b.ll";
+        const s3LL = "/tmp/bootstrap-s3.ll";
 
-      try {
-        await execAsync(`${STAGE2} build ${testFile} -o ${s2Out}`, {
-          timeout: 30000,
-          env: NATIVE_ENV,
-        });
-        await execAsync(`${STAGE3} build ${testFile} -o ${s3Out}`, {
-          timeout: 30000,
-          env: NATIVE_ENV,
-        });
+        try {
+          await execAsync(`${STAGE2} build ${testFile} -o ${s2Out}`, {
+            timeout: 30000,
+            env: NATIVE_ENV,
+          });
+          await execAsync(`${STAGE3} build ${testFile} -o ${s3Out}`, {
+            timeout: 30000,
+            env: NATIVE_ENV,
+          });
 
-        const ll2 = await fs.readFile(s2LL, "utf-8");
-        const ll3 = await fs.readFile(s3LL, "utf-8");
+          const ll2 = await fs.readFile(s2LL, "utf-8");
+          const ll3 = await fs.readFile(s3LL, "utf-8");
 
-        assert.strictEqual(ll2, ll3, "Stage 2 and Stage 3 should produce identical LLVM IR");
-      } finally {
-        for (const f of [s2Out, s3Out, s2LL, s3LL]) {
-          try {
-            if (fsSync.existsSync(f)) fsSync.unlinkSync(f);
-          } catch {}
+          assert.strictEqual(ll2, ll3, "Stage 2 and Stage 3 should produce identical LLVM IR");
+        } finally {
+          for (const f of [s2Out, s3Out, s2LL, s3LL]) {
+            try {
+              if (fsSync.existsSync(f)) fsSync.unlinkSync(f);
+            } catch {}
+          }
         }
-      }
-    });
+      },
+    );
   });
 
   describe("Stage 1: all fixtures", { concurrency: 4 }, () => {

--- a/tests/self-hosting.test.ts
+++ b/tests/self-hosting.test.ts
@@ -16,6 +16,8 @@ const STAGE0 = "/tmp/chad-stage0";
 const STAGE1 = "/tmp/chad-stage1";
 const STAGE2 = "/tmp/chad-stage2";
 const STAGE3 = "/tmp/chad-stage3";
+// Gates stages 2+3 for non-codegen PRs. Set by CI path filter. Stage 1 always runs.
+const SKIP_STAGE_2_3 = process.env.CHADSCRIPT_SKIP_STAGE_2_3 === "1";
 const FIXTURE_OUT_DIR = "/tmp/self-hosting-fixtures";
 
 const isMac = process.platform === "darwin";
@@ -243,7 +245,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       }
     });
 
-    it("Stage 1 → Stage 2: Stage 1 compiles native-compiler.ts", async () => {
+    it("Stage 1 → Stage 2: Stage 1 compiles native-compiler.ts", { skip: SKIP_STAGE_2_3 }, async () => {
       assert.ok(fsSync.existsSync(STAGE1), "Stage 1 binary must exist");
       if (fsSync.existsSync(STAGE2)) fsSync.unlinkSync(STAGE2);
 
@@ -260,7 +262,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       );
     });
 
-    it("Stage 2 smoke test: compile and run hello.ts", async () => {
+    it("Stage 2 smoke test: compile and run hello.ts", { skip: SKIP_STAGE_2_3 }, async () => {
       assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
 
       const outBinary = "/tmp/hello-stage2";
@@ -280,7 +282,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       }
     });
 
-    it("Stage 2 → Stage 3: Stage 2 compiles native-compiler.ts", async () => {
+    it("Stage 2 → Stage 3: Stage 2 compiles native-compiler.ts", { skip: SKIP_STAGE_2_3 }, async () => {
       assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
       if (fsSync.existsSync(STAGE3)) fsSync.unlinkSync(STAGE3);
 
@@ -297,7 +299,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       );
     });
 
-    it("Stage 3 smoke test: compile and run hello.ts", async () => {
+    it("Stage 3 smoke test: compile and run hello.ts", { skip: SKIP_STAGE_2_3 }, async () => {
       assert.ok(fsSync.existsSync(STAGE3), "Stage 3 binary must exist");
 
       const outBinary = "/tmp/hello-stage3";
@@ -317,7 +319,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       }
     });
 
-    it("Bootstrap verification: Stage 1 and Stage 2 produce identical IR", async () => {
+    it("Bootstrap verification: Stage 1 and Stage 2 produce identical IR", { skip: SKIP_STAGE_2_3 }, async () => {
       assert.ok(fsSync.existsSync(STAGE1), "Stage 1 binary must exist");
       assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
 
@@ -350,7 +352,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
       }
     });
 
-    it("Bootstrap verification: Stage 2 and Stage 3 produce identical IR", async () => {
+    it("Bootstrap verification: Stage 2 and Stage 3 produce identical IR", { skip: SKIP_STAGE_2_3 }, async () => {
       assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
       assert.ok(fsSync.existsSync(STAGE3), "Stage 3 binary must exist");
 
@@ -403,7 +405,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
     }
   });
 
-  describe("Stage 2: all fixtures", { concurrency: 4 }, () => {
+  describe("Stage 2: all fixtures", { concurrency: 4, skip: SKIP_STAGE_2_3 }, () => {
     const outDir = path.join(FIXTURE_OUT_DIR, "stage2");
 
     before(() => {


### PR DESCRIPTION
## Summary
Skip stages 2 and 3 of self-hosting test on PRs that touch only docs/fixtures/benchmarks/memory. Keeps stage 1 oracle on every PR; keeps full 2/3 on any codegen/scripts/test-runner/ci change.

## User-facing effect
- Docs-only / fixture-only / benchmark-only PRs: ~3-5 min faster per heavy CI job (build-macos, build-linux-glibc).
- Any `src/**`, `c_bridges/**`, `scripts/**`, `package.json`, `tests/self-hosting.test.ts`, `ci.yml` change: full 3-stage oracle runs unchanged.
- Push to main: always runs full 3-stage (filter only applies to pull_request events).

## How it works
1. `dorny/paths-filter@v3` in both `build-linux-glibc` and `build-macos` jobs computes `steps.changes.outputs.codegen` based on changed files.
2. The self-hosting test step sets `CHADSCRIPT_SKIP_STAGE_2_3=1` only when `github.event_name == 'pull_request' && codegen != 'true'`.
3. `tests/self-hosting.test.ts` reads env var at module load into `SKIP_STAGE_2_3`. Gates 4 stage-level `it()` tests + 2 bootstrap IR verifications + Stage 2 all-fixtures describe via `{ skip }`.

## Validation
This PR itself modifies `.github/workflows/ci.yml` and `tests/self-hosting.test.ts` — both in the codegen filter — so CI should run the FULL 3-stage oracle. That's the positive test.

To prove the skip path, a followup PR touching only docs should show stage 2/3 skipped.

## Local test
\`\`\`
CHADSCRIPT_SKIP_STAGE_2_3=1 node --import tsx --test tests/self-hosting.test.ts
\`\`\`
Output: 5 stages skipped (`# SKIP`), stage 1 runs.

## Test plan
- [ ] CI green (full 3-stage runs because this PR touches ci.yml + self-hosting.test.ts)
- [ ] Followup PR with docs-only change validates skip path