### PR TITLE
[stdlib/pg] extended protocol + text-mode param binding

### DIFF
--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -507,6 +507,10 @@ declare module "chadscript/pg" {
     constructor(opts: ClientOpts);
     connect(): boolean;
     query(sql: string): QueryResult;
+    // Extended protocol with text-mode parameter binding. Placeholders
+    // in SQL use `$1`, `$2`, ... positional markers. Each param is
+    // sent as its text representation (format code 0).
+    queryParams(sql: string, params: string[]): QueryResult;
     end(): void;
     lastError(): string;
   }

--- a/lib/pg.ts
+++ b/lib/pg.ts
@@ -32,6 +32,9 @@ const T_CMD_DONE: number = 67; // 'C'
 const T_READY: number = 90; // 'Z'
 const T_ERROR: number = 69; // 'E'
 const T_AUTH: number = 82; // 'R' AuthenticationRequest
+const T_PARSE_COMPLETE: number = 49; // '1'
+const T_BIND_COMPLETE: number = 50; // '2'
+const T_NO_DATA: number = 110; // 'n'
 
 // Auth sub-type codes (first 4 bytes of AuthenticationRequest body)
 const AUTH_OK: number = 0;
@@ -218,6 +221,151 @@ export class Client {
         result.command = this._parseCString(this._framePayloadOff, this._framePayloadEnd);
       } else if (t === T_ERROR) {
         // _lastError already set in _pumpOneFrame
+      }
+      this._consumeCurrentFrame();
+      if (t === T_READY) return result;
+    }
+    return result;
+  }
+
+  // Extended protocol: Parse + Bind + Describe + Execute + Sync.
+  // params are text-encoded (format 0) — pass numbers as their string form.
+  // Empty string "" is sent as length=0. NULL parameters not yet supported
+  // (needs a sentinel distinct from "").
+  queryParams(sql: string, params: string[]): QueryResult {
+    const result: QueryResult = {
+      fields: [],
+      rows: [],
+      rowCount: 0,
+      command: "",
+    };
+    if (this.connected === 0) {
+      this._lastError = "not connected";
+      return result;
+    }
+
+    const tx = this.tx;
+    let off = 0;
+
+    // ---- Parse 'P' ----
+    const pStart = off;
+    tx[off] = 80; // 'P'
+    off = off + 5;
+    tx[off] = 0; // unnamed prepared stmt
+    off = off + 1;
+    const sqlLen = sql.length;
+    let si = 0;
+    while (si < sqlLen) {
+      tx[off + si] = sql.charCodeAt(si) & 0xff;
+      si = si + 1;
+    }
+    off = off + sqlLen;
+    tx[off] = 0;
+    off = off + 1;
+    tx[off] = 0;
+    tx[off + 1] = 0; // numParamTypes=0 (server infers)
+    off = off + 2;
+    const pLen = off - pStart - 1;
+    tx[pStart + 1] = (pLen >> 24) & 0xff;
+    tx[pStart + 2] = (pLen >> 16) & 0xff;
+    tx[pStart + 3] = (pLen >> 8) & 0xff;
+    tx[pStart + 4] = pLen & 0xff;
+
+    // ---- Bind 'B' ----
+    const bStart = off;
+    tx[off] = 66; // 'B'
+    off = off + 5;
+    tx[off] = 0; // unnamed portal
+    off = off + 1;
+    tx[off] = 0; // unnamed prepared stmt
+    off = off + 1;
+    tx[off] = 0;
+    tx[off + 1] = 0; // numFormatCodes=0 → all text
+    off = off + 2;
+    const nParams = params.length;
+    tx[off] = (nParams >> 8) & 0xff;
+    tx[off + 1] = nParams & 0xff;
+    off = off + 2;
+    let pi = 0;
+    while (pi < nParams) {
+      const p = params[pi];
+      const pl = p.length;
+      tx[off] = (pl >> 24) & 0xff;
+      tx[off + 1] = (pl >> 16) & 0xff;
+      tx[off + 2] = (pl >> 8) & 0xff;
+      tx[off + 3] = pl & 0xff;
+      off = off + 4;
+      let pj = 0;
+      while (pj < pl) {
+        tx[off + pj] = p.charCodeAt(pj) & 0xff;
+        pj = pj + 1;
+      }
+      off = off + pl;
+      pi = pi + 1;
+    }
+    tx[off] = 0;
+    tx[off + 1] = 0; // numResultFormats=0 → all text
+    off = off + 2;
+    const bLen = off - bStart - 1;
+    tx[bStart + 1] = (bLen >> 24) & 0xff;
+    tx[bStart + 2] = (bLen >> 16) & 0xff;
+    tx[bStart + 3] = (bLen >> 8) & 0xff;
+    tx[bStart + 4] = bLen & 0xff;
+
+    // ---- Describe 'D' portal '' ----
+    const dStart = off;
+    tx[off] = 68; // 'D'
+    off = off + 5;
+    tx[off] = 80; // 'P'
+    off = off + 1;
+    tx[off] = 0;
+    off = off + 1;
+    const dLen = off - dStart - 1;
+    tx[dStart + 1] = (dLen >> 24) & 0xff;
+    tx[dStart + 2] = (dLen >> 16) & 0xff;
+    tx[dStart + 3] = (dLen >> 8) & 0xff;
+    tx[dStart + 4] = dLen & 0xff;
+
+    // ---- Execute 'E' portal '' maxRows=0 ----
+    const eStart = off;
+    tx[off] = 69; // 'E'
+    off = off + 5;
+    tx[off] = 0;
+    off = off + 1;
+    tx[off] = 0;
+    tx[off + 1] = 0;
+    tx[off + 2] = 0;
+    tx[off + 3] = 0;
+    off = off + 4;
+    const eLen = off - eStart - 1;
+    tx[eStart + 1] = (eLen >> 24) & 0xff;
+    tx[eStart + 2] = (eLen >> 16) & 0xff;
+    tx[eStart + 3] = (eLen >> 8) & 0xff;
+    tx[eStart + 4] = eLen & 0xff;
+
+    // ---- Sync 'S' ----
+    tx[off] = 83;
+    tx[off + 1] = 0;
+    tx[off + 2] = 0;
+    tx[off + 3] = 0;
+    tx[off + 4] = 4;
+    off = off + 5;
+
+    this.sock.writeBytes(tx, off);
+
+    const deadline = Date.now() + 30000;
+    while (true) {
+      const t = this._pumpOneFrame(deadline);
+      if (t === 0) {
+        this._lastError = "query timeout / closed";
+        return result;
+      }
+      if (t === T_ROW_DESC) {
+        this._parseRowDescInto(result);
+      } else if (t === T_DATA_ROW) {
+        this._parseDataRowInto(result);
+      } else if (t === T_CMD_DONE) {
+        result.command = this._parseCString(this._framePayloadOff, this._framePayloadEnd);
       }
       this._consumeCurrentFrame();
       if (t === T_READY) return result;

--- a/tests/fixtures/stdlib/pg-extended-params.ts
+++ b/tests/fixtures/stdlib/pg-extended-params.ts
@@ -1,0 +1,76 @@
+// @test-requires-env: PG_TESTS_ENABLED
+// Pure-TS Postgres — extended protocol + param binding (text mode).
+
+import { Client } from "chadscript/pg";
+
+function main(): void {
+  const user = process.env.PGUSER ?? "postgres";
+  const db = process.env.PGDATABASE ?? "chadtest";
+  const pw = process.env.PGPASSWORD ?? "test";
+  const c = new Client({
+    host: "127.0.0.1",
+    port: 5432,
+    user: user,
+    database: db,
+    password: pw,
+  });
+  if (!c.connect()) {
+    console.log("FAIL connect: " + c.lastError());
+    return;
+  }
+
+  // Single int param
+  const r1 = c.queryParams("SELECT $1::int AS n", ["42"]);
+  if (r1.rowCount !== 1) {
+    console.log("FAIL r1 rowCount=" + r1.rowCount + " err=" + c.lastError());
+    return;
+  }
+  const row1 = r1.rows[0] as string[];
+  if (row1[0] !== "42") {
+    console.log("FAIL r1 val " + row1[0]);
+    return;
+  }
+
+  // Multi params, mixed types (all bound as text, server casts)
+  const r2 = c.queryParams("SELECT $1::int AS n, $2::text AS s, $3::text AS t", [
+    "7",
+    "hello",
+    "world",
+  ]);
+  if (r2.rowCount !== 1) {
+    console.log("FAIL r2 rc=" + r2.rowCount);
+    return;
+  }
+  const row2 = r2.rows[0] as string[];
+  if (row2[0] !== "7" || row2[1] !== "hello" || row2[2] !== "world") {
+    console.log("FAIL r2 " + row2[0] + "|" + row2[1] + "|" + row2[2]);
+    return;
+  }
+
+  // Param used twice
+  const r3 = c.queryParams("SELECT $1::int * 2 AS double_n, $1::int + 1 AS inc", ["5"]);
+  const row3 = r3.rows[0] as string[];
+  if (row3[0] !== "10" || row3[1] !== "6") {
+    console.log("FAIL r3 " + row3[0] + "|" + row3[1]);
+    return;
+  }
+
+  // Multi-row w/ generate_series and a param
+  const r4 = c.queryParams("SELECT n FROM generate_series(1, $1::int) AS n", ["3"]);
+  if (r4.rowCount !== 3) {
+    console.log("FAIL r4 rc=" + r4.rowCount);
+    return;
+  }
+  const r40 = r4.rows[0] as string[];
+  const r41 = r4.rows[1] as string[];
+  const r42 = r4.rows[2] as string[];
+  if (r40[0] !== "1" || r41[0] !== "2" || r42[0] !== "3") {
+    console.log("FAIL r4 vals");
+    return;
+  }
+
+  c.end();
+  console.log("TEST_PASSED");
+}
+
+main();


### PR DESCRIPTION
## Before
Only simple-protocol `Q` queries with inline SQL. No param binding — callers had to build SQL strings with manually escaped literals, risking injection and string-handling overhead on every call.

## After
`client.queryParams(sql, params: string[])` sends Parse + Bind + Describe + Execute + Sync with unnamed prepared statements. Placeholders use positional `$1`, `$2`, ... markers and each param is bound as text (format code 0). Server handles casting via `$1::int`, `$2::text`, etc.

```ts
const r = c.queryParams(
  "SELECT n FROM generate_series(1, \$1::int) AS n",
  ["3"],
);
// r.rows = [["1"], ["2"], ["3"]]
```

## Description
All five frames (Parse 'P', Bind 'B', Describe 'D', Execute 'E', Sync 'S') built into the pre-allocated tx buffer and sent in one `writeBytes` call for minimum syscall overhead. Response loop reuses the existing `_pumpOneFrame`/`_parseRowDescInto`/`_parseDataRowInto` machinery — new frame types (`1` ParseComplete, `2` BindComplete, `n` NoData) are parsed only for their headers and silently consumed.

Uses unnamed prepared statement + unnamed portal — no cross-query caching yet, but avoids needing a statement-name allocator. Binary parameter format (code 1) is a follow-up; text covers 95% of app traffic.

## Test plan
- [x] `PGUSER=csmith PGDATABASE=postgres PGPASSWORD="" node dist/chad-node.js run tests/fixtures/stdlib/pg-extended-params.ts` — TEST_PASSED (int, mixed types, param-reuse, multi-row with `generate_series`).
- [x] Native compiler path: `.build/chad build tests/fixtures/stdlib/pg-extended-params.ts` compiles + passes.
- [ ] CI against pg:16 md5-auth service.

## Next steps
- Binary param format (code 1) for ints/doubles/timestamps — skips text encoding round-trip.
- Binary result format — avoid server text encoding for numeric/timestamp columns.
- Named prepared statement cache keyed by SQL hash.
- NULL param support (needs a sentinel distinct from "" — currently `""` and NULL are ambiguous at the param level).
- SCRAM-SHA-256 auth (independent, tracked for its own PR).
- `Pool` with request queue + backpressure.

Closes none (multi-phase pg driver work, tracked locally).