### PR TITLE
fix(codegen): seed symbol table on typed let-decl without init (#590)

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -706,6 +706,12 @@ export class VariableAllocator {
           );
         }
       }
+      // Seed symbol-table with declared type so later method/member access on
+      // this variable resolves via the declared interface even before any
+      // assignment. Fixes #590 — `let sock: Socket; sock = ...; sock.on(...)`.
+      if (stmt.declaredType) {
+        this.ctx.symbolTable.setResolvedType(stmt.name, parseTypeString(stmt.declaredType));
+      }
       return;
     }
 

--- a/tests/fixtures/edge-cases/decl-without-init-method.ts
+++ b/tests/fixtures/edge-cases/decl-without-init-method.ts
@@ -1,0 +1,39 @@
+// @test-description: let x: T; without init lets later method resolution work
+
+interface Shape {
+  area(): number;
+  name(): string;
+}
+
+class Circle {
+  area(): number {
+    return 3.14;
+  }
+  name(): string {
+    return "circle";
+  }
+}
+
+function getShape(useCircle: boolean): Shape {
+  let s: Shape;
+  if (useCircle) {
+    s = new Circle() as Shape;
+  } else {
+    s = new Circle() as Shape;
+  }
+  return s;
+}
+
+function main(): number {
+  const shape = getShape(true);
+  const a = shape.area();
+  const n = shape.name();
+  if (a === 3.14 && n === "circle") {
+    console.log("TEST_PASSED");
+    return 0;
+  }
+  console.log("FAIL a=" + a + " n=" + n);
+  return 1;
+}
+
+main();


### PR DESCRIPTION
## Summary
Fixes #590. \`let sock: Socket;\` now registers the declared type in the symbol table on the decl line, so later method resolution works regardless of where/how the variable is assigned.

## User-facing effect
Unblocks common conditional-initialization:
\`\`\`ts
let sock: Socket;
if (useTls) { sock = tlsConnect(...); } else { sock = createConnection(...); }
sock.on(\"connect\", ...);  // now resolves via Socket interface
\`\`\`

Previously failed with \"Method 'on' on 'sock' is not supported\" because the decl-without-init path in \`variable-allocator.ts\` allocated storage but never called \`setResolvedType\` — later member access had no declared type to consult and fell through to inferring from the RHS.

## Fix (6 LOC)
At the end of the null-value branch in \`variable-allocator.ts:allocateVariable\`, call \`setResolvedType\` with the parsed declared type.

## Test plan
- [x] Fixture \`tests/fixtures/edge-cases/decl-without-init-method.ts\` — interface + decl-without-init + later assignment + method call. Passes on node and native.
- [x] \`npm run verify\` — full tests + 3-stage self-host green locally
- [ ] CI green