### PR TITLE
crypto: accept Uint8Array input (binary-safe hashing)

### DIFF
--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -398,6 +398,11 @@ export interface IGeneratorContext {
   isObjectArrayExpression(expr: Expression): boolean;
 
   /**
+   * Check if expression evaluates to a Uint8Array (byte buffer).
+   */
+  isUint8ArrayExpression(expr: Expression): boolean;
+
+  /**
    * Check if expression evaluates to an object
    */
   isObjectExpression(expr: Expression): boolean;
@@ -1479,6 +1484,10 @@ export class MockGeneratorContext implements IGeneratorContext {
   }
 
   isObjectArrayExpression(_expr: Expression): boolean {
+    return false; // Simplified mock
+  }
+
+  isUint8ArrayExpression(_expr: Expression): boolean {
     return false; // Simplified mock
   }
 

--- a/src/codegen/stdlib/crypto.ts
+++ b/src/codegen/stdlib/crypto.ts
@@ -43,10 +43,29 @@ export class CryptoGenerator {
       return this.ctx.emitError(`crypto.${expr.method}() requires 1 argument`, expr.loc);
     }
 
-    const inputPtr = this.ctx.generateExpression(expr.args[0], params);
+    const arg = expr.args[0];
+    const isBytes = this.ctx.isUint8ArrayExpression(arg);
+    const argVal = this.ctx.generateExpression(arg, params);
 
-    const inputLen = this.ctx.nextTemp();
-    this.ctx.emit(`${inputLen} = call i64 @strlen(i8* ${inputPtr})`);
+    let inputPtr: string;
+    let inputLen: string;
+    if (isBytes) {
+      // %Uint8Array = type { i8*, i32, i32 } — load data ptr and length.
+      const dataGep = this.ctx.nextTemp();
+      this.ctx.emit(`${dataGep} = getelementptr %Uint8Array, %Uint8Array* ${argVal}, i32 0, i32 0`);
+      inputPtr = this.ctx.nextTemp();
+      this.ctx.emit(`${inputPtr} = load i8*, i8** ${dataGep}`);
+      const lenGep = this.ctx.nextTemp();
+      this.ctx.emit(`${lenGep} = getelementptr %Uint8Array, %Uint8Array* ${argVal}, i32 0, i32 1`);
+      const lenI32 = this.ctx.nextTemp();
+      this.ctx.emit(`${lenI32} = load i32, i32* ${lenGep}`);
+      inputLen = this.ctx.nextTemp();
+      this.ctx.emit(`${inputLen} = sext i32 ${lenI32} to i64`);
+    } else {
+      inputPtr = argVal;
+      inputLen = this.ctx.nextTemp();
+      this.ctx.emit(`${inputLen} = call i64 @strlen(i8* ${inputPtr})`);
+    }
 
     const mdCtx = this.ctx.nextTemp();
     this.ctx.emit(`${mdCtx} = call i8* @EVP_MD_CTX_new()`);
@@ -183,16 +202,56 @@ export class CryptoGenerator {
       return this.ctx.emitError("crypto.hmacSha256() requires 2 arguments (key, data)", expr.loc);
     }
 
-    const keyPtr = this.ctx.generateExpression(expr.args[0], params);
-    const dataPtr = this.ctx.generateExpression(expr.args[1], params);
+    const keyArg = expr.args[0];
+    const dataArg = expr.args[1];
+    const keyIsBytes = this.ctx.isUint8ArrayExpression(keyArg);
+    const dataIsBytes = this.ctx.isUint8ArrayExpression(dataArg);
+    const keyVal = this.ctx.generateExpression(keyArg, params);
+    const dataVal = this.ctx.generateExpression(dataArg, params);
 
-    const keyLen64 = this.ctx.nextTemp();
-    this.ctx.emit(`${keyLen64} = call i64 @strlen(i8* ${keyPtr})`);
-    const keyLen32 = this.ctx.nextTemp();
-    this.ctx.emit(`${keyLen32} = trunc i64 ${keyLen64} to i32`);
+    let keyPtr: string;
+    let keyLen32: string;
+    if (keyIsBytes) {
+      const kDataGep = this.ctx.nextTemp();
+      this.ctx.emit(
+        `${kDataGep} = getelementptr %Uint8Array, %Uint8Array* ${keyVal}, i32 0, i32 0`,
+      );
+      keyPtr = this.ctx.nextTemp();
+      this.ctx.emit(`${keyPtr} = load i8*, i8** ${kDataGep}`);
+      const kLenGep = this.ctx.nextTemp();
+      this.ctx.emit(`${kLenGep} = getelementptr %Uint8Array, %Uint8Array* ${keyVal}, i32 0, i32 1`);
+      keyLen32 = this.ctx.nextTemp();
+      this.ctx.emit(`${keyLen32} = load i32, i32* ${kLenGep}`);
+    } else {
+      keyPtr = keyVal;
+      const keyLen64 = this.ctx.nextTemp();
+      this.ctx.emit(`${keyLen64} = call i64 @strlen(i8* ${keyPtr})`);
+      keyLen32 = this.ctx.nextTemp();
+      this.ctx.emit(`${keyLen32} = trunc i64 ${keyLen64} to i32`);
+    }
 
-    const dataLen = this.ctx.nextTemp();
-    this.ctx.emit(`${dataLen} = call i64 @strlen(i8* ${dataPtr})`);
+    let dataPtr: string;
+    let dataLen: string;
+    if (dataIsBytes) {
+      const dDataGep = this.ctx.nextTemp();
+      this.ctx.emit(
+        `${dDataGep} = getelementptr %Uint8Array, %Uint8Array* ${dataVal}, i32 0, i32 0`,
+      );
+      dataPtr = this.ctx.nextTemp();
+      this.ctx.emit(`${dataPtr} = load i8*, i8** ${dDataGep}`);
+      const dLenGep = this.ctx.nextTemp();
+      this.ctx.emit(
+        `${dLenGep} = getelementptr %Uint8Array, %Uint8Array* ${dataVal}, i32 0, i32 1`,
+      );
+      const dLenI32 = this.ctx.nextTemp();
+      this.ctx.emit(`${dLenI32} = load i32, i32* ${dLenGep}`);
+      dataLen = this.ctx.nextTemp();
+      this.ctx.emit(`${dataLen} = sext i32 ${dLenI32} to i64`);
+    } else {
+      dataPtr = dataVal;
+      dataLen = this.ctx.nextTemp();
+      this.ctx.emit(`${dataLen} = call i64 @strlen(i8* ${dataPtr})`);
+    }
 
     const evpMd = this.ctx.nextTemp();
     this.ctx.emit(`${evpMd} = call i8* @EVP_sha256()`);

--- a/tests/fixtures/crypto/crypto-uint8array-input.ts
+++ b/tests/fixtures/crypto/crypto-uint8array-input.ts
@@ -1,0 +1,50 @@
+// crypto.md5 / sha256 / hmacSha256 accept Uint8Array input.
+// Strings with embedded NUL would be truncated at the NUL by strlen —
+// Uint8Array carries an explicit length, so the full payload is hashed.
+
+const buf = new Uint8Array(5);
+buf[0] = 97; // 'a'
+buf[1] = 98; // 'b'
+buf[2] = 0; // NUL
+buf[3] = 99; // 'c'
+buf[4] = 100; // 'd'
+
+const h = crypto.md5(buf);
+// md5 of "ab" alone (if NUL truncated) = 187ef4436122d1cc2f40dc2b92f0eba0
+// md5 of full "ab\x00cd" should differ.
+if (h === "187ef4436122d1cc2f40dc2b92f0eba0") {
+  console.log("FAIL md5 NUL-truncated: " + h);
+  process.exit(1);
+}
+if (h.length !== 32) {
+  console.log("FAIL md5 len: " + h);
+  process.exit(1);
+}
+
+const s = crypto.sha256(buf);
+// sha256 of "ab" = fb8e20fc2e4c3f248c60c39bd652f3c1347298bb977b8b4d5903b85055620603
+if (s === "fb8e20fc2e4c3f248c60c39bd652f3c1347298bb977b8b4d5903b85055620603") {
+  console.log("FAIL sha256 truncated: " + s);
+  process.exit(1);
+}
+if (s.length !== 64) {
+  console.log("FAIL sha256 len: " + s);
+  process.exit(1);
+}
+
+// HMAC-SHA256 with binary key + binary data
+const key = new Uint8Array(3);
+key[0] = 0;
+key[1] = 1;
+key[2] = 2;
+const data = new Uint8Array(3);
+data[0] = 3;
+data[1] = 0;
+data[2] = 4;
+const mac: string = crypto.hmacSha256(key, data);
+if (mac.length !== 64) {
+  console.log("FAIL hmac len: " + mac);
+  process.exit(1);
+}
+
+console.log("TEST_PASSED");


### PR DESCRIPTION
## Summary
`crypto.sha256`, `crypto.md5`, `crypto.sha512`, and `crypto.hmacSha256` now accept `Uint8Array` in addition to `string`. When a `Uint8Array` is passed, the compiler extracts the struct's data pointer + length field directly instead of calling `strlen`, so embedded NUL bytes are hashed correctly.

## Why user-facing
`strlen` truncates any payload at the first NUL byte, silently producing wrong hashes for binary data. This blocks:
- Postgres SCRAM-SHA-256 auth (SaltedPassword, ClientKey are raw 32-byte buffers with NULs)
- Any binary-wire checksum (IPMI, custom protocols)
- Hashing network packet payloads

Strings still work — only the `Uint8Array` overload is new.

## Test plan
- [x] `tests/fixtures/crypto/crypto-uint8array-input.ts` — md5/sha256 of `"ab\x00cd"` differs from `"ab"` (proves NUL not truncated)
- [x] Existing `hmac-sha256.ts` and `pbkdf2.ts` fixtures still pass
- [ ] CI full verify

## Follow-up
Raw-byte return variants (for SCRAM ClientKey without hex round-trip) + `pbkdf2Sha256(pw, salt, iters, keylen): Uint8Array` land in a separate PR.