### PR TITLE
[v8-bridge] surface unhandled promise rejections via cs_v8_last_error

### DIFF
--- a/c_bridges/node-bridge.cc
+++ b/c_bridges/node-bridge.cc
@@ -48,6 +48,13 @@ std::string g_init_error;
 
 thread_local std::string t_last_error;
 
+// Captures the last unhandled promise rejection seen in this thread's
+// Node environment. Set by the v8 PromiseRejectCallback, consumed and
+// cleared by run_script / eval_script_node once SpinEventLoop returns.
+// Separate from t_last_error so a caller that already set an error for
+// a synchronous throw is not overwritten.
+thread_local std::string t_last_unhandled_rejection;
+
 // ---- JSHandle table (same layout as v8-bridge) ----
 
 constexpr uint64_t JS_HANDLE_TAG = 0x100000000ULL;
@@ -121,6 +128,26 @@ bool cs_node_lazy_init() {
     g_isolate = g_setup->isolate();
     g_env = g_setup->env();
 
+    // Wire unhandled-promise-rejection hook. V8 fires this for both
+    // `kPromiseRejectWithNoHandler` (no .catch ever attached by the end of
+    // the microtask queue flush) and `kPromiseHandlerAddedAfterReject`
+    // (a late handler — not actually unhandled). We only record the former
+    // so a later .catch() doesn't look like a failure.
+    g_isolate->SetPromiseRejectCallback(
+        [](v8::PromiseRejectMessage msg) {
+            if (msg.GetEvent() != v8::kPromiseRejectWithNoHandler) return;
+            v8::Isolate* iso = v8::Isolate::GetCurrent();
+            if (!iso) return;
+            v8::HandleScope hs(iso);
+            v8::Local<v8::Value> val = msg.GetValue();
+            std::string s = "unhandled promise rejection";
+            if (!val.IsEmpty()) {
+                v8::String::Utf8Value u(iso, val);
+                if (*u) { s += ": "; s += *u; }
+            }
+            t_last_unhandled_rejection = s;
+        });
+
     // NOTE: We do NOT call LoadEnvironment here. LoadEnvironment can only be
     // called once per Environment; the pragma path calls it later with the
     // real user source. The non-pragma JSHandle API uses v8::Script::Run
@@ -144,6 +171,8 @@ bool run_script(const char* src, v8::Local<v8::Value>* out_result) {
     v8::Local<v8::Context> ctx = g_setup->context();
     v8::Context::Scope cscope(ctx);
     v8::TryCatch try_catch(g_isolate);
+    // Fresh per-call — stale rejection from an earlier eval must not leak.
+    t_last_unhandled_rejection.clear();
 
     v8::Local<v8::String> source;
     if (!v8::String::NewFromUtf8(g_isolate, src ? src : "",
@@ -171,6 +200,16 @@ bool run_script(const char* src, v8::Local<v8::Value>* out_result) {
     // Drain microtasks + libuv. SpinEventLoop runs until there are no more
     // refs or the loop is stopped — that's what makes setTimeout work.
     node::SpinEventLoop(g_env);
+
+    // Surface any unhandled promise rejection captured during this run.
+    // Without this the rejection is swallowed and the caller thinks the
+    // script succeeded. We report it as a run failure so cs_v8_last_error
+    // reads it like any other thrown exception.
+    if (!t_last_unhandled_rejection.empty()) {
+        t_last_error = t_last_unhandled_rejection;
+        t_last_unhandled_rejection.clear();
+        return false;
+    }
 
     *out_result = result;
     return true;
@@ -255,6 +294,7 @@ char* cs_v8_eval_string(const char* src) {
 char* cs_v8_eval_script_node(const char* src, const char* filename) {
     if (!cs_node_lazy_init()) return nullptr;
     t_last_error.clear();
+    t_last_unhandled_rejection.clear();
 
     v8::Locker locker(g_isolate);
     v8::Isolate::Scope iscope(g_isolate);
@@ -309,6 +349,15 @@ char* cs_v8_eval_script_node(const char* src, const char* filename) {
     // Drain microtasks + libuv until the loop is empty (or all handles unref'd).
     // This is what lets setTimeout, fs.promises, async fetch actually finish.
     node::SpinEventLoop(g_env);
+
+    // Surface any unhandled promise rejection captured while the loop ran.
+    // Without this, pragma scripts whose top-level flow is a Promise chain
+    // with no .catch() would exit silently with undefined behavior.
+    if (!t_last_unhandled_rejection.empty()) {
+        t_last_error = t_last_unhandled_rejection;
+        t_last_unhandled_rejection.clear();
+        return nullptr;
+    }
 
     v8::Local<v8::Value> result = maybe.ToLocalChecked();
     if (result->IsUndefined() || result->IsNull()) return strdup("");


### PR DESCRIPTION
## Before
Unhandled promise rejections in `@chadscript: interpret` pragma code vanished silently. A script like `new Promise((_, rej) => rej("boom"))` with no `.catch()` would run, `SpinEventLoop` would drain, and `cs_v8_last_error` stayed empty — the caller treated the script as successful.

## After
V8's `PromiseRejectCallback` is wired on isolate init. Unhandled rejections (event `kPromiseRejectWithNoHandler` — specifically ignoring the `kPromiseHandlerAddedAfterReject` false-positive) are captured into a thread-local. After `SpinEventLoop` returns, both `run_script` and `cs_v8_eval_script_node` propagate the captured rejection into `t_last_error` and fail the call so `cs_v8_last_error` reads it like any synchronous throw.

## Description
~49 LOC, all in `c_bridges/node-bridge.cc`:
- New `thread_local t_last_unhandled_rejection` separate from `t_last_error` so a sync throw isn't clobbered.
- `SetPromiseRejectCallback` installed in `cs_node_lazy_init` right after the Environment is set up.
- Callback filters on `kPromiseRejectWithNoHandler`, stringifies the rejection value.
- Cleared at the start of each eval; propagated + cleared after each eval's `SpinEventLoop`.

Follows the same per-call-clear → run → check-after pattern as existing `try_catch` error handling.

## Test plan
- [x] Reads compile cleanly (visual review against existing patterns in node-bridge.cc).
- [ ] Runtime verification requires a built `vendor/node/` + libnode toolchain. My worktree doesn't have it; node-bridge.cc isn't compiled in CI either (no libnode step in `ci.yml`). Anyone with libnode locally can run a pragma file that rejects without `.catch` and observe that `cs_v8_last_error` now returns the rejection string instead of empty.
- [ ] Follow-up test: a fixture under `tests/fixtures/pragma-interpret/` that asserts a pragma file with an unhandled rejection fails with the expected message (once pragma test infra exists).

Closes #617.

## Next steps / Gaps
- Dedicated fixture under a new `pragma-interpret/` test category once the pragma+libnode path has a CI lane.
- `kPromiseHandlerAddedAfterReject` is ignored so a late `.catch()` doesn't trip the error — but Node's process-level `unhandledRejection` event is NOT forwarded; if a Node handler is attached, V8 still fires the `kPromiseRejectWithNoHandler` event before the handler sees it. Cleaner integration would route through `process.on('unhandledRejection')` instead.
- Multiple rejections in a single eval are collapsed into one — only the last is reported.