### PR TITLE
[stdlib/json] pre-init any/unknown slots to empty string so absent fields don't segfault

### DIFF
--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -345,7 +345,11 @@ export class JsonGenerator {
 
     for (let fieldIndex = 0; fieldIndex < fieldCount; fieldIndex++) {
       const fieldType = this.ctx.interfaceStructGenGetFieldTsType(typeName, fieldIndex);
-      if (fieldType === "string") {
+      // Pre-initialize string and any/unknown slots to "" so an absent field
+      // yields a safe empty string instead of a null pointer. length===0 is
+      // the idiomatic absence check; without this, .length / === "null" /
+      // any other string op on an absent `any` field segfaults. (#631)
+      if (fieldType === "string" || fieldType === "any" || fieldType === "unknown") {
         lines.push(
           "  %init_ptr_" +
             fieldIndex +

--- a/tests/fixtures/builtins/json-parse-any-field-absent.ts
+++ b/tests/fixtures/builtins/json-parse-any-field-absent.ts
@@ -1,0 +1,21 @@
+// @test expectTestPassed
+// Regression for #631: absent `any`-typed field must be an empty string, not
+// a null pointer. Prior behavior: string ops (===, concat) on an absent any
+// field segfaulted because the slot was left as a raw null pointer. Fix:
+// pre-init any/unknown slots to "" during struct allocation, same as
+// string fields.
+interface E {
+  seq: number;
+  body: any;
+}
+const e = JSON.parse<E>('{"seq":1}');
+let ok = e.seq === 1;
+// These all segfaulted prior to the fix when body was absent:
+ok = ok && e.body === "";
+ok = ok && e.body !== "null";
+ok = ok && "body=[" + e.body + "]" === "body=[]";
+
+const e2 = JSON.parse<E>('{"seq":2,"body":{"x":7}}');
+ok = ok && e2.seq === 2;
+ok = ok && e2.body !== "";
+if (ok) console.log("TEST_PASSED");


### PR DESCRIPTION
## Before
`JSON.parse<T>` on an interface with an `any`-typed field returned a **null pointer** when that field was absent from the input JSON. String concat silently coerced to the text `null` (looked fine in `console.log`), but any real string op segfaulted:

```ts
interface E { seq: number; body: any; }
const e = JSON.parse<E>('{"seq":1}');
console.log("body=[" + e.body + "]");   // prints: body=[null]  (lies)
if (e.body.length === 0) { ... }        // SEGFAULT
if (e.body === "null")   { ... }        // SEGFAULT
```

Worst-of-both-worlds shape: silent in the easy case (println), catastrophic in the careful case (guarded checks).

## After
Absent `any` / `unknown` fields are now `""` (empty string). `=== ""` is a safe, idiomatic absence check, and every string op on the field works:

```ts
if (e.body === "")       { ... }   // clean absence check
if (e.body !== "")       { ... }   // present — re-parse with JSON.parse<ConcreteShape>(e.body)
"body=[" + e.body + "]"            // "body=[]" when absent
```

## Description
Extends the existing string-field pre-initialization loop in `parse_json_<T>` to also cover `any`/`unknown`-typed slots. The parser already pre-inits `string` slots to `@.empty_str` before the yyjson lookup; absent fields then keep that empty string. This change just adds `any`/`unknown` to the same init — 1-line condition tweak in `src/codegen/stdlib/json.ts`.

Paired with a regression fixture `tests/fixtures/builtins/json-parse-any-field-absent.ts` covering both the absent-body and present-body shapes.

## Test plan
- [x] New fixture `json-parse-any-field-absent.ts` covers `=== ""`, `!== "null"`, concat — previously segfaulted, now passes
- [x] Existing `json-parse-any-field.ts` still passes (present-body case unaffected)
- [x] `npm run verify:quick` green

## Next steps
Orthogonal gap spotted while writing the fixture: `e.body.length` on an `any`-typed field generates an `%ObjectArray*` bitcast + length-field load instead of `@strlen`, so it returns garbage regardless of present/absent. That's a pre-existing `.length`-on-any codegen bug, unrelated to the null-pointer crash fixed here. Worth a follow-up issue once the envelope pattern sees more use.

Closes #631