### PR TITLE
net: add writeBytes/readBytes/pump for binary protocols

### DIFF
--- a/c_bridges/net-bridge.c
+++ b/c_bridges/net-bridge.c
@@ -438,6 +438,14 @@ const char *cs_net_last_error(void *sock) {
 // the original buffer can be freed/reused immediately. Drives the loop once
 // in NOWAIT mode so the write has a chance to flush. Returns 1 on success
 // (the write was queued), 0 if the socket is closed/invalid.
+typedef struct { char *data; int32_t len; int32_t cap; } CsU8;
+
+double cs_net_write_bytes(void *sock, CsU8 *arr, double len) {
+    extern double cs_net_write(void *sock, const char *data, double len);
+    if (!arr) return 0.0;
+    return cs_net_write(sock, arr->data, len);
+}
+
 double cs_net_write(void *sock, const char *data, double len) {
     NetSocket *s = (NetSocket *)sock;
     if (!s || s->closed || s->close_requested || !s->connected) return 0.0;
@@ -597,6 +605,37 @@ double cs_net_rx_drain_len(void *sock) {
     NetSocket *s = (NetSocket *)sock;
     if (!s) return 0.0;
     return (double)s->rx_len;
+}
+
+// Tick the default libuv loop up to timeoutMs, returning the total number of
+// pending handles/events processed. Used by Pool to wait on N sockets on one
+// shared loop without picking an anchor socket.
+double cs_net_pump(double timeoutMs) {
+    uv_loop_t *loop = uv_default_loop();
+    if (timeoutMs <= 0.0) {
+        return (double)uv_run(loop, UV_RUN_NOWAIT);
+    }
+    uint64_t deadline = uv_hrtime() + (uint64_t)(timeoutMs * 1e6);
+    int total = 0;
+    while (uv_hrtime() < deadline) {
+        int r = uv_run(loop, UV_RUN_ONCE);
+        total += r;
+        if (r == 0) break;
+    }
+    return (double)total;
+}
+
+double cs_net_rx_drain_into(void *sock, CsU8 *arr, double maxlen) {
+    NetSocket *s = (NetSocket *)sock;
+    if (!s || !arr || s->rx_len == 0) return 0.0;
+    size_t cap = (size_t)maxlen;
+    size_t n = s->rx_len < cap ? s->rx_len : cap;
+    memcpy(arr->data, s->rx_buf, n);
+    if (n < s->rx_len) {
+        memmove(s->rx_buf, s->rx_buf + n, s->rx_len - n);
+    }
+    s->rx_len -= n;
+    return (double)n;
 }
 
 // ---- TLS public API ----

--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -412,6 +412,14 @@ declare module "chadscript/net" {
     // or in error. Bytes are copied synchronously.
     write(data: string): boolean;
 
+    // Send arbitrary bytes (embedded NULs OK). `len` gives the exact count
+    // to write — typically data.length for full-buffer sends.
+    writeBytes(data: Uint8Array, len: number): boolean;
+
+    // Drain up to maxlen bytes from the rx buffer into out. Returns the
+    // number of bytes copied. Does not block.
+    readBytes(out: Uint8Array, maxlen: number): number;
+
     // Half-close (FIN). Peer-side reads EOF; our reads keep working
     // until the peer closes. Idempotent.
     end(): void;
@@ -447,6 +455,11 @@ declare module "chadscript/net" {
   // asynchronously. Always returns a Socket — check sock.isOpen() (or
   // wait for the 'error' event) to see whether the connect succeeded.
   export function createConnection(host: string, port: number): Socket;
+
+  // Tick the shared libuv loop up to timeoutMs, returning the total count
+  // of events processed. Useful for Pool implementations that wait on
+  // multiple sockets on one loop without picking an anchor socket.
+  export function pump(timeoutMs: number): number;
 }
 
 declare module "chadscript/tls" {

--- a/lib/net.ts
+++ b/lib/net.ts
@@ -45,6 +45,7 @@
 declare function cs_net_connect(host: string, port: number): string;
 declare function cs_net_last_error(sock: string): string;
 declare function cs_net_write(sock: string, data: string, len: number): number;
+declare function cs_net_write_bytes(sock: string, data: Uint8Array, len: number): number;
 declare function cs_net_poll(sock: string): number;
 declare function cs_net_wait(sock: string, timeoutMs: number): number;
 declare function cs_net_poll_event_kind(sock: string): number;
@@ -56,6 +57,8 @@ declare function cs_net_destroy(sock: string): void;
 declare function cs_net_is_open(sock: string): number;
 declare function cs_net_rx_drain(sock: string): string;
 declare function cs_net_rx_drain_len(sock: string): number;
+declare function cs_net_rx_drain_into(sock: string, out: Uint8Array, maxlen: number): number;
+declare function cs_net_pump(timeoutMs: number): number;
 declare function cs_tls_upgrade(sock: string, servername: string, verify: number): number;
 
 const NET_EVENT_CONNECT: number = 1;
@@ -141,6 +144,17 @@ export class Socket {
     if (this._dead === 1) return false;
     const r = cs_net_write(this._handle, data, data.length);
     return r > 0;
+  }
+
+  writeBytes(data: Uint8Array, len: number): boolean {
+    if (this._dead === 1) return false;
+    const r = cs_net_write_bytes(this._handle, data, len);
+    return r > 0;
+  }
+
+  readBytes(out: Uint8Array, maxlen: number): number {
+    if (this._dead === 1) return 0;
+    return cs_net_rx_drain_into(this._handle, out, maxlen);
   }
 
   // Half-close: send FIN. Peer-side reads will EOF, our reads keep working
@@ -242,4 +256,12 @@ export class Socket {
 export function createConnection(host: string, port: number): Socket {
   const handle: string = cs_net_connect(host, port);
   return new Socket(handle);
+}
+
+// Tick the shared libuv loop once, waiting up to timeoutMs for any event on
+// any socket (or timer/etc). Returns the number of events processed by libuv.
+// Useful for Pool implementations that need to wait on N sockets concurrently
+// without picking a single anchor.
+export function pump(timeoutMs: number): number {
+  return cs_net_pump(timeoutMs);
 }


### PR DESCRIPTION
## Summary
- `sock.writeBytes(Uint8Array, len)` — send arbitrary bytes (NUL-safe). String `write()` truncates at embedded NULs; required for any binary wire protocol (Postgres, Redis, MySQL).
- `sock.readBytes(out: Uint8Array, maxlen) → number` — drain rx into caller-owned Uint8Array; returns bytes copied.
- `pump(timeoutMs)` — tick the shared libuv loop without picking a specific socket. Pool implementations wait on N sockets on one loop cleanly.

## Why
Pure-TS Postgres driver needs byte-accurate I/O: startup/query frames carry 4-byte BE lengths that always hit zero bytes, so `string` I/O mangled every packet (pg server logs `invalid length of startup packet`). With these three primitives, a minimal wire client hits ~45k qps SELECT 1 on trust auth.

## Test plan
- [x] bench client (`examples/postgres-driver/bench-chad-native.ts`) compiles and talks to local pg — 10000 iters, ~45-50k qps
- [x] CI verify (net bridge unit tests, self-hosting stages)