### PR TITLE
pg: md5 + cleartext password auth (phase 3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,19 @@ jobs:
 
     env:
       PG_TESTS_ENABLED: 1
+      PGPASSWORD: test
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Force pg password to md5 encryption
+        # postgres:16 image defaults to password_encryption=scram-sha-256, so
+        # the `postgres` user is scram-hashed. Our pure-TS pg driver implements
+        # md5 auth (SCRAM is follow-up) — re-hash password as md5.
+        run: |
+          sudo apt-get install -y postgresql-client
+          psql -h localhost -p 5432 -U postgres -d chadtest \
+            -c "SET password_encryption='md5'; ALTER USER postgres PASSWORD 'test';"
 
       - uses: dorny/paths-filter@v3
         id: changes
@@ -399,8 +409,8 @@ jobs:
             fi
             sleep 1
           done
-          psql postgres -c "CREATE USER postgres SUPERUSER PASSWORD 'test';" || echo "postgres user already exists"
-          psql postgres -c "ALTER USER postgres WITH PASSWORD 'test';"
+          psql postgres -c "SET password_encryption='md5'; CREATE USER postgres SUPERUSER PASSWORD 'test';" || echo "postgres user already exists"
+          psql postgres -c "SET password_encryption='md5'; ALTER USER postgres WITH PASSWORD 'test';"
           psql postgres -c "CREATE DATABASE chadtest OWNER postgres;" || echo "chadtest db already exists"
           psql -h localhost -p 5432 -U postgres -d chadtest -c "SELECT 1;" postgresql://postgres:test@localhost:5432/chadtest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,6 @@ jobs:
 
     env:
       PG_TESTS_ENABLED: 1
-      PGUSER: postgres
-      PGPASSWORD: test
-      PGDATABASE: chadtest
 
     steps:
       - uses: actions/checkout@v4
@@ -354,9 +351,6 @@ jobs:
 
     env:
       PG_TESTS_ENABLED: 1
-      PGUSER: postgres
-      PGPASSWORD: test
-      PGDATABASE: chadtest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,10 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: test
           POSTGRES_DB: chadtest
+          # md5 pg_hba entry — our pure-TS pg driver does md5 auth but not
+          # SCRAM yet. The docker entrypoint writes `host all all all md5`
+          # into pg_hba.conf when this var is md5.
+          POSTGRES_HOST_AUTH_METHOD: md5
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,9 @@ jobs:
 
     env:
       PG_TESTS_ENABLED: 1
+      PGUSER: postgres
+      PGPASSWORD: test
+      PGDATABASE: chadtest
 
     steps:
       - uses: actions/checkout@v4
@@ -351,6 +354,9 @@ jobs:
 
     env:
       PG_TESTS_ENABLED: 1
+      PGUSER: postgres
+      PGPASSWORD: test
+      PGDATABASE: chadtest
 
     steps:
       - uses: actions/checkout@v4

--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -492,6 +492,8 @@ declare module "chadscript/pg" {
     port: number;
     user: string;
     database: string;
+    // Password for cleartext or md5 auth. Leave empty string for trust auth.
+    password: string;
   }
 
   export interface QueryResult {

--- a/lib/pg.ts
+++ b/lib/pg.ts
@@ -15,6 +15,7 @@ export interface ClientOpts {
   port: number;
   user: string;
   database: string;
+  password: string; // empty string when using trust auth
 }
 
 export interface QueryResult {
@@ -30,6 +31,13 @@ const T_DATA_ROW: number = 68; // 'D'
 const T_CMD_DONE: number = 67; // 'C'
 const T_READY: number = 90; // 'Z'
 const T_ERROR: number = 69; // 'E'
+const T_AUTH: number = 82; // 'R' AuthenticationRequest
+
+// Auth sub-type codes (first 4 bytes of AuthenticationRequest body)
+const AUTH_OK: number = 0;
+const AUTH_CLEARTEXT: number = 3;
+const AUTH_MD5: number = 5;
+const AUTH_SASL: number = 10;
 
 export class Client {
   private opts: ClientOpts;
@@ -123,13 +131,39 @@ export class Client {
     tx[off] = 0;
     s.writeBytes(tx, total);
 
-    // Drain until Z or E.
-    const deadline = Date.now() + 5000;
+    // Drain until Z or E; handle auth request in-between.
+    const deadline = Date.now() + 15000;
     while (true) {
       const t = this._pumpOneFrame(deadline);
       if (t === 0) {
         this._lastError = "connect timeout / closed";
         return false;
+      }
+      if (t === T_AUTH) {
+        // Inspect first 4 bytes of body to determine auth sub-type.
+        const rx = this.rx;
+        const po = this._framePayloadOff;
+        const sub = (rx[po] << 24) | (rx[po + 1] << 16) | (rx[po + 2] << 8) | rx[po + 3];
+        if (sub === AUTH_OK) {
+          this._consumeCurrentFrame();
+          // continue loop — server will send S/K frames then Z
+        } else if (sub === AUTH_CLEARTEXT) {
+          this._sendCleartextPassword();
+          this._consumeCurrentFrame();
+        } else if (sub === AUTH_MD5) {
+          this._sendMd5Password();
+          this._consumeCurrentFrame();
+        } else if (sub === AUTH_SASL) {
+          this._lastError =
+            "SCRAM-SHA-256 not yet supported — use password_encryption=md5 or trust on the server";
+          this._consumeCurrentFrame();
+          return false;
+        } else {
+          this._lastError = "unsupported auth sub-type " + sub;
+          this._consumeCurrentFrame();
+          return false;
+        }
+        continue;
       }
       this._consumeCurrentFrame();
       if (t === T_ERROR) return false;
@@ -189,6 +223,67 @@ export class Client {
       if (t === T_READY) return result;
     }
     return result;
+  }
+
+  private _sendCleartextPassword(): void {
+    const tx = this.tx;
+    const pw = this.opts.password;
+    const pwLen = pw.length;
+    const len = 4 + pwLen + 1;
+    tx[0] = 112; // 'p'
+    tx[1] = (len >> 24) & 0xff;
+    tx[2] = (len >> 16) & 0xff;
+    tx[3] = (len >> 8) & 0xff;
+    tx[4] = len & 0xff;
+    let i = 0;
+    while (i < pwLen) {
+      tx[5 + i] = pw.charCodeAt(i) & 0xff;
+      i = i + 1;
+    }
+    tx[5 + pwLen] = 0;
+    this.sock.writeBytes(tx, 1 + len);
+  }
+
+  private _sendMd5Password(): void {
+    // inner = md5(password + username) — 32 hex chars
+    const pw = this.opts.password;
+    const user = this.opts.user;
+    const inner = crypto.md5(pw + user);
+
+    // combined = inner (32 ASCII bytes) + salt (4 raw bytes)
+    const rx = this.rx;
+    const po = this._framePayloadOff;
+    const combined = new Uint8Array(36);
+    let i = 0;
+    while (i < 32) {
+      combined[i] = inner.charCodeAt(i) & 0xff;
+      i = i + 1;
+    }
+    combined[32] = rx[po + 4];
+    combined[33] = rx[po + 5];
+    combined[34] = rx[po + 6];
+    combined[35] = rx[po + 7];
+
+    const outer = crypto.md5(combined);
+
+    // Send PasswordMessage: 'p' + len(4) + "md5" + outer + \0
+    const tx = this.tx;
+    const len = 4 + 3 + 32 + 1;
+    tx[0] = 112; // 'p'
+    tx[1] = (len >> 24) & 0xff;
+    tx[2] = (len >> 16) & 0xff;
+    tx[3] = (len >> 8) & 0xff;
+    tx[4] = len & 0xff;
+    tx[5] = 109; // 'm'
+    tx[6] = 100; // 'd'
+    tx[7] = 53; // '5'
+    let j = 0;
+    while (j < 32) {
+      tx[8 + j] = outer.charCodeAt(j) & 0xff;
+      j = j + 1;
+    }
+    tx[8 + 32] = 0;
+    this.sock.writeBytes(tx, 1 + len);
   }
 
   end(): void {

--- a/src/chad-native.ts
+++ b/src/chad-native.ts
@@ -25,6 +25,7 @@ registerStdlib("compress.ts", ChadScript.embedFile("../lib/compress.ts"));
 registerStdlib("postgres.ts", ChadScript.embedFile("../lib/postgres.ts"));
 registerStdlib("net.ts", ChadScript.embedFile("../lib/net.ts"));
 registerStdlib("tls.ts", ChadScript.embedFile("../lib/tls.ts"));
+registerStdlib("pg.ts", ChadScript.embedFile("../lib/pg.ts"));
 const skillContent = ChadScript.embedFile("../lib/skill.md");
 import { ArgumentParser } from "chadscript/argparse";
 

--- a/tests/fixtures/stdlib/pg-simple-query.ts
+++ b/tests/fixtures/stdlib/pg-simple-query.ts
@@ -1,19 +1,18 @@
-// @test-skip
-// Pure-TS Postgres driver — trust auth + simple 'Q' protocol.
-// Skipped in CI because the CI pg server requires MD5 password auth (coming
-// in phase 3). Run locally against a trust-auth pg:
-//   PGUSER=... PGDATABASE=... chad run tests/fixtures/stdlib/pg-simple-query.ts
+// @test-requires-env: PG_TESTS_ENABLED
+// Pure-TS Postgres driver — trust/md5 auth + simple 'Q' protocol.
 
 import { Client } from "chadscript/pg";
 
 function main(): void {
   const user = process.env.PGUSER ?? "postgres";
   const db = process.env.PGDATABASE ?? "postgres";
+  const pw = process.env.PGPASSWORD ?? "";
   const c = new Client({
     host: "127.0.0.1",
     port: 5432,
     user: user,
     database: db,
+    password: pw,
   });
   if (!c.connect()) {
     console.log("FAIL connect: " + c.lastError());

--- a/tests/fixtures/stdlib/pg-simple-query.ts
+++ b/tests/fixtures/stdlib/pg-simple-query.ts
@@ -4,9 +4,13 @@
 import { Client } from "chadscript/pg";
 
 function main(): void {
+  // Defaults match the credentials the CI workflow provisions for the
+  // `postgres` service (POSTGRES_USER=postgres POSTGRES_PASSWORD=test
+  // POSTGRES_DB=chadtest). Override via env for local runs against a
+  // different pg instance.
   const user = process.env.PGUSER ?? "postgres";
-  const db = process.env.PGDATABASE ?? "postgres";
-  const pw = process.env.PGPASSWORD ?? "";
+  const db = process.env.PGDATABASE ?? "chadtest";
+  const pw = process.env.PGPASSWORD ?? "test";
   const c = new Client({
     host: "127.0.0.1",
     port: 5432,


### PR DESCRIPTION
## Summary
`chadscript/pg` Client now negotiates password auth in addition to trust:
- Handles `AuthenticationRequest` ('R') frames with sub-type 3 (cleartext) or 5 (md5).
- MD5 algorithm: `md5("md5" + md5(md5(password + user) + salt_4bytes))`, sent as `PasswordMessage` ('p').
- `ClientOpts.password` added.
- CI exports `PGUSER=postgres PGPASSWORD=test PGDATABASE=chadtest` so the fixture actually talks to the CI pg (previously skipped).

## Why user-facing
Real Postgres servers almost always require password auth. Before this PR you could only connect to trust-auth dev boxes. Now the driver connects to anything using the pg_hba `md5` method — the default for most managed pg configs before pg13.

## Not yet supported
- SCRAM-SHA-256 (`AUTH_SASL=10`) — deferred. pg ≥14 defaults to SCRAM; this PR will fail with a clear error against those servers. Follow-up PR adds it (needs raw-byte `pbkdf2Sha256` + HMAC-SHA256 output already unlocked in #612).

## Test plan
- [x] Trust auth still works (`PGUSER=csmith PGDATABASE=postgres PGPASSWORD=""` locally).
- [ ] CI runs fixture against md5-auth pg service.

## Follow-ups
Phase 4: extended protocol + param binding + binary codecs. Phase 5: Pool w/ queue+BP. Phase 6: bench vs node/bun/c/go.