### PR TITLE
[codegen] emit compile error for module-scope Map<number, string>

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2638,6 +2638,11 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
             continue;
           }
         } else if (isMap) {
+          let declaredKeyType: string | null = null;
+          if (stmt.declaredType) {
+            const parsedDecl = parseMapTypeString(stmt.declaredType);
+            if (parsedDecl) declaredKeyType = parsedDecl.keyType;
+          }
           let isStringMap = false;
           let mapValueType = "string";
           if (stmt.declaredType) {
@@ -2648,14 +2653,14 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               if (parsed) mapValueType = parsed.valueType;
             }
           }
-          if (!isStringMap && stmt.value) {
+          if (!isStringMap && declaredKeyType === null && stmt.value) {
             const mapNode = stmt.value as MapNode;
             if (mapNode.keyType === "string") {
               isStringMap = true;
               mapValueType = mapNode.valueType || "string";
             }
           }
-          if (!isStringMap && resolvedBase.startsWith("Map<")) {
+          if (!isStringMap && declaredKeyType === null && resolvedBase.startsWith("Map<")) {
             const parsed = parseMapTypeString(resolvedBase);
             if (parsed && parsed.keyType === "string") {
               isStringMap = true;
@@ -2695,7 +2700,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               pointerMapValueType = parsed.valueType;
             }
           }
-          if (!isPointerMap && resolvedBase.startsWith("Map<")) {
+          if (!isPointerMap && declaredKeyType === null && resolvedBase.startsWith("Map<")) {
             const parsed = parseMapTypeString(resolvedBase);
             if (parsed && parsed.keyType !== "string" && parsed.keyType !== "number") {
               isPointerMap = true;

--- a/tests/fixtures/edge-cases/map-number-string-error-module-scope.ts
+++ b/tests/fixtures/edge-cases/map-number-string-error-module-scope.ts
@@ -1,0 +1,5 @@
+// @test-description: Map<number, string> at module scope should emit compile error
+// @test-compile-error: Map<number, string> is not supported
+const m: Map<number, string> = new Map();
+m.set(1, "one");
+console.log(m.get(1));


### PR DESCRIPTION
## Before
`const m: Map<number, string> = new Map();` at module scope produced invalid LLVM IR that failed at the `clang` stage with a cryptic message:
```
error: '%18' defined with type 'i64' but expected 'ptr'
  %42 = call i32 @__string_hash(i8* %18)
```
The same code inside a function already emitted a clean compile error, but the module-scope path in `generateGlobalVariableDeclarations` let the inferred `Map<string, string>` from the bare `new Map()` RHS win over the declared `Map<number, string>`, routing the variable into the string-map generator with numeric keys.

## After
Module-scope `Map<number, string>` (and other unsupported `Map<number, X>` where `X` is not `number`/`boolean`) now emits the same clean compile error as the function-scope path: `Map<number, string> is not supported. Use Map<string, string> instead`.

## Description
In `generateGlobalVariableDeclarations`, parse the declared type's key type once up front. When it is set, do not let the inferred `resolvedBase` or map-literal key type override it into the string-map / pointer-map branches. This keeps the flow on the numeric-map path where the existing validation fires.

Closes Step 3a of #640.