### PR TITLE
Node.js runtime escape hatch via // @chadscript: interpret pragma

### DIFF
--- a/.github/workflows/libnode.yml
+++ b/.github/workflows/libnode.yml
@@ -1,0 +1,130 @@
+name: libnode-pragma
+# Dedicated workflow for the `@chadscript: interpret` pragma path that
+# embeds libnode (Node.js shared lib). Isolated from the main CI so the
+# ~30-60 min first-time libnode build doesn't block regular PRs, and so
+# the job can be disabled independently if libnode v22 EOLs or the metacall
+# pattern hits an upstream issue.
+#
+# Stage 2 self-hosting continues to run in ci.yml and MUST NOT link libnode.
+# This workflow only touches compiled binaries produced from user .ts files
+# that carry `// @chadscript: interpret`.
+
+on:
+  push:
+    branches: [main, dev, v8-phase0]
+    paths:
+      - "c_bridges/node-bridge.cc"
+      - "vendor/**"
+      - "scripts/build-vendor.sh"
+      - "scripts/vendor-pins.sh"
+      - "tests/fixtures/v8/**"
+      - "src/compiler.ts"
+      - ".github/workflows/libnode.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "c_bridges/node-bridge.cc"
+      - "vendor/**"
+      - "scripts/build-vendor.sh"
+      - "scripts/vendor-pins.sh"
+      - "tests/fixtures/v8/**"
+      - "src/compiler.ts"
+      - ".github/workflows/libnode.yml"
+
+jobs:
+  libnode-pragma:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    env:
+      CHAD_NODE_SRC: ${{ github.workspace }}/node-src
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install system dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" | sudo tee /etc/apt/sources.list.d/llvm-21.list
+          sudo apt-get update
+          sudo apt-get install -y clang-21 lld-21 llvm-21-dev \
+            cmake make gcc g++ python3 \
+            autoconf automake libtool \
+            libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev libpq-dev
+          sudo ln -sf /usr/bin/clang-21 /usr/bin/clang
+          sudo ln -sf /usr/bin/clang++-21 /usr/bin/clang++
+          sudo ln -sf /usr/bin/llvm-config-21 /usr/bin/llvm-config
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install system dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install llvm python@3 make
+          echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+
+      - name: Cache libnode build
+        uses: actions/cache@v4
+        with:
+          path: |
+            node-src/out/Release/libnode.*
+            node-src/src/**/*.h
+            node-src/deps/v8/include/**
+            node-src/deps/uv/include/**
+            node-src/config.status
+            node-src/Makefile
+          key: libnode-${{ runner.os }}-${{ hashFiles('scripts/vendor-pins.sh') }}
+
+      - name: Cache vendor artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor/
+            c_bridges/*.o
+          key: libnode-vendor-${{ runner.os }}-${{ hashFiles('scripts/build-vendor.sh', 'scripts/vendor-pins.sh', 'c_bridges/*.c', 'c_bridges/*.cc', 'c_bridges/*.cpp') }}
+
+      - run: npm install
+
+      - name: Build vendor (includes libnode, first run is slow)
+        run: bash scripts/build-vendor.sh
+        timeout-minutes: 75
+
+      - run: npm run build
+
+      - name: Build + run libnode fixtures
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install ms
+          FAIL=0
+          for f in node-require-ms node-set-timeout node-fs-read pragma-interpret; do
+            echo "=== $f ==="
+            node dist/chad-node.js build "tests/fixtures/v8/${f}.ts" -o "/tmp/chad-${f}"
+            OUT="$("/tmp/chad-${f}")"
+            echo "stdout: $OUT"
+            case "$f" in
+              node-require-ms)    [ "$OUT" = "172800000" ] || { echo "FAIL: expected 172800000"; FAIL=1; } ;;
+              node-set-timeout)   [ "$OUT" = "TEST_PASSED" ] || { echo "FAIL: expected TEST_PASSED"; FAIL=1; } ;;
+              node-fs-read)       [[ "$OUT" == len=* ]] || { echo "FAIL: expected len=..."; FAIL=1; } ;;
+              pragma-interpret)   [ "$OUT" = "TEST_PASSED" ] || { echo "FAIL: expected TEST_PASSED"; FAIL=1; } ;;
+            esac
+          done
+          exit $FAIL
+
+      - name: Confirm libnode is linked
+        shell: bash
+        run: |
+          set -e
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            otool -L /tmp/chad-node-require-ms | grep -q libnode || { echo "libnode not linked"; exit 1; }
+          else
+            ldd /tmp/chad-node-require-ms | grep -q libnode || { echo "libnode not linked"; exit 1; }
+          fi

--- a/.github/workflows/libnode.yml
+++ b/.github/workflows/libnode.yml
@@ -41,6 +41,7 @@ jobs:
     timeout-minutes: 200
     env:
       CHAD_NODE_SRC: ${{ github.workspace }}/node-src
+      CHAD_SKIP_NODE: "0"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/libnode.yml
+++ b/.github/workflows/libnode.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 200
     env:
       CHAD_NODE_SRC: ${{ github.workspace }}/node-src
     steps:
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build vendor (includes libnode, first run is slow)
         run: bash scripts/build-vendor.sh
-        timeout-minutes: 75
+        timeout-minutes: 180
 
       - run: npm run build
 

--- a/c_bridges/node-bridge.cc
+++ b/c_bridges/node-bridge.cc
@@ -517,4 +517,229 @@ double cs_v8_handle_call(double fn_handle_d,
     return h2d(store_handle(g_isolate, result));
 }
 
+// Ensure the Node environment has the CJS-require bootstrap loaded exactly
+// once. Subsequent pragma-module registrations use v8::Script::Run to wrap
+// the user source in a CJS IIFE referencing globalThis.__chad_cjs_require.
+// Returns true on success; on failure t_last_error is set.
+bool ensure_pragma_bootstrap(const char* entry_dir) {
+    static bool loaded = false;
+    if (loaded) return true;
+    if (!cs_node_lazy_init()) return false;
+    std::string esc;
+    const char* dir = (entry_dir && *entry_dir) ? entry_dir : ".";
+    for (const char* p = dir; *p; ++p) {
+        if (*p == '\\' || *p == '"') esc.push_back('\\');
+        esc.push_back(*p);
+    }
+    std::string bootstrap =
+        "globalThis.__chad_cjs_require = require('module').createRequire("
+        "require('path').join(\"" + esc + "\", 'package.json'));\n";
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::TryCatch try_catch(g_isolate);
+    v8::MaybeLocal<v8::Value> maybe = node::LoadEnvironment(g_env, bootstrap.c_str());
+    if (maybe.IsEmpty()) {
+        if (try_catch.HasCaught()) {
+            v8::String::Utf8Value m(g_isolate, try_catch.Exception());
+            t_last_error = "pragma bootstrap threw";
+            if (*m) { t_last_error += ": "; t_last_error += *m; }
+        } else {
+            t_last_error = "pragma bootstrap returned empty";
+        }
+        return false;
+    }
+    g_load_env_called = true;
+    loaded = true;
+    return true;
+}
+
+// Evaluate the pragma-module source inside an on-the-fly CJS wrapper and
+// return a JSHandle to its module.exports object. Multiple modules can be
+// registered — each runs in its own closure with its own module/exports.
+double cs_v8_register_pragma_module(const char* src, const char* filename) {
+    t_last_error.clear();
+    if (!ensure_pragma_bootstrap(filename)) return 0.0;
+
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::TryCatch tc(g_isolate);
+
+    std::string fesc;
+    if (filename && *filename) {
+        for (const char* p = filename; *p; ++p) {
+            if (*p == '\\' || *p == '"') fesc.push_back('\\');
+            fesc.push_back(*p);
+        }
+    }
+
+    // Wrap user source as: (function(module, exports, require, __filename,
+    // __dirname){ USER_SRC; return module.exports; })({exports:{}}, {}, ...)
+    // Since JavaScript requires passing module as arg, we build:
+    //   (function(){ const module={exports:{}}; const exports=module.exports;
+    //     const require=globalThis.__chad_cjs_require;
+    //     const __filename="..."; const __dirname=require('path').dirname(__filename);
+    //     /* USER_SRC */
+    //     return module.exports;
+    //   })()
+    std::string wrapped;
+    wrapped += "(function(){\n";
+    wrapped += "const module={exports:{}};\n";
+    wrapped += "const exports=module.exports;\n";
+    wrapped += "const require=globalThis.__chad_cjs_require;\n";
+    if (!fesc.empty()) {
+        wrapped += "const __filename=\"" + fesc + "\";\n";
+        wrapped += "const __dirname=require('path').dirname(__filename);\n";
+    }
+    wrapped += (src ? src : "");
+    wrapped += "\n;return module.exports;\n})()\n";
+
+    v8::Local<v8::String> source;
+    if (!v8::String::NewFromUtf8(g_isolate, wrapped.c_str(),
+                                 v8::NewStringType::kNormal).ToLocal(&source)) {
+        t_last_error = "register_pragma_module: alloc source failed";
+        return 0.0;
+    }
+    v8::Local<v8::Script> script;
+    if (!v8::Script::Compile(ctx, source).ToLocal(&script)) {
+        v8::String::Utf8Value m(g_isolate, tc.Exception());
+        t_last_error = "register_pragma_module: compile failed";
+        if (*m) { t_last_error += ": "; t_last_error += *m; }
+        return 0.0;
+    }
+    v8::Local<v8::Value> result;
+    if (!script->Run(ctx).ToLocal(&result)) {
+        v8::String::Utf8Value m(g_isolate, tc.Exception());
+        t_last_error = "register_pragma_module: run failed";
+        if (*m) { t_last_error += ": "; t_last_error += *m; }
+        return 0.0;
+    }
+    node::SpinEventLoop(g_env);
+    return h2d(store_handle(g_isolate, result));
+}
+
+// Marshal a bool primitive → JSHandle for the argv array.
+double cs_v8_make_bool_handle(double b) {
+    if (!cs_node_lazy_init()) return 0.0;
+    t_last_error.clear();
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = v8::Boolean::New(g_isolate, b != 0.0);
+    return h2d(store_handle(g_isolate, val));
+}
+
+// Fixed-arity call wrappers — ChadScript's FFI cannot pass a raw `double*`
+// array (its `number[]` is a struct). Calling sites up to 8 args cover the
+// vast majority of JS APIs; extend with higher arities if needed.
+static double call_fixed(double fn_h, double recv_h,
+                         const double* args, int32_t n) {
+    return cs_v8_handle_call(fn_h, recv_h, n, args);
+}
+double cs_v8_call0(double fn, double recv) {
+    return call_fixed(fn, recv, nullptr, 0);
+}
+double cs_v8_call1(double fn, double recv, double a0) {
+    double a[] = {a0};
+    return call_fixed(fn, recv, a, 1);
+}
+double cs_v8_call2(double fn, double recv, double a0, double a1) {
+    double a[] = {a0, a1};
+    return call_fixed(fn, recv, a, 2);
+}
+double cs_v8_call3(double fn, double recv, double a0, double a1, double a2) {
+    double a[] = {a0, a1, a2};
+    return call_fixed(fn, recv, a, 3);
+}
+double cs_v8_call4(double fn, double recv, double a0, double a1, double a2,
+                   double a3) {
+    double a[] = {a0, a1, a2, a3};
+    return call_fixed(fn, recv, a, 4);
+}
+double cs_v8_call5(double fn, double recv, double a0, double a1, double a2,
+                   double a3, double a4) {
+    double a[] = {a0, a1, a2, a3, a4};
+    return call_fixed(fn, recv, a, 5);
+}
+double cs_v8_call6(double fn, double recv, double a0, double a1, double a2,
+                   double a3, double a4, double a5) {
+    double a[] = {a0, a1, a2, a3, a4, a5};
+    return call_fixed(fn, recv, a, 6);
+}
+double cs_v8_call7(double fn, double recv, double a0, double a1, double a2,
+                   double a3, double a4, double a5, double a6) {
+    double a[] = {a0, a1, a2, a3, a4, a5, a6};
+    return call_fixed(fn, recv, a, 7);
+}
+double cs_v8_call8(double fn, double recv, double a0, double a1, double a2,
+                   double a3, double a4, double a5, double a6, double a7) {
+    double a[] = {a0, a1, a2, a3, a4, a5, a6, a7};
+    return call_fixed(fn, recv, a, 8);
+}
+
+// If the handle points to a Promise, spin the event loop until it settles
+// (fulfilled/rejected) and return a handle to the resolved value (or throw-
+// equivalent: set t_last_error and return 0). If the handle is not a Promise,
+// return it unchanged. Native `await` across the boundary flows through this.
+double cs_v8_handle_await(double handle_d) {
+    uint64_t handle = d2h(handle_d);
+    t_last_error.clear();
+    if (!is_handle(handle)) { t_last_error = "await: not JSHandle"; return 0.0; }
+    auto it = t_handles.find(handle);
+    if (it == t_handles.end()) { t_last_error = "await: released"; return 0.0; }
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = it->second.Get(g_isolate);
+    if (!val->IsPromise()) {
+        // Nothing to await — re-store & return same value as a fresh handle
+        // (the caller expects to own it, matching Promise path semantics).
+        return h2d(store_handle(g_isolate, val));
+    }
+    v8::Local<v8::Promise> promise = val.As<v8::Promise>();
+    // Drain microtasks + libuv until the promise is settled. Cap iterations
+    // so a never-resolving promise doesn't spin forever silently.
+    int iters = 0;
+    while (promise->State() == v8::Promise::kPending && iters < 10000) {
+        node::SpinEventLoop(g_env);
+        iters++;
+    }
+    if (promise->State() == v8::Promise::kPending) {
+        t_last_error = "await: promise pending after 10000 iterations";
+        return 0.0;
+    }
+    v8::Local<v8::Value> resolved = promise->Result();
+    if (promise->State() == v8::Promise::kRejected) {
+        v8::String::Utf8Value m(g_isolate, resolved);
+        t_last_error = "await: promise rejected";
+        if (*m) { t_last_error += ": "; t_last_error += *m; }
+        return 0.0;
+    }
+    return h2d(store_handle(g_isolate, resolved));
+}
+
+double cs_v8_handle_to_bool(double handle_d) {
+    uint64_t handle = d2h(handle_d);
+    t_last_error.clear();
+    if (!is_handle(handle)) { t_last_error = "to_bool: not JSHandle"; return 0.0; }
+    auto it = t_handles.find(handle);
+    if (it == t_handles.end()) { t_last_error = "to_bool: released"; return 0.0; }
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = it->second.Get(g_isolate);
+    return val->BooleanValue(g_isolate) ? 1.0 : 0.0;
+}
+
 } // extern "C"

--- a/c_bridges/node-bridge.cc
+++ b/c_bridges/node-bridge.cc
@@ -1,0 +1,412 @@
+// node-bridge.cc — embed Node.js (libnode) for the `@chadscript: interpret`
+// pragma. Replaces the raw-V8 bridge (c_bridges/v8-bridge.cc). Keeping the
+// `cs_v8_*` symbol names lets the rest of the compiler pipeline and the 40
+// existing C unit tests continue to link unchanged.
+//
+// Why Node instead of raw V8: we get `require`, `fs`, `Buffer`, `setTimeout`,
+// Promise microtasks, and the full Node CJS/ESM module loaders "for free",
+// rather than reimplementing each one on top of raw V8. Electron / NW.js
+// prove this embedding pattern scales to production.
+//
+// Lifecycle: the process holds a single `MultiIsolatePlatform` + one
+// `CommonEnvironmentSetup` for the interpret pragma's isolate. Each eval
+// reuses that environment (required for `require` caching to work).
+//
+// ABI: all JSHandle functions cross the boundary as `double` (see h2d/d2h).
+// ChadScript's `number` FFI lowering reads the integer return register via
+// double, so integer-typed handles would read garbage. This matches the
+// existing v8-bridge ABI — diff-minimizing swap.
+
+#include <node.h>
+#include <node_api.h>
+#include <uv.h>
+#include <v8.h>
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+// ---- Global Node embedding state ----
+
+std::unique_ptr<node::MultiIsolatePlatform> g_platform;
+std::unique_ptr<node::CommonEnvironmentSetup> g_setup;
+v8::Isolate* g_isolate = nullptr;
+node::Environment* g_env = nullptr;
+bool g_initialized = false;
+std::mutex g_init_mu;
+std::string g_init_error;
+
+thread_local std::string t_last_error;
+
+// ---- JSHandle table (same layout as v8-bridge) ----
+
+constexpr uint64_t JS_HANDLE_TAG = 0x100000000ULL;
+constexpr uint64_t JS_HANDLE_TAG_MASK = 0xFFFFFFFF00000000ULL;
+thread_local uint64_t t_next_handle_id = 1;
+thread_local std::unordered_map<uint64_t, v8::Global<v8::Value>> t_handles;
+
+inline double h2d(uint64_t h) { return (double)h; }
+inline uint64_t d2h(double d) {
+    if (d < 0.0 || !std::isfinite(d)) return 0;
+    return (uint64_t)d;
+}
+
+uint64_t store_handle(v8::Isolate* iso, v8::Local<v8::Value> value) {
+    uint64_t id = JS_HANDLE_TAG | (t_next_handle_id++);
+    t_handles.emplace(id, v8::Global<v8::Value>(iso, value));
+    return id;
+}
+
+bool is_handle(uint64_t id) {
+    return (id & JS_HANDLE_TAG_MASK) == JS_HANDLE_TAG;
+}
+
+// ---- Node lazy init ----
+
+bool cs_node_lazy_init() {
+    std::lock_guard<std::mutex> lk(g_init_mu);
+    if (g_initialized) return true;
+    if (!g_init_error.empty()) {
+        t_last_error = g_init_error;
+        return false;
+    }
+
+    // argv seen by Node. "chad" is the embedder-visible process.argv[0].
+    std::vector<std::string> args{"chad"};
+    std::vector<std::string> exec_args;
+    std::vector<std::string> errors;
+
+    int rc = node::InitializeNodeWithArgs(&args, &exec_args, &errors);
+    if (rc != 0 || !errors.empty()) {
+        g_init_error = "node::InitializeNodeWithArgs failed";
+        for (auto& e : errors) { g_init_error += ": "; g_init_error += e; }
+        t_last_error = g_init_error;
+        return false;
+    }
+
+    g_platform = node::MultiIsolatePlatform::Create(/*thread_pool_size=*/4);
+    v8::V8::InitializePlatform(g_platform.get());
+    v8::V8::Initialize();
+
+    errors.clear();
+    g_setup = node::CommonEnvironmentSetup::Create(
+        g_platform.get(), &errors, args, exec_args);
+    if (!g_setup) {
+        g_init_error = "CommonEnvironmentSetup::Create failed";
+        for (auto& e : errors) { g_init_error += ": "; g_init_error += e; }
+        t_last_error = g_init_error;
+        return false;
+    }
+
+    g_isolate = g_setup->isolate();
+    g_env = g_setup->env();
+
+    // Bootstrap: minimal script so Node wires up its internals. Real user
+    // code is executed later via node::LoadEnvironment-style eval (see
+    // cs_v8_eval_string below). An empty bootstrap is valid.
+    {
+        v8::Locker locker(g_isolate);
+        v8::Isolate::Scope iscope(g_isolate);
+        v8::HandleScope hs(g_isolate);
+        v8::Local<v8::Context> ctx = g_setup->context();
+        v8::Context::Scope cscope(ctx);
+        v8::MaybeLocal<v8::Value> boot = node::LoadEnvironment(g_env, "");
+        if (boot.IsEmpty()) {
+            g_init_error = "node::LoadEnvironment(bootstrap) returned empty";
+            t_last_error = g_init_error;
+            return false;
+        }
+    }
+
+    g_initialized = true;
+    return true;
+}
+
+// Runs `src` inside the persistent Node environment. Returns the last
+// expression's value via v8::Script::Run; then drains the libuv event loop so
+// setTimeout/fs/promises tasks complete before we return.
+bool run_script(const char* src, v8::Local<v8::Value>* out_result) {
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::TryCatch try_catch(g_isolate);
+
+    v8::Local<v8::String> source;
+    if (!v8::String::NewFromUtf8(g_isolate, src ? src : "",
+                                 v8::NewStringType::kNormal).ToLocal(&source)) {
+        t_last_error = "failed to allocate source string";
+        return false;
+    }
+
+    v8::Local<v8::Script> script;
+    if (!v8::Script::Compile(ctx, source).ToLocal(&script)) {
+        v8::String::Utf8Value m(g_isolate, try_catch.Exception());
+        t_last_error = "compile failed";
+        if (*m) { t_last_error += ": "; t_last_error += *m; }
+        return false;
+    }
+
+    v8::Local<v8::Value> result;
+    if (!script->Run(ctx).ToLocal(&result)) {
+        v8::String::Utf8Value m(g_isolate, try_catch.Exception());
+        t_last_error = "run failed";
+        if (*m) { t_last_error += ": "; t_last_error += *m; }
+        return false;
+    }
+
+    // Drain microtasks + libuv. SpinEventLoop runs until there are no more
+    // refs or the loop is stopped — that's what makes setTimeout work.
+    node::SpinEventLoop(g_env);
+
+    *out_result = result;
+    return true;
+}
+
+} // namespace
+
+extern "C" {
+
+double cs_v8_available(void) {
+    return cs_node_lazy_init() ? 1.0 : 0.0;
+}
+
+const char* cs_v8_last_error(void) {
+    return t_last_error.empty() ? "" : t_last_error.c_str();
+}
+
+void cs_v8_clear_error(void) {
+    t_last_error.clear();
+}
+
+double cs_v8_eval_number(const char* src) {
+    if (!cs_node_lazy_init()) return std::nan("");
+    t_last_error.clear();
+    v8::Local<v8::Value> result;
+    if (!run_script(src, &result)) return std::nan("");
+
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+
+    if (!result->IsNumber()) {
+        v8::String::Utf8Value got(g_isolate, result);
+        t_last_error = "expected number, got: ";
+        t_last_error += *got ? *got : "<?>";
+        return std::nan("");
+    }
+    double out;
+    if (!result->NumberValue(ctx).To(&out)) {
+        t_last_error = "NumberValue conversion failed";
+        return std::nan("");
+    }
+    return out;
+}
+
+char* cs_v8_eval_string(const char* src) {
+    if (!cs_node_lazy_init()) return nullptr;
+    t_last_error.clear();
+    v8::Local<v8::Value> result;
+    if (!run_script(src, &result)) return nullptr;
+
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+
+    if (result->IsUndefined() || result->IsNull()) return strdup("");
+    v8::Local<v8::String> str;
+    if (!result->ToString(ctx).ToLocal(&str)) {
+        t_last_error = "ToString failed";
+        return nullptr;
+    }
+    v8::String::Utf8Value utf8(g_isolate, str);
+    return strdup(*utf8 ? *utf8 : "");
+}
+
+// ---- JSHandle API ----
+
+double cs_v8_eval_handle(const char* src) {
+    if (!cs_node_lazy_init()) return 0.0;
+    t_last_error.clear();
+    v8::Local<v8::Value> result;
+    if (!run_script(src, &result)) return 0.0;
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    return h2d(store_handle(g_isolate, result));
+}
+
+double cs_v8_handle_to_number(double handle_d) {
+    uint64_t handle = d2h(handle_d);
+    t_last_error.clear();
+    if (!is_handle(handle)) { t_last_error = "not a JSHandle"; return std::nan(""); }
+    auto it = t_handles.find(handle);
+    if (it == t_handles.end()) { t_last_error = "JSHandle released"; return std::nan(""); }
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = it->second.Get(g_isolate);
+    if (!val->IsNumber()) { t_last_error = "handle not a number"; return std::nan(""); }
+    double out;
+    if (!val->NumberValue(ctx).To(&out)) { t_last_error = "NumberValue failed"; return std::nan(""); }
+    return out;
+}
+
+char* cs_v8_handle_to_string(double handle_d) {
+    uint64_t handle = d2h(handle_d);
+    t_last_error.clear();
+    if (!is_handle(handle)) { t_last_error = "not a JSHandle"; return nullptr; }
+    auto it = t_handles.find(handle);
+    if (it == t_handles.end()) { t_last_error = "JSHandle released"; return nullptr; }
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = it->second.Get(g_isolate);
+    v8::Local<v8::String> str;
+    if (!val->ToString(ctx).ToLocal(&str)) { t_last_error = "ToString failed"; return nullptr; }
+    v8::String::Utf8Value utf8(g_isolate, str);
+    return strdup(*utf8 ? *utf8 : "");
+}
+
+void cs_v8_handle_release(double handle_d) {
+    uint64_t handle = d2h(handle_d);
+    if (!is_handle(handle)) return;
+    auto it = t_handles.find(handle);
+    if (it != t_handles.end()) {
+        it->second.Reset();
+        t_handles.erase(it);
+    }
+}
+
+double cs_v8_handle_table_size(void) { return (double)t_handles.size(); }
+
+double cs_v8_is_handle(double value_d) {
+    return is_handle(d2h(value_d)) ? 1.0 : 0.0;
+}
+
+double cs_v8_make_number_handle(double n) {
+    if (!cs_node_lazy_init()) return 0.0;
+    t_last_error.clear();
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = v8::Number::New(g_isolate, n);
+    return h2d(store_handle(g_isolate, val));
+}
+
+double cs_v8_make_string_handle(const char* s) {
+    if (!cs_node_lazy_init()) return 0.0;
+    t_last_error.clear();
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::String> str;
+    if (!v8::String::NewFromUtf8(g_isolate, s ? s : "",
+                                 v8::NewStringType::kNormal).ToLocal(&str)) {
+        t_last_error = "alloc string failed";
+        return 0.0;
+    }
+    return h2d(store_handle(g_isolate, str));
+}
+
+double cs_v8_handle_get_property(double obj_handle_d, const char* name) {
+    uint64_t obj_handle = d2h(obj_handle_d);
+    t_last_error.clear();
+    if (!is_handle(obj_handle)) { t_last_error = "get_property: not a JSHandle"; return 0.0; }
+    auto it = t_handles.find(obj_handle);
+    if (it == t_handles.end()) { t_last_error = "get_property: released"; return 0.0; }
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::TryCatch tc(g_isolate);
+    v8::Local<v8::Value> obj_val = it->second.Get(g_isolate);
+    if (!obj_val->IsObject()) { t_last_error = "get_property: not object"; return 0.0; }
+    v8::Local<v8::Object> obj = obj_val.As<v8::Object>();
+    v8::Local<v8::String> key;
+    if (!v8::String::NewFromUtf8(g_isolate, name ? name : "",
+                                 v8::NewStringType::kNormal).ToLocal(&key)) {
+        t_last_error = "get_property: alloc key failed";
+        return 0.0;
+    }
+    v8::Local<v8::Value> prop;
+    if (!obj->Get(ctx, key).ToLocal(&prop)) { t_last_error = "get_property: threw"; return 0.0; }
+    return h2d(store_handle(g_isolate, prop));
+}
+
+double cs_v8_handle_call(double fn_handle_d,
+                         double this_handle_or_zero_d,
+                         int32_t n_args,
+                         const double* arg_handles) {
+    uint64_t fn_handle = d2h(fn_handle_d);
+    uint64_t this_handle_or_zero = d2h(this_handle_or_zero_d);
+    t_last_error.clear();
+    if (!is_handle(fn_handle)) { t_last_error = "call: fn not JSHandle"; return 0.0; }
+    auto fn_it = t_handles.find(fn_handle);
+    if (fn_it == t_handles.end()) { t_last_error = "call: fn released"; return 0.0; }
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::TryCatch tc(g_isolate);
+    v8::Local<v8::Value> fn_val = fn_it->second.Get(g_isolate);
+    if (!fn_val->IsFunction()) { t_last_error = "call: not function"; return 0.0; }
+    v8::Local<v8::Function> fn = fn_val.As<v8::Function>();
+
+    v8::Local<v8::Value> recv;
+    if (this_handle_or_zero == 0) {
+        recv = v8::Undefined(g_isolate);
+    } else if (!is_handle(this_handle_or_zero)) {
+        t_last_error = "call: this not JSHandle"; return 0.0;
+    } else {
+        auto ti = t_handles.find(this_handle_or_zero);
+        if (ti == t_handles.end()) { t_last_error = "call: this released"; return 0.0; }
+        recv = ti->second.Get(g_isolate);
+    }
+
+    std::vector<v8::Local<v8::Value>> args;
+    args.reserve(n_args < 0 ? 0 : (size_t)n_args);
+    for (int i = 0; i < n_args; i++) {
+        uint64_t ah = d2h(arg_handles[i]);
+        if (!is_handle(ah)) { t_last_error = "call: arg not JSHandle"; return 0.0; }
+        auto ai = t_handles.find(ah);
+        if (ai == t_handles.end()) { t_last_error = "call: arg released"; return 0.0; }
+        args.push_back(ai->second.Get(g_isolate));
+    }
+
+    v8::Local<v8::Value> result;
+    if (!fn->Call(ctx, recv, n_args, args.data()).ToLocal(&result)) {
+        t_last_error = "call: threw";
+        return 0.0;
+    }
+
+    node::SpinEventLoop(g_env);
+    return h2d(store_handle(g_isolate, result));
+}
+
+} // extern "C"

--- a/c_bridges/node-bridge.cc
+++ b/c_bridges/node-bridge.cc
@@ -82,23 +82,33 @@ bool cs_node_lazy_init() {
     }
 
     // argv seen by Node. "chad" is the embedder-visible process.argv[0].
+    // Use InitializeOncePerProcess (modern API) rather than the deprecated
+    // InitializeNodeWithArgs — the deprecated path skips cppgc, v8, and the
+    // default Node v8 platform, and reassembling those manually is fragile.
+    // kNoDefaultSignalHandling keeps Node from hijacking the chad process's
+    // signal handlers (we still want to CTRL-C out of a long eval).
     std::vector<std::string> args{"chad"};
-    std::vector<std::string> exec_args;
-    std::vector<std::string> errors;
-
-    int rc = node::InitializeNodeWithArgs(&args, &exec_args, &errors);
-    if (rc != 0 || !errors.empty()) {
-        g_init_error = "node::InitializeNodeWithArgs failed";
-        for (auto& e : errors) { g_init_error += ": "; g_init_error += e; }
+    auto init_result = node::InitializeOncePerProcess(
+        args,
+        {node::ProcessInitializationFlags::kNoDefaultSignalHandling,
+         node::ProcessInitializationFlags::kDisableNodeOptionsEnv,
+         node::ProcessInitializationFlags::kDisableCLIOptions});
+    if (init_result->early_return()) {
+        g_init_error = "node::InitializeOncePerProcess early return";
+        for (auto& e : init_result->errors()) {
+            g_init_error += ": ";
+            g_init_error += e;
+        }
         t_last_error = g_init_error;
         return false;
     }
 
-    g_platform = node::MultiIsolatePlatform::Create(/*thread_pool_size=*/4);
-    v8::V8::InitializePlatform(g_platform.get());
-    v8::V8::Initialize();
+    g_platform.reset(init_result->platform());
+    // Ownership: we keep the default platform alive via g_platform. Node's
+    // init_result hands us a raw pointer; we take ownership.
 
-    errors.clear();
+    std::vector<std::string> errors;
+    std::vector<std::string> exec_args = init_result->exec_args();
     g_setup = node::CommonEnvironmentSetup::Create(
         g_platform.get(), &errors, args, exec_args);
     if (!g_setup) {
@@ -111,26 +121,18 @@ bool cs_node_lazy_init() {
     g_isolate = g_setup->isolate();
     g_env = g_setup->env();
 
-    // Bootstrap: minimal script so Node wires up its internals. Real user
-    // code is executed later via node::LoadEnvironment-style eval (see
-    // cs_v8_eval_string below). An empty bootstrap is valid.
-    {
-        v8::Locker locker(g_isolate);
-        v8::Isolate::Scope iscope(g_isolate);
-        v8::HandleScope hs(g_isolate);
-        v8::Local<v8::Context> ctx = g_setup->context();
-        v8::Context::Scope cscope(ctx);
-        v8::MaybeLocal<v8::Value> boot = node::LoadEnvironment(g_env, "");
-        if (boot.IsEmpty()) {
-            g_init_error = "node::LoadEnvironment(bootstrap) returned empty";
-            t_last_error = g_init_error;
-            return false;
-        }
-    }
-
+    // NOTE: We do NOT call LoadEnvironment here. LoadEnvironment can only be
+    // called once per Environment; the pragma path calls it later with the
+    // real user source. The non-pragma JSHandle API uses v8::Script::Run
+    // directly, which does not require LoadEnvironment to have been called.
     g_initialized = true;
     return true;
 }
+
+// Track whether LoadEnvironment has been called — it can only fire once per
+// Environment. JSHandle-only calls won't trip this; pragma eval_script_node
+// sets it.
+bool g_load_env_called = false;
 
 // Runs `src` inside the persistent Node environment. Returns the last
 // expression's value via v8::Script::Run; then drains the libuv event loop so
@@ -236,6 +238,100 @@ char* cs_v8_eval_string(const char* src) {
     }
     v8::String::Utf8Value utf8(g_isolate, str);
     return strdup(*utf8 ? *utf8 : "");
+}
+
+// Run user source via node::LoadEnvironment(env, src). Unlike raw V8 Script::Run,
+// LoadEnvironment wraps the source in Node's CJS wrapper so `require`,
+// `__filename`, `__dirname`, `module`, and `exports` are available. Event loop
+// is drained before returning so setTimeout/fs.promises finish.
+//
+// Returns strdup'd stdout-intended string. Empty string if eval value is
+// undefined/null. nullptr on failure (caller reads cs_v8_last_error).
+//
+// NOTE: LoadEnvironment can only be called once per Environment. For the
+// pragma use case the file is the whole program, so that's fine. If we ever
+// need to eval multiple scripts in sequence we'll need to either (a) recreate
+// the env per call, or (b) fall back to Script::Run for the secondary evals.
+char* cs_v8_eval_script_node(const char* src, const char* filename) {
+    if (!cs_node_lazy_init()) return nullptr;
+    t_last_error.clear();
+
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::TryCatch try_catch(g_isolate);
+
+    // Seed process.argv[1] and __filename/__dirname via a preamble. Node's
+    // LoadEnvironment injects a CJS wrapper; __filename is derived from the
+    // script origin but that's not settable directly here. The cheap, robust
+    // path: set globals before invoking LoadEnvironment on the user source.
+    std::string preamble;
+    if (filename && *filename) {
+        // Escape backslashes + quotes for JS string literal safety.
+        std::string esc;
+        for (const char* p = filename; *p; ++p) {
+            if (*p == '\\' || *p == '"') esc.push_back('\\');
+            esc.push_back(*p);
+        }
+        preamble = "process.argv[1] = \"" + esc + "\";\n";
+        preamble += "try { global.__filename = \"" + esc + "\"; "
+                    "global.__dirname = require('path').dirname(\"" + esc + "\"); } "
+                    "catch (e) {}\n";
+    }
+    std::string full_src = preamble + (src ? src : "");
+
+    v8::MaybeLocal<v8::Value> maybe = node::LoadEnvironment(g_env, full_src.c_str());
+    if (maybe.IsEmpty()) {
+        if (try_catch.HasCaught()) {
+            v8::String::Utf8Value m(g_isolate, try_catch.Exception());
+            t_last_error = "LoadEnvironment threw";
+            if (*m) { t_last_error += ": "; t_last_error += *m; }
+        } else {
+            t_last_error = "LoadEnvironment returned empty";
+        }
+        return nullptr;
+    }
+
+    // Drain microtasks + libuv until the loop is empty (or all handles unref'd).
+    // This is what lets setTimeout, fs.promises, async fetch actually finish.
+    node::SpinEventLoop(g_env);
+
+    v8::Local<v8::Value> result = maybe.ToLocalChecked();
+    if (result->IsUndefined() || result->IsNull()) return strdup("");
+    v8::Local<v8::String> str;
+    if (!result->ToString(ctx).ToLocal(&str)) {
+        t_last_error = "ToString failed on LoadEnvironment result";
+        return strdup("");
+    }
+    v8::String::Utf8Value utf8(g_isolate, str);
+    return strdup(*utf8 ? *utf8 : "");
+}
+
+// Shut down the Node environment cleanly. The pragma wrapper calls this after
+// eval completes so the process can exit — otherwise the isolate + platform
+// static state keeps uv handles pinned and main's return hangs in static
+// destructors. Safe to call more than once.
+void cs_v8_shutdown_node(void) {
+    std::lock_guard<std::mutex> lk(g_init_mu);
+    if (!g_initialized) return;
+    // Drop all outstanding handles first — each v8::Global<Value> pins the
+    // isolate. Release them before the isolate itself goes away.
+    t_handles.clear();
+    if (g_env) {
+        node::Stop(g_env);
+    }
+    g_setup.reset();  // disposes isolate + context + env
+    g_isolate = nullptr;
+    g_env = nullptr;
+    // node::TearDownOncePerProcess disposes V8 + the default platform that
+    // InitializeOncePerProcess installed. Releasing g_platform here before
+    // TearDown is a no-op (we never owned it — init_result->platform() is
+    // the default platform, also owned by Node's per-process state).
+    g_platform.release();
+    node::TearDownOncePerProcess();
+    g_initialized = false;
 }
 
 // ---- JSHandle API ----

--- a/c_bridges/node-bridge.cc
+++ b/c_bridges/node-bridge.cc
@@ -263,24 +263,36 @@ char* cs_v8_eval_script_node(const char* src, const char* filename) {
     v8::Context::Scope cscope(ctx);
     v8::TryCatch try_catch(g_isolate);
 
-    // Seed process.argv[1] and __filename/__dirname via a preamble. Node's
-    // LoadEnvironment injects a CJS wrapper; __filename is derived from the
-    // script origin but that's not settable directly here. The cheap, robust
-    // path: set globals before invoking LoadEnvironment on the user source.
-    std::string preamble;
+    // Build a preamble that:
+    //   1. Sets process.argv[1] so programs inspecting argv see the user script.
+    //   2. Replaces the builtin `require` with a CJS-style require created via
+    //      `module.createRequire(filename)`. LoadEnvironment's default
+    //      `require` is the internal builtin loader — it only resolves
+    //      `node:foo` modules, not npm packages / relative paths.
+    //   3. Sets __filename / __dirname as globals so user code can read them.
+    std::string esc;
     if (filename && *filename) {
-        // Escape backslashes + quotes for JS string literal safety.
-        std::string esc;
         for (const char* p = filename; *p; ++p) {
             if (*p == '\\' || *p == '"') esc.push_back('\\');
             esc.push_back(*p);
         }
-        preamble = "process.argv[1] = \"" + esc + "\";\n";
-        preamble += "try { global.__filename = \"" + esc + "\"; "
-                    "global.__dirname = require('path').dirname(\"" + esc + "\"); } "
-                    "catch (e) {}\n";
     }
-    std::string full_src = preamble + (src ? src : "");
+    std::string preamble;
+    std::string user_prologue;
+    if (!esc.empty()) {
+        preamble =
+            "process.argv[1] = \"" + esc + "\";\n"
+            "globalThis.__chad_cjs_require = require('module').createRequire(\"" + esc + "\");\n"
+            "globalThis.__filename = \"" + esc + "\";\n"
+            "globalThis.__dirname = require('path').dirname(\"" + esc + "\");\n";
+        // Inside the CJS wrapper LoadEnvironment injects, `require` is a
+        // parameter bound to the internal builtin loader (resolves only
+        // `node:*`). Rebind the local name to our CJS-style one so user code
+        // that calls `require("some-npm-pkg")` hits the real module resolver.
+        user_prologue =
+            "require = globalThis.__chad_cjs_require;\n";
+    }
+    std::string full_src = preamble + user_prologue + (src ? src : "");
 
     v8::MaybeLocal<v8::Value> maybe = node::LoadEnvironment(g_env, full_src.c_str());
     if (maybe.IsEmpty()) {

--- a/c_bridges/v8-bridge-bench.c
+++ b/c_bridges/v8-bridge-bench.c
@@ -1,0 +1,105 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <mach/mach.h>
+
+extern double cs_v8_available(void);
+extern double cs_v8_eval_number(const char* src);
+extern char* cs_v8_eval_string(const char* src);
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1.0e6;
+}
+
+static size_t rss_bytes(void) {
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                  (task_info_t)&info, &count) != KERN_SUCCESS) {
+        return 0;
+    }
+    return (size_t)info.resident_size;
+}
+
+static double mb(size_t b) { return b / (1024.0 * 1024.0); }
+
+int main(void) {
+    printf("v8 bridge phase 0 benchmarks\n");
+    printf("============================\n\n");
+
+    size_t rss_startup = rss_bytes();
+    printf("RSS at process start (before any v8 call): %.2f MB\n", mb(rss_startup));
+
+    double t0 = now_ms();
+    double warm = cs_v8_eval_number("1");
+    double t1 = now_ms();
+    printf("V8 cold init + first eval: %.2f ms (result=%g)\n", t1 - t0, warm);
+
+    size_t rss_after_init = rss_bytes();
+    printf("RSS after v8 init: %.2f MB (+%.2f MB)\n",
+           mb(rss_after_init), mb(rss_after_init - rss_startup));
+
+    printf("\n-- eval_number throughput --\n");
+    const int N_NUM = 100000;
+    t0 = now_ms();
+    double sum = 0;
+    for (int i = 0; i < N_NUM; i++) {
+        sum += cs_v8_eval_number("2 + 2");
+    }
+    t1 = now_ms();
+    double num_elapsed_ms = t1 - t0;
+    double num_ops_per_sec = (N_NUM * 1000.0) / num_elapsed_ms;
+    double num_us_per_op = (num_elapsed_ms * 1000.0) / N_NUM;
+    printf("  %d evals in %.0f ms → %.0f ops/sec → %.2f µs/op  (sum=%g)\n",
+           N_NUM, num_elapsed_ms, num_ops_per_sec, num_us_per_op, sum);
+
+    printf("\n-- eval_string throughput --\n");
+    const int N_STR = 100000;
+    t0 = now_ms();
+    size_t total_len = 0;
+    for (int i = 0; i < N_STR; i++) {
+        char* s = cs_v8_eval_string("'ok'");
+        if (s) {
+            total_len += strlen(s);
+            free(s);
+        }
+    }
+    t1 = now_ms();
+    double str_elapsed_ms = t1 - t0;
+    double str_ops_per_sec = (N_STR * 1000.0) / str_elapsed_ms;
+    double str_us_per_op = (str_elapsed_ms * 1000.0) / N_STR;
+    printf("  %d evals in %.0f ms → %.0f ops/sec → %.2f µs/op  (total_len=%zu)\n",
+           N_STR, str_elapsed_ms, str_ops_per_sec, str_us_per_op, total_len);
+
+    printf("\n-- memory stability: 1M evals with RSS samples --\n");
+    const int N_LEAK = 1000000;
+    const int SAMPLE_EVERY = 100000;
+    size_t rss_before_leak = rss_bytes();
+    printf("  RSS before loop: %.2f MB\n", mb(rss_before_leak));
+    t0 = now_ms();
+    double acc = 0;
+    for (int i = 0; i < N_LEAK; i++) {
+        acc += cs_v8_eval_number("1 + 1");
+        if (i > 0 && i % SAMPLE_EVERY == 0) {
+            size_t r = rss_bytes();
+            double delta = (double)r - (double)rss_before_leak;
+            printf("  after %7d evals: RSS %.2f MB (%+.2f MB vs start)\n",
+                   i, mb(r), delta / (1024.0 * 1024.0));
+        }
+    }
+    t1 = now_ms();
+    size_t rss_after_leak = rss_bytes();
+    double leak_elapsed_ms = t1 - t0;
+    double leak_ops_per_sec = (N_LEAK * 1000.0) / leak_elapsed_ms;
+    printf("  1M evals in %.0f ms → %.0f ops/sec (acc=%g)\n",
+           leak_elapsed_ms, leak_ops_per_sec, acc);
+    printf("  RSS delta across 1M evals: %+.2f MB\n",
+           ((double)rss_after_leak - (double)rss_before_leak) / (1024.0 * 1024.0));
+
+    printf("\n============================\n");
+    printf("BENCH_DONE\n");
+    return 0;
+}

--- a/c_bridges/v8-bridge-test.c
+++ b/c_bridges/v8-bridge-test.c
@@ -2,12 +2,20 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <stdint.h>
 
 extern double cs_v8_available(void);
 extern double cs_v8_eval_number(const char* src);
 extern char* cs_v8_eval_string(const char* src);
 extern const char* cs_v8_last_error(void);
 extern void cs_v8_clear_error(void);
+
+extern uint64_t cs_v8_eval_handle(const char* src);
+extern double   cs_v8_handle_to_number(uint64_t h);
+extern char*    cs_v8_handle_to_string(uint64_t h);
+extern void     cs_v8_handle_release(uint64_t h);
+extern uint64_t cs_v8_handle_table_size(void);
+extern double   cs_v8_is_handle(uint64_t v);
 
 static int g_pass = 0;
 static int g_fail = 0;
@@ -69,6 +77,66 @@ int main(void) {
         if (r != (double)(i * 2)) { seq_ok = 0; break; }
     }
     check("1000 sequential evals state clean", seq_ok, NULL);
+
+    printf("\n-- JSHandle v0 --\n");
+
+    uint64_t h_num = cs_v8_eval_handle("6 * 7");
+    check("eval_handle returns non-zero", h_num != 0, NULL);
+    check("eval_handle returns tagged handle", cs_v8_is_handle(h_num) == 1.0, NULL);
+    check("handle_to_number reads 42", cs_v8_handle_to_number(h_num) == 42.0, NULL);
+
+    char* h_num_str = cs_v8_handle_to_string(h_num);
+    check("handle_to_string of number == '42'",
+          h_num_str != NULL && strcmp(h_num_str, "42") == 0, h_num_str);
+    free(h_num_str);
+
+    uint64_t h_str = cs_v8_eval_handle("'v8 live'");
+    char* h_str_val = cs_v8_handle_to_string(h_str);
+    check("handle_to_string of string == 'v8 live'",
+          h_str_val != NULL && strcmp(h_str_val, "v8 live") == 0, h_str_val);
+    free(h_str_val);
+
+    check("handle_to_number on string handle sets error",
+          isnan(cs_v8_handle_to_number(h_str))
+          && strstr(cs_v8_last_error(), "does not hold a number") != NULL,
+          cs_v8_last_error());
+
+    uint64_t h_obj = cs_v8_eval_handle("({name: 'chad', count: 3})");
+    char* h_obj_str = cs_v8_handle_to_string(h_obj);
+    check("handle_to_string of object contains '[object Object]' or serialization",
+          h_obj_str != NULL, h_obj_str);
+    free(h_obj_str);
+
+    uint64_t table_before = cs_v8_handle_table_size();
+    check("handle table has 3 entries before releases", table_before == 3, NULL);
+
+    cs_v8_handle_release(h_num);
+    cs_v8_handle_release(h_str);
+    cs_v8_handle_release(h_obj);
+    check("handle table empty after releases", cs_v8_handle_table_size() == 0, NULL);
+
+    check("use-after-release returns NaN + error",
+          isnan(cs_v8_handle_to_number(h_num))
+          && strstr(cs_v8_last_error(), "already released") != NULL,
+          cs_v8_last_error());
+
+    int churn_ok = 1;
+    for (int i = 0; i < 10000; i++) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%d", i);
+        uint64_t h = cs_v8_eval_handle(buf);
+        if (h == 0) { churn_ok = 0; break; }
+        if (cs_v8_handle_to_number(h) != (double)i) { churn_ok = 0; break; }
+        cs_v8_handle_release(h);
+    }
+    check("10k handle alloc+release churn", churn_ok, NULL);
+    check("handle table empty after churn",
+          cs_v8_handle_table_size() == 0, NULL);
+
+    check("cs_v8_is_handle rejects a raw integer",
+          cs_v8_is_handle(42) == 0.0, NULL);
+    check("cs_v8_is_handle rejects a NULL pointer",
+          cs_v8_is_handle(0) == 0.0, NULL);
 
     printf("\n%d passed, %d failed\n", g_pass, g_fail);
     if (g_fail == 0) {

--- a/c_bridges/v8-bridge-test.c
+++ b/c_bridges/v8-bridge-test.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+extern double cs_v8_available(void);
+extern double cs_v8_eval_number(const char* src);
+extern char* cs_v8_eval_string(const char* src);
+extern const char* cs_v8_last_error(void);
+extern void cs_v8_clear_error(void);
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+static void check(const char* name, int ok, const char* extra) {
+    if (ok) {
+        printf("  PASS: %s\n", name);
+        g_pass++;
+    } else {
+        printf("  FAIL: %s  (%s)\n", name, extra ? extra : "");
+        g_fail++;
+    }
+}
+
+int main(void) {
+    printf("v8 bridge unit tests\n");
+
+    check("v8 available", cs_v8_available() == 1.0, NULL);
+
+    double n = cs_v8_eval_number("1 + 2 * 3");
+    check("happy number: 1+2*3 = 7", n == 7.0, NULL);
+    check("no error set after happy number", strlen(cs_v8_last_error()) == 0, cs_v8_last_error());
+
+    char* s = cs_v8_eval_string("'hello ' + 'v8'");
+    check("happy string: concat", s != NULL && strcmp(s, "hello v8") == 0, s);
+    free(s);
+
+    double thrown = cs_v8_eval_number("throw new Error('oops')");
+    check("throw returns NaN", isnan(thrown), NULL);
+    check("throw error message contains 'oops'",
+          strstr(cs_v8_last_error(), "oops") != NULL, cs_v8_last_error());
+
+    double syntax = cs_v8_eval_number("1 +");
+    check("syntax error returns NaN", isnan(syntax), NULL);
+    check("syntax error message contains 'SyntaxError'",
+          strstr(cs_v8_last_error(), "SyntaxError") != NULL, cs_v8_last_error());
+
+    double wrong = cs_v8_eval_number("'hello'");
+    check("type mismatch returns NaN", isnan(wrong), NULL);
+    check("type mismatch message contains 'expected number'",
+          strstr(cs_v8_last_error(), "expected number") != NULL, cs_v8_last_error());
+
+    cs_v8_clear_error();
+    double recovered = cs_v8_eval_number("42");
+    check("recovery after error: eval 42", recovered == 42.0, NULL);
+    check("error cleared after successful eval",
+          strlen(cs_v8_last_error()) == 0, cs_v8_last_error());
+
+    char* str_throw = cs_v8_eval_string("throw new Error('string oops')");
+    check("eval_string returns NULL on throw", str_throw == NULL, NULL);
+    check("string throw error contains 'string oops'",
+          strstr(cs_v8_last_error(), "string oops") != NULL, cs_v8_last_error());
+
+    int seq_ok = 1;
+    for (int i = 0; i < 1000; i++) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "%d * 2", i);
+        double r = cs_v8_eval_number(buf);
+        if (r != (double)(i * 2)) { seq_ok = 0; break; }
+    }
+    check("1000 sequential evals state clean", seq_ok, NULL);
+
+    printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    if (g_fail == 0) {
+        printf("TEST_PASSED\n");
+        return 0;
+    }
+    printf("TEST_FAILED\n");
+    return 1;
+}

--- a/c_bridges/v8-bridge-test.c
+++ b/c_bridges/v8-bridge-test.c
@@ -16,6 +16,11 @@ extern char*    cs_v8_handle_to_string(uint64_t h);
 extern void     cs_v8_handle_release(uint64_t h);
 extern uint64_t cs_v8_handle_table_size(void);
 extern double   cs_v8_is_handle(uint64_t v);
+extern uint64_t cs_v8_make_number_handle(double n);
+extern uint64_t cs_v8_make_string_handle(const char* s);
+extern uint64_t cs_v8_handle_get_property(uint64_t obj, const char* name);
+extern uint64_t cs_v8_handle_call(uint64_t fn, uint64_t this_or_zero,
+                                  int32_t n_args, const uint64_t* args);
 
 static int g_pass = 0;
 static int g_fail = 0;
@@ -137,6 +142,93 @@ int main(void) {
           cs_v8_is_handle(42) == 0.0, NULL);
     check("cs_v8_is_handle rejects a NULL pointer",
           cs_v8_is_handle(0) == 0.0, NULL);
+
+    printf("\n-- JSHandle v1: make, get_property, call --\n");
+
+    uint64_t h_n = cs_v8_make_number_handle(3.14);
+    check("make_number_handle round-trip",
+          cs_v8_handle_to_number(h_n) == 3.14, NULL);
+    cs_v8_handle_release(h_n);
+
+    uint64_t h_s = cs_v8_make_string_handle("round trip");
+    char* s_back = cs_v8_handle_to_string(h_s);
+    check("make_string_handle round-trip",
+          s_back != NULL && strcmp(s_back, "round trip") == 0, s_back);
+    free(s_back);
+    cs_v8_handle_release(h_s);
+
+    uint64_t h_obj2 = cs_v8_eval_handle("({name: 'chad', count: 3})");
+    uint64_t h_name = cs_v8_handle_get_property(h_obj2, "name");
+    char* name_str = cs_v8_handle_to_string(h_name);
+    check("get_property 'name' == 'chad'",
+          name_str != NULL && strcmp(name_str, "chad") == 0, name_str);
+    free(name_str);
+
+    uint64_t h_count = cs_v8_handle_get_property(h_obj2, "count");
+    check("get_property 'count' == 3",
+          cs_v8_handle_to_number(h_count) == 3.0, NULL);
+
+    uint64_t h_missing = cs_v8_handle_get_property(h_obj2, "nonexistent");
+    check("get_property of missing key returns non-zero handle to undefined",
+          h_missing != 0, NULL);
+    cs_v8_handle_release(h_missing);
+
+    uint64_t h_num_handle_for_get = cs_v8_make_number_handle(42);
+    uint64_t bad_get = cs_v8_handle_get_property(h_num_handle_for_get, "foo");
+    check("get_property on non-object returns 0 + error",
+          bad_get == 0 &&
+          strstr(cs_v8_last_error(), "not") != NULL,
+          cs_v8_last_error());
+    cs_v8_handle_release(h_num_handle_for_get);
+    cs_v8_handle_release(h_obj2);
+    cs_v8_handle_release(h_name);
+    cs_v8_handle_release(h_count);
+
+    uint64_t h_double = cs_v8_eval_handle("(function(x) { return x * 2; })");
+    uint64_t arg = cs_v8_make_number_handle(21);
+    uint64_t h_result = cs_v8_handle_call(h_double, 0, 1, &arg);
+    check("call function (x => x*2)(21) == 42",
+          cs_v8_handle_to_number(h_result) == 42.0, NULL);
+    cs_v8_handle_release(h_double);
+    cs_v8_handle_release(arg);
+    cs_v8_handle_release(h_result);
+
+    uint64_t h_greeter = cs_v8_eval_handle(
+        "({prefix: 'hi ', greet(n) { return this.prefix + n; }})"
+    );
+    uint64_t h_greet = cs_v8_handle_get_property(h_greeter, "greet");
+    uint64_t h_who = cs_v8_make_string_handle("world");
+    uint64_t h_greeting = cs_v8_handle_call(h_greet, h_greeter, 1, &h_who);
+    char* greeting = cs_v8_handle_to_string(h_greeting);
+    check("method call with this-binding: greeter.greet('world') == 'hi world'",
+          greeting != NULL && strcmp(greeting, "hi world") == 0, greeting);
+    free(greeting);
+    cs_v8_handle_release(h_greeter);
+    cs_v8_handle_release(h_greet);
+    cs_v8_handle_release(h_who);
+    cs_v8_handle_release(h_greeting);
+
+    uint64_t h_not_fn = cs_v8_eval_handle("({notCallable: true})");
+    uint64_t dummy = cs_v8_make_number_handle(1);
+    uint64_t bad_call = cs_v8_handle_call(h_not_fn, 0, 1, &dummy);
+    check("call on non-function returns 0 + error",
+          bad_call == 0 && strstr(cs_v8_last_error(), "function") != NULL,
+          cs_v8_last_error());
+    cs_v8_handle_release(h_not_fn);
+    cs_v8_handle_release(dummy);
+
+    uint64_t h_thrower = cs_v8_eval_handle(
+        "(function() { throw new Error('js side crash'); })"
+    );
+    uint64_t thrown_result = cs_v8_handle_call(h_thrower, 0, 0, NULL);
+    check("call that throws returns 0 + error contains 'crash'",
+          thrown_result == 0 &&
+          strstr(cs_v8_last_error(), "crash") != NULL,
+          cs_v8_last_error());
+    cs_v8_handle_release(h_thrower);
+
+    check("handle table empty at end of v1 tests",
+          cs_v8_handle_table_size() == 0, NULL);
 
     printf("\n%d passed, %d failed\n", g_pass, g_fail);
     if (g_fail == 0) {

--- a/c_bridges/v8-bridge-test.c
+++ b/c_bridges/v8-bridge-test.c
@@ -10,17 +10,21 @@ extern char* cs_v8_eval_string(const char* src);
 extern const char* cs_v8_last_error(void);
 extern void cs_v8_clear_error(void);
 
-extern uint64_t cs_v8_eval_handle(const char* src);
-extern double   cs_v8_handle_to_number(uint64_t h);
-extern char*    cs_v8_handle_to_string(uint64_t h);
-extern void     cs_v8_handle_release(uint64_t h);
-extern uint64_t cs_v8_handle_table_size(void);
-extern double   cs_v8_is_handle(uint64_t v);
-extern uint64_t cs_v8_make_number_handle(double n);
-extern uint64_t cs_v8_make_string_handle(const char* s);
-extern uint64_t cs_v8_handle_get_property(uint64_t obj, const char* name);
-extern uint64_t cs_v8_handle_call(uint64_t fn, uint64_t this_or_zero,
-                                  int32_t n_args, const uint64_t* args);
+// Handles cross the ABI as `double` — this matches ChadScript's `number` FFI
+// lowering (values travel in the float return register). See h2d/d2h in
+// v8-bridge.cc for the lossless conversion (tag at bit 32, fits in 53-bit
+// exact-integer range).
+extern double cs_v8_eval_handle(const char* src);
+extern double cs_v8_handle_to_number(double h);
+extern char*  cs_v8_handle_to_string(double h);
+extern void   cs_v8_handle_release(double h);
+extern double cs_v8_handle_table_size(void);
+extern double cs_v8_is_handle(double v);
+extern double cs_v8_make_number_handle(double n);
+extern double cs_v8_make_string_handle(const char* s);
+extern double cs_v8_handle_get_property(double obj, const char* name);
+extern double cs_v8_handle_call(double fn, double this_or_zero,
+                                int32_t n_args, const double* args);
 
 static int g_pass = 0;
 static int g_fail = 0;
@@ -85,7 +89,7 @@ int main(void) {
 
     printf("\n-- JSHandle v0 --\n");
 
-    uint64_t h_num = cs_v8_eval_handle("6 * 7");
+    double h_num = cs_v8_eval_handle("6 * 7");
     check("eval_handle returns non-zero", h_num != 0, NULL);
     check("eval_handle returns tagged handle", cs_v8_is_handle(h_num) == 1.0, NULL);
     check("handle_to_number reads 42", cs_v8_handle_to_number(h_num) == 42.0, NULL);
@@ -95,7 +99,7 @@ int main(void) {
           h_num_str != NULL && strcmp(h_num_str, "42") == 0, h_num_str);
     free(h_num_str);
 
-    uint64_t h_str = cs_v8_eval_handle("'v8 live'");
+    double h_str = cs_v8_eval_handle("'v8 live'");
     char* h_str_val = cs_v8_handle_to_string(h_str);
     check("handle_to_string of string == 'v8 live'",
           h_str_val != NULL && strcmp(h_str_val, "v8 live") == 0, h_str_val);
@@ -106,13 +110,13 @@ int main(void) {
           && strstr(cs_v8_last_error(), "does not hold a number") != NULL,
           cs_v8_last_error());
 
-    uint64_t h_obj = cs_v8_eval_handle("({name: 'chad', count: 3})");
+    double h_obj = cs_v8_eval_handle("({name: 'chad', count: 3})");
     char* h_obj_str = cs_v8_handle_to_string(h_obj);
     check("handle_to_string of object contains '[object Object]' or serialization",
           h_obj_str != NULL, h_obj_str);
     free(h_obj_str);
 
-    uint64_t table_before = cs_v8_handle_table_size();
+    double table_before = cs_v8_handle_table_size();
     check("handle table has 3 entries before releases", table_before == 3, NULL);
 
     cs_v8_handle_release(h_num);
@@ -129,7 +133,7 @@ int main(void) {
     for (int i = 0; i < 10000; i++) {
         char buf[32];
         snprintf(buf, sizeof(buf), "%d", i);
-        uint64_t h = cs_v8_eval_handle(buf);
+        double h = cs_v8_eval_handle(buf);
         if (h == 0) { churn_ok = 0; break; }
         if (cs_v8_handle_to_number(h) != (double)i) { churn_ok = 0; break; }
         cs_v8_handle_release(h);
@@ -145,36 +149,36 @@ int main(void) {
 
     printf("\n-- JSHandle v1: make, get_property, call --\n");
 
-    uint64_t h_n = cs_v8_make_number_handle(3.14);
+    double h_n = cs_v8_make_number_handle(3.14);
     check("make_number_handle round-trip",
           cs_v8_handle_to_number(h_n) == 3.14, NULL);
     cs_v8_handle_release(h_n);
 
-    uint64_t h_s = cs_v8_make_string_handle("round trip");
+    double h_s = cs_v8_make_string_handle("round trip");
     char* s_back = cs_v8_handle_to_string(h_s);
     check("make_string_handle round-trip",
           s_back != NULL && strcmp(s_back, "round trip") == 0, s_back);
     free(s_back);
     cs_v8_handle_release(h_s);
 
-    uint64_t h_obj2 = cs_v8_eval_handle("({name: 'chad', count: 3})");
-    uint64_t h_name = cs_v8_handle_get_property(h_obj2, "name");
+    double h_obj2 = cs_v8_eval_handle("({name: 'chad', count: 3})");
+    double h_name = cs_v8_handle_get_property(h_obj2, "name");
     char* name_str = cs_v8_handle_to_string(h_name);
     check("get_property 'name' == 'chad'",
           name_str != NULL && strcmp(name_str, "chad") == 0, name_str);
     free(name_str);
 
-    uint64_t h_count = cs_v8_handle_get_property(h_obj2, "count");
+    double h_count = cs_v8_handle_get_property(h_obj2, "count");
     check("get_property 'count' == 3",
           cs_v8_handle_to_number(h_count) == 3.0, NULL);
 
-    uint64_t h_missing = cs_v8_handle_get_property(h_obj2, "nonexistent");
+    double h_missing = cs_v8_handle_get_property(h_obj2, "nonexistent");
     check("get_property of missing key returns non-zero handle to undefined",
           h_missing != 0, NULL);
     cs_v8_handle_release(h_missing);
 
-    uint64_t h_num_handle_for_get = cs_v8_make_number_handle(42);
-    uint64_t bad_get = cs_v8_handle_get_property(h_num_handle_for_get, "foo");
+    double h_num_handle_for_get = cs_v8_make_number_handle(42);
+    double bad_get = cs_v8_handle_get_property(h_num_handle_for_get, "foo");
     check("get_property on non-object returns 0 + error",
           bad_get == 0 &&
           strstr(cs_v8_last_error(), "not") != NULL,
@@ -184,21 +188,21 @@ int main(void) {
     cs_v8_handle_release(h_name);
     cs_v8_handle_release(h_count);
 
-    uint64_t h_double = cs_v8_eval_handle("(function(x) { return x * 2; })");
-    uint64_t arg = cs_v8_make_number_handle(21);
-    uint64_t h_result = cs_v8_handle_call(h_double, 0, 1, &arg);
+    double h_double = cs_v8_eval_handle("(function(x) { return x * 2; })");
+    double arg = cs_v8_make_number_handle(21);
+    double h_result = cs_v8_handle_call(h_double, 0, 1, &arg);
     check("call function (x => x*2)(21) == 42",
           cs_v8_handle_to_number(h_result) == 42.0, NULL);
     cs_v8_handle_release(h_double);
     cs_v8_handle_release(arg);
     cs_v8_handle_release(h_result);
 
-    uint64_t h_greeter = cs_v8_eval_handle(
+    double h_greeter = cs_v8_eval_handle(
         "({prefix: 'hi ', greet(n) { return this.prefix + n; }})"
     );
-    uint64_t h_greet = cs_v8_handle_get_property(h_greeter, "greet");
-    uint64_t h_who = cs_v8_make_string_handle("world");
-    uint64_t h_greeting = cs_v8_handle_call(h_greet, h_greeter, 1, &h_who);
+    double h_greet = cs_v8_handle_get_property(h_greeter, "greet");
+    double h_who = cs_v8_make_string_handle("world");
+    double h_greeting = cs_v8_handle_call(h_greet, h_greeter, 1, &h_who);
     char* greeting = cs_v8_handle_to_string(h_greeting);
     check("method call with this-binding: greeter.greet('world') == 'hi world'",
           greeting != NULL && strcmp(greeting, "hi world") == 0, greeting);
@@ -208,19 +212,19 @@ int main(void) {
     cs_v8_handle_release(h_who);
     cs_v8_handle_release(h_greeting);
 
-    uint64_t h_not_fn = cs_v8_eval_handle("({notCallable: true})");
-    uint64_t dummy = cs_v8_make_number_handle(1);
-    uint64_t bad_call = cs_v8_handle_call(h_not_fn, 0, 1, &dummy);
+    double h_not_fn = cs_v8_eval_handle("({notCallable: true})");
+    double dummy = cs_v8_make_number_handle(1);
+    double bad_call = cs_v8_handle_call(h_not_fn, 0, 1, &dummy);
     check("call on non-function returns 0 + error",
           bad_call == 0 && strstr(cs_v8_last_error(), "function") != NULL,
           cs_v8_last_error());
     cs_v8_handle_release(h_not_fn);
     cs_v8_handle_release(dummy);
 
-    uint64_t h_thrower = cs_v8_eval_handle(
+    double h_thrower = cs_v8_eval_handle(
         "(function() { throw new Error('js side crash'); })"
     );
-    uint64_t thrown_result = cs_v8_handle_call(h_thrower, 0, 0, NULL);
+    double thrown_result = cs_v8_handle_call(h_thrower, 0, 0, NULL);
     check("call that throws returns 0 + error contains 'crash'",
           thrown_result == 0 &&
           strstr(cs_v8_last_error(), "crash") != NULL,

--- a/c_bridges/v8-bridge.cc
+++ b/c_bridges/v8-bridge.cc
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 static std::unique_ptr<v8::Platform> g_platform;
 static v8::Isolate* g_isolate = nullptr;
@@ -310,6 +311,138 @@ uint64_t cs_v8_handle_table_size(void) {
 
 double cs_v8_is_handle(uint64_t value) {
     return is_handle(value) ? 1.0 : 0.0;
+}
+
+uint64_t cs_v8_make_number_handle(double n) {
+    cs_v8_lazy_init();
+    t_last_error.clear();
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(ctx);
+    v8::Local<v8::Value> val = v8::Number::New(g_isolate, n);
+    return store_handle(g_isolate, val);
+}
+
+uint64_t cs_v8_make_string_handle(const char* s) {
+    cs_v8_lazy_init();
+    t_last_error.clear();
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(ctx);
+    v8::Local<v8::String> str;
+    if (!v8::String::NewFromUtf8(g_isolate, s ? s : "", v8::NewStringType::kNormal)
+             .ToLocal(&str)) {
+        t_last_error = "failed to allocate string";
+        return 0;
+    }
+    return store_handle(g_isolate, str);
+}
+
+uint64_t cs_v8_handle_get_property(uint64_t obj_handle, const char* name) {
+    t_last_error.clear();
+    if (!is_handle(obj_handle)) {
+        t_last_error = "get_property: not a JSHandle";
+        return 0;
+    }
+    auto it = t_handles.find(obj_handle);
+    if (it == t_handles.end()) {
+        t_last_error = "get_property: JSHandle released or invalid";
+        return 0;
+    }
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(ctx);
+    v8::TryCatch try_catch(g_isolate);
+
+    v8::Local<v8::Value> obj_val = it->second.Get(g_isolate);
+    if (!obj_val->IsObject()) {
+        t_last_error = "get_property: handle does not hold an object";
+        return 0;
+    }
+    v8::Local<v8::Object> obj = obj_val.As<v8::Object>();
+    v8::Local<v8::String> key;
+    if (!v8::String::NewFromUtf8(g_isolate, name ? name : "",
+                                 v8::NewStringType::kNormal).ToLocal(&key)) {
+        t_last_error = "get_property: failed to allocate key";
+        return 0;
+    }
+    v8::Local<v8::Value> prop;
+    if (!obj->Get(ctx, key).ToLocal(&prop)) {
+        set_error_from_trycatch(g_isolate, ctx, try_catch,
+                                "get_property: Get threw");
+        return 0;
+    }
+    return store_handle(g_isolate, prop);
+}
+
+uint64_t cs_v8_handle_call(uint64_t fn_handle,
+                           uint64_t this_handle_or_zero,
+                           int32_t n_args,
+                           const uint64_t* arg_handles) {
+    t_last_error.clear();
+    if (!is_handle(fn_handle)) {
+        t_last_error = "call: fn is not a JSHandle";
+        return 0;
+    }
+    auto fn_it = t_handles.find(fn_handle);
+    if (fn_it == t_handles.end()) {
+        t_last_error = "call: fn JSHandle released or invalid";
+        return 0;
+    }
+
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(ctx);
+    v8::TryCatch try_catch(g_isolate);
+
+    v8::Local<v8::Value> fn_val = fn_it->second.Get(g_isolate);
+    if (!fn_val->IsFunction()) {
+        t_last_error = "call: handle does not hold a function";
+        return 0;
+    }
+    v8::Local<v8::Function> fn = fn_val.As<v8::Function>();
+
+    v8::Local<v8::Value> recv;
+    if (this_handle_or_zero == 0) {
+        recv = v8::Undefined(g_isolate);
+    } else if (!is_handle(this_handle_or_zero)) {
+        t_last_error = "call: this is not a JSHandle";
+        return 0;
+    } else {
+        auto this_it = t_handles.find(this_handle_or_zero);
+        if (this_it == t_handles.end()) {
+            t_last_error = "call: this JSHandle released or invalid";
+            return 0;
+        }
+        recv = this_it->second.Get(g_isolate);
+    }
+
+    std::vector<v8::Local<v8::Value>> args;
+    args.reserve(n_args < 0 ? 0 : (size_t)n_args);
+    for (int i = 0; i < n_args; i++) {
+        uint64_t ah = arg_handles[i];
+        if (!is_handle(ah)) {
+            t_last_error = "call: arg is not a JSHandle";
+            return 0;
+        }
+        auto ait = t_handles.find(ah);
+        if (ait == t_handles.end()) {
+            t_last_error = "call: arg JSHandle released or invalid";
+            return 0;
+        }
+        args.push_back(ait->second.Get(g_isolate));
+    }
+
+    v8::Local<v8::Value> result;
+    if (!fn->Call(ctx, recv, n_args, args.data()).ToLocal(&result)) {
+        set_error_from_trycatch(g_isolate, ctx, try_catch, "call: threw");
+        return 0;
+    }
+    return store_handle(g_isolate, result);
 }
 
 }

--- a/c_bridges/v8-bridge.cc
+++ b/c_bridges/v8-bridge.cc
@@ -17,13 +17,24 @@ static bool g_initialized = false;
 static thread_local std::string t_last_error;
 
 // JSHandle v0: thread-local handle table. Phase 2 will add Boehm finalizers;
-// for now handles are explicitly released. High byte is JS_HANDLE_TAG so the
-// id is cheaply distinguishable from a primitive/pointer.
-static constexpr uint64_t JS_HANDLE_TAG = 0xC4AD000000000000ULL;
-static constexpr uint64_t JS_HANDLE_TAG_MASK = 0xFFFF000000000000ULL;
+// for now handles are explicitly released. The public ABI uses `double` to
+// match ChadScript's lowering of `number` FFI — integer-register returns
+// wouldn't be read from the float register the TS side expects. We set the
+// tag at bit 32 (0x100000000) so handle ids live in 33 bits, well under
+// IEEE 754's 53-bit exact-integer range: uint64_t <-> double is lossless.
+static constexpr uint64_t JS_HANDLE_TAG = 0x100000000ULL;
+static constexpr uint64_t JS_HANDLE_TAG_MASK = 0xFFFFFFFF00000000ULL;
 
 static thread_local uint64_t t_next_handle_id = 1;
 static thread_local std::unordered_map<uint64_t, v8::Global<v8::Value>> t_handles;
+
+// Convert handle to/from double at the ABI boundary. Handles fit in 33 bits
+// (tag at bit 32 + monotonic counter below) so both conversions are lossless.
+static inline double h2d(uint64_t h) { return (double)h; }
+static inline uint64_t d2h(double d) {
+    if (d < 0.0 || !std::isfinite(d)) return 0;
+    return (uint64_t)d;
+}
 
 static uint64_t store_handle(v8::Isolate* iso, v8::Local<v8::Value> value) {
     uint64_t id = JS_HANDLE_TAG | (t_next_handle_id++);
@@ -209,8 +220,10 @@ char* cs_v8_eval_string(const char* src) {
 }
 
 // ---- JSHandle API (Phase 2 foundation) ----
+// ABI note: handles cross the boundary as `double` so ChadScript's `number`
+// FFI lowering reads the correct return register. See h2d/d2h above.
 
-uint64_t cs_v8_eval_handle(const char* src) {
+double cs_v8_eval_handle(const char* src) {
     cs_v8_lazy_init();
     t_last_error.clear();
     v8::Isolate::Scope isolate_scope(g_isolate);
@@ -225,25 +238,26 @@ uint64_t cs_v8_eval_handle(const char* src) {
     if (!v8::String::NewFromUtf8(g_isolate, src, v8::NewStringType::kNormal)
              .ToLocal(&source)) {
         t_last_error = "failed to allocate source string";
-        return 0;
+        return 0.0;
     }
 
     v8::Local<v8::Script> script;
     if (!v8::Script::Compile(context, source).ToLocal(&script)) {
         set_error_from_trycatch(g_isolate, context, try_catch, "compile failed");
-        return 0;
+        return 0.0;
     }
 
     v8::Local<v8::Value> result;
     if (!script->Run(context).ToLocal(&result)) {
         set_error_from_trycatch(g_isolate, context, try_catch, "run failed");
-        return 0;
+        return 0.0;
     }
 
-    return store_handle(g_isolate, result);
+    return h2d(store_handle(g_isolate, result));
 }
 
-double cs_v8_handle_to_number(uint64_t handle) {
+double cs_v8_handle_to_number(double handle_d) {
+    uint64_t handle = d2h(handle_d);
     t_last_error.clear();
     if (!is_handle(handle)) {
         t_last_error = "not a JSHandle";
@@ -271,7 +285,8 @@ double cs_v8_handle_to_number(uint64_t handle) {
     return out;
 }
 
-char* cs_v8_handle_to_string(uint64_t handle) {
+char* cs_v8_handle_to_string(double handle_d) {
+    uint64_t handle = d2h(handle_d);
     t_last_error.clear();
     if (!is_handle(handle)) {
         t_last_error = "not a JSHandle";
@@ -296,7 +311,8 @@ char* cs_v8_handle_to_string(uint64_t handle) {
     return strdup(*utf8 ? *utf8 : "");
 }
 
-void cs_v8_handle_release(uint64_t handle) {
+void cs_v8_handle_release(double handle_d) {
+    uint64_t handle = d2h(handle_d);
     if (!is_handle(handle)) return;
     auto it = t_handles.find(handle);
     if (it != t_handles.end()) {
@@ -305,15 +321,16 @@ void cs_v8_handle_release(uint64_t handle) {
     }
 }
 
-uint64_t cs_v8_handle_table_size(void) {
-    return (uint64_t)t_handles.size();
+double cs_v8_handle_table_size(void) {
+    return (double)t_handles.size();
 }
 
-double cs_v8_is_handle(uint64_t value) {
+double cs_v8_is_handle(double value_d) {
+    uint64_t value = d2h(value_d);
     return is_handle(value) ? 1.0 : 0.0;
 }
 
-uint64_t cs_v8_make_number_handle(double n) {
+double cs_v8_make_number_handle(double n) {
     cs_v8_lazy_init();
     t_last_error.clear();
     v8::Isolate::Scope isolate_scope(g_isolate);
@@ -321,10 +338,10 @@ uint64_t cs_v8_make_number_handle(double n) {
     v8::Local<v8::Context> ctx = v8::Context::New(g_isolate);
     v8::Context::Scope context_scope(ctx);
     v8::Local<v8::Value> val = v8::Number::New(g_isolate, n);
-    return store_handle(g_isolate, val);
+    return h2d(store_handle(g_isolate, val));
 }
 
-uint64_t cs_v8_make_string_handle(const char* s) {
+double cs_v8_make_string_handle(const char* s) {
     cs_v8_lazy_init();
     t_last_error.clear();
     v8::Isolate::Scope isolate_scope(g_isolate);
@@ -335,21 +352,22 @@ uint64_t cs_v8_make_string_handle(const char* s) {
     if (!v8::String::NewFromUtf8(g_isolate, s ? s : "", v8::NewStringType::kNormal)
              .ToLocal(&str)) {
         t_last_error = "failed to allocate string";
-        return 0;
+        return 0.0;
     }
-    return store_handle(g_isolate, str);
+    return h2d(store_handle(g_isolate, str));
 }
 
-uint64_t cs_v8_handle_get_property(uint64_t obj_handle, const char* name) {
+double cs_v8_handle_get_property(double obj_handle_d, const char* name) {
+    uint64_t obj_handle = d2h(obj_handle_d);
     t_last_error.clear();
     if (!is_handle(obj_handle)) {
         t_last_error = "get_property: not a JSHandle";
-        return 0;
+        return 0.0;
     }
     auto it = t_handles.find(obj_handle);
     if (it == t_handles.end()) {
         t_last_error = "get_property: JSHandle released or invalid";
-        return 0;
+        return 0.0;
     }
     v8::Isolate::Scope isolate_scope(g_isolate);
     v8::HandleScope hs(g_isolate);
@@ -360,37 +378,39 @@ uint64_t cs_v8_handle_get_property(uint64_t obj_handle, const char* name) {
     v8::Local<v8::Value> obj_val = it->second.Get(g_isolate);
     if (!obj_val->IsObject()) {
         t_last_error = "get_property: handle does not hold an object";
-        return 0;
+        return 0.0;
     }
     v8::Local<v8::Object> obj = obj_val.As<v8::Object>();
     v8::Local<v8::String> key;
     if (!v8::String::NewFromUtf8(g_isolate, name ? name : "",
                                  v8::NewStringType::kNormal).ToLocal(&key)) {
         t_last_error = "get_property: failed to allocate key";
-        return 0;
+        return 0.0;
     }
     v8::Local<v8::Value> prop;
     if (!obj->Get(ctx, key).ToLocal(&prop)) {
         set_error_from_trycatch(g_isolate, ctx, try_catch,
                                 "get_property: Get threw");
-        return 0;
+        return 0.0;
     }
-    return store_handle(g_isolate, prop);
+    return h2d(store_handle(g_isolate, prop));
 }
 
-uint64_t cs_v8_handle_call(uint64_t fn_handle,
-                           uint64_t this_handle_or_zero,
-                           int32_t n_args,
-                           const uint64_t* arg_handles) {
+double cs_v8_handle_call(double fn_handle_d,
+                         double this_handle_or_zero_d,
+                         int32_t n_args,
+                         const double* arg_handles) {
+    uint64_t fn_handle = d2h(fn_handle_d);
+    uint64_t this_handle_or_zero = d2h(this_handle_or_zero_d);
     t_last_error.clear();
     if (!is_handle(fn_handle)) {
         t_last_error = "call: fn is not a JSHandle";
-        return 0;
+        return 0.0;
     }
     auto fn_it = t_handles.find(fn_handle);
     if (fn_it == t_handles.end()) {
         t_last_error = "call: fn JSHandle released or invalid";
-        return 0;
+        return 0.0;
     }
 
     v8::Isolate::Scope isolate_scope(g_isolate);
@@ -402,7 +422,7 @@ uint64_t cs_v8_handle_call(uint64_t fn_handle,
     v8::Local<v8::Value> fn_val = fn_it->second.Get(g_isolate);
     if (!fn_val->IsFunction()) {
         t_last_error = "call: handle does not hold a function";
-        return 0;
+        return 0.0;
     }
     v8::Local<v8::Function> fn = fn_val.As<v8::Function>();
 
@@ -411,12 +431,12 @@ uint64_t cs_v8_handle_call(uint64_t fn_handle,
         recv = v8::Undefined(g_isolate);
     } else if (!is_handle(this_handle_or_zero)) {
         t_last_error = "call: this is not a JSHandle";
-        return 0;
+        return 0.0;
     } else {
         auto this_it = t_handles.find(this_handle_or_zero);
         if (this_it == t_handles.end()) {
             t_last_error = "call: this JSHandle released or invalid";
-            return 0;
+            return 0.0;
         }
         recv = this_it->second.Get(g_isolate);
     }
@@ -424,15 +444,15 @@ uint64_t cs_v8_handle_call(uint64_t fn_handle,
     std::vector<v8::Local<v8::Value>> args;
     args.reserve(n_args < 0 ? 0 : (size_t)n_args);
     for (int i = 0; i < n_args; i++) {
-        uint64_t ah = arg_handles[i];
+        uint64_t ah = d2h(arg_handles[i]);
         if (!is_handle(ah)) {
             t_last_error = "call: arg is not a JSHandle";
-            return 0;
+            return 0.0;
         }
         auto ait = t_handles.find(ah);
         if (ait == t_handles.end()) {
             t_last_error = "call: arg JSHandle released or invalid";
-            return 0;
+            return 0.0;
         }
         args.push_back(ait->second.Get(g_isolate));
     }
@@ -440,9 +460,9 @@ uint64_t cs_v8_handle_call(uint64_t fn_handle,
     v8::Local<v8::Value> result;
     if (!fn->Call(ctx, recv, n_args, args.data()).ToLocal(&result)) {
         set_error_from_trycatch(g_isolate, ctx, try_catch, "call: threw");
-        return 0;
+        return 0.0;
     }
-    return store_handle(g_isolate, result);
+    return h2d(store_handle(g_isolate, result));
 }
 
 }

--- a/c_bridges/v8-bridge.cc
+++ b/c_bridges/v8-bridge.cc
@@ -4,7 +4,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
+#include <cstdint>
 #include <string>
+#include <unordered_map>
 
 static std::unique_ptr<v8::Platform> g_platform;
 static v8::Isolate* g_isolate = nullptr;
@@ -12,6 +14,25 @@ static v8::Isolate::CreateParams g_create_params;
 static bool g_initialized = false;
 
 static thread_local std::string t_last_error;
+
+// JSHandle v0: thread-local handle table. Phase 2 will add Boehm finalizers;
+// for now handles are explicitly released. High byte is JS_HANDLE_TAG so the
+// id is cheaply distinguishable from a primitive/pointer.
+static constexpr uint64_t JS_HANDLE_TAG = 0xC4AD000000000000ULL;
+static constexpr uint64_t JS_HANDLE_TAG_MASK = 0xFFFF000000000000ULL;
+
+static thread_local uint64_t t_next_handle_id = 1;
+static thread_local std::unordered_map<uint64_t, v8::Global<v8::Value>> t_handles;
+
+static uint64_t store_handle(v8::Isolate* iso, v8::Local<v8::Value> value) {
+    uint64_t id = JS_HANDLE_TAG | (t_next_handle_id++);
+    t_handles.emplace(id, v8::Global<v8::Value>(iso, value));
+    return id;
+}
+
+static bool is_handle(uint64_t id) {
+    return (id & JS_HANDLE_TAG_MASK) == JS_HANDLE_TAG;
+}
 
 static void cs_v8_lazy_init(void) {
     if (g_initialized) return;
@@ -184,6 +205,111 @@ char* cs_v8_eval_string(const char* src) {
 
     v8::String::Utf8Value utf8(g_isolate, str);
     return strdup(*utf8 ? *utf8 : "");
+}
+
+// ---- JSHandle API (Phase 2 foundation) ----
+
+uint64_t cs_v8_eval_handle(const char* src) {
+    cs_v8_lazy_init();
+    t_last_error.clear();
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope handle_scope(g_isolate);
+    v8::Local<v8::Context> context = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(context);
+    install_host_env(g_isolate, context);
+
+    v8::TryCatch try_catch(g_isolate);
+
+    v8::Local<v8::String> source;
+    if (!v8::String::NewFromUtf8(g_isolate, src, v8::NewStringType::kNormal)
+             .ToLocal(&source)) {
+        t_last_error = "failed to allocate source string";
+        return 0;
+    }
+
+    v8::Local<v8::Script> script;
+    if (!v8::Script::Compile(context, source).ToLocal(&script)) {
+        set_error_from_trycatch(g_isolate, context, try_catch, "compile failed");
+        return 0;
+    }
+
+    v8::Local<v8::Value> result;
+    if (!script->Run(context).ToLocal(&result)) {
+        set_error_from_trycatch(g_isolate, context, try_catch, "run failed");
+        return 0;
+    }
+
+    return store_handle(g_isolate, result);
+}
+
+double cs_v8_handle_to_number(uint64_t handle) {
+    t_last_error.clear();
+    if (!is_handle(handle)) {
+        t_last_error = "not a JSHandle";
+        return std::nan("");
+    }
+    auto it = t_handles.find(handle);
+    if (it == t_handles.end()) {
+        t_last_error = "JSHandle already released or invalid";
+        return std::nan("");
+    }
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(ctx);
+    v8::Local<v8::Value> val = it->second.Get(g_isolate);
+    if (!val->IsNumber()) {
+        t_last_error = "handle does not hold a number";
+        return std::nan("");
+    }
+    double out;
+    if (!val->NumberValue(ctx).To(&out)) {
+        t_last_error = "NumberValue failed";
+        return std::nan("");
+    }
+    return out;
+}
+
+char* cs_v8_handle_to_string(uint64_t handle) {
+    t_last_error.clear();
+    if (!is_handle(handle)) {
+        t_last_error = "not a JSHandle";
+        return nullptr;
+    }
+    auto it = t_handles.find(handle);
+    if (it == t_handles.end()) {
+        t_last_error = "JSHandle already released or invalid";
+        return nullptr;
+    }
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(ctx);
+    v8::Local<v8::Value> val = it->second.Get(g_isolate);
+    v8::Local<v8::String> str;
+    if (!val->ToString(ctx).ToLocal(&str)) {
+        t_last_error = "ToString failed";
+        return nullptr;
+    }
+    v8::String::Utf8Value utf8(g_isolate, str);
+    return strdup(*utf8 ? *utf8 : "");
+}
+
+void cs_v8_handle_release(uint64_t handle) {
+    if (!is_handle(handle)) return;
+    auto it = t_handles.find(handle);
+    if (it != t_handles.end()) {
+        it->second.Reset();
+        t_handles.erase(it);
+    }
+}
+
+uint64_t cs_v8_handle_table_size(void) {
+    return (uint64_t)t_handles.size();
+}
+
+double cs_v8_is_handle(uint64_t value) {
+    return is_handle(value) ? 1.0 : 0.0;
 }
 
 }

--- a/c_bridges/v8-bridge.cc
+++ b/c_bridges/v8-bridge.cc
@@ -26,6 +26,37 @@ static void cs_v8_lazy_init(void) {
     g_initialized = true;
 }
 
+static void native_print_callback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    v8::Isolate* iso = args.GetIsolate();
+    v8::HandleScope hs(iso);
+    for (int i = 0; i < args.Length(); i++) {
+        if (i > 0) fputc(' ', stdout);
+        v8::String::Utf8Value s(iso, args[i]);
+        fputs(*s ? *s : "<?>", stdout);
+    }
+    fputc('\n', stdout);
+    fflush(stdout);
+}
+
+static void install_host_env(v8::Isolate* iso, v8::Local<v8::Context> context) {
+    v8::Local<v8::Object> global = context->Global();
+    v8::Local<v8::FunctionTemplate> tmpl =
+        v8::FunctionTemplate::New(iso, native_print_callback);
+    v8::Local<v8::Function> fn;
+    if (!tmpl->GetFunction(context).ToLocal(&fn)) return;
+    v8::Local<v8::String> print_name =
+        v8::String::NewFromUtf8Literal(iso, "print");
+    global->Set(context, print_name, fn).Check();
+
+    v8::Local<v8::Object> console_obj = v8::Object::New(iso);
+    console_obj->Set(context, v8::String::NewFromUtf8Literal(iso, "log"), fn).Check();
+    console_obj->Set(context, v8::String::NewFromUtf8Literal(iso, "error"), fn).Check();
+    console_obj->Set(context, v8::String::NewFromUtf8Literal(iso, "warn"), fn).Check();
+    global->Set(context,
+                v8::String::NewFromUtf8Literal(iso, "console"),
+                console_obj).Check();
+}
+
 static void set_error_from_trycatch(v8::Isolate* iso,
                                     v8::Local<v8::Context> ctx,
                                     v8::TryCatch& tc,
@@ -73,6 +104,7 @@ double cs_v8_eval_number(const char* src) {
     v8::HandleScope handle_scope(g_isolate);
     v8::Local<v8::Context> context = v8::Context::New(g_isolate);
     v8::Context::Scope context_scope(context);
+    install_host_env(g_isolate, context);
 
     v8::TryCatch try_catch(g_isolate);
 
@@ -117,6 +149,7 @@ char* cs_v8_eval_string(const char* src) {
     v8::HandleScope handle_scope(g_isolate);
     v8::Local<v8::Context> context = v8::Context::New(g_isolate);
     v8::Context::Scope context_scope(context);
+    install_host_env(g_isolate, context);
 
     v8::TryCatch try_catch(g_isolate);
 
@@ -137,6 +170,10 @@ char* cs_v8_eval_string(const char* src) {
     if (!script->Run(context).ToLocal(&result)) {
         set_error_from_trycatch(g_isolate, context, try_catch, "run failed");
         return nullptr;
+    }
+
+    if (result->IsUndefined() || result->IsNull()) {
+        return strdup("");
     }
 
     v8::Local<v8::String> str;

--- a/c_bridges/v8-bridge.cc
+++ b/c_bridges/v8-bridge.cc
@@ -1,13 +1,17 @@
 #include <v8.h>
 #include <libplatform/libplatform.h>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cmath>
 #include <string>
 
 static std::unique_ptr<v8::Platform> g_platform;
 static v8::Isolate* g_isolate = nullptr;
 static v8::Isolate::CreateParams g_create_params;
 static bool g_initialized = false;
+
+static thread_local std::string t_last_error;
 
 static void cs_v8_lazy_init(void) {
     if (g_initialized) return;
@@ -22,14 +26,49 @@ static void cs_v8_lazy_init(void) {
     g_initialized = true;
 }
 
+static void set_error_from_trycatch(v8::Isolate* iso,
+                                    v8::Local<v8::Context> ctx,
+                                    v8::TryCatch& tc,
+                                    const char* fallback) {
+    if (!tc.HasCaught()) {
+        t_last_error = fallback;
+        return;
+    }
+    v8::Local<v8::Value> ex = tc.Exception();
+    v8::String::Utf8Value msg(iso, ex);
+    const char* m = *msg;
+    t_last_error = m ? m : fallback;
+
+    v8::Local<v8::Message> message = tc.Message();
+    if (!message.IsEmpty()) {
+        v8::Local<v8::String> srcline;
+        if (message->GetSourceLine(ctx).ToLocal(&srcline)) {
+            v8::String::Utf8Value line(iso, srcline);
+            if (*line) {
+                t_last_error += " | source: ";
+                t_last_error += *line;
+            }
+        }
+    }
+}
+
 extern "C" {
 
 double cs_v8_available(void) {
     return 1.0;
 }
 
+const char* cs_v8_last_error(void) {
+    return t_last_error.empty() ? "" : t_last_error.c_str();
+}
+
+void cs_v8_clear_error(void) {
+    t_last_error.clear();
+}
+
 double cs_v8_eval_number(const char* src) {
     cs_v8_lazy_init();
+    t_last_error.clear();
     v8::Isolate::Scope isolate_scope(g_isolate);
     v8::HandleScope handle_scope(g_isolate);
     v8::Local<v8::Context> context = v8::Context::New(g_isolate);
@@ -37,28 +76,43 @@ double cs_v8_eval_number(const char* src) {
 
     v8::TryCatch try_catch(g_isolate);
 
-    v8::Local<v8::String> source =
-        v8::String::NewFromUtf8(g_isolate, src, v8::NewStringType::kNormal)
-            .ToLocalChecked();
+    v8::Local<v8::String> source;
+    if (!v8::String::NewFromUtf8(g_isolate, src, v8::NewStringType::kNormal)
+             .ToLocal(&source)) {
+        t_last_error = "failed to allocate source string";
+        return std::nan("");
+    }
 
     v8::Local<v8::Script> script;
     if (!v8::Script::Compile(context, source).ToLocal(&script)) {
-        return 0.0;
+        set_error_from_trycatch(g_isolate, context, try_catch, "compile failed");
+        return std::nan("");
     }
 
     v8::Local<v8::Value> result;
     if (!script->Run(context).ToLocal(&result)) {
-        return 0.0;
+        set_error_from_trycatch(g_isolate, context, try_catch, "run failed");
+        return std::nan("");
     }
 
     if (!result->IsNumber()) {
-        return 0.0;
+        v8::String::Utf8Value got(g_isolate, result);
+        t_last_error = "expected number, got: ";
+        t_last_error += *got ? *got : "<unprintable>";
+        return std::nan("");
     }
-    return result->NumberValue(context).FromMaybe(0.0);
+
+    double out;
+    if (!result->NumberValue(context).To(&out)) {
+        t_last_error = "NumberValue conversion failed";
+        return std::nan("");
+    }
+    return out;
 }
 
 char* cs_v8_eval_string(const char* src) {
     cs_v8_lazy_init();
+    t_last_error.clear();
     v8::Isolate::Scope isolate_scope(g_isolate);
     v8::HandleScope handle_scope(g_isolate);
     v8::Local<v8::Context> context = v8::Context::New(g_isolate);
@@ -66,21 +120,32 @@ char* cs_v8_eval_string(const char* src) {
 
     v8::TryCatch try_catch(g_isolate);
 
-    v8::Local<v8::String> source =
-        v8::String::NewFromUtf8(g_isolate, src, v8::NewStringType::kNormal)
-            .ToLocalChecked();
+    v8::Local<v8::String> source;
+    if (!v8::String::NewFromUtf8(g_isolate, src, v8::NewStringType::kNormal)
+             .ToLocal(&source)) {
+        t_last_error = "failed to allocate source string";
+        return nullptr;
+    }
 
     v8::Local<v8::Script> script;
     if (!v8::Script::Compile(context, source).ToLocal(&script)) {
-        return strdup("");
+        set_error_from_trycatch(g_isolate, context, try_catch, "compile failed");
+        return nullptr;
     }
 
     v8::Local<v8::Value> result;
     if (!script->Run(context).ToLocal(&result)) {
-        return strdup("");
+        set_error_from_trycatch(g_isolate, context, try_catch, "run failed");
+        return nullptr;
     }
 
-    v8::String::Utf8Value utf8(g_isolate, result);
+    v8::Local<v8::String> str;
+    if (!result->ToString(context).ToLocal(&str)) {
+        set_error_from_trycatch(g_isolate, context, try_catch, "ToString failed");
+        return nullptr;
+    }
+
+    v8::String::Utf8Value utf8(g_isolate, str);
     return strdup(*utf8 ? *utf8 : "");
 }
 

--- a/c_bridges/v8-bridge.cc
+++ b/c_bridges/v8-bridge.cc
@@ -1,0 +1,87 @@
+#include <v8.h>
+#include <libplatform/libplatform.h>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+static std::unique_ptr<v8::Platform> g_platform;
+static v8::Isolate* g_isolate = nullptr;
+static v8::Isolate::CreateParams g_create_params;
+static bool g_initialized = false;
+
+static void cs_v8_lazy_init(void) {
+    if (g_initialized) return;
+    v8::V8::InitializeICUDefaultLocation("chad");
+    v8::V8::InitializeExternalStartupData("chad");
+    g_platform = v8::platform::NewDefaultPlatform();
+    v8::V8::InitializePlatform(g_platform.get());
+    v8::V8::Initialize();
+    g_create_params.array_buffer_allocator =
+        v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+    g_isolate = v8::Isolate::New(g_create_params);
+    g_initialized = true;
+}
+
+extern "C" {
+
+double cs_v8_available(void) {
+    return 1.0;
+}
+
+double cs_v8_eval_number(const char* src) {
+    cs_v8_lazy_init();
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope handle_scope(g_isolate);
+    v8::Local<v8::Context> context = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(context);
+
+    v8::TryCatch try_catch(g_isolate);
+
+    v8::Local<v8::String> source =
+        v8::String::NewFromUtf8(g_isolate, src, v8::NewStringType::kNormal)
+            .ToLocalChecked();
+
+    v8::Local<v8::Script> script;
+    if (!v8::Script::Compile(context, source).ToLocal(&script)) {
+        return 0.0;
+    }
+
+    v8::Local<v8::Value> result;
+    if (!script->Run(context).ToLocal(&result)) {
+        return 0.0;
+    }
+
+    if (!result->IsNumber()) {
+        return 0.0;
+    }
+    return result->NumberValue(context).FromMaybe(0.0);
+}
+
+char* cs_v8_eval_string(const char* src) {
+    cs_v8_lazy_init();
+    v8::Isolate::Scope isolate_scope(g_isolate);
+    v8::HandleScope handle_scope(g_isolate);
+    v8::Local<v8::Context> context = v8::Context::New(g_isolate);
+    v8::Context::Scope context_scope(context);
+
+    v8::TryCatch try_catch(g_isolate);
+
+    v8::Local<v8::String> source =
+        v8::String::NewFromUtf8(g_isolate, src, v8::NewStringType::kNormal)
+            .ToLocalChecked();
+
+    v8::Local<v8::Script> script;
+    if (!v8::Script::Compile(context, source).ToLocal(&script)) {
+        return strdup("");
+    }
+
+    v8::Local<v8::Value> result;
+    if (!script->Run(context).ToLocal(&result)) {
+        return strdup("");
+    }
+
+    v8::String::Utf8Value utf8(g_isolate, result);
+    return strdup(*utf8 ? *utf8 : "");
+}
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^5.2.1",
+        "ms": "^2.1.3",
         "tree-sitter": "^0.21.1",
         "tree-sitter-typescript": "^0.23.2"
       },

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
-    "date-fns": "^4.1.0",
     "c8": "^11.0.0",
+    "date-fns": "^4.1.0",
     "prettier": "^3.8.1",
     "ts-node": "^10.9.0",
     "tsx": "^4.20.6",
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "express": "^5.2.1",
+    "ms": "^2.1.3",
     "tree-sitter": "^0.21.1",
     "tree-sitter-typescript": "^0.23.2"
   }

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -469,6 +469,40 @@ else
   fi
 fi
 
+# --- v8-bridge (requires brew v8 on macOS, apt libv8-dev on Linux) ---
+V8_BRIDGE_SRC="$C_BRIDGES_DIR/v8-bridge.cc"
+V8_BRIDGE_OBJ="$C_BRIDGES_DIR/v8-bridge.o"
+if [ -f "$V8_BRIDGE_SRC" ]; then
+  V8_INCLUDE=""
+  if [ -d "/opt/homebrew/opt/v8/include" ]; then
+    V8_INCLUDE="/opt/homebrew/opt/v8/include"
+  elif [ -d "/usr/local/opt/v8/include" ]; then
+    V8_INCLUDE="/usr/local/opt/v8/include"
+  elif [ -d "/usr/include/v8" ]; then
+    V8_INCLUDE="/usr/include/v8"
+  fi
+  if [ -n "$V8_INCLUDE" ]; then
+    if [ ! -f "$V8_BRIDGE_OBJ" ] || [ "$V8_BRIDGE_SRC" -nt "$V8_BRIDGE_OBJ" ]; then
+      echo "==> Building v8-bridge (headers at $V8_INCLUDE)..."
+      V8_CXX="c++"
+      if [ -n "${LLVM_CONFIG:-}" ]; then
+        LLVM_BINDIR=$(dirname "$LLVM_CONFIG")
+        if [ -f "$LLVM_BINDIR/clang++" ]; then
+          V8_CXX="$LLVM_BINDIR/clang++"
+        fi
+      fi
+      $V8_CXX -c -std=c++20 -O2 -fPIC \
+        -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX \
+        -I"$V8_INCLUDE" "$V8_BRIDGE_SRC" -o "$V8_BRIDGE_OBJ"
+      echo "  -> $V8_BRIDGE_OBJ"
+    else
+      echo "==> v8-bridge already built, skipping"
+    fi
+  else
+    echo "==> v8-bridge skipped (no v8 headers found — brew install v8)"
+  fi
+fi
+
 # --- child-process-spawn (async, requires libuv) ---
 CP_SPAWN_SRC="$C_BRIDGES_DIR/child-process-spawn.c"
 CP_SPAWN_OBJ="$C_BRIDGES_DIR/child-process-spawn.o"

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -469,38 +469,120 @@ else
   fi
 fi
 
-# --- v8-bridge (requires brew v8 on macOS, apt libv8-dev on Linux) ---
-V8_BRIDGE_SRC="$C_BRIDGES_DIR/v8-bridge.cc"
-V8_BRIDGE_OBJ="$C_BRIDGES_DIR/v8-bridge.o"
-if [ -f "$V8_BRIDGE_SRC" ]; then
-  V8_INCLUDE=""
-  if [ -d "/opt/homebrew/opt/v8/include" ]; then
-    V8_INCLUDE="/opt/homebrew/opt/v8/include"
-  elif [ -d "/usr/local/opt/v8/include" ]; then
-    V8_INCLUDE="/usr/local/opt/v8/include"
-  elif [ -d "/usr/include/v8" ]; then
-    V8_INCLUDE="/usr/include/v8"
+# --- libnode (Node.js built from source as a shared lib for pragma-interpret) ---
+# We clone nodejs/node at a pinned tag and build a shared libnode. The bridge
+# links against it to get full Node semantics (require, fs, Buffer, setTimeout,
+# async) for files using the `// @chadscript: interpret` pragma. Lean ChadScript
+# binaries never touch libnode — this is gated by the `usesNode` feature flag.
+#
+# First build is slow (30-90 min). Subsequent builds are cached via the
+# `vendor/node/.pinned-version` sentinel. Windows is intentionally unsupported
+# for now — darwin-arm64, darwin-x64, linux-x64 only.
+NODE_DIR="$VENDOR_DIR/node"
+NODE_SRC_DIR="${CHAD_NODE_SRC:-$HOME/git/node}"
+NODE_PINNED_SENTINEL="$NODE_DIR/.pinned-version"
+NODE_SKIP="${CHAD_SKIP_NODE:-0}"
+
+case "$(uname -s)" in
+  Darwin) NODE_PLATFORM="darwin" ;;
+  Linux)  NODE_PLATFORM="linux" ;;
+  *)      NODE_PLATFORM="unsupported" ;;
+esac
+
+if [ "$NODE_SKIP" = "1" ]; then
+  echo "==> libnode skipped (CHAD_SKIP_NODE=1)"
+elif [ "$NODE_PLATFORM" = "unsupported" ]; then
+  echo "==> libnode skipped (unsupported platform: $(uname -s))"
+elif [ -f "$NODE_PINNED_SENTINEL" ] && [ "$(cat "$NODE_PINNED_SENTINEL")" = "$NODE_TAG" ]; then
+  echo "==> libnode already built at $NODE_TAG, skipping"
+else
+  echo "==> Building libnode $NODE_TAG from source (this takes 30-90 minutes on first run)"
+  mkdir -p "$NODE_DIR/lib" "$NODE_DIR/include"
+  if [ ! -d "$NODE_SRC_DIR/.git" ]; then
+    echo "  -> cloning nodejs/node at $NODE_TAG (shallow) into $NODE_SRC_DIR"
+    mkdir -p "$(dirname "$NODE_SRC_DIR")"
+    rm -rf "$NODE_SRC_DIR"
+    git clone --depth 1 --branch "$NODE_TAG" https://github.com/nodejs/node.git "$NODE_SRC_DIR"
+  else
+    echo "  -> reusing node-src at $NODE_SRC_DIR"
   fi
-  if [ -n "$V8_INCLUDE" ]; then
-    if [ ! -f "$V8_BRIDGE_OBJ" ] || [ "$V8_BRIDGE_SRC" -nt "$V8_BRIDGE_OBJ" ]; then
-      echo "==> Building v8-bridge (headers at $V8_INCLUDE)..."
-      V8_CXX="c++"
-      if [ -n "${LLVM_CONFIG:-}" ]; then
-        LLVM_BINDIR=$(dirname "$LLVM_CONFIG")
-        if [ -f "$LLVM_BINDIR/clang++" ]; then
-          V8_CXX="$LLVM_BINDIR/clang++"
-        fi
-      fi
-      $V8_CXX -c -std=c++20 -O2 -fPIC \
-        -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX \
-        -I"$V8_INCLUDE" "$V8_BRIDGE_SRC" -o "$V8_BRIDGE_OBJ"
-      echo "  -> $V8_BRIDGE_OBJ"
-    else
-      echo "==> v8-bridge already built, skipping"
+  (
+    cd "$NODE_SRC_DIR"
+    # Trim the bloat: no npm, no corepack, no snapshot/code-cache. Keep ICU for
+    # realistic npm-ecosystem semantics. `--shared` produces libnode.dylib/.so
+    # rather than the standalone node binary.
+    if [ ! -f config.status ]; then
+      echo "  -> configure --shared (trimmed)"
+      # `--shared` makes the build produce libnode.dylib/.so instead of a
+      # standalone node binary. We intentionally bundle OpenSSL statically
+      # (default, no --shared-openssl) to avoid a system-openssl runtime dep.
+      ./configure \
+        --shared \
+        --without-npm \
+        --without-corepack \
+        --without-node-snapshot \
+        --without-node-code-cache
+    fi
+    echo "  -> make -j$NPROC (this is the slow part)"
+    make -j"$NPROC"
+  )
+
+  # Extract the shared library + headers into vendor/node/.
+  # Node builds put the dylib under out/Release; layout differs slightly by OS.
+  if [ "$NODE_PLATFORM" = "darwin" ]; then
+    NODE_LIB_SRC=$(ls "$NODE_SRC_DIR/out/Release/libnode."*.dylib 2>/dev/null | head -n 1 || true)
+    if [ -z "$NODE_LIB_SRC" ]; then
+      NODE_LIB_SRC="$NODE_SRC_DIR/out/Release/libnode.dylib"
     fi
   else
-    echo "==> v8-bridge skipped (no v8 headers found — brew install v8)"
+    NODE_LIB_SRC=$(ls "$NODE_SRC_DIR/out/Release/libnode.so."* 2>/dev/null | head -n 1 || true)
+    if [ -z "$NODE_LIB_SRC" ]; then
+      NODE_LIB_SRC="$NODE_SRC_DIR/out/Release/libnode.so"
+    fi
   fi
+  if [ ! -f "$NODE_LIB_SRC" ]; then
+    echo "ERROR: libnode was not produced at $NODE_LIB_SRC" >&2
+    exit 1
+  fi
+  cp "$NODE_LIB_SRC" "$NODE_DIR/lib/"
+  # Headers: node embedding API + V8 + libuv. Copy each tree preserving layout.
+  rm -rf "$NODE_DIR/include"
+  mkdir -p "$NODE_DIR/include"
+  cp -R "$NODE_SRC_DIR/src/"*.h "$NODE_DIR/include/" 2>/dev/null || true
+  mkdir -p "$NODE_DIR/include/v8"
+  cp -R "$NODE_SRC_DIR/deps/v8/include/"* "$NODE_DIR/include/v8/"
+  mkdir -p "$NODE_DIR/include/uv"
+  cp -R "$NODE_SRC_DIR/deps/uv/include/"* "$NODE_DIR/include/uv/"
+
+  echo "$NODE_TAG" > "$NODE_PINNED_SENTINEL"
+  echo "  -> libnode installed at $NODE_DIR (lib/, include/)"
+fi
+
+# --- node-bridge (libnode embedder for `@chadscript: interpret` pragma) ---
+NODE_BRIDGE_SRC="$C_BRIDGES_DIR/node-bridge.cc"
+NODE_BRIDGE_OBJ="$C_BRIDGES_DIR/node-bridge.o"
+if [ -f "$NODE_BRIDGE_SRC" ] && [ -f "$NODE_DIR/lib/"*libnode* 2>/dev/null ] || \
+   { [ -f "$NODE_BRIDGE_SRC" ] && ls "$NODE_DIR/lib/" >/dev/null 2>&1 && [ -n "$(ls "$NODE_DIR/lib/" 2>/dev/null)" ]; }; then
+  if [ ! -f "$NODE_BRIDGE_OBJ" ] || [ "$NODE_BRIDGE_SRC" -nt "$NODE_BRIDGE_OBJ" ]; then
+    echo "==> Building node-bridge..."
+    NODE_CXX="c++"
+    if [ -n "${LLVM_CONFIG:-}" ]; then
+      LLVM_BINDIR=$(dirname "$LLVM_CONFIG")
+      if [ -f "$LLVM_BINDIR/clang++" ]; then
+        NODE_CXX="$LLVM_BINDIR/clang++"
+      fi
+    fi
+    $NODE_CXX -c -std=c++20 -O2 -fPIC \
+      -I"$NODE_DIR/include" \
+      -I"$NODE_DIR/include/v8" \
+      -I"$NODE_DIR/include/uv" \
+      "$NODE_BRIDGE_SRC" -o "$NODE_BRIDGE_OBJ"
+    echo "  -> $NODE_BRIDGE_OBJ"
+  else
+    echo "==> node-bridge already built, skipping"
+  fi
+else
+  echo "==> node-bridge skipped (no libnode or no source)"
 fi
 
 # --- child-process-spawn (async, requires libuv) ---

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -545,6 +545,18 @@ else
     exit 1
   fi
   cp "$NODE_LIB_SRC" "$NODE_DIR/lib/"
+  # Linker expects a plain `libnode.dylib`/`libnode.so` for `-lnode`; the
+  # built file is versioned (e.g. libnode.127.dylib). Create an unversioned
+  # symlink so `-lnode` resolves.
+  (
+    cd "$NODE_DIR/lib"
+    NODE_LIB_FILE=$(basename "$NODE_LIB_SRC")
+    if [ "$NODE_PLATFORM" = "darwin" ]; then
+      ln -sf "$NODE_LIB_FILE" libnode.dylib
+    else
+      ln -sf "$NODE_LIB_FILE" libnode.so
+    fi
+  )
   # Headers: node embedding API + V8 + libuv. Copy each tree preserving layout.
   rm -rf "$NODE_DIR/include"
   mkdir -p "$NODE_DIR/include"

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -481,7 +481,7 @@ fi
 NODE_DIR="$VENDOR_DIR/node"
 NODE_SRC_DIR="${CHAD_NODE_SRC:-$HOME/git/node}"
 NODE_PINNED_SENTINEL="$NODE_DIR/.pinned-version"
-NODE_SKIP="${CHAD_SKIP_NODE:-0}"
+NODE_SKIP="${CHAD_SKIP_NODE:-1}"
 
 case "$(uname -s)" in
   Darwin) NODE_PLATFORM="darwin" ;;

--- a/scripts/vendor-pins.sh
+++ b/scripts/vendor-pins.sh
@@ -14,3 +14,7 @@ PICOHTTPPARSER_COMMIT="f8326098f63eefabfa2b6ec595d90e9ed5ed958a"
 # rust-lang/regex provides the `rure` C ABI staticlib in the regex-capi crate.
 # Pin to a regex release tag so vendor builds are reproducible.
 RUST_REGEX_TAG="1.11.1"
+
+# nodejs/node built from source as a shared library (libnode) for the
+# pragma-interpret embedding path. Pin to a stable v22 LTS tag.
+NODE_TAG="v22.22.2"

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -270,6 +270,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   public usesStringBuilder: number = 0;
   public usesLLVM: number = 0;
   public usesLLD: number = 0;
+  public usesV8: number = 0;
   public usesCompression: number = 0;
   public usesYaml: number = 0;
   private stringBuilderSlen: Map<string, string> = new Map();
@@ -1020,6 +1021,12 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
   }
   public getUsesLLD(): boolean {
     return this.usesLLD !== 0;
+  }
+  public getUsesV8(): boolean {
+    return this.usesV8 !== 0;
+  }
+  public setUsesV8(value: boolean): void {
+    this.usesV8 = value ? 1 : 0;
   }
   public setUsesCompression(value: boolean): void {
     this.usesCompression = value ? 1 : 0;
@@ -3588,6 +3595,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     this.declaredExternFunctions.push(func.name);
     if (func.name.startsWith("cs_llvm_")) this.usesLLVM = 1;
     if (func.name.startsWith("cs_lld_")) this.usesLLD = 1;
+    if (func.name.startsWith("cs_v8_")) this.usesV8 = 1;
     return `declare ${retType} @${func.name}(${paramLlvmTypes.join(", ")})\n`;
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -14,6 +14,7 @@ import { TargetInfo, resolveTarget, getHostTarget, isCrossCompiling } from "./ta
 import { loadTargetSDK, ensureTargetSDK, TargetSDK } from "./cross-compile.js";
 import { VERSION } from "./version.js";
 import { setGlobalDiagnosticColor } from "./diagnostics/engine.js";
+import { buildMarshalWrapper, hasInterpretPragma } from "./marshal-wrapper.js";
 
 function detectInterpretPragma(source: string): boolean {
   const lines = source.split("\n", 10);
@@ -1007,7 +1008,28 @@ function compileMultiFile(
       );
     }
 
-    const importPath = resolveImportPath(absPath, imp.source);
+    let importPath = resolveImportPath(absPath, imp.source);
+
+    // Cross-boundary marshal: if the resolved target has the interpret pragma
+    // AND the importer does NOT (importer == native side), synthesize a
+    // replacement `.ts` wrapper that calls JSHandle FFI under the hood, then
+    // recurse on that wrapper instead of the pragma source. The wrapper
+    // exposes the same exports as the pragma file so the native importer's
+    // `import { foo }` resolves without any caller-side changes.
+    if (fs.existsSync(importPath) && !detectInterpretPragma(code)) {
+      const targetSource = fs.readFileSync(importPath, "utf8");
+      if (hasInterpretPragma(targetSource)) {
+        const wrapperSrc = buildMarshalWrapper(path.resolve(importPath), targetSource);
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "chad-marshal-"));
+        const tmpFile = path.join(tmpDir, path.basename(importPath));
+        fs.writeFileSync(tmpFile, wrapperSrc);
+        logger.info(
+          `@chadscript: interpret detected in import — synthesizing marshal wrapper for ${importPath}`,
+        );
+        importPath = tmpFile;
+      }
+    }
+
     const importedAST = compileMultiFile(
       importPath,
       compiledFiles,

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -205,6 +205,7 @@ const YYJSON_PATH = process.env.CHADSCRIPT_YYJSON_PATH || "./vendor/yyjson";
 const LIBUV_PATH = process.env.CHADSCRIPT_LIBUV_PATH || "./vendor/libuv/build";
 const TREESITTER_LIB_PATH = process.env.CHADSCRIPT_TREESITTER_PATH || "./vendor/tree-sitter";
 const RURE_LIB_PATH = process.env.CHADSCRIPT_RURE_PATH || "./vendor/rure";
+const NODE_LIB_PATH = process.env.CHADSCRIPT_NODE_PATH || "./vendor/node";
 // TSX grammar is a strict superset of TypeScript — all .ts code parses identically.
 // The only difference: <Type>expr angle-bracket assertions become JSX, but ChadScript
 // uses `as Type` so there's no impact on existing code.
@@ -494,9 +495,20 @@ export function compile(
     }
   }
   if (generator.getUsesV8()) {
-    const brewV8 = process.arch === "arm64" ? "/opt/homebrew/opt/v8" : "/usr/local/opt/v8";
-    linkLibs += ` -L${brewV8}/lib -lv8 -lv8_libplatform -lv8_libbase`;
-    linkLibs += ` -Wl,-rpath,${brewV8}/lib`;
+    // libnode swap: link Node.js shared lib instead of raw V8. libnode
+    // statically bundles v8_libplatform + v8_libbase, so only `-lnode` is
+    // needed. rpath resolves libnode.*.dylib/.so next to the compiled binary.
+    const nodeLibDir = sdk ? `${sdk.vendorPath}/node/lib` : `${NODE_LIB_PATH}/lib`;
+    linkLibs += ` -L${nodeLibDir} -lnode`;
+    if (targetIsMac) {
+      linkLibs += ` -Wl,-rpath,@loader_path/../vendor/node/lib`;
+      linkLibs += ` -Wl,-rpath,@loader_path`;
+      linkLibs += ` -Wl,-rpath,${path.resolve(nodeLibDir)}`;
+    } else {
+      linkLibs += ` -Wl,-rpath,\\$ORIGIN/../vendor/node/lib`;
+      linkLibs += ` -Wl,-rpath,\\$ORIGIN`;
+      linkLibs += ` -Wl,-rpath,${path.resolve(nodeLibDir)}`;
+    }
     if (hostIsMac) {
       linkLibs += " -lc++";
     } else {
@@ -611,8 +623,13 @@ export function compile(
   }
 
   if (generator.getUsesV8()) {
+    // libnode swap: the bridge is now node-bridge.o (embeds libnode).
+    // Keep v8-bridge.o fallback for any half-migrated vendor dir.
+    const nodeBridgeObj = `${bridgePath}/node-bridge.o`;
     const v8BridgeObj = `${bridgePath}/v8-bridge.o`;
-    if (fs.existsSync(v8BridgeObj)) {
+    if (fs.existsSync(nodeBridgeObj)) {
+      extraObjs += ` ${nodeBridgeObj}`;
+    } else if (fs.existsSync(v8BridgeObj)) {
       extraObjs += ` ${v8BridgeObj}`;
     }
   }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import { fileURLToPath } from "url";
 const _libDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "../lib");
@@ -13,6 +14,37 @@ import { TargetInfo, resolveTarget, getHostTarget, isCrossCompiling } from "./ta
 import { loadTargetSDK, ensureTargetSDK, TargetSDK } from "./cross-compile.js";
 import { VERSION } from "./version.js";
 import { setGlobalDiagnosticColor } from "./diagnostics/engine.js";
+
+function detectInterpretPragma(source: string): boolean {
+  const lines = source.split("\n", 10);
+  for (const line of lines) {
+    if (/^\s*\/\/\s*@chadscript\s*:\s*interpret\b/.test(line)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function buildInterpretWrapper(originalSource: string): string {
+  // Phase 1 pragma: embed user source as a JS string literal, evaluate under V8,
+  // print whatever it evaluates to. No console polyfill yet — user source should
+  // be a single expression or end with one. Phase 2 will inject a native print().
+  const encoded = JSON.stringify(originalSource);
+  return (
+    "declare function cs_v8_eval_string(src: string): string;\n" +
+    "declare function cs_v8_last_error(): string;\n" +
+    "const __chad_src = " +
+    encoded +
+    ";\n" +
+    "const __chad_out = cs_v8_eval_string(__chad_src);\n" +
+    "const __chad_err = cs_v8_last_error();\n" +
+    "if (__chad_err.length > 0) {\n" +
+    "  console.log('interpret error: ' + __chad_err);\n" +
+    "} else {\n" +
+    "  console.log(__chad_out);\n" +
+    "}\n"
+  );
+}
 
 function findLLVMTool(name: string): string {
   const candidates = [
@@ -189,6 +221,20 @@ export function compile(
 ): void {
   // Set the global logger level
   logger.setLevel(logLevel);
+
+  // Phase 1 pragma: if the entry file has `// @chadscript: interpret`, rewrite
+  // it into a wrapper .ts that embeds the original source and eval's it under V8.
+  if (fs.existsSync(inputFile)) {
+    const entrySource = fs.readFileSync(inputFile, "utf8");
+    if (detectInterpretPragma(entrySource)) {
+      const wrapper = buildInterpretWrapper(entrySource);
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "chad-interpret-"));
+      const tmpFile = path.join(tmpDir, path.basename(inputFile));
+      fs.writeFileSync(tmpFile, wrapper);
+      logger.info(`@chadscript: interpret detected — routing ${inputFile} through V8`);
+      return compile(tmpFile, outputFile, logLevel);
+    }
+  }
 
   const target = targetOverride || getHostTarget();
   const crossCompiling = isCrossCompiling(target);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -25,24 +25,29 @@ function detectInterpretPragma(source: string): boolean {
   return false;
 }
 
-function buildInterpretWrapper(originalSource: string): string {
-  // Phase 1 pragma: embed user source as a JS string literal, evaluate under V8,
-  // print whatever it evaluates to. No console polyfill yet — user source should
-  // be a single expression or end with one. Phase 2 will inject a native print().
-  const encoded = JSON.stringify(originalSource);
+function buildInterpretWrapper(originalSource: string, sourceFilename: string = ""): string {
+  // libnode swap: call cs_v8_eval_script_node, which drives the source via
+  // node::LoadEnvironment inside a Node Environment. That hands the user code
+  // real `require`, `__filename`, `__dirname`, `process.argv`, `setTimeout`,
+  // `fs`, etc. Console output already goes through Node's stdio.
+  const encodedSrc = JSON.stringify(originalSource);
+  const encodedFile = JSON.stringify(sourceFilename);
   return (
-    "declare function cs_v8_eval_string(src: string): string;\n" +
+    "declare function cs_v8_eval_script_node(src: string, filename: string): string;\n" +
     "declare function cs_v8_last_error(): string;\n" +
+    "declare function cs_v8_shutdown_node(): void;\n" +
     "const __chad_src = " +
-    encoded +
+    encodedSrc +
     ";\n" +
-    "const __chad_out = cs_v8_eval_string(__chad_src);\n" +
+    "const __chad_file = " +
+    encodedFile +
+    ";\n" +
+    "const __chad_out = cs_v8_eval_script_node(__chad_src, __chad_file);\n" +
     "const __chad_err = cs_v8_last_error();\n" +
     "if (__chad_err.length > 0) {\n" +
     "  console.log('interpret error: ' + __chad_err);\n" +
-    "} else if (__chad_out.length > 0) {\n" +
-    "  console.log(__chad_out);\n" +
-    "}\n"
+    "}\n" +
+    "cs_v8_shutdown_node();\n"
   );
 }
 
@@ -228,7 +233,7 @@ export function compile(
   if (fs.existsSync(inputFile)) {
     const entrySource = fs.readFileSync(inputFile, "utf8");
     if (detectInterpretPragma(entrySource)) {
-      const wrapper = buildInterpretWrapper(entrySource);
+      const wrapper = buildInterpretWrapper(entrySource, path.resolve(inputFile));
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "chad-interpret-"));
       const tmpFile = path.join(tmpDir, path.basename(inputFile));
       fs.writeFileSync(tmpFile, wrapper);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -447,6 +447,16 @@ export function compile(
       linkLibs += " -framework Security -framework CoreFoundation";
     }
   }
+  if (generator.getUsesV8()) {
+    const brewV8 = process.arch === "arm64" ? "/opt/homebrew/opt/v8" : "/usr/local/opt/v8";
+    linkLibs += ` -L${brewV8}/lib -lv8 -lv8_libplatform -lv8_libbase`;
+    linkLibs += ` -Wl,-rpath,${brewV8}/lib`;
+    if (hostIsMac) {
+      linkLibs += " -lc++";
+    } else {
+      linkLibs += " -lstdc++";
+    }
+  }
 
   // Platform-specific library search paths
   if (sdk) {
@@ -551,6 +561,13 @@ export function compile(
 
       extraObjs = ` ${tsParserObj} ${tsScannerObj} ${bridgeObj}`;
       linkLibs += ` ${TREESITTER_LIB_PATH}/libtree-sitter.a`;
+    }
+  }
+
+  if (generator.getUsesV8()) {
+    const v8BridgeObj = `${bridgePath}/v8-bridge.o`;
+    if (fs.existsSync(v8BridgeObj)) {
+      extraObjs += ` ${v8BridgeObj}`;
     }
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -40,7 +40,7 @@ function buildInterpretWrapper(originalSource: string): string {
     "const __chad_err = cs_v8_last_error();\n" +
     "if (__chad_err.length > 0) {\n" +
     "  console.log('interpret error: ' + __chad_err);\n" +
-    "} else {\n" +
+    "} else if (__chad_out.length > 0) {\n" +
     "  console.log(__chad_out);\n" +
     "}\n"
   );

--- a/src/diagnostics/engine.ts
+++ b/src/diagnostics/engine.ts
@@ -239,6 +239,9 @@ export function setGlobalDiagnosticColor(enabled: boolean): void {
   globalColorEnabled = enabled;
 }
 
+export const INTERPRET_PRAGMA_HINT =
+  "If this file needs full JS semantics, add '// @chadscript: interpret' to the top to run it under V8 (slower, full JS).";
+
 export function formatCompileError(
   sourceCode: string,
   message: string,

--- a/src/marshal-wrapper.ts
+++ b/src/marshal-wrapper.ts
@@ -1,0 +1,306 @@
+// Cross-boundary export marshal.
+//
+// When a native ChadScript file imports from another `.ts` that has
+// `// @chadscript: interpret` at the top, the imported file's source runs
+// under Node. The importer wants to call the exported functions naturally —
+// `import { ms } from './pragma-file'` followed by `ms("2 days")` — without
+// writing any JSHandle FFI by hand.
+//
+// This module synthesizes a replacement `.ts` wrapper for the pragma file.
+// The wrapper has the same exported function signatures as the original but
+// each body calls into the libnode JSHandle bridge: one bootstrap step evals
+// the pragma source inside Node and captures its module.exports as a handle;
+// each call marshals args per declared types, invokes cs_v8_callN, and
+// unmarshals the result per declared return type.
+
+import { parseWithTSAPI } from "./parser-ts/index.js";
+import { FunctionNode } from "./ast/types.js";
+
+// Mirrors detectInterpretPragma in compiler.ts (kept local to avoid import cycle).
+export function hasInterpretPragma(source: string): boolean {
+  const lines = source.split("\n", 10);
+  for (const line of lines) {
+    if (/^\s*\/\/\s*@chadscript\s*:\s*interpret\b/.test(line)) return true;
+  }
+  return false;
+}
+
+const EXTERN_DECLS =
+  `declare function cs_v8_register_pragma_module(src: string, file: string): number;\n` +
+  `declare function cs_v8_handle_get_property(obj: number, name: string): number;\n` +
+  `declare function cs_v8_make_string_handle(s: string): number;\n` +
+  `declare function cs_v8_make_number_handle(n: number): number;\n` +
+  `declare function cs_v8_make_bool_handle(b: number): number;\n` +
+  `declare function cs_v8_handle_to_string(h: number): string;\n` +
+  `declare function cs_v8_handle_to_number(h: number): number;\n` +
+  `declare function cs_v8_handle_to_bool(h: number): number;\n` +
+  `declare function cs_v8_handle_release(h: number): void;\n` +
+  `declare function cs_v8_last_error(): string;\n` +
+  `declare function cs_v8_call0(fn: number, recv: number): number;\n` +
+  `declare function cs_v8_call1(fn: number, recv: number, a0: number): number;\n` +
+  `declare function cs_v8_call2(fn: number, recv: number, a0: number, a1: number): number;\n` +
+  `declare function cs_v8_call3(fn: number, recv: number, a0: number, a1: number, a2: number): number;\n` +
+  `declare function cs_v8_call4(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number): number;\n` +
+  `declare function cs_v8_call5(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number, a4: number): number;\n` +
+  `declare function cs_v8_call6(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number, a4: number, a5: number): number;\n` +
+  `declare function cs_v8_call7(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number, a4: number, a5: number, a6: number): number;\n` +
+  `declare function cs_v8_call8(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number, a4: number, a5: number, a6: number, a7: number): number;\n` +
+  `declare function cs_v8_handle_await(h: number): number;\n`;
+
+// Turn an absolute filesystem path into a sanitized identifier-safe suffix
+// used to disambiguate globals across multiple imported pragma modules.
+function moduleSlug(absPath: string): string {
+  let h = 0;
+  for (let i = 0; i < absPath.length; i++) {
+    h = (h * 31 + absPath.charCodeAt(i)) | 0;
+  }
+  const base = absPath
+    .replace(/^.*[\\/]/, "")
+    .replace(/\.[^.]*$/, "")
+    .replace(/[^a-zA-Z0-9_]/g, "_");
+  const hex = (h >>> 0).toString(16);
+  return `${base}_${hex}`;
+}
+
+// Return the TS expression that marshals `varName` (typed `tsType`) into a
+// JSHandle `number`. Primitive fast-path; anything else is assumed to already
+// be a handle (number).
+function marshalArg(varName: string, tsType: string | undefined): string {
+  const t = (tsType || "").trim();
+  if (t === "string") return `cs_v8_make_string_handle(${varName})`;
+  if (t === "number") return `cs_v8_make_number_handle(${varName})`;
+  if (t === "boolean") return `cs_v8_make_bool_handle(${varName} ? 1 : 0)`;
+  // Fallback: assume the caller passed a JSHandle (number) already. Future
+  // work: objects, arrays, class instances.
+  return varName;
+}
+
+// Return TS that unmarshals `handleVar` (JSHandle) into a value typed `tsType`.
+// Uses a temporary `const` so we can release the handle before returning.
+function unmarshalResult(
+  handleVar: string,
+  tsType: string | undefined,
+): {
+  body: string;
+  returnExpr: string;
+} {
+  const t = (tsType || "").trim();
+  if (t === "" || t === "void") {
+    return { body: `cs_v8_handle_release(${handleVar});\n`, returnExpr: "" };
+  }
+  if (t === "string") {
+    return {
+      body: `const __out_val: string = cs_v8_handle_to_string(${handleVar});\ncs_v8_handle_release(${handleVar});\n`,
+      returnExpr: "__out_val",
+    };
+  }
+  if (t === "number") {
+    return {
+      body: `const __out_val: number = cs_v8_handle_to_number(${handleVar});\ncs_v8_handle_release(${handleVar});\n`,
+      returnExpr: "__out_val",
+    };
+  }
+  if (t === "boolean") {
+    return {
+      body: `const __out_val: number = cs_v8_handle_to_bool(${handleVar});\n// retain handle; callers asked for bool\ncs_v8_handle_release(${handleVar});\n`,
+      returnExpr: "__out_val !== 0",
+    };
+  }
+  // Anything else: return the handle itself (caller sees a `number`).
+  return { body: "", returnExpr: handleVar };
+}
+
+// Build the wrapper for one exported function.
+function buildFunctionWrapper(fn: FunctionNode, slug: string, moduleName: string): string | null {
+  const arity = fn.params.length;
+  if (arity > 8) {
+    return (
+      `// marshal: skipping export '${fn.name}' — arity ${arity} exceeds max 8. ` +
+      `Add cs_v8_call${arity} to node-bridge.cc to enable.\n`
+    );
+  }
+  const paramTypes = fn.paramTypes || [];
+  const paramDecls: string[] = [];
+  for (let i = 0; i < arity; i++) {
+    const p = fn.params[i];
+    const t = paramTypes[i] || "number";
+    paramDecls.push(`${p}: ${t}`);
+  }
+  const ret = (fn.returnType || "void").trim();
+  const exportKw = "export ";
+  // Unwrap Promise<T>: the JS-side call returns a Promise handle, then we
+  // spin the event loop via cs_v8_handle_await to resolve it. Native side
+  // sees a synchronous T — avoids plumbing JS promise identity through the
+  // native async/await machinery.
+  let effectiveRet = ret;
+  let isAsync = false;
+  const promiseMatch = /^Promise\s*<\s*(.+)\s*>$/.exec(ret);
+  if (promiseMatch) {
+    effectiveRet = promiseMatch[1].trim();
+    isAsync = true;
+  }
+
+  const argMarshals: string[] = [];
+  for (let i = 0; i < arity; i++) {
+    argMarshals.push(`const __a${i}: number = ${marshalArg(fn.params[i], paramTypes[i])};`);
+  }
+
+  const callArgs: string[] = ["__fn_" + fn.name, "0"];
+  for (let i = 0; i < arity; i++) callArgs.push(`__a${i}`);
+  const callExpr = `cs_v8_call${arity}(${callArgs.join(", ")})`;
+  const postCall = isAsync
+    ? `const __res_raw: number = ${callExpr};\n  const __res: number = cs_v8_handle_await(__res_raw);\n  cs_v8_handle_release(__res_raw);`
+    : `const __res: number = ${callExpr};`;
+
+  const unm = unmarshalResult("__res", effectiveRet);
+
+  // Release arg handles after the call (cleanup). Skip releasing pass-through
+  // handles (when param type is a JSHandle number — releasing would pull the
+  // rug from a caller who still holds the handle).
+  const argReleases: string[] = [];
+  for (let i = 0; i < arity; i++) {
+    const t = (paramTypes[i] || "").trim();
+    if (t === "string" || t === "number" || t === "boolean") {
+      argReleases.push(`cs_v8_handle_release(__a${i});`);
+    }
+  }
+
+  const retKw = effectiveRet === "" || effectiveRet === "void" ? "void" : effectiveRet;
+  const retStmt = unm.returnExpr === "" ? "" : `return ${unm.returnExpr};\n`;
+  // Preserve async declaration so native callers can `await` the returned
+  // value. The body runs synchronously (via handle_await's SpinEventLoop),
+  // but TypeScript's async-function wrapping makes the return a Promise<T>.
+  const asyncKw = isAsync ? "async " : "";
+  const sigRet = isAsync ? `Promise<${retKw}>` : retKw;
+
+  return (
+    `${exportKw}${asyncKw}function ${fn.name}(${paramDecls.join(", ")}): ${sigRet} {\n` +
+    `  const __mod: number = __marshal_ensure_${slug}();\n` +
+    `  const __fn_${fn.name}: number = cs_v8_handle_get_property(__mod, "${fn.name}");\n` +
+    `  ${argMarshals.join("\n  ")}\n` +
+    `  ${postCall}\n` +
+    `  const __err: string = cs_v8_last_error();\n` +
+    `  if (__err.length > 0) {\n` +
+    `    console.log("marshal: call to ${fn.name} in ${moduleName} failed: " + __err);\n` +
+    `    process.exit(1);\n` +
+    `  }\n` +
+    `  ${argReleases.join("\n  ")}\n` +
+    `  cs_v8_handle_release(__fn_${fn.name});\n` +
+    `  ${unm.body}` +
+    `  ${retStmt}` +
+    `}\n`
+  );
+}
+
+// Escape a string for embedding as a TS string literal inside double quotes.
+function tsStringLit(s: string): string {
+  let out = '"';
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c === 0x5c /* \ */) out += "\\\\";
+    else if (c === 0x22 /* " */) out += '\\"';
+    else if (c === 0x0a /* \n */) out += "\\n";
+    else if (c === 0x0d /* \r */) out += "\\r";
+    else if (c === 0x09 /* \t */) out += "\\t";
+    else if (c < 0x20) out += "\\u" + c.toString(16).padStart(4, "0");
+    else out += s[i];
+  }
+  out += '"';
+  return out;
+}
+
+// Rewrite `export function foo` / `export async function foo` / `export const foo =`
+// into CJS-compatible `module.exports.foo = ...` form. Our pragma wrapper in
+// node-bridge.cc runs the source inside a synthetic CJS function body where
+// ES-module `export` is a syntax error. TS types are stripped by the fact that
+// Node sees this source only after we also strip `: Type` annotations.
+function rewriteExportsForCJS(src: string): string {
+  // Strip TS type annotations on exported function parameters and return type.
+  // Pragma files are limited in scope — this covers the 90% case. Future work:
+  // use the TS parser to do a proper lowering.
+  let out = src;
+  // export async function name(params): ret { → module.exports.name = async function(params){
+  out = out.replace(
+    /\bexport\s+async\s+function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*(?::\s*[^({]+)?\s*\{/g,
+    (_m, name, params) => `module.exports.${name} = async function(${stripParamTypes(params)}){`,
+  );
+  out = out.replace(
+    /\bexport\s+function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*(?::\s*[^({]+)?\s*\{/g,
+    (_m, name, params) => `module.exports.${name} = function(${stripParamTypes(params)}){`,
+  );
+  // export const name = ...  → module.exports.name = ...
+  out = out.replace(
+    /\bexport\s+const\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+)?\s*=/g,
+    (_m, name) => `module.exports.${name} =`,
+  );
+  return out;
+}
+
+function stripParamTypes(params: string): string {
+  // For each top-level comma-separated parameter, drop `: Type` suffix but keep
+  // defaults. Shallow split — doesn't handle `foo: {a: b}` object-type
+  // annotations (unusual in hand-written pragma files).
+  const parts = params.split(",");
+  const cleaned: string[] = [];
+  for (const p of parts) {
+    const trimmed = p.trim();
+    if (!trimmed) continue;
+    const colon = trimmed.indexOf(":");
+    const eq = trimmed.indexOf("=");
+    if (colon >= 0 && (eq < 0 || colon < eq)) {
+      const name = trimmed.substring(0, colon).trim();
+      if (eq > colon) {
+        cleaned.push(`${name} ${trimmed.substring(eq)}`);
+      } else {
+        cleaned.push(name);
+      }
+    } else {
+      cleaned.push(trimmed);
+    }
+  }
+  return cleaned.join(", ");
+}
+
+// Build the full wrapper `.ts` source replacing a pragma file from the
+// native side's perspective. Returns a complete, standalone TS module.
+export function buildMarshalWrapper(absPath: string, pragmaSource: string): string {
+  const slug = moduleSlug(absPath);
+  const ast = parseWithTSAPI(pragmaSource, { filename: absPath });
+  const jsSource = rewriteExportsForCJS(pragmaSource);
+
+  // Collect exported function declarations. `ast.exports` holds ExportDeclaration
+  // for `export function foo`; we also include top-level functions flagged as
+  // exported (the parser already adds them to exports).
+  const exportedFns: FunctionNode[] = [];
+  for (const exp of ast.exports) {
+    if (exp.declaration && (exp.declaration as FunctionNode).params !== undefined) {
+      exportedFns.push(exp.declaration as FunctionNode);
+    }
+  }
+
+  const parts: string[] = [];
+  parts.push("// Auto-generated marshal wrapper for: " + absPath);
+  parts.push(EXTERN_DECLS);
+  parts.push(`let __marshal_exports_${slug}: number = 0;`);
+  parts.push(`function __marshal_ensure_${slug}(): number {`);
+  parts.push(`  if (__marshal_exports_${slug} !== 0) return __marshal_exports_${slug};`);
+  parts.push(`  const __src: string = ${tsStringLit(jsSource)};`);
+  parts.push(`  const __file: string = ${tsStringLit(absPath)};`);
+  parts.push(`  __marshal_exports_${slug} = cs_v8_register_pragma_module(__src, __file);`);
+  parts.push(`  const __err: string = cs_v8_last_error();`);
+  parts.push(`  if (__err.length > 0) {`);
+  parts.push(
+    `    console.log("marshal: failed to load pragma module ${absPath.replace(/\\/g, "/").replace(/"/g, '\\"')}: " + __err);`,
+  );
+  parts.push(`    process.exit(1);`);
+  parts.push(`  }`);
+  parts.push(`  return __marshal_exports_${slug};`);
+  parts.push(`}`);
+
+  for (const fn of exportedFns) {
+    const w = buildFunctionWrapper(fn, slug, absPath);
+    if (w) parts.push(w);
+  }
+
+  return parts.join("\n") + "\n";
+}

--- a/src/parser-ts/handlers/declarations.ts
+++ b/src/parser-ts/handlers/declarations.ts
@@ -16,6 +16,7 @@ import {
 import { transformBlock } from "./statements.js";
 import { transformExpression } from "./expressions.js";
 import { getLoc } from "../transformer.js";
+import { INTERPRET_PRAGMA_HINT } from "../../diagnostics/engine.js";
 
 export function transformFunctionDeclaration(
   node: ts.FunctionDeclaration,
@@ -133,7 +134,8 @@ export function transformClassDeclaration(
       const memberName = ts.isIdentifier(member.name) ? member.name.text : "?";
       const loc = getLoc(member);
       console.error(
-        `${loc.file}:${loc.line}:${loc.column}: error: '${kind} ${memberName}()' is not supported; use a regular public method instead`,
+        `${loc.file}:${loc.line}:${loc.column}: error: '${kind} ${memberName}()' (getter/setter) is not supported in native mode; use a regular public method instead.\n` +
+          `  help: ${INTERPRET_PRAGMA_HINT}`,
       );
       process.exit(1);
     }

--- a/src/parser-ts/handlers/expressions.ts
+++ b/src/parser-ts/handlers/expressions.ts
@@ -27,6 +27,28 @@ import {
 } from "../../ast/types.js";
 import { transformStatement, extractTypeString } from "./statements.js";
 import { getLoc } from "../transformer.js";
+import { INTERPRET_PRAGMA_HINT } from "../../diagnostics/engine.js";
+
+function describeSyntaxKind(kind: ts.SyntaxKind): string {
+  if (kind === ts.SyntaxKind.YieldExpression) return "generator functions (yield)";
+  if (kind === ts.SyntaxKind.TaggedTemplateExpression) return "tagged template literals";
+  if (kind === ts.SyntaxKind.ClassExpression) return "class expressions";
+  if (kind === ts.SyntaxKind.Decorator) return "decorators";
+  if (kind === ts.SyntaxKind.BigIntLiteral) return "bigint literals";
+  if (kind === ts.SyntaxKind.MetaProperty) return "meta properties (new.target, import.meta)";
+  if (kind === ts.SyntaxKind.SpreadElement) return "spread in this position";
+  if (kind === ts.SyntaxKind.CommaListExpression) return "comma expressions";
+  return ts.SyntaxKind[kind];
+}
+
+function unsupportedExpressionError(node: ts.Node, category: string): Error {
+  const feature = describeSyntaxKind(node.kind);
+  const loc = getLoc(node);
+  const msg =
+    `${loc.file}:${loc.line}:${loc.column}: error: ${feature} ${category} — not supported in native mode.\n` +
+    `  help: ${INTERPRET_PRAGMA_HINT}`;
+  return new Error(msg);
+}
 
 export function transformExpression(
   node: ts.Expression,
@@ -145,7 +167,7 @@ export function transformExpression(
       return { type: "undefined", loc: getLoc(node) };
 
     default:
-      throw new Error(`Unsupported expression kind: ${ts.SyntaxKind[node.kind]}`);
+      throw unsupportedExpressionError(node, "expression");
   }
 }
 
@@ -456,7 +478,7 @@ function transformCallExpression(
     };
   }
 
-  throw new Error(`Unsupported call expression: ${ts.SyntaxKind[node.expression.kind]}`);
+  throw unsupportedExpressionError(node.expression, "as a call target");
 }
 
 function transformPropertyAccessExpression(
@@ -612,7 +634,7 @@ function transformNewExpression(
     return { type: "new", className, args, loc: getLoc(node) };
   }
 
-  throw new Error(`Unsupported new expression: ${ts.SyntaxKind[node.expression.kind]}`);
+  throw unsupportedExpressionError(node.expression, "in 'new' position");
 }
 
 function transformTemplateExpression(

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -33,6 +33,7 @@ import {
   transformTypeAliasDeclaration,
   transformImportDeclaration,
 } from "./handlers/declarations.js";
+import { INTERPRET_PRAGMA_HINT } from "../diagnostics/engine.js";
 
 let currentSourceFile: ts.SourceFile | null = null;
 
@@ -289,7 +290,9 @@ function transformTopLevelStatement(
         ast.topLevelItemTypes!.push(expr.type);
       } else if (expr.type === "unary") {
         throw new Error(
-          "Increment/decrement (++/--) at global scope is not supported. Use x = x + 1 instead, or wrap in a function.",
+          "Increment/decrement (++/--) at global scope is not supported. Use x = x + 1 instead, or wrap in a function.\n" +
+            "  help: " +
+            INTERPRET_PRAGMA_HINT,
         );
       } else if (isAssignmentExpression(exprStmt.expression)) {
         const binExpr = exprStmt.expression as ts.BinaryExpression;
@@ -367,7 +370,9 @@ function transformTopLevelStatement(
           loc.line +
           ":" +
           loc.column +
-          ": error: labeled statements (e.g., 'outer: for') are not supported; use a flag variable with regular break instead",
+          ": error: labeled statements (e.g., 'outer: for') are not supported; use a flag variable with regular break instead.\n" +
+          "  help: " +
+          INTERPRET_PRAGMA_HINT,
       );
       process.exit(1);
       break;

--- a/tests/fixtures/v8/marshal-async-main.ts
+++ b/tests/fixtures/v8/marshal-async-main.ts
@@ -1,0 +1,15 @@
+// @test-description: marshal async — native awaits pragma-side setTimeout
+// @test-skip
+
+import { delayedHi } from "./marshal-async-pragma";
+
+async function main(): Promise<void> {
+  const r: string = await delayedHi("chad");
+  if (r === "hi chad") {
+    console.log("TEST_PASSED");
+  } else {
+    console.log("FAIL: " + r);
+  }
+}
+
+main();

--- a/tests/fixtures/v8/marshal-async-pragma.ts
+++ b/tests/fixtures/v8/marshal-async-pragma.ts
@@ -1,0 +1,7 @@
+// @chadscript: interpret
+// @test-skip
+
+export async function delayedHi(name: string): Promise<string> {
+  await new Promise((r) => setTimeout(r, 10));
+  return "hi " + name;
+}

--- a/tests/fixtures/v8/marshal-main.ts
+++ b/tests/fixtures/v8/marshal-main.ts
@@ -1,0 +1,11 @@
+// @test-description: cross-boundary marshal — native imports pragma-file export
+// @test-skip
+
+import { ms } from "./marshal-ms";
+
+const r: string = ms("2 days");
+if (r === "172800000") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: " + r);
+}

--- a/tests/fixtures/v8/marshal-ms.ts
+++ b/tests/fixtures/v8/marshal-ms.ts
@@ -1,0 +1,6 @@
+// @chadscript: interpret
+// @test-skip
+
+export function ms(s: string): string {
+  return String(require("ms")(s));
+}

--- a/tests/fixtures/v8/marshal-num-main.ts
+++ b/tests/fixtures/v8/marshal-num-main.ts
@@ -1,0 +1,11 @@
+// @test-description: marshal number-return across boundary
+// @test-skip
+
+import { parseMs } from "./marshal-num-pragma";
+
+const n: number = parseMs("3s");
+if (n === 3000) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: " + n.toString());
+}

--- a/tests/fixtures/v8/marshal-num-pragma.ts
+++ b/tests/fixtures/v8/marshal-num-pragma.ts
@@ -1,0 +1,6 @@
+// @chadscript: interpret
+// @test-skip
+
+export function parseMs(s: string): number {
+  return Number(require("ms")(s));
+}

--- a/tests/fixtures/v8/mixed-mode.ts
+++ b/tests/fixtures/v8/mixed-mode.ts
@@ -1,0 +1,42 @@
+// @test-description: v8 mixed-mode — normal-mode ts calling jshandle externs
+// @test-skip
+
+declare function cs_v8_eval_handle(src: string): number;
+declare function cs_v8_handle_get_property(h: number, name: string): number;
+declare function cs_v8_handle_to_number(h: number): number;
+declare function cs_v8_handle_to_string(h: number): string;
+declare function cs_v8_handle_release(h: number): void;
+declare function cs_v8_is_handle(v: number): number;
+declare function cs_v8_handle_table_size(): number;
+declare function cs_v8_last_error(): string;
+
+function fail(msg: string): void {
+  console.log("TEST_FAILED: " + msg);
+}
+
+const obj = cs_v8_eval_handle("({name: 'chad', count: 42})");
+if (obj === 0) {
+  fail("eval_handle returned 0: " + cs_v8_last_error());
+} else if (cs_v8_is_handle(obj) !== 1) {
+  fail("eval_handle result is not a tagged jshandle");
+} else {
+  const name_h = cs_v8_handle_get_property(obj, "name");
+  const count_h = cs_v8_handle_get_property(obj, "count");
+  const name = cs_v8_handle_to_string(name_h);
+  const count = cs_v8_handle_to_number(count_h);
+  if (name !== "chad") {
+    fail("expected name='chad', got '" + name + "'");
+  } else if (count !== 42) {
+    fail("expected count=42, got " + count.toString());
+  } else {
+    cs_v8_handle_release(name_h);
+    cs_v8_handle_release(count_h);
+    cs_v8_handle_release(obj);
+    const remaining = cs_v8_handle_table_size();
+    if (remaining !== 0) {
+      fail("expected empty handle table, got " + remaining.toString());
+    } else {
+      console.log("TEST_PASSED");
+    }
+  }
+}

--- a/tests/fixtures/v8/node-async-await.ts
+++ b/tests/fixtures/v8/node-async-await.ts
@@ -1,0 +1,15 @@
+// @chadscript: interpret
+// @test-skip
+// @test-description: libnode pragma supports async/await + Node fs.promises
+const fs = require("fs").promises;
+
+async function main() {
+  const data = await fs.readFile(__filename, "utf8");
+  const len = data.length;
+  await new Promise((r) => setTimeout(r, 25));
+  if (len > 0) {
+    console.log("TEST_PASSED len=" + len);
+  }
+}
+
+main();

--- a/tests/fixtures/v8/node-fetch.ts
+++ b/tests/fixtures/v8/node-fetch.ts
@@ -1,0 +1,14 @@
+// @chadscript: interpret
+// @test-skip
+// @test-description: libnode pragma supports Node 18+ native fetch
+async function main() {
+  const res = await fetch("https://httpbin.org/uuid");
+  const body = await res.json();
+  if (typeof body.uuid === "string" && body.uuid.length > 30) {
+    console.log("TEST_PASSED");
+  } else {
+    console.log("FAIL " + JSON.stringify(body));
+  }
+}
+
+main();

--- a/tests/fixtures/v8/node-fs-read.ts
+++ b/tests/fixtures/v8/node-fs-read.ts
@@ -1,0 +1,6 @@
+// @chadscript: interpret
+// @test-skip
+// @test-description: libnode pragma has fs + __filename; reads its own source file
+const fs = require("fs");
+const d = fs.readFileSync(__filename, "utf8");
+console.log("len=" + d.length);

--- a/tests/fixtures/v8/node-require-ms.ts
+++ b/tests/fixtures/v8/node-require-ms.ts
@@ -1,0 +1,5 @@
+// @chadscript: interpret
+// @test-skip
+// @test-description: libnode pragma can require() an installed npm package
+const ms = require("ms");
+console.log(ms("2 days"));

--- a/tests/fixtures/v8/node-set-timeout.ts
+++ b/tests/fixtures/v8/node-set-timeout.ts
@@ -1,0 +1,4 @@
+// @chadscript: interpret
+// @test-skip
+// @test-description: libnode pragma drains libuv: setTimeout callback fires before process exit
+setTimeout(() => console.log("TEST_PASSED"), 50);

--- a/tests/fixtures/v8/pragma-interpret.ts
+++ b/tests/fixtures/v8/pragma-interpret.ts
@@ -1,0 +1,4 @@
+// @chadscript: interpret
+// @test-description: pragma routes this file through V8; last expression becomes stdout
+// @test-skip
+"TEST_PASSED";

--- a/tests/fixtures/v8/pragma-interpret.ts
+++ b/tests/fixtures/v8/pragma-interpret.ts
@@ -1,4 +1,4 @@
 // @chadscript: interpret
-// @test-description: pragma routes this file through V8; last expression becomes stdout
+// @test-description: pragma runs this file under V8; native print callback forwards console.log to stdout
 // @test-skip
-"TEST_PASSED";
+console.log("TEST_PASSED");

--- a/tests/fixtures/v8/smoke-eval.ts
+++ b/tests/fixtures/v8/smoke-eval.ts
@@ -1,11 +1,34 @@
-// @test-description: v8 phase 0 smoke — eval JS from native and round-trip a number
+// @test-description: v8 phase 0 smoke — primitives + tagged error path
 // @test-skip
 
 declare function cs_v8_eval_number(src: string): number;
+declare function cs_v8_eval_string(src: string): string;
+declare function cs_v8_last_error(): string;
+declare function cs_v8_clear_error(): void;
 
-const result = cs_v8_eval_number("1 + 2 * 3");
-if (result === 7) {
-  console.log("TEST_PASSED");
+function fail(msg: string): void {
+  console.log("TEST_FAILED: " + msg);
+}
+
+const happy = cs_v8_eval_number("1 + 2 * 3");
+if (happy !== 7) {
+  fail("expected 7, got " + happy.toString());
+} else if (cs_v8_last_error().length !== 0) {
+  fail("unexpected error after happy path: " + cs_v8_last_error());
 } else {
-  console.log("TEST_FAILED: expected 7, got " + result.toString());
+  const thrown = cs_v8_eval_number("throw new Error('oops from ts')");
+  const err = cs_v8_last_error();
+  if (err.indexOf("oops from ts") < 0) {
+    fail("expected error to contain 'oops from ts', got: " + err);
+  } else {
+    cs_v8_clear_error();
+    const recovered = cs_v8_eval_number("100 + 1");
+    if (recovered !== 101) {
+      fail("recovery failed, got " + recovered.toString());
+    } else if (cs_v8_last_error().length !== 0) {
+      fail("error not cleared after recovery: " + cs_v8_last_error());
+    } else {
+      console.log("TEST_PASSED");
+    }
+  }
 }

--- a/tests/fixtures/v8/smoke-eval.ts
+++ b/tests/fixtures/v8/smoke-eval.ts
@@ -1,0 +1,11 @@
+// @test-description: v8 phase 0 smoke — eval JS from native and round-trip a number
+// @test-skip
+
+declare function cs_v8_eval_number(src: string): number;
+
+const result = cs_v8_eval_number("1 + 2 * 3");
+if (result === 7) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("TEST_FAILED: expected 7, got " + result.toString());
+}


### PR DESCRIPTION
## Summary
- **New capability**: any `.ts` file starting with `// @chadscript: interpret` runs under an embedded Node.js 22 runtime. Users get full `require("...")`, `fs`, `Buffer`, `setTimeout`, `async/await`, native `fetch`, and every npm package Node can load — inside a ChadScript-compiled native binary.
- **Cross-boundary marshal**: native (non-pragma) TS files can `import { fn } from "./pragma-file"` and call pragma-file exports naturally. Compiler auto-synthesizes JSHandle FFI wrappers — no hand-written extern declarations.
- **Lean binaries are unchanged** (267 KB, links only `libSystem`). Node runtime is gated behind pragma usage; only pragma-using programs pull in `libnode.127.dylib` (~110 MB, resolved via `@rpath`/`$ORIGIN`).
- **Self-hosting firewall intact**: Stage 2 self-hosting never links libnode. `.build/chad` has zero Node dependency.

## What this unlocks for users
Drop `// @chadscript: interpret` at the top of any file using TS features outside ChadScript's native subset (decorators, `Proxy`, generators, dynamic require, complex generics) or any npm package. Then import from it as normal:

```ts
// ms-wrapper.ts
// @chadscript: interpret
export function ms(s: string): string { return String(require("ms")(s)); }

// main.ts  (native AOT)
import { ms } from "./ms-wrapper";
console.log(ms("2 days"));  // → "172800000"
```

Verified examples (see `tests/fixtures/v8/`):
- `require("ms")` → real npm package
- `setTimeout` → real libuv event loop
- `fs.readFileSync(__filename)` → real fs
- `async/await` + `fs.promises.readFile` + `await setTimeout(...)`
- `await fetch("https://httpbin.org/uuid")` + JSON parse
- `import { fn } from "./pragma-file"` native import from non-pragma file (sync string, sync number, async await)

## How it works
- Node source (`nodejs/node@v22.22.2`) cloned once into `~/git/node` (or `CHAD_NODE_SRC`), built `--shared` → `libnode.127.dylib` + headers copied into `vendor/node/`. Cached across worktrees.
- `c_bridges/node-bridge.cc` uses `node::InitializeOncePerProcess` + `MultiIsolatePlatform` + `CommonEnvironmentSetup` + `LoadEnvironment` to host a single Node env for process lifetime, with `SpinEventLoop` draining microtasks/timers/I/O between calls.
- Pragma wrapper injects `createRequire(__filename)` so pragma code gets a real CJS resolver anchored at user's source file.
- Cross-boundary marshal: at import resolution, if target has pragma, compiler synthesizes replacement `.ts` wrapper that embeds pragma source, registers via `cs_v8_register_pragma_module`, re-declares each export with marshal body (primitives → JSHandles → call → unmarshal).
- V8 `TryCatch` surfaces JS exceptions to thread-local `cs_v8_last_error` buffer — no silent `undefined`.

## Known limitations (for follow-up PRs)
1. `libnode.dylib` distribution story not yet wired into `scripts/build-target-sdk.sh` / release tarballs.
2. Marshal `export` keyword stripped via regex + shallow param-type stripper (90% case; proper TS lowering = future).
3. Marshal arity >8 exports dropped with a comment.
4. First pragma module fixes `require` base dir (single-env limitation of libnode's `LoadEnvironment`).
5. Marshal errors are fail-fast (`process.exit(1)`); exception propagation across boundary needs ChadScript exception support.
6. Non-primitive params/returns fall back to JSHandle passthrough; typed JSHandle aliases for ergonomics = future.
7. `require` rebind prologue is a small hack; `EmbedderPreload` is a cleaner long-term path.

## Test plan
- [x] `npm run verify` green (full Stage 2, libnode-free self-hosting)
- [x] 8 pragma fixtures built + run locally, all pass
- [x] `otool -L` on lean binary: only `libSystem`
- [x] `otool -L` on pragma binary: `@rpath/libnode.127.dylib`
- [x] CI libnode workflow passes on macOS + Linux
- [ ] Release-binary `install_name_tool` / rpath packaging (follow-up)