### PR TITLE
[codegen] propagate concreteClass through closure capture

### DIFF
--- a/src/codegen/expressions/arrow-functions.ts
+++ b/src/codegen/expressions/arrow-functions.ts
@@ -73,6 +73,7 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
     scopeVarNames?: string[],
     scopeVarTypes?: string[],
     scopeVarInterfaceTypes?: string[],
+    scopeVarConcreteClasses?: string[],
   ): string {
     const funcName = `__lambda_${this.anonFuncCounter++}`;
 
@@ -129,6 +130,7 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
         scopeVarTypes,
         funcName,
         scopeVarInterfaceTypes,
+        scopeVarConcreteClasses,
       );
       closureCaptures = analyzeResult.captures;
       closureEnvStructName = analyzeResult.envStructName;

--- a/src/codegen/expressions/method-calls/promise-handlers.ts
+++ b/src/codegen/expressions/method-calls/promise-handlers.ts
@@ -169,7 +169,12 @@ export function handlePromiseThen(
 
   const promiseCallbackTypes = { paramTypes: ["string", "any"], returnType: "void" };
   const scopeVarsResult = ctx.symbolTable.getScopeVarsArraysForClosure();
-  const scopeVarsTyped = scopeVarsResult as { names: string[]; types: string[] };
+  const scopeVarsTyped = scopeVarsResult as {
+    names: string[];
+    types: string[];
+    interfaceTypes: string[];
+    concreteClasses: string[];
+  };
 
   if (isCatch) {
     if (expr.args.length > 0) {
@@ -182,6 +187,8 @@ export function handlePromiseThen(
           promiseCallbackTypes,
           scopeVarsTyped.names,
           scopeVarsTyped.types,
+          scopeVarsTyped.interfaceTypes,
+          scopeVarsTyped.concreteClasses,
         );
         onRejected = `@${ctx.mangleUserName(callbackName)}`;
       } else if (callbackBase.type === "variable") {
@@ -199,6 +206,8 @@ export function handlePromiseThen(
           promiseCallbackTypes,
           scopeVarsTyped.names,
           scopeVarsTyped.types,
+          scopeVarsTyped.interfaceTypes,
+          scopeVarsTyped.concreteClasses,
         );
         onFulfilled = `@${ctx.mangleUserName(callbackName)}`;
       } else if (callbackBase.type === "variable") {
@@ -215,6 +224,8 @@ export function handlePromiseThen(
           promiseCallbackTypes,
           scopeVarsTyped.names,
           scopeVarsTyped.types,
+          scopeVarsTyped.interfaceTypes,
+          scopeVarsTyped.concreteClasses,
         );
         onRejected = `@${ctx.mangleUserName(callbackName)}`;
       } else if (callbackBase.type === "variable") {
@@ -257,7 +268,12 @@ export function handlePromiseFinally(
   // finally callbacks take no meaningful args but need void(i8*,i8*)* signature
   const finallyCallbackTypes = { paramTypes: ["string", "string"], returnType: "void" };
   const scopeVarsResult = ctx.symbolTable.getScopeVarsArraysForClosure();
-  const scopeVarsTyped = scopeVarsResult as { names: string[]; types: string[] };
+  const scopeVarsTyped = scopeVarsResult as {
+    names: string[];
+    types: string[];
+    interfaceTypes: string[];
+    concreteClasses: string[];
+  };
 
   if (expr.args.length > 0) {
     const callback = expr.args[0] as Expression;
@@ -269,6 +285,8 @@ export function handlePromiseFinally(
         finallyCallbackTypes,
         scopeVarsTyped.names,
         scopeVarsTyped.types,
+        scopeVarsTyped.interfaceTypes,
+        scopeVarsTyped.concreteClasses,
       );
       userCallback = `@${ctx.mangleUserName(callbackName)}`;
     } else if (callbackBase.type === "variable") {

--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -234,6 +234,7 @@ export class ExpressionGenerator {
       names: string[];
       types: string[];
       interfaceTypes: string[];
+      concreteClasses: string[];
     };
     let typeHints: { paramTypes?: string[]; returnType?: string } | undefined = undefined;
     const cbParamTypes = this.ctx.getExpectedCallbackParamTypes();
@@ -257,6 +258,7 @@ export class ExpressionGenerator {
       scopeVarsTyped.names,
       scopeVarsTyped.types,
       scopeVarsTyped.interfaceTypes,
+      scopeVarsTyped.concreteClasses,
     );
 
     const closureInfoResult = this.arrowFunctionGen.getClosureInfoForLambda(lambdaName);

--- a/src/codegen/infrastructure/closure-analyzer.ts
+++ b/src/codegen/infrastructure/closure-analyzer.ts
@@ -31,6 +31,7 @@ export interface CapturedVariable {
   name: string;
   llvmType: string;
   interfaceType?: string;
+  concreteClass?: string;
 }
 
 export interface ClosureInfo {
@@ -44,6 +45,7 @@ export class ClosureAnalyzer {
   private scopeVarNames: string[] = [];
   private scopeVarTypes: string[] = [];
   private scopeVarInterfaceTypes: string[] = [];
+  private scopeVarConcreteClasses: string[] = [];
 
   constructor() {
     this.declaredVars = new Set();
@@ -56,6 +58,7 @@ export class ClosureAnalyzer {
     scopeVarTypesIn: string[],
     lambdaName: string,
     scopeVarInterfaceTypesIn?: string[],
+    scopeVarConcreteClassesIn?: string[],
   ): ClosureInfo {
     this.declaredVars = new Set();
     this.referencedVarsList = [];
@@ -63,11 +66,15 @@ export class ClosureAnalyzer {
     this.scopeVarNames = [];
     this.scopeVarTypes = [];
     this.scopeVarInterfaceTypes = [];
+    this.scopeVarConcreteClasses = [];
     for (let i = 0; i < scopeVarNamesIn.length; i++) {
       this.scopeVarNames.push(scopeVarNamesIn[i]);
       this.scopeVarTypes.push(scopeVarTypesIn[i]);
       this.scopeVarInterfaceTypes.push(
         scopeVarInterfaceTypesIn ? scopeVarInterfaceTypesIn[i] || "" : "",
+      );
+      this.scopeVarConcreteClasses.push(
+        scopeVarConcreteClassesIn ? scopeVarConcreteClassesIn[i] || "" : "",
       );
     }
 
@@ -88,10 +95,12 @@ export class ClosureAnalyzer {
       if (!this.declaredVars.has(varName) && this.hasScopeVar(varName)) {
         const idx = this.scopeVarNames.indexOf(varName);
         const ifaceType = idx >= 0 ? this.scopeVarInterfaceTypes[idx] : "";
+        const concreteCls = idx >= 0 ? this.scopeVarConcreteClasses[idx] : "";
         captures.push({
           name: varName,
           llvmType: this.getScopeVarType(varName),
           interfaceType: ifaceType || undefined,
+          concreteClass: concreteCls || undefined,
         });
       }
     }

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -701,8 +701,24 @@ export class FunctionGenerator {
         this.ctx.emit(`store ${capture.llvmType} ${valueReg}, ${capture.llvmType}* ${allocaReg}`);
 
         const kind = this.llvmTypeToSymbolKind(capture.llvmType);
-        this.ctx.defineVariable(capture.name, allocaReg, capture.llvmType, kind, "local");
-        const captureTyped = capture as { name: string; llvmType: string; interfaceType?: string };
+        const captureTyped = capture as {
+          name: string;
+          llvmType: string;
+          interfaceType?: string;
+          concreteClass?: string;
+        };
+        if (captureTyped.concreteClass) {
+          this.ctx.defineVariableWithMetadata(
+            capture.name,
+            allocaReg,
+            capture.llvmType,
+            kind,
+            "local",
+            createClassMetadata({ className: captureTyped.concreteClass }),
+          );
+        } else {
+          this.ctx.defineVariable(capture.name, allocaReg, capture.llvmType, kind, "local");
+        }
         if (captureTyped.interfaceType && capture.llvmType === "%ObjectArray*") {
           this.ctx.setRawInterfaceType(capture.name, captureTyped.interfaceType);
         }

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -258,6 +258,8 @@ export interface IArrowFunctionGenerator {
     typeHints: { paramTypes?: string[]; returnType?: string } | undefined,
     scopeVarNames: string[] | undefined,
     scopeVarTypes: string[] | undefined,
+    scopeVarInterfaceTypes?: string[],
+    scopeVarConcreteClasses?: string[],
   ): string;
   getClosureInfoForLambda(
     lambdaName: string,

--- a/src/codegen/infrastructure/symbol-table.ts
+++ b/src/codegen/infrastructure/symbol-table.ts
@@ -1522,10 +1522,16 @@ export class SymbolTable {
     return scopeVars;
   }
 
-  getScopeVarsArraysForClosure(): { names: string[]; types: string[]; interfaceTypes: string[] } {
+  getScopeVarsArraysForClosure(): {
+    names: string[];
+    types: string[];
+    interfaceTypes: string[];
+    concreteClasses: string[];
+  } {
     const names: string[] = [];
     const types: string[] = [];
     const interfaceTypes: string[] = [];
+    const concreteClasses: string[] = [];
     for (let i = 0; i < this.symbolKeys.length; i++) {
       const name = this.symbolKeys[i];
       if (!name) {
@@ -1536,9 +1542,18 @@ export class SymbolTable {
         names.push(name);
         types.push(symbol.llvmType);
         interfaceTypes.push(this.interfaceTypes.get(name) || "");
+        let cc = "";
+        if (symbol.concreteClass) cc = symbol.concreteClass;
+        else if (symbol.classMetadata) cc = symbol.classMetadata.className;
+        concreteClasses.push(cc);
       }
     }
-    return { names: names, types: types, interfaceTypes: interfaceTypes };
+    return {
+      names: names,
+      types: types,
+      interfaceTypes: interfaceTypes,
+      concreteClasses: concreteClasses,
+    };
   }
 
   /**

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -107,6 +107,8 @@ interface ArrowFunctionGeneratorLike {
     returnType?: string | { paramTypes?: string[]; returnType?: string },
     scopeVarNames?: string[],
     scopeVarTypes?: string[],
+    scopeVarInterfaceTypes?: string[],
+    scopeVarConcreteClasses?: string[],
   ): string;
   getClosureInfoForLambda(lambdaName: string): ClosureInfoResult | null;
   getLiftedFunctionByName(name: string): { returnType?: string } | undefined;
@@ -1971,13 +1973,20 @@ export class VariableAllocator {
   private allocateArrowFunction(stmt: VariableDeclaration, params: string[]): void {
     if (!stmt.value) return;
     const scopeVarsResult = this.ctx.symbolTable.getScopeVarsArraysForClosure();
-    const scopeVarsTyped = scopeVarsResult as { names: string[]; types: string[] };
+    const scopeVarsTyped = scopeVarsResult as {
+      names: string[];
+      types: string[];
+      interfaceTypes: string[];
+      concreteClasses: string[];
+    };
     const lambdaName = this.ctx.arrowFunctionGen.generateArrowFunction(
       stmt.value,
       params,
       undefined,
       scopeVarsTyped.names,
       scopeVarsTyped.types,
+      scopeVarsTyped.interfaceTypes,
+      scopeVarsTyped.concreteClasses,
     );
 
     const closureInfoResult = this.ctx.arrowFunctionGen.getClosureInfoForLambda(lambdaName);

--- a/tests/fixtures/closures-cabi/setinterval-capture-class-field-store.ts
+++ b/tests/fixtures/closures-cabi/setinterval-capture-class-field-store.ts
@@ -1,0 +1,23 @@
+// @test-description: setInterval result stored in class-field via captured class ptr; closure reads class field type via concreteClass plumbing
+class T {
+  h: string = "";
+  n: number = 0;
+}
+
+const t = new T();
+
+t.h = setInterval(() => {
+  t.n = t.n + 1;
+}, 10);
+
+setTimeout(() => {
+  clearInterval(t.h);
+}, 200);
+
+runEventLoop();
+
+if (t.n >= 3) {
+  console.log("TEST_PASSED");
+} else {
+  console.log("FAIL: n=" + t.n);
+}


### PR DESCRIPTION
## Before
An arrow function that captures a class instance by value and accesses a field on it emitted silently-wrong IR. The captured local alloca was registered with `SymbolKind_Object` but without the concrete class name, so the member-access path couldn't find a GEP for the field and degenerated to loading the alloca as whatever type the field nominally was. For `string` fields this produced garbage/segfault. Repro — both of these misbehaved on main:

```ts
class T { h: string = ""; n: number = 0; }
const t = new T();
t.h = setInterval(() => { t.n = t.n + 1; }, 10);
setTimeout(() => { clearInterval(t.h); }, 200);
runEventLoop();
```

and even simpler:

```ts
class T { h: string = "hello"; }
const t = new T();
setTimeout(() => { console.log(t.h); }, 10); // prints garbage
```

## After
Captured class instances retain their concrete class in the inner scope, so `capturedVar.field` generates the correct GEP + load. setInterval handle capture works, and the minimal `console.log(t.h)` repro prints the string correctly.

## Description
Closes Step 3b of #640. Threads the `concreteClass` of scope vars from the outer symbol table through `ClosureAnalyzer` and into the capture records, then calls `defineVariableWithMetadata(..., createClassMetadata({className}))` instead of plain `defineVariable` when re-binding the capture inside the lambda body.

~60 LOC plumbing across `closure-analyzer`, `symbol-table.getScopeVarsArraysForClosure`, `arrow-functions.generateArrowFunction`, and `function-generator`'s capture-by-value loop. All existing callers of `generateArrowFunction` updated to forward the new field.

Fixture: `tests/fixtures/closures-cabi/setinterval-capture-class-field-store.ts`.

Verified: `npm run verify:quick` green, full `bash scripts/self-hosting.sh` (stages 0/1/2) green.