### PR TITLE
step4-phase1: emit-site audit + bitwise bridge ops + TS FFI declares

### DIFF
--- a/c_bridges/llvm-builder-bridge.c
+++ b/c_bridges/llvm-builder-bridge.c
@@ -571,6 +571,66 @@ char* cs_llvm_build_mul(const char* lhs_name, const char* rhs_name) {
     return strdup(name);
 }
 
+char* cs_llvm_build_and(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildAnd(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_or(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildOr(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_xor(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildXor(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_shl(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildShl(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_ashr(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildAShr(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_lshr(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildLShr(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
 char* cs_llvm_build_fadd(const char* lhs_name, const char* rhs_name) {
     LLVMValueRef lhs = lookup_value(lhs_name);
     LLVMValueRef rhs = lookup_value(rhs_name);

--- a/scripts/audit-emit-sites.sh
+++ b/scripts/audit-emit-sites.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Audit ctx.emit(`...`) sites in src/codegen/**/*.ts and classify each by the
+# LLVM instruction it emits. Output JSON to stdout.
+#
+# Used by Step 4 (IRBuilder migration) to track bridge-coverage vs gaps.
+# See memory/step4-irbuilder-design-2026-04-20.md.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Patterns the llvm-builder-bridge.c currently covers (keep sorted).
+COVERED=(
+  add alloca ashr and bitcast br br_cond call call_void
+  fadd fcmp fdiv fmul fneg fptosi frem fsub
+  gep icmp inttoptr load lshr mul or phi ptrtoint
+  ret ret_void select sext shl sitofp srem store
+  sub trunc unreachable xor zext
+)
+
+# Output: { total, by_instruction, uncovered_samples }
+awk '
+BEGIN {
+  # Bridge-covered instructions (must match COVERED above).
+  covered["add"]=1; covered["alloca"]=1; covered["ashr"]=1; covered["and"]=1
+  covered["bitcast"]=1; covered["br"]=1
+  covered["call"]=1
+  covered["fadd"]=1; covered["fcmp"]=1; covered["fdiv"]=1; covered["fmul"]=1
+  covered["fneg"]=1; covered["fptosi"]=1; covered["frem"]=1; covered["fsub"]=1
+  covered["gep"]=1; covered["getelementptr"]=1
+  covered["icmp"]=1; covered["inttoptr"]=1
+  covered["load"]=1; covered["lshr"]=1; covered["mul"]=1
+  covered["or"]=1; covered["phi"]=1; covered["ptrtoint"]=1
+  covered["ret"]=1; covered["select"]=1; covered["sext"]=1
+  covered["shl"]=1; covered["sitofp"]=1; covered["srem"]=1; covered["store"]=1
+  covered["sub"]=1; covered["trunc"]=1; covered["unreachable"]=1
+  covered["xor"]=1; covered["zext"]=1
+  # Labels are handled by bb_create + bb_position in bridge.
+  covered["label"]=1
+}
+# match ctx.emit(`...`) or this.emit(`...`) or gen.emit(`...`)
+/\.emit\(`/ {
+  total++
+  line = $0
+  # Strip up through ".emit(\`" so we see the template.
+  sub(/^.*\.emit\(`/, "", line)
+  # Extract first token after any "${assignee} = " prefix.
+  tok = ""
+  if (match(line, /^\$\{[^}]+\} = /)) {
+    line = substr(line, RLENGTH + 1)
+  }
+  # First whitespace-delimited word is the LLVM opcode.
+  n = split(line, parts, /[[:space:]]+/)
+  tok = parts[1]
+  # Strip trailing back-tick/paren/semicolon from the token.
+  sub(/[`);].*$/, "", tok)
+  # Labels end with ":" — classify separately, bridge handles via bb_create/position.
+  if (tok ~ /:$/) tok = "label"
+  # Normalize common variants.
+  if (tok ~ /^getelementptr/) tok = "gep"
+  if (tok == "") tok = "(none)"
+  by_op[tok]++
+  if (!(tok in covered)) {
+    uncovered[tok]++
+    if (uncov_sample[tok] == "") uncov_sample[tok] = FILENAME ":" FNR
+  }
+}
+END {
+  # JSON-ish output; consumers can pipe through jq.
+  printf "{\n"
+  printf "  \"total\": %d,\n", total
+  printf "  \"by_instruction\": {\n"
+  first = 1
+  for (op in by_op) {
+    if (!first) printf ",\n"
+    first = 0
+    cov = (op in covered) ? "true" : "false"
+    printf "    \"%s\": { \"count\": %d, \"covered\": %s }", op, by_op[op], cov
+  }
+  printf "\n  },\n"
+  printf "  \"uncovered_patterns\": {\n"
+  first = 1
+  for (op in uncovered) {
+    if (!first) printf ",\n"
+    first = 0
+    printf "    \"%s\": { \"count\": %d, \"first_seen\": \"%s\" }", op, uncovered[op], uncov_sample[op]
+  }
+  printf "\n  }\n"
+  printf "}\n"
+}
+' $(find src/codegen -name '*.ts' -not -path '*/node_modules/*')

--- a/src/codegen/infrastructure/llvm-builder-ffi.ts
+++ b/src/codegen/infrastructure/llvm-builder-ffi.ts
@@ -1,0 +1,158 @@
+// FFI declares for c_bridges/llvm-builder-bridge.c — the Step 4 IRBuilder
+// C-API path. No codegen sites call these yet; this file exists to (a) exercise
+// the linkage contract, (b) let future codegen flips import a stable API, and
+// (c) track bridge coverage against the emit-site audit.
+//
+// See memory/step4-irbuilder-design-2026-04-20.md for the full plan.
+//
+// Bridge state machine (set by the compiler driver, not the codegen helpers):
+//   1. cs_llvm_builder_init(moduleName, triple) — once per compilation
+//   2. cs_llvm_add_struct_type / add_function / add_extern — type + symbol decls
+//   3. Per function:
+//        cs_llvm_fn_begin(name)
+//        cs_llvm_bb_create / bb_position
+//        cs_llvm_build_* — one call per LLVM instruction
+//        cs_llvm_fn_end()
+//   4. cs_llvm_builder_print() — dump the module as LLVM IR text
+//   5. cs_llvm_builder_optimize / emit_object — optional lowering
+//   6. cs_llvm_builder_dispose() — release globals
+//
+// The bridge is already linked into the native compiler binary; these declares
+// only surface the symbols to TypeScript callers.
+
+// ---- Module lifecycle ----
+
+export declare function cs_llvm_builder_init(moduleName: string, triple: string): void;
+export declare function cs_llvm_builder_dispose(): void;
+export declare function cs_llvm_builder_print(): string;
+export declare function cs_llvm_builder_optimize(level: number): void;
+export declare function cs_llvm_builder_emit_object(path: string): void;
+
+// ---- Type / symbol decls ----
+
+export declare function cs_llvm_add_struct_type(
+  name: string,
+  fieldTypesCsv: string,
+  fieldCount: number,
+): void;
+export declare function cs_llvm_add_function(
+  name: string,
+  retTypeStr: string,
+  paramTypesCsv: string,
+  paramCount: number,
+): void;
+export declare function cs_llvm_add_extern(
+  name: string,
+  retTypeStr: string,
+  paramTypesCsv: string,
+  paramCount: number,
+): void;
+export declare function cs_llvm_add_global_string(name: string, value: string): void;
+
+// ---- Function / block scaffolding ----
+
+export declare function cs_llvm_fn_begin(name: string): void;
+export declare function cs_llvm_fn_end(): void;
+export declare function cs_llvm_fn_set_param_name(idx: number, name: string): void;
+export declare function cs_llvm_bb_create(name: string): void;
+export declare function cs_llvm_bb_position(name: string): void;
+
+// ---- Arithmetic (integer) ----
+
+export declare function cs_llvm_build_add(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_sub(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_mul(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_srem(lhs: string, rhs: string): string;
+
+// ---- Arithmetic (float) ----
+
+export declare function cs_llvm_build_fadd(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_fsub(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_fmul(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_fdiv(lhs: string, rhs: string): string;
+
+// ---- Bitwise (added this PR) ----
+
+export declare function cs_llvm_build_and(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_or(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_xor(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_shl(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_ashr(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_lshr(lhs: string, rhs: string): string;
+
+// ---- Memory ----
+
+export declare function cs_llvm_build_alloca(typeStr: string): string;
+export declare function cs_llvm_build_load(typeStr: string, ptr: string): string;
+export declare function cs_llvm_build_store(typeStr: string, value: string, ptr: string): void;
+export declare function cs_llvm_build_gep(
+  typeStr: string,
+  ptr: string,
+  indicesCsv: string,
+  indexCount: number,
+): string;
+
+// ---- Casts ----
+
+export declare function cs_llvm_build_bitcast(value: string, destType: string): string;
+export declare function cs_llvm_build_sext(value: string, destType: string): string;
+export declare function cs_llvm_build_zext(value: string, destType: string): string;
+export declare function cs_llvm_build_trunc(value: string, destType: string): string;
+export declare function cs_llvm_build_sitofp(value: string, destType: string): string;
+export declare function cs_llvm_build_fptosi(value: string, destType: string): string;
+export declare function cs_llvm_build_inttoptr(value: string, destType: string): string;
+export declare function cs_llvm_build_ptrtoint(value: string, destType: string): string;
+
+// ---- Control flow ----
+
+export declare function cs_llvm_build_br(label: string): void;
+export declare function cs_llvm_build_br_cond(
+  cond: string,
+  thenLabel: string,
+  elseLabel: string,
+): void;
+export declare function cs_llvm_build_ret(typeStr: string, value: string): void;
+export declare function cs_llvm_build_ret_void(): void;
+export declare function cs_llvm_build_unreachable(): void;
+
+// ---- Comparison + ternary ----
+
+export declare function cs_llvm_build_icmp(pred: string, lhs: string, rhs: string): string;
+export declare function cs_llvm_build_fcmp(pred: string, lhs: string, rhs: string): string;
+export declare function cs_llvm_build_select(
+  cond: string,
+  thenVal: string,
+  elseVal: string,
+): string;
+export declare function cs_llvm_build_phi(
+  typeStr: string,
+  valuesCsv: string,
+  blocksCsv: string,
+  count: number,
+): string;
+
+// ---- Calls ----
+
+export declare function cs_llvm_build_call(
+  funcName: string,
+  argsCsv: string,
+  argCount: number,
+): string;
+export declare function cs_llvm_build_call_void(
+  funcName: string,
+  argsCsv: string,
+  argCount: number,
+): void;
+
+// ---- Audit: patterns NOT yet covered by bridge ----
+//
+// As of this PR, `scripts/audit-emit-sites.sh` reports these uncovered patterns
+// in src/codegen/:
+//
+//   sdiv    (4 sites)
+//   uitofp  (15 sites)
+//   fptrunc (1 site)
+//   fpext   (1 site)
+//   dynamic ${op} templates  (2 sites — variable opcode, needs investigation)
+//
+// Followup PRs add the corresponding cs_llvm_build_* wrappers.


### PR DESCRIPTION
## Summary
First PR toward Step 4 (IRBuilder migration) per \`memory/step4-irbuilder-design-2026-04-20.md\`. **Purely additive** — no codegen behavior changes, no callers wired, stage 2 unchanged.

## Why this is the first move
Step 4 swaps 2880 \`ctx.emit(\\\`...\\\`)\` string-concat sites for \`cs_llvm_build_*\` LLVM C-API calls so LLVM verifies types at build time, killing the silent IR-typo bug class permanently. Before flipping any codegen, we need (a) visibility into what patterns exist, (b) bridge parity for all of them, (c) FFI scaffolding.

## Changes
- **\`scripts/audit-emit-sites.sh\`** — classify every \`ctx.emit(\\\`...\\\`)\` site in \`src/codegen/\` by LLVM instruction. Flags patterns not yet covered by \`llvm-builder-bridge.c\`. Current report: **2880 total sites, 6 uncovered patterns**:
  - \`sdiv\` (4 sites)
  - \`uitofp\` (15 sites)
  - \`fptrunc\` (1 site)
  - \`fpext\` (1 site)
  - 2 dynamic \`\\\${op}\` templates (variable opcode, needs investigation)
- **\`c_bridges/llvm-builder-bridge.c\`** — add 6 bitwise ops: \`cs_llvm_build_and/or/xor/shl/ashr/lshr\`. ~55 LOC C, mechanically identical to existing \`build_add\`.
- **\`src/codegen/infrastructure/llvm-builder-ffi.ts\`** — TypeScript extern declares for 51 bridge functions (existing 45 + 6 new). Surfaces a stable API for future codegen flips. Imports nothing, called by nothing yet — lives to be visible and to fail TS compilation if a bridge function renames.

## User-facing effect
None. Audit script is a new dev tool. C bridge additions link but no caller invokes them. FFI declares exist as intent signal.

## Followups
1. Add remaining 6 uncovered patterns as \`cs_llvm_build_*\` wrappers.
2. Build Phase 2 parallel-emit diff harness (emit both via string-concat AND bridge, assert byte-equal IR output on stage 2 self-host).
3. Flip files one at a time (Phase 3), smallest first.

## Test plan
- [x] \`bash scripts/audit-emit-sites.sh\` runs cleanly and produces JSON
- [x] \`npm run verify\` — full tests + 3-stage self-host green locally
- [ ] CI green