### PR TITLE
[llvm-builder] add 5 opcode wrappers + PR title/body rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,33 @@ merge when green, delete the remote branch, and remove the local worktree.
 
 **Never push to main directly.** Always go through PRs.
 
-PR descriptions should be **user-centric** — lead with how the change affects users (better error messages,
-fewer crashes, new capabilities), not just technical implementation details.
+## PR title + body format
+
+**Title**: `[topic] change` — topic is the area touched (e.g. `codegen`, `parser-native`, `ci`, `stdlib/net`, `llvm-builder`). Change is the one-line summary of what this PR does. **Never** use internal step/phase names like "phase 3 step 2" or "step4-phase1b" in the title — those mean nothing to anyone reading the PR list.
+
+Good:
+- `[codegen] seed symbol table on typed let-decl without init`
+- `[parser-native] restore trailing return in bare switch case bodies`
+- `[llvm-builder] add 5 remaining opcode wrappers`
+
+Bad:
+- `step4-phase1b: remaining ops`
+- `phase-e step 5 part 3 follow-up`
+
+**Body** must include **Before** and **After** sections describing the user-facing change (or, if purely internal, the behavior difference before vs after). Add `## Description` with any additional context. Example:
+
+```
+## Before
+Compiler failed with "Method 'on' on 'sock' is not supported" when using `let sock: Socket;` followed by a conditional assignment.
+
+## After
+`sock.on(...)` resolves correctly via the declared `Socket` interface regardless of how `sock` is later assigned.
+
+## Description
+Seeds the symbol table with the declared type at decl-without-init sites in variable-allocator. ~6 LOC fix.
+```
+
+If the PR is purely internal (no user-visible effect), state that explicitly in **After**: `No user-facing change. Internal refactor only.`
 
 ## Testing & Commit Workflow
 

--- a/c_bridges/llvm-builder-bridge.c
+++ b/c_bridges/llvm-builder-bridge.c
@@ -681,6 +681,26 @@ char* cs_llvm_build_srem(const char* lhs_name, const char* rhs_name) {
     return strdup(name);
 }
 
+char* cs_llvm_build_sdiv(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildSDiv(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_udiv(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildUDiv(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
 // ============ Casts ============
 
 char* cs_llvm_build_zext(const char* val_name, const char* to_type_str) {
@@ -724,6 +744,33 @@ char* cs_llvm_build_fptosi(const char* val_name, const char* to_type_str) {
     if (!val) return strdup("");
     char* name = next_temp();
     LLVMValueRef result = LLVMBuildFPToSI(b_builder, val, parse_type(to_type_str), name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_uitofp(const char* val_name, const char* to_type_str) {
+    LLVMValueRef val = lookup_value(val_name);
+    if (!val) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildUIToFP(b_builder, val, parse_type(to_type_str), name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_fptrunc(const char* val_name, const char* to_type_str) {
+    LLVMValueRef val = lookup_value(val_name);
+    if (!val) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildFPTrunc(b_builder, val, parse_type(to_type_str), name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_fpext(const char* val_name, const char* to_type_str) {
+    LLVMValueRef val = lookup_value(val_name);
+    if (!val) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildFPExt(b_builder, val, parse_type(to_type_str), name + 1);
     register_value(name, result);
     return strdup(name);
 }

--- a/scripts/audit-emit-sites.sh
+++ b/scripts/audit-emit-sites.sh
@@ -11,10 +11,10 @@ cd "$(dirname "$0")/.."
 # Patterns the llvm-builder-bridge.c currently covers (keep sorted).
 COVERED=(
   add alloca ashr and bitcast br br_cond call call_void
-  fadd fcmp fdiv fmul fneg fptosi frem fsub
+  fadd fcmp fdiv fmul fneg fpext fptosi fptrunc frem fsub
   gep icmp inttoptr load lshr mul or phi ptrtoint
-  ret ret_void select sext shl sitofp srem store
-  sub trunc unreachable xor zext
+  ret ret_void sdiv select sext shl sitofp srem store
+  sub trunc udiv uitofp unreachable xor zext
 )
 
 # Output: { total, by_instruction, uncovered_samples }
@@ -34,6 +34,12 @@ BEGIN {
   covered["shl"]=1; covered["sitofp"]=1; covered["srem"]=1; covered["store"]=1
   covered["sub"]=1; covered["trunc"]=1; covered["unreachable"]=1
   covered["xor"]=1; covered["zext"]=1
+  # Added in step4-phase1b.
+  covered["sdiv"]=1; covered["udiv"]=1; covered["uitofp"]=1
+  covered["fptrunc"]=1; covered["fpext"]=1
+  # Dynamic-op templates in binary.ts — templates pick add/sub/mul/fadd/fsub/fmul/fdiv
+  # at runtime; all underlying ops are individually covered.
+  covered["${i64Op}"]=1; covered["${llvmOp}"]=1
   # Labels are handled by bb_create + bb_position in bridge.
   covered["label"]=1
 }

--- a/src/codegen/infrastructure/llvm-builder-ffi.ts
+++ b/src/codegen/infrastructure/llvm-builder-ffi.ts
@@ -63,6 +63,8 @@ export declare function cs_llvm_build_add(lhs: string, rhs: string): string;
 export declare function cs_llvm_build_sub(lhs: string, rhs: string): string;
 export declare function cs_llvm_build_mul(lhs: string, rhs: string): string;
 export declare function cs_llvm_build_srem(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_sdiv(lhs: string, rhs: string): string;
+export declare function cs_llvm_build_udiv(lhs: string, rhs: string): string;
 
 // ---- Arithmetic (float) ----
 
@@ -100,6 +102,9 @@ export declare function cs_llvm_build_zext(value: string, destType: string): str
 export declare function cs_llvm_build_trunc(value: string, destType: string): string;
 export declare function cs_llvm_build_sitofp(value: string, destType: string): string;
 export declare function cs_llvm_build_fptosi(value: string, destType: string): string;
+export declare function cs_llvm_build_uitofp(value: string, destType: string): string;
+export declare function cs_llvm_build_fptrunc(value: string, destType: string): string;
+export declare function cs_llvm_build_fpext(value: string, destType: string): string;
 export declare function cs_llvm_build_inttoptr(value: string, destType: string): string;
 export declare function cs_llvm_build_ptrtoint(value: string, destType: string): string;
 


### PR DESCRIPTION
## Before
6 emit-site patterns (\`sdiv\`, \`udiv\`, \`uitofp\`, \`fptrunc\`, \`fpext\`, 2 dynamic-op templates) lacked \`cs_llvm_build_*\` wrappers. Audit script flagged them as uncovered, blocking Step 4 Phase 2 (parallel-emit diff harness).

## After
Audit reports **0 uncovered patterns**. All 2880 \`ctx.emit()\` sites now have a documented bridge equivalent. Phase 2 unblocked.

## Description
Completes Step 4 Phase 1 (bridge parity) per \`memory/step4-irbuilder-design-2026-04-20.md\`. No user-facing change — bridge additions are callable from TS via FFI declares but no codegen site invokes them yet. The 5 new C wrappers mirror existing ones exactly.

Also updates \`CLAUDE.md\` with PR title + body rules:
- Title format: \`[topic] change\` (no internal phase names like \"step4-phase1b\")
- Body must include **Before**/**After** sections. \"No user-facing change\" is a valid After.

### Files
- \`c_bridges/llvm-builder-bridge.c\` — +5 wrappers
- \`src/codegen/infrastructure/llvm-builder-ffi.ts\` — +5 extern declares
- \`scripts/audit-emit-sites.sh\` — coverage list updated
- \`CLAUDE.md\` — PR title + body rule section

## Test plan
- [x] \`bash scripts/audit-emit-sites.sh\` — uncovered_patterns is empty
- [x] \`npm run verify\` — full 3-stage self-host + all tests green locally
- [ ] CI green