### PR TITLE
TLS support: tls.connect() + Socket.upgradeToTLS() via OpenSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install -y clang-21 lld-21 llvm-21-dev \
             cmake make gcc g++ \
             autoconf automake libtool \
-            libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev libpq-dev
+            libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev libpq-dev libssl-dev
           sudo ln -sf /usr/bin/clang-21 /usr/bin/clang
           sudo ln -sf /usr/bin/llvm-config-21 /usr/bin/llvm-config
           # Rust toolchain for vendor build of librure (rust-lang/regex C ABI).
@@ -213,7 +213,7 @@ jobs:
           sudo apt-get install -y clang-21 lld-21 llvm-21-dev \
             cmake make gcc g++ \
             autoconf automake libtool \
-            libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev libpq-dev
+            libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev libpq-dev libssl-dev
           sudo ln -sf /usr/bin/clang-21 /usr/bin/clang
           sudo ln -sf /usr/bin/llvm-config-21 /usr/bin/llvm-config
           # Rust toolchain for vendor build of librure (rust-lang/regex C ABI).

--- a/c_bridges/net-bridge.c
+++ b/c_bridges/net-bridge.c
@@ -26,6 +26,11 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+#include <openssl/x509v3.h>
+
 extern void *GC_malloc(size_t);
 extern void *GC_malloc_atomic(size_t);
 
@@ -62,7 +67,59 @@ typedef struct {
 
     // Last error message, GC-allocated.
     char *last_error;
+
+    // TLS state. NULL until upgraded via cs_tls_upgrade / cs_tls_connect.
+    // rbio holds ciphertext bytes received from the peer (fed from net_read_cb);
+    // wbio receives ciphertext that SSL wants to send (drained into uv_write).
+    SSL *ssl;
+    BIO *rbio;
+    BIO *wbio;
+    int tls_handshaking;
+    int tls_error;
 } NetSocket;
+
+// Global SSL_CTX — one per (verify-mode) for the whole process. TLS client
+// contexts are thread-safe-to-reuse once initialized, and all client
+// connections share identical configuration, so caching avoids per-connect
+// SSL_CTX_new cost (~ms on first call due to default CA load).
+static SSL_CTX *g_ssl_ctx_verify = NULL;
+static SSL_CTX *g_ssl_ctx_noverify = NULL;
+static int g_ssl_inited = 0;
+
+static void ensure_ssl_inited(void) {
+    if (g_ssl_inited) return;
+    SSL_library_init();
+    SSL_load_error_strings();
+    OpenSSL_add_all_algorithms();
+    g_ssl_inited = 1;
+}
+
+static SSL_CTX *ensure_ssl_ctx(int verify) {
+    ensure_ssl_inited();
+    SSL_CTX **slot = verify ? &g_ssl_ctx_verify : &g_ssl_ctx_noverify;
+    if (*slot) return *slot;
+    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+    if (!ctx) return NULL;
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+    SSL_CTX_set_mode(ctx, SSL_MODE_ENABLE_PARTIAL_WRITE | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+    if (verify) {
+        SSL_CTX_set_default_verify_paths(ctx);
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+    } else {
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+    }
+    *slot = ctx;
+    return ctx;
+}
+
+static void set_last_error_gc(NetSocket *s, const char *msg) {
+    if (!msg) msg = "unknown tls error";
+    size_t n = strlen(msg);
+    char *copy = (char *)GC_malloc_atomic(n + 1);
+    memcpy(copy, msg, n + 1);
+    s->last_error = copy;
+}
+
 
 static void net_enqueue(NetSocket *s, int kind, const char *data, size_t data_len) {
     NetEvent *ev = (NetEvent *)GC_malloc(sizeof(NetEvent));
@@ -86,6 +143,13 @@ static void net_enqueue(NetSocket *s, int kind, const char *data, size_t data_le
     }
 }
 
+// Forward declarations for TLS helpers (defined after net_write_done so they
+// can reference net_write_req_t, but called from net_read_cb above).
+struct NetSocket;
+static int tls_handshake_pump(NetSocket *s);
+static void tls_drain_ssl_read(NetSocket *s);
+static int tls_flush_wbio(NetSocket *s);
+
 static void net_alloc_cb(uv_handle_t *h, size_t suggested, uv_buf_t *buf) {
     (void)h;
     buf->base = (char *)malloc(suggested);
@@ -106,19 +170,30 @@ static void net_read_cb(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
         return;
     }
     if (nread > 0) {
-        size_t needed = s->rx_len + (size_t)nread;
-        if (needed > s->rx_cap) {
-            size_t newcap = s->rx_cap > 0 ? s->rx_cap : 4096;
-            while (newcap < needed) newcap *= 2;
-            char *nb = (char *)malloc(newcap);
-            if (s->rx_len > 0) memcpy(nb, s->rx_buf, s->rx_len);
-            free(s->rx_buf);
-            s->rx_buf = nb;
-            s->rx_cap = newcap;
+        if (s->ssl) {
+            // TLS path: feed ciphertext into rbio, then either advance the
+            // handshake or drain plaintext (whichever state we're in).
+            BIO_write(s->rbio, buf->base, (int)nread);
+            if (s->tls_handshaking) {
+                tls_handshake_pump(s);
+            } else {
+                tls_drain_ssl_read(s);
+            }
+        } else {
+            size_t needed = s->rx_len + (size_t)nread;
+            if (needed > s->rx_cap) {
+                size_t newcap = s->rx_cap > 0 ? s->rx_cap : 4096;
+                while (newcap < needed) newcap *= 2;
+                char *nb = (char *)malloc(newcap);
+                if (s->rx_len > 0) memcpy(nb, s->rx_buf, s->rx_len);
+                free(s->rx_buf);
+                s->rx_buf = nb;
+                s->rx_cap = newcap;
+            }
+            memcpy(s->rx_buf + s->rx_len, buf->base, (size_t)nread);
+            s->rx_len += (size_t)nread;
+            net_enqueue(s, NET_EVENT_DATA, buf->base, (size_t)nread);
         }
-        memcpy(s->rx_buf + s->rx_len, buf->base, (size_t)nread);
-        s->rx_len += (size_t)nread;
-        net_enqueue(s, NET_EVENT_DATA, buf->base, (size_t)nread);
     } else if (nread < 0) {
         if (nread == UV_EOF) {
             if (!s->close_requested && !s->closed) {
@@ -193,6 +268,86 @@ static void net_write_done(uv_write_t *req, int status) {
     net_write_req_t *wr = (net_write_req_t *)req;
     free(wr->owned);
     free(wr);
+}
+
+// ---- TLS helpers ----
+//
+// The TLS path layers on top of the plain-TCP plumbing without forking the
+// event loop or event queue. Bytes arriving from the peer land in rbio via
+// net_read_cb; SSL_read drains them into plaintext and we enqueue DATA
+// events exactly like the plain path. Outbound plaintext goes into SSL_write,
+// which pushes ciphertext into wbio, which we drain into uv_write.
+
+// Drain wbio (ciphertext SSL produced) into uv_write. Returns 0 on success
+// (even if nothing to write), negative libuv errno on write submission fail.
+static int tls_flush_wbio(NetSocket *s) {
+    if (!s->ssl) return 0;
+    int pending = BIO_pending(s->wbio);
+    if (pending <= 0) return 0;
+    char *buf = (char *)malloc((size_t)pending);
+    int got = BIO_read(s->wbio, buf, pending);
+    if (got <= 0) { free(buf); return 0; }
+    net_write_req_t *wr = (net_write_req_t *)malloc(sizeof(net_write_req_t));
+    wr->owned = buf;
+    uv_buf_t ub = uv_buf_init(buf, (unsigned int)got);
+    int r = uv_write(&wr->req, (uv_stream_t *)&s->handle, &ub, 1, net_write_done);
+    if (r < 0) { free(buf); free(wr); return r; }
+    return 0;
+}
+
+// Drain decrypted plaintext out of SSL and push it into rx_buf + DATA events.
+// Idempotent — caller invokes after every rbio feed.
+static void tls_drain_ssl_read(NetSocket *s) {
+    if (!s->ssl) return;
+    char tmp[4096];
+    for (;;) {
+        int n = SSL_read(s->ssl, tmp, sizeof(tmp));
+        if (n <= 0) {
+            int err = SSL_get_error(s->ssl, n);
+            if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) return;
+            if (err == SSL_ERROR_ZERO_RETURN) return;
+            return;
+        }
+        size_t needed = s->rx_len + (size_t)n;
+        if (needed > s->rx_cap) {
+            size_t newcap = s->rx_cap > 0 ? s->rx_cap : 4096;
+            while (newcap < needed) newcap *= 2;
+            char *nb = (char *)malloc(newcap);
+            if (s->rx_len > 0) memcpy(nb, s->rx_buf, s->rx_len);
+            free(s->rx_buf);
+            s->rx_buf = nb;
+            s->rx_cap = newcap;
+        }
+        memcpy(s->rx_buf + s->rx_len, tmp, (size_t)n);
+        s->rx_len += (size_t)n;
+        net_enqueue(s, NET_EVENT_DATA, tmp, (size_t)n);
+    }
+}
+
+// Pump the handshake forward. Returns 1 on complete, 0 if still in progress,
+// -1 on fatal error.
+static int tls_handshake_pump(NetSocket *s) {
+    if (!s->ssl) return -1;
+    int r = SSL_do_handshake(s->ssl);
+    // Always flush any bytes SSL produced (ClientHello, Finished, etc).
+    tls_flush_wbio(s);
+    if (r == 1) {
+        s->tls_handshaking = 0;
+        return 1;
+    }
+    int err = SSL_get_error(s->ssl, r);
+    if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) return 0;
+    s->tls_error = 1;
+    unsigned long e = ERR_get_error();
+    char errbuf[256];
+    if (e) {
+        ERR_error_string_n(e, errbuf, sizeof(errbuf));
+    } else {
+        snprintf(errbuf, sizeof(errbuf), "tls handshake failed (ssl err %d)", err);
+    }
+    set_last_error_gc(s, errbuf);
+    net_enqueue(s, NET_EVENT_ERROR, errbuf, strlen(errbuf));
+    return -1;
 }
 
 // ---- public API ----
@@ -288,6 +443,33 @@ double cs_net_write(void *sock, const char *data, double len) {
     if (!s || s->closed || s->close_requested || !s->connected) return 0.0;
 
     size_t n = (size_t)len;
+
+    if (s->ssl) {
+        // TLS: encrypt through SSL_write (ciphertext lands in wbio), then
+        // drain wbio into uv_write. Partial-write mode is enabled on the
+        // CTX so SSL_write returns as soon as >=1 byte is buffered.
+        size_t off = 0;
+        while (off < n) {
+            int w = SSL_write(s->ssl, data + off, (int)(n - off));
+            if (w <= 0) {
+                int err = SSL_get_error(s->ssl, w);
+                if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+                    // Shouldn't happen with memory BIOs + partial writes on
+                    // a post-handshake socket, but treat as transient.
+                    break;
+                }
+                s->tls_error = 1;
+                set_last_error_gc(s, "SSL_write failed");
+                return 0.0;
+            }
+            off += (size_t)w;
+        }
+        int fr = tls_flush_wbio(s);
+        if (fr < 0) return 0.0;
+        uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+        return 1.0;
+    }
+
     char *copy = (char *)malloc(n);
     memcpy(copy, data, n);
 
@@ -415,4 +597,98 @@ double cs_net_rx_drain_len(void *sock) {
     NetSocket *s = (NetSocket *)sock;
     if (!s) return 0.0;
     return (double)s->rx_len;
+}
+
+// ---- TLS public API ----
+
+// Upgrade an already-connected plain socket to TLS. Used for STARTTLS-style
+// protocols (Postgres SSLRequest, SMTP STARTTLS, IMAP STARTTLS). Drives the
+// handshake synchronously by spinning UV_RUN_ONCE until SSL_do_handshake
+// reports complete or errors out. Returns 1 on success, 0 on failure (with
+// last_error set to the OpenSSL error string).
+//
+// Preconditions: socket must be connected, not closed, and must not have any
+// unread ciphertext buffered in rx_buf (i.e. the STARTTLS reply byte must
+// have already been consumed by the caller before the upgrade). The rx_buf
+// is left untouched — post-upgrade reads land as plaintext there.
+double cs_tls_upgrade(void *sock, const char *servername, double verify) {
+    NetSocket *s = (NetSocket *)sock;
+    if (!s || s->closed || s->close_requested || !s->connected) return 0.0;
+    if (s->ssl) return 1.0;  // idempotent
+
+    SSL_CTX *ctx = ensure_ssl_ctx((int)verify);
+    if (!ctx) {
+        set_last_error_gc(s, "SSL_CTX_new failed");
+        return 0.0;
+    }
+    s->rbio = BIO_new(BIO_s_mem());
+    s->wbio = BIO_new(BIO_s_mem());
+    s->ssl = SSL_new(ctx);
+    if (!s->ssl || !s->rbio || !s->wbio) {
+        set_last_error_gc(s, "SSL_new failed");
+        return 0.0;
+    }
+    SSL_set_bio(s->ssl, s->rbio, s->wbio);
+    if (servername && servername[0]) {
+        SSL_set_tlsext_host_name(s->ssl, servername);
+        // X509 hostname check
+        if ((int)verify) {
+            X509_VERIFY_PARAM *param = SSL_get0_param(s->ssl);
+            X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+            X509_VERIFY_PARAM_set1_host(param, servername, 0);
+        }
+    }
+    SSL_set_connect_state(s->ssl);
+    s->tls_handshaking = 1;
+    s->tls_error = 0;
+
+    // Kick off: SSL_do_handshake emits ClientHello into wbio; flush, then
+    // tick the loop until the handshake completes or errors.
+    int pump = tls_handshake_pump(s);
+    uv_loop_t *loop = uv_default_loop();
+    uint64_t deadline = uv_hrtime() + (uint64_t)(30ull * 1000ull * 1000000ull);  // 30s
+    while (pump == 0 && !s->tls_error && !s->closed && !s->close_requested) {
+        if (uv_hrtime() >= deadline) {
+            set_last_error_gc(s, "tls handshake timeout");
+            s->tls_error = 1;
+            break;
+        }
+        if (uv_run(loop, UV_RUN_ONCE) == 0) break;
+        // net_read_cb will feed rbio and call tls_handshake_pump already.
+        if (!s->tls_handshaking) { pump = 1; break; }
+        if (s->tls_error) { pump = -1; break; }
+    }
+    if (pump != 1 || s->tls_error) {
+        // Tear down TLS state; socket stays open so caller can close cleanly.
+        SSL_free(s->ssl);
+        s->ssl = NULL;
+        s->rbio = NULL;
+        s->wbio = NULL;
+        s->tls_handshaking = 0;
+        return 0.0;
+    }
+    return 1.0;
+}
+
+// Open a TLS connection in one call: plain connect then upgrade. For
+// implicit-TLS protocols (HTTPS, MQTTS, pg with sslmode=require-no-starttls).
+// Returns the same NetSocket* as cs_net_connect — on failure the socket has
+// connect_failed or tls_error set and closed=1.
+void *cs_tls_connect(const char *host, double port, const char *servername, double verify) {
+    void *sock = cs_net_connect(host, port);
+    NetSocket *s = (NetSocket *)sock;
+    if (!s || !s->connected) return sock;
+    double up = cs_tls_upgrade(sock, servername, verify);
+    if (up <= 0.0) {
+        // Upgrade failed — close the underlying socket so caller sees a dead
+        // handle, matching connect-failure semantics.
+        if (!s->close_requested && !s->closed) {
+            s->close_requested = 1;
+            uv_close((uv_handle_t *)&s->handle, net_close_cb);
+            while (!s->closed) {
+                if (uv_run(uv_default_loop(), UV_RUN_ONCE) == 0) break;
+            }
+        }
+    }
+    return sock;
 }

--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -436,12 +436,37 @@ declare module "chadscript/net" {
     // 'data' event — callers pick either style, not both.
     read(): string;
     readLen(): number;
+
+    // Upgrade to TLS via OpenSSL (STARTTLS pattern). Drives the handshake
+    // synchronously. verify=1 enables system-CA + hostname validation,
+    // verify=0 skips (dev / self-signed). Returns true on success.
+    upgradeToTLS(servername: string, verify: number): boolean;
   }
 
   // Open a TCP connection. Returns immediately; handshake completes
   // asynchronously. Always returns a Socket — check sock.isOpen() (or
   // wait for the 'error' event) to see whether the connect succeeded.
   export function createConnection(host: string, port: number): Socket;
+}
+
+declare module "chadscript/tls" {
+  import { Socket } from "chadscript/net";
+
+  export interface TlsConnectOpts {
+    host: string;
+    port: number;
+    servername: string;
+    // When true, verify the peer certificate against the system CA chain and
+    // match the cert's SAN/CN against `servername`. When false, skip both
+    // checks (dev only).
+    rejectUnauthorized: boolean;
+  }
+
+  // Open a TLS connection (implicit TLS — TCP connect + handshake combined).
+  // Use this for HTTPS, MQTTS, Postgres sslmode=require (no SSLRequest byte),
+  // etc. For STARTTLS-style protocols, open plain via net.createConnection()
+  // and call sock.upgradeToTLS() after the negotiation byte.
+  export function connect(opts: TlsConnectOpts): Socket;
 }
 
 declare module "chadscript/http" {

--- a/lib/net.ts
+++ b/lib/net.ts
@@ -22,10 +22,10 @@
 // - No server-side API (createServer/listen). Client-only today — lws-bridge
 //   already covers HTTP/WS server needs; TCP servers will arrive alongside
 //   a custom-protocol server use-case (Redis-style, Postgres-proxy, etc.).
-// - No TLS. starttls() is a separate bridge (mbedTLS / OpenSSL BIO layer) —
-//   tracked as a followup. removeDataListener() is provided specifically so
-//   a future TLS upgrade can detach the plaintext data handler and hand the
-//   socket to the TLS layer.
+// - TLS upgrade: `sock.upgradeToTLS(servername, verify)` upgrades an already-
+//   connected plain socket to TLS via OpenSSL (STARTTLS pattern). For
+//   implicit-TLS use cases, import from "chadscript/tls" and call
+//   `tls.connect({host, port, servername, rejectUnauthorized})`.
 // - Callbacks are dispatched from poll()/wait() — not interrupt-driven. User
 //   code must periodically call sock.poll() or sock.wait(timeoutMs) from its
 //   own event loop. This is a deliberate tradeoff: keeps the FFI surface
@@ -56,6 +56,7 @@ declare function cs_net_destroy(sock: string): void;
 declare function cs_net_is_open(sock: string): number;
 declare function cs_net_rx_drain(sock: string): string;
 declare function cs_net_rx_drain_len(sock: string): number;
+declare function cs_tls_upgrade(sock: string, servername: string, verify: number): number;
 
 const NET_EVENT_CONNECT: number = 1;
 const NET_EVENT_DATA: number = 2;
@@ -158,6 +159,25 @@ export class Socket {
 
   isOpen(): boolean {
     return cs_net_is_open(this._handle) > 0;
+  }
+
+  // Upgrade this socket's transport to TLS via OpenSSL (STARTTLS pattern).
+  // Drives the handshake synchronously — returns after handshake completes
+  // or fails. Pass verify=1 for default certificate verification (system CA
+  // chain + servername hostname match), verify=0 to skip (dev/self-signed).
+  // After a successful upgrade subsequent write() calls encrypt transparently
+  // and data events deliver decrypted plaintext. Returns true on success,
+  // false on handshake failure.
+  upgradeToTLS(servername: string, verify: number): boolean {
+    if (this._dead === 1) return false;
+    const r = cs_tls_upgrade(this._handle, servername, verify);
+    return r > 0;
+  }
+
+  // Expose the underlying handle so the tls.connect() helper can wrap a
+  // socket returned from cs_tls_connect without duplicating state. Internal.
+  _rawHandle(): string {
+    return this._handle;
   }
 
   // Tick the libuv loop once in non-blocking mode, then dispatch any queued

--- a/lib/tls.ts
+++ b/lib/tls.ts
@@ -1,0 +1,45 @@
+// tls.ts — implicit-TLS client sockets via OpenSSL (c_bridges/net-bridge.c).
+//
+// Wraps `cs_tls_connect` — a combined TCP-connect + TLS-handshake call. The
+// returned Socket is a regular net.Socket with the TLS layer active; read/
+// write/poll/wait all behave identically, operating on plaintext. Ciphertext
+// stays inside the bridge.
+//
+// For STARTTLS (plain connect first, then upgrade after a protocol negotiation
+// message), use `net.createConnection()` followed by `sock.upgradeToTLS(...)`.
+//
+// Example:
+//   import { connect } from "chadscript/tls";
+//   const sock = connect({
+//     host: "www.example.com", port: 443,
+//     servername: "www.example.com", rejectUnauthorized: true,
+//   });
+//   if (!sock.isOpen()) { console.error("tls failed"); process.exit(1); }
+//   sock.write("GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n");
+//   sock.wait(5000);
+//   console.log(sock.read());
+
+import { Socket } from "./net.js";
+
+declare function cs_tls_connect(
+  host: string,
+  port: number,
+  servername: string,
+  verify: number,
+): string;
+
+export interface TlsConnectOpts {
+  host: string;
+  port: number;
+  servername: string;
+  rejectUnauthorized: boolean;
+}
+
+// Open a TLS connection synchronously (drives the handshake inline via the
+// bridge). Returns a Socket — check sock.isOpen() to see whether the
+// connect + handshake succeeded.
+export function connect(opts: TlsConnectOpts): Socket {
+  const verify: number = opts.rejectUnauthorized ? 1 : 0;
+  const handle: string = cs_tls_connect(opts.host, opts.port, opts.servername, verify);
+  return new Socket(handle);
+}

--- a/scripts/build-target-sdk.sh
+++ b/scripts/build-target-sdk.sh
@@ -72,7 +72,7 @@ fi
 
 # Copy C bridge object files
 echo "  Copying bridge objects..."
-for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o trampoline-bridge.o arena-bridge.o curl-bridge.o pg-bridge.o compress-bridge.o yaml-bridge.o string-ops-bridge.o llvm-bridge.o llvm-builder-bridge.o lld-bridge.o; do
+for bridge in child-process-bridge.o os-bridge.o strlen-cache.o time-bridge.o base64-bridge.o url-bridge.o uri-bridge.o regex-bridge.o dotenv-bridge.o watch-bridge.o lws-bridge.o multipart-bridge.o child-process-spawn.o trampoline-bridge.o arena-bridge.o curl-bridge.o pg-bridge.o net-bridge.o compress-bridge.o yaml-bridge.o string-ops-bridge.o llvm-bridge.o llvm-builder-bridge.o lld-bridge.o; do
   if [ -f "$C_BRIDGES_DIR/$bridge" ]; then
     cp "$C_BRIDGES_DIR/$bridge" "$SDK_DIR/bridges/"
   fi

--- a/scripts/build-vendor.sh
+++ b/scripts/build-vendor.sh
@@ -485,7 +485,14 @@ NET_BRIDGE_SRC="$C_BRIDGES_DIR/net-bridge.c"
 NET_BRIDGE_OBJ="$C_BRIDGES_DIR/net-bridge.o"
 if [ ! -f "$NET_BRIDGE_OBJ" ] || [ "$NET_BRIDGE_SRC" -nt "$NET_BRIDGE_OBJ" ]; then
   echo "==> Building net-bridge..."
-  cc -c -O2 -fPIC -I"$VENDOR_DIR/libuv/include" "$NET_BRIDGE_SRC" -o "$NET_BRIDGE_OBJ"
+  # OpenSSL headers: brew on mac, system on linux (libssl-dev provides /usr/include/openssl).
+  OSSL_INC=""
+  if [ -d "/opt/homebrew/opt/openssl/include" ]; then
+    OSSL_INC="-I/opt/homebrew/opt/openssl/include"
+  elif [ -d "/usr/local/opt/openssl/include" ]; then
+    OSSL_INC="-I/usr/local/opt/openssl/include"
+  fi
+  cc -c -O2 -fPIC -I"$VENDOR_DIR/libuv/include" $OSSL_INC "$NET_BRIDGE_SRC" -o "$NET_BRIDGE_OBJ"
   echo "  -> $NET_BRIDGE_OBJ"
 else
   echo "==> net-bridge already built, skipping"

--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -24,6 +24,7 @@ registerStdlib("glob.ts", ChadScript.embedFile("../lib/glob.ts"));
 registerStdlib("compress.ts", ChadScript.embedFile("../lib/compress.ts"));
 registerStdlib("postgres.ts", ChadScript.embedFile("../lib/postgres.ts"));
 registerStdlib("net.ts", ChadScript.embedFile("../lib/net.ts"));
+registerStdlib("tls.ts", ChadScript.embedFile("../lib/tls.ts"));
 const skillContent = ChadScript.embedFile("../lib/skill.md");
 import { ArgumentParser } from "chadscript/argparse";
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -411,16 +411,25 @@ export function compile(
   }
   let usesPostgres = false;
   let usesNet = false;
+  let usesTls = false;
   for (let i = 0; i < generator.declaredExternFunctions.length; i++) {
     const fn = generator.declaredExternFunctions[i];
     if (fn.startsWith("cs_pg_")) {
       usesPostgres = true;
     } else if (fn.startsWith("cs_net_")) {
       usesNet = true;
+    } else if (fn.startsWith("cs_tls_")) {
+      usesNet = true;
+      usesTls = true;
     }
   }
   if (usesPostgres) {
     linkLibs += " -lpq";
+  }
+  // net-bridge.o references OpenSSL symbols (TLS inline with plain path);
+  // link libssl/libcrypto whenever net is used.
+  if (usesNet) {
+    linkLibs += " -lssl -lcrypto";
   }
   if (generator.usesHttpServer) {
     linkLibs += ` -lz -lzstd`;
@@ -450,7 +459,7 @@ export function compile(
   } else if (targetIsMac && hostIsMac) {
     // Native macOS: use Homebrew paths and Xcode SDK
     const brewPrefix = process.arch === "arm64" ? "/opt/homebrew/opt" : "/usr/local/opt";
-    if (generator.usesCrypto) {
+    if (generator.usesCrypto || usesNet) {
       linkLibs = `-L${brewPrefix}/openssl/lib ` + linkLibs;
     }
     if (generator.usesSqlite) {

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -668,13 +668,23 @@ export function compileNative(inputFile: string, outputFile: string): void {
   }
   let usesPostgres: boolean = false;
   let usesNet: boolean = false;
+  let usesTls: boolean = false;
   for (let i = 0; i < generator.declaredExternFunctions.length; i++) {
     const fn = generator.declaredExternFunctions[i];
     if (fn.startsWith("cs_pg_")) {
       usesPostgres = true;
     } else if (fn.startsWith("cs_net_")) {
       usesNet = true;
+    } else if (fn.startsWith("cs_tls_")) {
+      usesNet = true;
+      usesTls = true;
     }
+  }
+  // net-bridge.o references OpenSSL symbols unconditionally (TLS is inline
+  // with the plain path, gated at runtime on s->ssl != NULL). Any program
+  // that links net-bridge must also link libssl + libcrypto.
+  if (usesNet) {
+    linkLibs = "-lssl -lcrypto " + linkLibs;
   }
   if (usesPostgres) {
     linkLibs = "-lpq " + linkLibs;
@@ -853,7 +863,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
 
   if (useLLD && targetIsDarwin) {
     if (!crossCompiling && isMac) {
-      if (generator.getUsesCrypto()) {
+      if (generator.getUsesCrypto() || usesNet) {
         if (fs.existsSync("/opt/homebrew/opt/openssl/lib"))
           linkLibs = "-L/opt/homebrew/opt/openssl/lib " + linkLibs;
         if (fs.existsSync("/usr/local/opt/openssl/lib"))
@@ -934,7 +944,7 @@ export function compileNative(inputFile: string, outputFile: string): void {
     if (hasSDK && sdkSysroot.length > 0) {
       linkLibs = "--sysroot=" + sdkSysroot + " " + linkLibs;
     } else if (!crossCompiling && isMac) {
-      if (generator.getUsesCrypto()) {
+      if (generator.getUsesCrypto() || usesNet) {
         if (fs.existsSync("/opt/homebrew/opt/openssl/lib"))
           linkLibs = "-L/opt/homebrew/opt/openssl/lib " + linkLibs;
         if (fs.existsSync("/usr/local/opt/openssl/lib"))

--- a/tests/fixtures/net/tls-connect-https-get.ts
+++ b/tests/fixtures/net/tls-connect-https-get.ts
@@ -1,0 +1,61 @@
+// @test-skip
+// Skipped by default — needs outbound network. Run manually to validate
+// the implicit-TLS path:
+//   node dist/chad-node.js run tests/fixtures/net/tls-connect-https-get.ts
+//
+// Exercises tls.connect() end-to-end: TCP connect + handshake, plaintext
+// write, ciphertext wire, decrypted read. A successful TLS 1.2/1.3 session
+// to a public HTTPS server should return an HTTP response starting with
+// "HTTP/1.1" and carrying a non-empty body.
+
+import { connect } from "chadscript/tls";
+
+function run(): void {
+  const sock = connect({
+    host: "example.com",
+    port: 443,
+    servername: "example.com",
+    rejectUnauthorized: true,
+  });
+
+  if (!sock.isOpen()) {
+    console.log("FAIL: tls connect failed");
+    return;
+  }
+
+  const ok = sock.write("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n");
+  if (!ok) {
+    console.log("FAIL: tls write failed");
+    return;
+  }
+
+  // Drain for up to 5 seconds. HTTP/1.1 response with Connection: close
+  // terminates when the peer closes; we keep waiting while the socket is
+  // open and we haven't exceeded 10 polls of a 500ms slot each.
+  let received: string = "";
+  let iterations: number = 0;
+  while (iterations < 20) {
+    sock.wait(500);
+    const chunk = sock.read();
+    if (chunk.length > 0) received = received + chunk;
+    if (!sock.isOpen()) break;
+    iterations = iterations + 1;
+  }
+
+  sock.destroy();
+
+  if (received.length < 12) {
+    console.log("FAIL: too few bytes received: " + received.length.toString());
+    return;
+  }
+  // First line should be the HTTP status line. We don't pin the exact code —
+  // example.com has returned 200 and 301 at various times.
+  if (received.substring(0, 7) !== "HTTP/1.") {
+    console.log("FAIL: bad status line: " + received.substring(0, 20));
+    return;
+  }
+
+  console.log("TEST_PASSED");
+}
+
+run();

--- a/tests/fixtures/net/tls-upgrade-dead-socket.ts
+++ b/tests/fixtures/net/tls-upgrade-dead-socket.ts
@@ -1,0 +1,29 @@
+// Deterministic unit test for Socket.upgradeToTLS: calling it on a dead
+// (closed-before-use) socket must return false and must not crash or hang.
+// This exercises the early-out path in cs_tls_upgrade without touching the
+// network, so it runs offline in CI.
+
+import { createConnection } from "chadscript/net";
+
+function run(): void {
+  // Port 59999 — deterministic connect-refused. By the time poll/wait
+  // returns, the socket is dead (connect_failed + closed both set).
+  const sock = createConnection("127.0.0.1", 59999);
+  sock.wait(500);
+
+  if (sock.isOpen()) {
+    console.log("FAIL: socket reports open against closed port");
+    return;
+  }
+
+  const upgraded = sock.upgradeToTLS("example.com", 1);
+  if (upgraded) {
+    console.log("FAIL: upgradeToTLS succeeded on dead socket");
+    return;
+  }
+
+  sock.destroy();
+  console.log("TEST_PASSED");
+}
+
+run();


### PR DESCRIPTION
## Summary

- Adds **TLS client support** to ChadScript's networking stack. Two new capabilities:
  - `tls.connect({host, port, servername, rejectUnauthorized})` — implicit-TLS: TCP connect + handshake in one call. For HTTPS, MQTTS, Postgres `sslmode=require` (no SSLRequest byte), etc.
  - `socket.upgradeToTLS(servername, verify)` — STARTTLS-style upgrade of an already-connected plain socket. Unblocks pure-ChadScript Postgres driver (perry) — its `upgrade-tls.ts` transport calls exactly this shape.
- Uses system OpenSSL (brew on macOS, `libssl-dev` on Linux). No vendored TLS library.
- Default certificate verification uses the system CA chain + SNI hostname check. Pass `rejectUnauthorized: false` / `verify=0` for self-signed / dev.
- Plain-TCP path is byte-identical — TLS branches are gated on `s->ssl != NULL` in the bridge.

## What's in the diff

- `c_bridges/net-bridge.c` — +300 LOC: SSL/BIO state on `NetSocket`, lazy `SSL_CTX` init, `cs_tls_connect` + `cs_tls_upgrade`, handshake pump, encrypt/decrypt wiring into existing libuv read/write callbacks and event queue.
- `lib/tls.ts` — new module exposing `connect()` wrapping `cs_tls_connect`.
- `lib/net.ts` — adds `Socket.upgradeToTLS()`.
- `chadscript.d.ts` — ambient declarations for `chadscript/tls`, plus `upgradeToTLS` on Socket.
- `src/compiler.ts` + `src/native-compiler-lib.ts` — link `-lssl -lcrypto` and add OpenSSL libdir when net-bridge is used (the bridge references OpenSSL symbols unconditionally).
- `scripts/build-vendor.sh` — adds OpenSSL include path when compiling net-bridge.
- `scripts/build-target-sdk.sh` — includes `net-bridge.o` in SDK bundle.
- `.github/workflows/ci.yml` — adds `libssl-dev` to Linux deps.
- Fixtures: `tls-upgrade-dead-socket.ts` (deterministic, runs in CI), `tls-connect-https-get.ts` (network-dependent, `@test-skip`).

## Test plan

- [x] `npm run verify:quick` — passes (Stage 0 + Stage 1 + tests green on macOS).
- [x] `tls-upgrade-dead-socket.ts` — passes (dead-socket upgrade returns false, no crash).
- [x] `tls-connect-https-get.ts` — manually verified against `example.com:443` — full handshake + HTTP/1.1 response body retrieved.
- [ ] CI on Linux — verifying `libssl-dev` flow.
- [ ] Wire up perry and confirm the STARTTLS upgrade-tls.ts path succeeds against a real Postgres.

## Open questions

- Handshake timeout is currently hard-coded at 30s. Happy to expose it if reviewers prefer.
- No session resumption / session cache — every connect is a fresh handshake. Fine for now; driver use cases are long-lived connections.