### PR TITLE
[benchmarks/pg] add Bun.SQL native variant

### DIFF
--- a/benchmarks/pg-driver/README.md
+++ b/benchmarks/pg-driver/README.md
@@ -4,15 +4,15 @@ SELECT-1 throughput loop, single connection, 10000 iterations, median of 3 runs.
 
 ## Variants
 
-| Variant                               | Command                                         | Notes                       |
-| ------------------------------------- | ----------------------------------------------- | --------------------------- |
-| ChadScript (pure-TS, compiled native) | `chad build bench-chad.ts -o /tmp/b && /tmp/b`  | Simple protocol, text-mode. |
-| pg on Node                            | `node bench-node-pg.mjs`                        | `pg@^8`.                    |
-| postgres.js on Node                   | `node bench-postgres-js.mjs`                    | `postgres@^3`.              |
-| postgres.js on Bun                    | `bun bench-postgres-js.mjs`                     | Same script, Bun runtime.   |
+| Variant                               | Command                                         | Notes                             |
+| ------------------------------------- | ----------------------------------------------- | --------------------------------- |
+| ChadScript (pure-TS, compiled native) | `chad build bench-chad.ts -o /tmp/b && /tmp/b`  | Simple protocol, text-mode.       |
+| pg on Node                            | `node bench-node-pg.mjs`                        | `pg@^8`.                          |
+| postgres.js on Node                   | `node bench-postgres-js.mjs`                    | `postgres@^3`.                    |
+| postgres.js on Bun                    | `bun bench-postgres-js.mjs`                     | Same script, Bun runtime.         |
 | Bun.SQL (native)                      | `bun bench-bun-native.mjs`                      | Bun's first-party C++ pg binding. |
-| C (libpq)                             | `cc bench-c.c ... -lpq -O2 -o /tmp/b && /tmp/b` | Reference ceiling.          |
-| Go (pgx)                              | `cd bench-go && go build -o /tmp/b && /tmp/b`   | `pgx/v5`.                   |
+| C (libpq)                             | `cc bench-c.c ... -lpq -O2 -o /tmp/b && /tmp/b` | Reference ceiling.                |
+| Go (pgx)                              | `cd bench-go && go build -o /tmp/b && /tmp/b`   | `pgx/v5`.                         |
 
 `run-all.sh` drives all of them and prints a summary. Defaults to `PGUSER=csmith PGDATABASE=postgres` — override via env for your pg instance.
 

--- a/benchmarks/pg-driver/README.md
+++ b/benchmarks/pg-driver/README.md
@@ -10,6 +10,7 @@ SELECT-1 throughput loop, single connection, 10000 iterations, median of 3 runs.
 | pg on Node                            | `node bench-node-pg.mjs`                        | `pg@^8`.                    |
 | postgres.js on Node                   | `node bench-postgres-js.mjs`                    | `postgres@^3`.              |
 | postgres.js on Bun                    | `bun bench-postgres-js.mjs`                     | Same script, Bun runtime.   |
+| Bun.SQL (native)                      | `bun bench-bun-native.mjs`                      | Bun's first-party C++ pg binding. |
 | C (libpq)                             | `cc bench-c.c ... -lpq -O2 -o /tmp/b && /tmp/b` | Reference ceiling.          |
 | Go (pgx)                              | `cd bench-go && go build -o /tmp/b && /tmp/b`   | `pgx/v5`.                   |
 
@@ -32,6 +33,7 @@ median_ms=<N> qps=<N>
 | C (libpq)                         | 58,139     |
 | **ChadScript (pure-TS → native)** | **52,023** |
 | postgres.js on Bun                | 48,780     |
+| Bun.SQL (native)                  | 47,170     |
 | pg on Node                        | 37,594     |
 | postgres.js on Node               | 35,587     |
 | Go (pgx)                          | 32,786     |

--- a/benchmarks/pg-driver/bench-bun-native.mjs
+++ b/benchmarks/pg-driver/bench-bun-native.mjs
@@ -1,0 +1,38 @@
+// Bun's built-in native Postgres client (Bun.SQL). Only runs under Bun.
+// Different from the `postgres` npm package — this is Bun's first-party
+// C++-backed binding, so the fair comparison to libpq and chadscript-native.
+//   bun bench-bun-native.mjs
+import { SQL } from "bun";
+
+const ITERS = 10000;
+const RUNS = 3;
+
+if (globalThis.Bun === undefined) {
+  console.error("bun-native bench requires Bun runtime");
+  process.exit(1);
+}
+
+async function runOnce() {
+  const client = new SQL({
+    host: "127.0.0.1",
+    port: 5432,
+    user: process.env.PGUSER ?? "postgres",
+    database: process.env.PGDATABASE ?? "postgres",
+    password: process.env.PGPASSWORD ?? "",
+    max: 1,
+  });
+  await client`SELECT 1`;
+  const t0 = Date.now();
+  for (let i = 0; i < ITERS; i++) await client`SELECT 1`;
+  const t1 = Date.now();
+  await client.end();
+  return t1 - t0;
+}
+
+const results = [];
+for (let r = 0; r < RUNS; r++) results.push(await runOnce());
+results.sort((a, b) => a - b);
+const mid = results[1];
+console.log(`bun-native iters=${ITERS} runs=${RUNS}`);
+console.log(`runs_ms=${results.join(",")}`);
+console.log(`median_ms=${mid} qps=${(ITERS / (mid / 1000)).toFixed(0)}`);

--- a/benchmarks/pg-driver/run-all.sh
+++ b/benchmarks/pg-driver/run-all.sh
@@ -34,6 +34,7 @@ run "postgres.js on Node" node bench-postgres-js.mjs
 # bun
 if command -v bun >/dev/null 2>&1; then
     run "postgres.js on Bun" bun bench-postgres-js.mjs
+    run "Bun.SQL native" bun bench-bun-native.mjs
 else
     echo "▸ bun — SKIPPED (bun not in PATH)" | tee -a $OUT
 fi


### PR DESCRIPTION
## Before
Bench suite covered postgres.js-on-Bun but not Bun's first-party `Bun.SQL` binding (different library, C++-backed inside Bun).

## After
New `bench-bun-native.mjs` + wired into `run-all.sh`. Uses `new SQL({...})` tagged-template API from the `"bun"` module.

## Results (macOS M-series, same pg instance as #635)

| Variant | qps |
|---|---|
| C (libpq) | 58,139 |
| **ChadScript (pure-TS → native)** | **52,023** |
| postgres.js on Bun | 48,780 |
| Bun.SQL (native) | 47,170 |
| pg on Node | 37,594 |
| postgres.js on Node | 35,587 |
| Go (pgx) | 32,786 |

Surprising: `Bun.SQL` native binding underperforms the pure-JS `postgres` package on Bun, and is ~10% slower than our ChadScript pure-TS driver. Likely the `Bun.SQL` connection-per-query path or some always-on connection pool overhead — single-conn tight loop isn't its happy case.

## Test plan
- [x] `PGUSER=csmith PGDATABASE=postgres PGPASSWORD="" bun bench-bun-native.mjs` runs and prints `median_ms=<N> qps=<N>`.
- [x] `run-all.sh` picks up the new variant when `bun` is on PATH.

## Next steps / Gaps
- Investigate why Bun.SQL is slower than postgres.js-on-Bun — maybe always-prepared-statement path, or connection-keepalive config.
- Add tokio-postgres (Rust) and mysql2 (Node) variants.
- Multi-conn / concurrent-query workloads to exercise the pool side.