### PR TITLE
Cross-boundary marshal: native TS imports pragma-file functions

### DIFF
--- a/c_bridges/node-bridge.cc
+++ b/c_bridges/node-bridge.cc
@@ -684,6 +684,49 @@ double cs_v8_call8(double fn, double recv, double a0, double a1, double a2,
     return call_fixed(fn, recv, a, 8);
 }
 
+// If the handle points to a Promise, spin the event loop until it settles
+// (fulfilled/rejected) and return a handle to the resolved value (or throw-
+// equivalent: set t_last_error and return 0). If the handle is not a Promise,
+// return it unchanged. Native `await` across the boundary flows through this.
+double cs_v8_handle_await(double handle_d) {
+    uint64_t handle = d2h(handle_d);
+    t_last_error.clear();
+    if (!is_handle(handle)) { t_last_error = "await: not JSHandle"; return 0.0; }
+    auto it = t_handles.find(handle);
+    if (it == t_handles.end()) { t_last_error = "await: released"; return 0.0; }
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = it->second.Get(g_isolate);
+    if (!val->IsPromise()) {
+        // Nothing to await — re-store & return same value as a fresh handle
+        // (the caller expects to own it, matching Promise path semantics).
+        return h2d(store_handle(g_isolate, val));
+    }
+    v8::Local<v8::Promise> promise = val.As<v8::Promise>();
+    // Drain microtasks + libuv until the promise is settled. Cap iterations
+    // so a never-resolving promise doesn't spin forever silently.
+    int iters = 0;
+    while (promise->State() == v8::Promise::kPending && iters < 10000) {
+        node::SpinEventLoop(g_env);
+        iters++;
+    }
+    if (promise->State() == v8::Promise::kPending) {
+        t_last_error = "await: promise pending after 10000 iterations";
+        return 0.0;
+    }
+    v8::Local<v8::Value> resolved = promise->Result();
+    if (promise->State() == v8::Promise::kRejected) {
+        v8::String::Utf8Value m(g_isolate, resolved);
+        t_last_error = "await: promise rejected";
+        if (*m) { t_last_error += ": "; t_last_error += *m; }
+        return 0.0;
+    }
+    return h2d(store_handle(g_isolate, resolved));
+}
+
 double cs_v8_handle_to_bool(double handle_d) {
     uint64_t handle = d2h(handle_d);
     t_last_error.clear();

--- a/c_bridges/node-bridge.cc
+++ b/c_bridges/node-bridge.cc
@@ -517,4 +517,186 @@ double cs_v8_handle_call(double fn_handle_d,
     return h2d(store_handle(g_isolate, result));
 }
 
+// Ensure the Node environment has the CJS-require bootstrap loaded exactly
+// once. Subsequent pragma-module registrations use v8::Script::Run to wrap
+// the user source in a CJS IIFE referencing globalThis.__chad_cjs_require.
+// Returns true on success; on failure t_last_error is set.
+bool ensure_pragma_bootstrap(const char* entry_dir) {
+    static bool loaded = false;
+    if (loaded) return true;
+    if (!cs_node_lazy_init()) return false;
+    std::string esc;
+    const char* dir = (entry_dir && *entry_dir) ? entry_dir : ".";
+    for (const char* p = dir; *p; ++p) {
+        if (*p == '\\' || *p == '"') esc.push_back('\\');
+        esc.push_back(*p);
+    }
+    std::string bootstrap =
+        "globalThis.__chad_cjs_require = require('module').createRequire("
+        "require('path').join(\"" + esc + "\", 'package.json'));\n";
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::TryCatch try_catch(g_isolate);
+    v8::MaybeLocal<v8::Value> maybe = node::LoadEnvironment(g_env, bootstrap.c_str());
+    if (maybe.IsEmpty()) {
+        if (try_catch.HasCaught()) {
+            v8::String::Utf8Value m(g_isolate, try_catch.Exception());
+            t_last_error = "pragma bootstrap threw";
+            if (*m) { t_last_error += ": "; t_last_error += *m; }
+        } else {
+            t_last_error = "pragma bootstrap returned empty";
+        }
+        return false;
+    }
+    g_load_env_called = true;
+    loaded = true;
+    return true;
+}
+
+// Evaluate the pragma-module source inside an on-the-fly CJS wrapper and
+// return a JSHandle to its module.exports object. Multiple modules can be
+// registered — each runs in its own closure with its own module/exports.
+double cs_v8_register_pragma_module(const char* src, const char* filename) {
+    t_last_error.clear();
+    if (!ensure_pragma_bootstrap(filename)) return 0.0;
+
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::TryCatch tc(g_isolate);
+
+    std::string fesc;
+    if (filename && *filename) {
+        for (const char* p = filename; *p; ++p) {
+            if (*p == '\\' || *p == '"') fesc.push_back('\\');
+            fesc.push_back(*p);
+        }
+    }
+
+    // Wrap user source as: (function(module, exports, require, __filename,
+    // __dirname){ USER_SRC; return module.exports; })({exports:{}}, {}, ...)
+    // Since JavaScript requires passing module as arg, we build:
+    //   (function(){ const module={exports:{}}; const exports=module.exports;
+    //     const require=globalThis.__chad_cjs_require;
+    //     const __filename="..."; const __dirname=require('path').dirname(__filename);
+    //     /* USER_SRC */
+    //     return module.exports;
+    //   })()
+    std::string wrapped;
+    wrapped += "(function(){\n";
+    wrapped += "const module={exports:{}};\n";
+    wrapped += "const exports=module.exports;\n";
+    wrapped += "const require=globalThis.__chad_cjs_require;\n";
+    if (!fesc.empty()) {
+        wrapped += "const __filename=\"" + fesc + "\";\n";
+        wrapped += "const __dirname=require('path').dirname(__filename);\n";
+    }
+    wrapped += (src ? src : "");
+    wrapped += "\n;return module.exports;\n})()\n";
+
+    v8::Local<v8::String> source;
+    if (!v8::String::NewFromUtf8(g_isolate, wrapped.c_str(),
+                                 v8::NewStringType::kNormal).ToLocal(&source)) {
+        t_last_error = "register_pragma_module: alloc source failed";
+        return 0.0;
+    }
+    v8::Local<v8::Script> script;
+    if (!v8::Script::Compile(ctx, source).ToLocal(&script)) {
+        v8::String::Utf8Value m(g_isolate, tc.Exception());
+        t_last_error = "register_pragma_module: compile failed";
+        if (*m) { t_last_error += ": "; t_last_error += *m; }
+        return 0.0;
+    }
+    v8::Local<v8::Value> result;
+    if (!script->Run(ctx).ToLocal(&result)) {
+        v8::String::Utf8Value m(g_isolate, tc.Exception());
+        t_last_error = "register_pragma_module: run failed";
+        if (*m) { t_last_error += ": "; t_last_error += *m; }
+        return 0.0;
+    }
+    node::SpinEventLoop(g_env);
+    return h2d(store_handle(g_isolate, result));
+}
+
+// Marshal a bool primitive → JSHandle for the argv array.
+double cs_v8_make_bool_handle(double b) {
+    if (!cs_node_lazy_init()) return 0.0;
+    t_last_error.clear();
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = v8::Boolean::New(g_isolate, b != 0.0);
+    return h2d(store_handle(g_isolate, val));
+}
+
+// Fixed-arity call wrappers — ChadScript's FFI cannot pass a raw `double*`
+// array (its `number[]` is a struct). Calling sites up to 8 args cover the
+// vast majority of JS APIs; extend with higher arities if needed.
+static double call_fixed(double fn_h, double recv_h,
+                         const double* args, int32_t n) {
+    return cs_v8_handle_call(fn_h, recv_h, n, args);
+}
+double cs_v8_call0(double fn, double recv) {
+    return call_fixed(fn, recv, nullptr, 0);
+}
+double cs_v8_call1(double fn, double recv, double a0) {
+    double a[] = {a0};
+    return call_fixed(fn, recv, a, 1);
+}
+double cs_v8_call2(double fn, double recv, double a0, double a1) {
+    double a[] = {a0, a1};
+    return call_fixed(fn, recv, a, 2);
+}
+double cs_v8_call3(double fn, double recv, double a0, double a1, double a2) {
+    double a[] = {a0, a1, a2};
+    return call_fixed(fn, recv, a, 3);
+}
+double cs_v8_call4(double fn, double recv, double a0, double a1, double a2,
+                   double a3) {
+    double a[] = {a0, a1, a2, a3};
+    return call_fixed(fn, recv, a, 4);
+}
+double cs_v8_call5(double fn, double recv, double a0, double a1, double a2,
+                   double a3, double a4) {
+    double a[] = {a0, a1, a2, a3, a4};
+    return call_fixed(fn, recv, a, 5);
+}
+double cs_v8_call6(double fn, double recv, double a0, double a1, double a2,
+                   double a3, double a4, double a5) {
+    double a[] = {a0, a1, a2, a3, a4, a5};
+    return call_fixed(fn, recv, a, 6);
+}
+double cs_v8_call7(double fn, double recv, double a0, double a1, double a2,
+                   double a3, double a4, double a5, double a6) {
+    double a[] = {a0, a1, a2, a3, a4, a5, a6};
+    return call_fixed(fn, recv, a, 7);
+}
+double cs_v8_call8(double fn, double recv, double a0, double a1, double a2,
+                   double a3, double a4, double a5, double a6, double a7) {
+    double a[] = {a0, a1, a2, a3, a4, a5, a6, a7};
+    return call_fixed(fn, recv, a, 8);
+}
+
+double cs_v8_handle_to_bool(double handle_d) {
+    uint64_t handle = d2h(handle_d);
+    t_last_error.clear();
+    if (!is_handle(handle)) { t_last_error = "to_bool: not JSHandle"; return 0.0; }
+    auto it = t_handles.find(handle);
+    if (it == t_handles.end()) { t_last_error = "to_bool: released"; return 0.0; }
+    v8::Locker locker(g_isolate);
+    v8::Isolate::Scope iscope(g_isolate);
+    v8::HandleScope hs(g_isolate);
+    v8::Local<v8::Context> ctx = g_setup->context();
+    v8::Context::Scope cscope(ctx);
+    v8::Local<v8::Value> val = it->second.Get(g_isolate);
+    return val->BooleanValue(g_isolate) ? 1.0 : 0.0;
+}
+
 } // extern "C"

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -14,6 +14,7 @@ import { TargetInfo, resolveTarget, getHostTarget, isCrossCompiling } from "./ta
 import { loadTargetSDK, ensureTargetSDK, TargetSDK } from "./cross-compile.js";
 import { VERSION } from "./version.js";
 import { setGlobalDiagnosticColor } from "./diagnostics/engine.js";
+import { buildMarshalWrapper, hasInterpretPragma } from "./marshal-wrapper.js";
 
 function detectInterpretPragma(source: string): boolean {
   const lines = source.split("\n", 10);
@@ -1007,7 +1008,28 @@ function compileMultiFile(
       );
     }
 
-    const importPath = resolveImportPath(absPath, imp.source);
+    let importPath = resolveImportPath(absPath, imp.source);
+
+    // Cross-boundary marshal: if the resolved target has the interpret pragma
+    // AND the importer does NOT (importer == native side), synthesize a
+    // replacement `.ts` wrapper that calls JSHandle FFI under the hood, then
+    // recurse on that wrapper instead of the pragma source. The wrapper
+    // exposes the same exports as the pragma file so the native importer's
+    // `import { foo }` resolves without any caller-side changes.
+    if (fs.existsSync(importPath) && !detectInterpretPragma(code)) {
+      const targetSource = fs.readFileSync(importPath, "utf8");
+      if (hasInterpretPragma(targetSource)) {
+        const wrapperSrc = buildMarshalWrapper(path.resolve(importPath), targetSource);
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "chad-marshal-"));
+        const tmpFile = path.join(tmpDir, path.basename(importPath));
+        fs.writeFileSync(tmpFile, wrapperSrc);
+        logger.info(
+          `@chadscript: interpret detected in import — synthesizing marshal wrapper for ${importPath}`,
+        );
+        importPath = tmpFile;
+      }
+    }
+
     const importedAST = compileMultiFile(
       importPath,
       compiledFiles,

--- a/src/marshal-wrapper.ts
+++ b/src/marshal-wrapper.ts
@@ -1,0 +1,306 @@
+// Cross-boundary export marshal.
+//
+// When a native ChadScript file imports from another `.ts` that has
+// `// @chadscript: interpret` at the top, the imported file's source runs
+// under Node. The importer wants to call the exported functions naturally —
+// `import { ms } from './pragma-file'` followed by `ms("2 days")` — without
+// writing any JSHandle FFI by hand.
+//
+// This module synthesizes a replacement `.ts` wrapper for the pragma file.
+// The wrapper has the same exported function signatures as the original but
+// each body calls into the libnode JSHandle bridge: one bootstrap step evals
+// the pragma source inside Node and captures its module.exports as a handle;
+// each call marshals args per declared types, invokes cs_v8_callN, and
+// unmarshals the result per declared return type.
+
+import { parseWithTSAPI } from "./parser-ts/index.js";
+import { FunctionNode } from "./ast/types.js";
+
+// Mirrors detectInterpretPragma in compiler.ts (kept local to avoid import cycle).
+export function hasInterpretPragma(source: string): boolean {
+  const lines = source.split("\n", 10);
+  for (const line of lines) {
+    if (/^\s*\/\/\s*@chadscript\s*:\s*interpret\b/.test(line)) return true;
+  }
+  return false;
+}
+
+const EXTERN_DECLS =
+  `declare function cs_v8_register_pragma_module(src: string, file: string): number;\n` +
+  `declare function cs_v8_handle_get_property(obj: number, name: string): number;\n` +
+  `declare function cs_v8_make_string_handle(s: string): number;\n` +
+  `declare function cs_v8_make_number_handle(n: number): number;\n` +
+  `declare function cs_v8_make_bool_handle(b: number): number;\n` +
+  `declare function cs_v8_handle_to_string(h: number): string;\n` +
+  `declare function cs_v8_handle_to_number(h: number): number;\n` +
+  `declare function cs_v8_handle_to_bool(h: number): number;\n` +
+  `declare function cs_v8_handle_release(h: number): void;\n` +
+  `declare function cs_v8_last_error(): string;\n` +
+  `declare function cs_v8_call0(fn: number, recv: number): number;\n` +
+  `declare function cs_v8_call1(fn: number, recv: number, a0: number): number;\n` +
+  `declare function cs_v8_call2(fn: number, recv: number, a0: number, a1: number): number;\n` +
+  `declare function cs_v8_call3(fn: number, recv: number, a0: number, a1: number, a2: number): number;\n` +
+  `declare function cs_v8_call4(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number): number;\n` +
+  `declare function cs_v8_call5(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number, a4: number): number;\n` +
+  `declare function cs_v8_call6(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number, a4: number, a5: number): number;\n` +
+  `declare function cs_v8_call7(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number, a4: number, a5: number, a6: number): number;\n` +
+  `declare function cs_v8_call8(fn: number, recv: number, a0: number, a1: number, a2: number, a3: number, a4: number, a5: number, a6: number, a7: number): number;\n` +
+  `declare function cs_v8_handle_await(h: number): number;\n`;
+
+// Turn an absolute filesystem path into a sanitized identifier-safe suffix
+// used to disambiguate globals across multiple imported pragma modules.
+function moduleSlug(absPath: string): string {
+  let h = 0;
+  for (let i = 0; i < absPath.length; i++) {
+    h = (h * 31 + absPath.charCodeAt(i)) | 0;
+  }
+  const base = absPath
+    .replace(/^.*[\\/]/, "")
+    .replace(/\.[^.]*$/, "")
+    .replace(/[^a-zA-Z0-9_]/g, "_");
+  const hex = (h >>> 0).toString(16);
+  return `${base}_${hex}`;
+}
+
+// Return the TS expression that marshals `varName` (typed `tsType`) into a
+// JSHandle `number`. Primitive fast-path; anything else is assumed to already
+// be a handle (number).
+function marshalArg(varName: string, tsType: string | undefined): string {
+  const t = (tsType || "").trim();
+  if (t === "string") return `cs_v8_make_string_handle(${varName})`;
+  if (t === "number") return `cs_v8_make_number_handle(${varName})`;
+  if (t === "boolean") return `cs_v8_make_bool_handle(${varName} ? 1 : 0)`;
+  // Fallback: assume the caller passed a JSHandle (number) already. Future
+  // work: objects, arrays, class instances.
+  return varName;
+}
+
+// Return TS that unmarshals `handleVar` (JSHandle) into a value typed `tsType`.
+// Uses a temporary `const` so we can release the handle before returning.
+function unmarshalResult(
+  handleVar: string,
+  tsType: string | undefined,
+): {
+  body: string;
+  returnExpr: string;
+} {
+  const t = (tsType || "").trim();
+  if (t === "" || t === "void") {
+    return { body: `cs_v8_handle_release(${handleVar});\n`, returnExpr: "" };
+  }
+  if (t === "string") {
+    return {
+      body: `const __out_val: string = cs_v8_handle_to_string(${handleVar});\ncs_v8_handle_release(${handleVar});\n`,
+      returnExpr: "__out_val",
+    };
+  }
+  if (t === "number") {
+    return {
+      body: `const __out_val: number = cs_v8_handle_to_number(${handleVar});\ncs_v8_handle_release(${handleVar});\n`,
+      returnExpr: "__out_val",
+    };
+  }
+  if (t === "boolean") {
+    return {
+      body: `const __out_val: number = cs_v8_handle_to_bool(${handleVar});\n// retain handle; callers asked for bool\ncs_v8_handle_release(${handleVar});\n`,
+      returnExpr: "__out_val !== 0",
+    };
+  }
+  // Anything else: return the handle itself (caller sees a `number`).
+  return { body: "", returnExpr: handleVar };
+}
+
+// Build the wrapper for one exported function.
+function buildFunctionWrapper(fn: FunctionNode, slug: string, moduleName: string): string | null {
+  const arity = fn.params.length;
+  if (arity > 8) {
+    return (
+      `// marshal: skipping export '${fn.name}' — arity ${arity} exceeds max 8. ` +
+      `Add cs_v8_call${arity} to node-bridge.cc to enable.\n`
+    );
+  }
+  const paramTypes = fn.paramTypes || [];
+  const paramDecls: string[] = [];
+  for (let i = 0; i < arity; i++) {
+    const p = fn.params[i];
+    const t = paramTypes[i] || "number";
+    paramDecls.push(`${p}: ${t}`);
+  }
+  const ret = (fn.returnType || "void").trim();
+  const exportKw = "export ";
+  // Unwrap Promise<T>: the JS-side call returns a Promise handle, then we
+  // spin the event loop via cs_v8_handle_await to resolve it. Native side
+  // sees a synchronous T — avoids plumbing JS promise identity through the
+  // native async/await machinery.
+  let effectiveRet = ret;
+  let isAsync = false;
+  const promiseMatch = /^Promise\s*<\s*(.+)\s*>$/.exec(ret);
+  if (promiseMatch) {
+    effectiveRet = promiseMatch[1].trim();
+    isAsync = true;
+  }
+
+  const argMarshals: string[] = [];
+  for (let i = 0; i < arity; i++) {
+    argMarshals.push(`const __a${i}: number = ${marshalArg(fn.params[i], paramTypes[i])};`);
+  }
+
+  const callArgs: string[] = ["__fn_" + fn.name, "0"];
+  for (let i = 0; i < arity; i++) callArgs.push(`__a${i}`);
+  const callExpr = `cs_v8_call${arity}(${callArgs.join(", ")})`;
+  const postCall = isAsync
+    ? `const __res_raw: number = ${callExpr};\n  const __res: number = cs_v8_handle_await(__res_raw);\n  cs_v8_handle_release(__res_raw);`
+    : `const __res: number = ${callExpr};`;
+
+  const unm = unmarshalResult("__res", effectiveRet);
+
+  // Release arg handles after the call (cleanup). Skip releasing pass-through
+  // handles (when param type is a JSHandle number — releasing would pull the
+  // rug from a caller who still holds the handle).
+  const argReleases: string[] = [];
+  for (let i = 0; i < arity; i++) {
+    const t = (paramTypes[i] || "").trim();
+    if (t === "string" || t === "number" || t === "boolean") {
+      argReleases.push(`cs_v8_handle_release(__a${i});`);
+    }
+  }
+
+  const retKw = effectiveRet === "" || effectiveRet === "void" ? "void" : effectiveRet;
+  const retStmt = unm.returnExpr === "" ? "" : `return ${unm.returnExpr};\n`;
+  // Preserve async declaration so native callers can `await` the returned
+  // value. The body runs synchronously (via handle_await's SpinEventLoop),
+  // but TypeScript's async-function wrapping makes the return a Promise<T>.
+  const asyncKw = isAsync ? "async " : "";
+  const sigRet = isAsync ? `Promise<${retKw}>` : retKw;
+
+  return (
+    `${exportKw}${asyncKw}function ${fn.name}(${paramDecls.join(", ")}): ${sigRet} {\n` +
+    `  const __mod: number = __marshal_ensure_${slug}();\n` +
+    `  const __fn_${fn.name}: number = cs_v8_handle_get_property(__mod, "${fn.name}");\n` +
+    `  ${argMarshals.join("\n  ")}\n` +
+    `  ${postCall}\n` +
+    `  const __err: string = cs_v8_last_error();\n` +
+    `  if (__err.length > 0) {\n` +
+    `    console.log("marshal: call to ${fn.name} in ${moduleName} failed: " + __err);\n` +
+    `    process.exit(1);\n` +
+    `  }\n` +
+    `  ${argReleases.join("\n  ")}\n` +
+    `  cs_v8_handle_release(__fn_${fn.name});\n` +
+    `  ${unm.body}` +
+    `  ${retStmt}` +
+    `}\n`
+  );
+}
+
+// Escape a string for embedding as a TS string literal inside double quotes.
+function tsStringLit(s: string): string {
+  let out = '"';
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c === 0x5c /* \ */) out += "\\\\";
+    else if (c === 0x22 /* " */) out += '\\"';
+    else if (c === 0x0a /* \n */) out += "\\n";
+    else if (c === 0x0d /* \r */) out += "\\r";
+    else if (c === 0x09 /* \t */) out += "\\t";
+    else if (c < 0x20) out += "\\u" + c.toString(16).padStart(4, "0");
+    else out += s[i];
+  }
+  out += '"';
+  return out;
+}
+
+// Rewrite `export function foo` / `export async function foo` / `export const foo =`
+// into CJS-compatible `module.exports.foo = ...` form. Our pragma wrapper in
+// node-bridge.cc runs the source inside a synthetic CJS function body where
+// ES-module `export` is a syntax error. TS types are stripped by the fact that
+// Node sees this source only after we also strip `: Type` annotations.
+function rewriteExportsForCJS(src: string): string {
+  // Strip TS type annotations on exported function parameters and return type.
+  // Pragma files are limited in scope — this covers the 90% case. Future work:
+  // use the TS parser to do a proper lowering.
+  let out = src;
+  // export async function name(params): ret { → module.exports.name = async function(params){
+  out = out.replace(
+    /\bexport\s+async\s+function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*(?::\s*[^({]+)?\s*\{/g,
+    (_m, name, params) => `module.exports.${name} = async function(${stripParamTypes(params)}){`,
+  );
+  out = out.replace(
+    /\bexport\s+function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*(?::\s*[^({]+)?\s*\{/g,
+    (_m, name, params) => `module.exports.${name} = function(${stripParamTypes(params)}){`,
+  );
+  // export const name = ...  → module.exports.name = ...
+  out = out.replace(
+    /\bexport\s+const\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+)?\s*=/g,
+    (_m, name) => `module.exports.${name} =`,
+  );
+  return out;
+}
+
+function stripParamTypes(params: string): string {
+  // For each top-level comma-separated parameter, drop `: Type` suffix but keep
+  // defaults. Shallow split — doesn't handle `foo: {a: b}` object-type
+  // annotations (unusual in hand-written pragma files).
+  const parts = params.split(",");
+  const cleaned: string[] = [];
+  for (const p of parts) {
+    const trimmed = p.trim();
+    if (!trimmed) continue;
+    const colon = trimmed.indexOf(":");
+    const eq = trimmed.indexOf("=");
+    if (colon >= 0 && (eq < 0 || colon < eq)) {
+      const name = trimmed.substring(0, colon).trim();
+      if (eq > colon) {
+        cleaned.push(`${name} ${trimmed.substring(eq)}`);
+      } else {
+        cleaned.push(name);
+      }
+    } else {
+      cleaned.push(trimmed);
+    }
+  }
+  return cleaned.join(", ");
+}
+
+// Build the full wrapper `.ts` source replacing a pragma file from the
+// native side's perspective. Returns a complete, standalone TS module.
+export function buildMarshalWrapper(absPath: string, pragmaSource: string): string {
+  const slug = moduleSlug(absPath);
+  const ast = parseWithTSAPI(pragmaSource, { filename: absPath });
+  const jsSource = rewriteExportsForCJS(pragmaSource);
+
+  // Collect exported function declarations. `ast.exports` holds ExportDeclaration
+  // for `export function foo`; we also include top-level functions flagged as
+  // exported (the parser already adds them to exports).
+  const exportedFns: FunctionNode[] = [];
+  for (const exp of ast.exports) {
+    if (exp.declaration && (exp.declaration as FunctionNode).params !== undefined) {
+      exportedFns.push(exp.declaration as FunctionNode);
+    }
+  }
+
+  const parts: string[] = [];
+  parts.push("// Auto-generated marshal wrapper for: " + absPath);
+  parts.push(EXTERN_DECLS);
+  parts.push(`let __marshal_exports_${slug}: number = 0;`);
+  parts.push(`function __marshal_ensure_${slug}(): number {`);
+  parts.push(`  if (__marshal_exports_${slug} !== 0) return __marshal_exports_${slug};`);
+  parts.push(`  const __src: string = ${tsStringLit(jsSource)};`);
+  parts.push(`  const __file: string = ${tsStringLit(absPath)};`);
+  parts.push(`  __marshal_exports_${slug} = cs_v8_register_pragma_module(__src, __file);`);
+  parts.push(`  const __err: string = cs_v8_last_error();`);
+  parts.push(`  if (__err.length > 0) {`);
+  parts.push(
+    `    console.log("marshal: failed to load pragma module ${absPath.replace(/\\/g, "/").replace(/"/g, '\\"')}: " + __err);`,
+  );
+  parts.push(`    process.exit(1);`);
+  parts.push(`  }`);
+  parts.push(`  return __marshal_exports_${slug};`);
+  parts.push(`}`);
+
+  for (const fn of exportedFns) {
+    const w = buildFunctionWrapper(fn, slug, absPath);
+    if (w) parts.push(w);
+  }
+
+  return parts.join("\n") + "\n";
+}

--- a/tests/fixtures/v8/marshal-async-main.ts
+++ b/tests/fixtures/v8/marshal-async-main.ts
@@ -1,0 +1,15 @@
+// @test-description: marshal async — native awaits pragma-side setTimeout
+// @test-skip
+
+import { delayedHi } from "./marshal-async-pragma";
+
+async function main(): Promise<void> {
+  const r: string = await delayedHi("chad");
+  if (r === "hi chad") {
+    console.log("TEST_PASSED");
+  } else {
+    console.log("FAIL: " + r);
+  }
+}
+
+main();

--- a/tests/fixtures/v8/marshal-async-pragma.ts
+++ b/tests/fixtures/v8/marshal-async-pragma.ts
@@ -1,0 +1,7 @@
+// @chadscript: interpret
+// @test-skip
+
+export async function delayedHi(name: string): Promise<string> {
+  await new Promise((r) => setTimeout(r, 10));
+  return "hi " + name;
+}

--- a/tests/fixtures/v8/marshal-main.ts
+++ b/tests/fixtures/v8/marshal-main.ts
@@ -1,0 +1,11 @@
+// @test-description: cross-boundary marshal — native imports pragma-file export
+// @test-skip
+
+import { ms } from "./marshal-ms";
+
+const r: string = ms("2 days");
+if (r === "172800000") {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: " + r);
+}

--- a/tests/fixtures/v8/marshal-ms.ts
+++ b/tests/fixtures/v8/marshal-ms.ts
@@ -1,0 +1,6 @@
+// @chadscript: interpret
+// @test-skip
+
+export function ms(s: string): string {
+  return String(require("ms")(s));
+}

--- a/tests/fixtures/v8/marshal-num-main.ts
+++ b/tests/fixtures/v8/marshal-num-main.ts
@@ -1,0 +1,11 @@
+// @test-description: marshal number-return across boundary
+// @test-skip
+
+import { parseMs } from "./marshal-num-pragma";
+
+const n: number = parseMs("3s");
+if (n === 3000) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: " + n.toString());
+}

--- a/tests/fixtures/v8/marshal-num-pragma.ts
+++ b/tests/fixtures/v8/marshal-num-pragma.ts
@@ -1,0 +1,6 @@
+// @chadscript: interpret
+// @test-skip
+
+export function parseMs(s: string): number {
+  return Number(require("ms")(s));
+}


### PR DESCRIPTION
## Summary
Builds on #605. Users can now `import { fn } from "./pragma-file"` in normal (non-pragma) TS and call `fn(...)` naturally — compiler auto-synthesizes the JSHandle FFI wrapper. Before this PR, cross-boundary work required hand-written extern declarations.

## What this unlocks
```ts
// ms-wrapper.ts
// @chadscript: interpret
export function ms(s: string): string { return String(require("ms")(s)); }

// main.ts  (no pragma, native AOT)
import { ms } from "./ms-wrapper";
console.log(ms("2 days"));  // → "172800000"
```

`main.ts` compiles to the usual native binary. The wrapper file runs under libnode. Compiler bridges them automatically — no `declare function` boilerplate.

## Design
At import resolution time, if the target file has `// @chadscript: interpret` the compiler synthesizes a replacement wrapper `.ts`:
- Embeds pragma source as a string, registers once via new bridge fn `cs_v8_register_pragma_module` (CJS-wrapped IIFE → `module.exports` JSHandle).
- For each exported function: re-declares with TS signature preserved, body marshals primitives via `cs_v8_make_*_handle`, calls `cs_v8_callN` (scalar wrappers, N=0..8), unmarshals via `cs_v8_handle_to_*`, and propagates `cs_v8_last_error` via `process.exit(1)`.
- Async exports: wrapper marked `async`, body calls new `cs_v8_handle_await` which spins the libuv event loop until the Promise settles (10k-iteration safety cap).
- Zero codegen changes — pure source-level synthesis in the module resolver.

## New bridge fns (`c_bridges/node-bridge.cc`)
- `cs_v8_register_pragma_module(source, filename) → handle`
- `cs_v8_handle_await(handle) → handle` — sync await via libuv spin
- `cs_v8_make_bool_handle(bool) → handle`
- `cs_v8_handle_to_bool(handle) → bool`
- `cs_v8_call0` … `cs_v8_call8` scalar call wrappers (side-stepping `const double*` FFI limitation)

## Fixtures verified locally
- `marshal-main.ts` → `TEST_PASSED` — sync string (`ms("2 days") === "172800000"`)
- `marshal-num-main.ts` → `TEST_PASSED` — sync number (`parseMs("3s") === 3000`)
- `marshal-async-main.ts` → `TEST_PASSED` — `await delayedHi("chad") === "hi chad"`, 10ms setTimeout across boundary

## Limitations (follow-up PRs)
1. `export` keyword stripped via regex + shallow param-type stripper (90% case; proper TS lowering = future work).
2. Arity >8 exports dropped with a comment; add more `call9`+ variants as needed.
3. First pragma module loaded fixes the `require` base dir for all subsequent registrations (single-env limitation of libnode's `LoadEnvironment`).
4. Errors are fail-fast (`process.exit(1)`); exception propagation across boundary needs ChadScript exception support.
5. Non-primitive params/returns fall back to JSHandle passthrough; typed JSHandle aliases for ergonomics = future.

## Test plan
- [x] Three fixtures build + run + print TEST_PASSED locally
- [x] `npm run verify:quick` green (818/819; 1 pre-existing `net` failure unrelated to marshal)
- [ ] CI libnode workflow passes on mac + linux with new fixtures (workflow auto-picks up `tests/fixtures/v8/marshal-*.ts`)
- [ ] Retarget to `main` once #605 merges

## Commits (5)
- `cc58316e` bridge: `register_pragma_module` + `call0`-`call8` + bool handles
- `88c73018` bridge: `handle_await` via libuv spin
- `698cdbad` compiler: synthesize FFI wrapper for pragma-module imports
- `62702c66` fixtures: sync string + sync number
- `e07497b2` fixture: async await