### PR TITLE
[codegen] support string | null with narrowing

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -14,6 +14,7 @@ import {
 import { IGeneratorContext } from "../infrastructure/generator-context.js";
 import {
   stripNullable,
+  isNullableType,
   mapParamTypeToLLVM,
   mapReturnTypeToLLVM,
 } from "../infrastructure/type-system.js";
@@ -1174,14 +1175,21 @@ export class CallExpressionGenerator {
     // from C should round-trip to TS as the empty string so `result === ""`
     // works reliably. Only applied to user-declared extern functions (not
     // internal runtime calls, which rely on NULL sentinels internally).
+    // SKIP this coercion when the declared return type is `string | null` —
+    // those callers explicitly want to observe NULL as JS null.
     if (returnType === "i8*" && func && func.declare) {
-      const emptyStr = this.ctx.stringGen.doCreateStringConstant("");
-      const isNull = this.ctx.nextTemp();
-      this.ctx.emit(`${isNull} = icmp eq i8* ${temp}, null`);
-      const coerced = this.ctx.nextTemp();
-      this.ctx.emit(`${coerced} = select i1 ${isNull}, i8* ${emptyStr}, i8* ${temp}`);
-      this.ctx.setVariableType(coerced, "i8*");
-      return coerced;
+      const declaredRet = func.returnType || "";
+      if (!isNullableType(declaredRet)) {
+        const emptyStr = this.ctx.stringGen.doCreateStringConstant("");
+        const isNull = this.ctx.nextTemp();
+        this.ctx.emit(`${isNull} = icmp eq i8* ${temp}, null`);
+        const coerced = this.ctx.nextTemp();
+        this.ctx.emit(`${coerced} = select i1 ${isNull}, i8* ${emptyStr}, i8* ${temp}`);
+        this.ctx.setVariableType(coerced, "i8*");
+        return coerced;
+      }
+      this.ctx.setVariableType(temp, "i8*");
+      return temp;
     }
 
     return temp;

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -15,6 +15,18 @@ export function stripNullable(t: string): string {
   return str.trim();
 }
 
+// Returns true when the TS type annotation includes ` | null` (before or after
+// the base type). Used to decide whether to skip NULL-coercion paths (e.g.
+// FFI NULL → "" on user extern returns) so that user code can distinguish
+// "no value" from "empty string" for `string | null` annotations.
+export function isNullableType(t: string): boolean {
+  if (!t) return false;
+  const str = t.trim();
+  if (str.indexOf(" | null") !== -1) return true;
+  if (str.indexOf("null | ") !== -1) return true;
+  return false;
+}
+
 interface TypeQualifiers {
   isNullable: boolean;
   isOptional: boolean;

--- a/tests/fixtures/types/nullable-string-assignment.ts
+++ b/tests/fixtures/types/nullable-string-assignment.ts
@@ -1,0 +1,9 @@
+// @test-description: string | null accepts null literal and string values
+const a: string | null = null;
+const b: string | null = "hello";
+
+if (a === null) {
+  if (b !== null) {
+    console.log("TEST_PASSED");
+  }
+}

--- a/tests/fixtures/types/nullable-string-ffi.ts
+++ b/tests/fixtures/types/nullable-string-ffi.ts
@@ -1,0 +1,14 @@
+// @test-description: FFI `declare function f(): string | null` round-trips C NULL to js null
+declare function getenv(name: string): string | null;
+
+// HOME is virtually always set on POSIX; use a nonsense name for the null case.
+const home = getenv("HOME");
+const missing = getenv("THIS_VAR_DEFINITELY_DOES_NOT_EXIST_ZZZZ");
+
+let ok = true;
+if (home === null) ok = false;
+if (missing !== null) ok = false;
+
+if (ok && home !== null && home.length > 0) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/types/nullable-string-narrowing.ts
+++ b/tests/fixtures/types/nullable-string-narrowing.ts
@@ -1,0 +1,18 @@
+// @test-description: string | null narrows to string after !== null guard
+function maybeStr(flag: boolean): string | null {
+  if (flag) return "hello";
+  return null;
+}
+
+const a = maybeStr(true);
+let passed = false;
+if (a !== null) {
+  // After the narrowing guard, string methods must work on `a`.
+  if (a.length === 5 && a.toUpperCase() === "HELLO") {
+    passed = true;
+  }
+}
+const b = maybeStr(false);
+if (b === null && passed) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/types/nullable-string-vs-empty.ts
+++ b/tests/fixtures/types/nullable-string-vs-empty.ts
@@ -1,0 +1,12 @@
+// @test-description: null is distinct from empty string under ===
+const empty: string = "";
+const missing: string | null = null;
+
+// Per #599 requirement 5: `empty === missing` must be false.
+let passed = true;
+if ((empty as string | null) === missing) passed = false;
+if (missing === (empty as string | null)) passed = false;
+if (missing !== null) passed = false;
+if (empty === null) passed = false;
+
+if (passed) console.log("TEST_PASSED");


### PR DESCRIPTION
Closes #599

## Before
`string | null` only partially worked. Extern functions declared to return `string | null` still had their NULL returns coerced to `""` by the FFI null-safety path in `CallExpressionGenerator`, so callers could not distinguish "no value" from "empty string". Fixtures exercising the five #599 requirements did not exist.

## After
User extern functions declared with a nullable return type (`string | null`) now return raw pointer results: a C `NULL` observes as JS `null`, a non-null pointer observes as the string. The existing NULL → `""` coercion remains for non-nullable `string` returns (prevents segfaults when user code doesn't guard). Added four fixtures covering assignment, narrowing via `!== null`, FFI null round-trip (`getenv`), and `"" === null` distinctness. All pass under both node and native compilers, full `npm run verify` (including Stage 2 self-hosting) is green.

Covers all 5 requirements from #599:
1. `string | null` annotation typechecks — works (handled upstream in parser/type-system via `stripNullable`).
2. `const x: string | null = null;` compiles + runs — `nullable-string-assignment.ts`.
3. `!== null` narrowing gives string methods — `nullable-string-narrowing.ts` (`a.length`, `a.toUpperCase()`).
4. FFI NULL → js null — `nullable-string-ffi.ts` (`getenv`).
5. `"" === null` is false — `nullable-string-vs-empty.ts`.

## Description
Adds `isNullableType(t)` helper in `src/codegen/infrastructure/type-system.ts`. In `src/codegen/expressions/calls.ts`, gates the FFI NULL-to-empty-string coercion on `!isNullableType(func.returnType)` so that `declare function f(): string | null` preserves NULL at the IR level and lets downstream `=== null` comparisons observe the actual pointer. Non-nullable extern declarations retain existing coercion behavior. ~30 LOC prod + 4 fixtures.