### PR TITLE
[stdlib/pg] Pool: round-robin connections + auto-reconnect

### DIFF
--- a/chadscript.d.ts
+++ b/chadscript.d.ts
@@ -514,6 +514,28 @@ declare module "chadscript/pg" {
     end(): void;
     lastError(): string;
   }
+
+  export interface PoolOpts {
+    host: string;
+    port: number;
+    user: string;
+    database: string;
+    password: string;
+    // Number of clients in the rotation (minimum 1).
+    size: number;
+  }
+
+  // Round-robin pool over N Clients. Lazily connects each client on first
+  // use, auto-reconnects on error. Synchronous — not a parallelism primitive;
+  // used for connection caching + per-connection server state spread.
+  export class Pool {
+    constructor(opts: PoolOpts);
+    query(sql: string): QueryResult;
+    queryParams(sql: string, params: string[]): QueryResult;
+    end(): void;
+    lastError(): string;
+    size(): number;
+  }
 }
 
 declare module "chadscript/http" {

--- a/lib/pg.ts
+++ b/lib/pg.ts
@@ -288,8 +288,8 @@ export class Client {
     off = off + 2;
     let pi = 0;
     while (pi < nParams) {
-      const p = params[pi];
-      const pl = p.length;
+      const pv = params[pi];
+      const pl = pv.length;
       tx[off] = (pl >> 24) & 0xff;
       tx[off + 1] = (pl >> 16) & 0xff;
       tx[off + 2] = (pl >> 8) & 0xff;
@@ -297,12 +297,13 @@ export class Client {
       off = off + 4;
       let pj = 0;
       while (pj < pl) {
-        tx[off + pj] = p.charCodeAt(pj) & 0xff;
+        tx[off + pj] = pv.charCodeAt(pj) & 0xff;
         pj = pj + 1;
       }
       off = off + pl;
       pi = pi + 1;
     }
+    // (end of bind param loop)
     tx[off] = 0;
     tx[off + 1] = 0; // numResultFormats=0 → all text
     off = off + 2;
@@ -601,6 +602,143 @@ export class Client {
       this._lastError = code + ": " + msg;
     } else {
       this._lastError = msg;
+    }
+  }
+}
+
+// Class-field array element access + method call hits a chad codegen
+// quirk — the element's type is lost across member access, so we dispatch
+// via free helpers that accept a Client parameter.
+
+function _poolConnectOne(c: Client): boolean {
+  return c.connect();
+}
+
+function _poolQuery(c: Client, sql: string): QueryResult {
+  return c.query(sql);
+}
+
+function _poolQueryParams(c: Client, sql: string, params: string[]): QueryResult {
+  return c.queryParams(sql, params);
+}
+
+function _poolClientError(c: Client): string {
+  return c.lastError();
+}
+
+function _poolEndOne(c: Client): void {
+  c.end();
+}
+
+// ---- Pool ----
+//
+// Round-robin over N Clients. Each query() / queryParams() picks the next
+// client, lazily (re)connects it on demand, and runs the query. ChadScript's
+// net stack is synchronous, so this is a connection cache + auto-reconnect +
+// server-side state spread — not a parallelism primitive. Backpressure/
+// async queueing lands as phase 5b once net has cooperative scheduling.
+
+export interface PoolOpts {
+  host: string;
+  port: number;
+  user: string;
+  database: string;
+  password: string;
+  size: number;
+}
+
+export class Pool {
+  private opts: PoolOpts;
+  private clients: Client[];
+  private alive: number[];
+  private cursor: number;
+  private _lastError: string;
+
+  constructor(opts: PoolOpts) {
+    this.opts = opts;
+    this.clients = [];
+    this.alive = [];
+    this.cursor = 0;
+    this._lastError = "";
+    const n = opts.size < 1 ? 1 : opts.size;
+    let i = 0;
+    while (i < n) {
+      const c = new Client({
+        host: opts.host,
+        port: opts.port,
+        user: opts.user,
+        database: opts.database,
+        password: opts.password,
+      });
+      this.clients.push(c);
+      this.alive.push(0);
+      i = i + 1;
+    }
+  }
+
+  lastError(): string {
+    return this._lastError;
+  }
+
+  size(): number {
+    return this.clients.length;
+  }
+
+  private _acquireIdx(): number {
+    const n = this.clients.length;
+    let attempts = 0;
+    while (attempts < n) {
+      const idx = this.cursor % n;
+      this.cursor = this.cursor + 1;
+      const c = this.clients[idx] as Client;
+      if (this.alive[idx] === 0) {
+        if (_poolConnectOne(c)) {
+          this.alive[idx] = 1;
+          return idx;
+        }
+        this._lastError = _poolClientError(c);
+      } else {
+        return idx;
+      }
+      attempts = attempts + 1;
+    }
+    return 0;
+  }
+
+  query(sql: string): QueryResult {
+    const idx = this._acquireIdx();
+    const c = this.clients[idx] as Client;
+    const r = _poolQuery(c, sql);
+    const err = _poolClientError(c);
+    if (err.length > 0) {
+      this.alive[idx] = 0;
+      this._lastError = err;
+    }
+    return r;
+  }
+
+  queryParams(sql: string, params: string[]): QueryResult {
+    const idx = this._acquireIdx();
+    const c = this.clients[idx] as Client;
+    const r = _poolQueryParams(c, sql, params);
+    const err = _poolClientError(c);
+    if (err.length > 0) {
+      this.alive[idx] = 0;
+      this._lastError = err;
+    }
+    return r;
+  }
+
+  end(): void {
+    let i = 0;
+    const n = this.clients.length;
+    while (i < n) {
+      if (this.alive[i] === 1) {
+        const c = this.clients[i] as Client;
+        _poolEndOne(c);
+        this.alive[i] = 0;
+      }
+      i = i + 1;
     }
   }
 }

--- a/tests/fixtures/stdlib/pg-pool.ts
+++ b/tests/fixtures/stdlib/pg-pool.ts
@@ -1,0 +1,68 @@
+// @test-requires-env: PG_TESTS_ENABLED
+// Pure-TS Postgres — round-robin Pool w/ N clients, auto-reconnect.
+
+import { Pool } from "chadscript/pg";
+
+function main(): void {
+  const user = process.env.PGUSER ?? "postgres";
+  const db = process.env.PGDATABASE ?? "chadtest";
+  const pw = process.env.PGPASSWORD ?? "test";
+  const p = new Pool({
+    host: "127.0.0.1",
+    port: 5432,
+    user: user,
+    database: db,
+    password: pw,
+    size: 3,
+  });
+  if (p.size() !== 3) {
+    console.log("FAIL size " + p.size());
+    return;
+  }
+
+  // Run 10 queries — should round-robin across 3 conns
+  let i = 0;
+  while (i < 10) {
+    const r = p.queryParams("SELECT $1::int AS n", ["" + i]);
+    if (r.rowCount !== 1) {
+      console.log("FAIL iter " + i + " rc=" + r.rowCount + " err=" + p.lastError());
+      return;
+    }
+    const row = r.rows[0] as string[];
+    if (row[0] !== "" + i) {
+      console.log("FAIL iter " + i + " got " + row[0]);
+      return;
+    }
+    i = i + 1;
+  }
+
+  // Verify each conn has distinct backend pid (would fail if all went through
+  // one client — Pool round-robin should spread them).
+  const seen: string[] = [];
+  let j = 0;
+  while (j < 6) {
+    const r = p.query("SELECT pg_backend_pid()::text AS pid");
+    const row = r.rows[0] as string[];
+    const pid = row[0];
+    let found = 0;
+    let k = 0;
+    while (k < seen.length) {
+      if (seen[k] === pid) {
+        found = 1;
+        break;
+      }
+      k = k + 1;
+    }
+    if (found === 0) seen.push(pid);
+    j = j + 1;
+  }
+  if (seen.length !== 3) {
+    console.log("FAIL distinct pids " + seen.length + " expected 3");
+    return;
+  }
+
+  p.end();
+  console.log("TEST_PASSED");
+}
+
+main();


### PR DESCRIPTION
## Before
Driver only exposed single-Client usage — each caller had to manage its own connection, handle reconnect-on-error, and decide when to open a new conn for concurrent workload.

## After
`Pool` class in `chadscript/pg` wraps N Clients. Each `pool.query()` / `pool.queryParams()` picks the next client in round-robin, lazily connects it on first use, and flips its slot to needs-reconnect on error.

```ts
const pool = new Pool({
  host: "127.0.0.1", port: 5432,
  user: "postgres", database: "chadtest", password: "test",
  size: 3,
});
// spreads across 3 server connections (3 distinct pg_backend_pid()s)
pool.queryParams("SELECT \$1::int", ["42"]);
```

## Description
ChadScript's net stack is synchronous, so this Pool is a connection **cache** + load-spreader across server-side per-connection state (prepared-statement caches, temp tables), not a parallelism primitive.

Implementation notes:
- Class-field array element + method call hits a codegen quirk (element type lost across member access). Workaround: free helpers (`_poolConnectOne`, `_poolQuery`, …) take `c: Client` and dispatch.
- Variable names inside Client methods needed renaming (`p` → `pv`) because `class Pool` in the same file shadows locals named `p`.

## Test plan
- [x] Local: `PGUSER=csmith PGDATABASE=postgres PGPASSWORD="" node dist/chad-node.js run tests/fixtures/stdlib/pg-pool.ts` — TEST_PASSED. 10 round-robin queries + 6 pid queries across 3 conns returning 3 distinct backend pids.
- [ ] CI against pg:16 md5-auth.

## Next steps / Gaps
- Async queue + backpressure: needs cooperative scheduling over the shared libuv loop (pump-driven). Blocked on a broader async-await story; not a pg-specific concern.
- Per-Client max-query-age eviction + idle timeout.
- Pool sizing heuristics (`min` vs `max`).
- Reconnect backoff instead of immediate retry.

## Known limitations
- Synchronous — one outstanding query at a time per process.
- No transactions API yet (`BEGIN`/`COMMIT` still work as raw queries, but a `client.tx(() => ...)` helper is cleaner).