### PR TITLE
[codegen] add emitSymbol/emitOperand helpers + migrate math/process stdlib

### DIFF
--- a/src/codegen/infrastructure/base-generator.ts
+++ b/src/codegen/infrastructure/base-generator.ts
@@ -553,6 +553,15 @@ export class BaseGenerator {
     return temp;
   }
 
+  emitSymbol(name: string, sigil: string): string {
+    if (name.length > 0 && (name[0] === "@" || name[0] === "%")) return name;
+    return `${sigil}${name}`;
+  }
+
+  emitOperand(value: string, llvmType: string): string {
+    return `${llvmType} ${value}`;
+  }
+
   // ============================================
   // Symbol table convenience methods
   // ============================================

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -731,6 +731,8 @@ export interface IGeneratorContext {
   emitGep(baseType: string, ptr: string, indices: string): string;
   emitIcmp(pred: string, type: string, lhs: string, rhs: string): string;
   emitBitcast(value: string, fromType: string, toType: string): string;
+  emitSymbol(name: string, sigil: string): string;
+  emitOperand(value: string, llvmType: string): string;
 
   getOutput(): string[];
   clearOutput(): void;
@@ -1746,6 +1748,15 @@ export class MockGeneratorContext implements IGeneratorContext {
     this.emit(`${temp} = bitcast ${fromType} ${value} to ${toType}`);
     this.setVariableType(temp, toType);
     return temp;
+  }
+
+  emitSymbol(name: string, sigil: string): string {
+    if (name.length > 0 && (name[0] === "@" || name[0] === "%")) return name;
+    return `${sigil}${name}`;
+  }
+
+  emitOperand(value: string, llvmType: string): string {
+    return `${llvmType} ${value}`;
   }
 
   getOutput(): string[] {

--- a/src/codegen/stdlib/math.ts
+++ b/src/codegen/stdlib/math.ts
@@ -109,10 +109,7 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.sqrt.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.sqrt.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   /**
@@ -126,10 +123,8 @@ export class MathGenerator {
     const exp = this.ctx.generateExpression(expr.args[1], params);
     const dblBase = this.ctx.ensureDouble(base);
     const dblExp = this.ctx.ensureDouble(exp);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.pow.f64(double ${dblBase}, double ${dblExp})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    const args = `${this.ctx.emitOperand(dblBase, "double")}, ${this.ctx.emitOperand(dblExp, "double")}`;
+    return this.ctx.emitCall("double", "@llvm.pow.f64", args);
   }
 
   /**
@@ -141,10 +136,7 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.floor.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.floor.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   /**
@@ -156,10 +148,7 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.ceil.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.ceil.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   /**
@@ -171,10 +160,7 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.round.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.round.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   /**
@@ -186,10 +172,7 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.fabs.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.fabs.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   private generateMax(expr: MethodCallNode, params: string[]): string {
@@ -199,9 +182,8 @@ export class MathGenerator {
     let current = this.ctx.ensureDouble(this.ctx.generateExpression(expr.args[0], params));
     for (let i = 1; i < expr.args.length; i++) {
       const next = this.ctx.ensureDouble(this.ctx.generateExpression(expr.args[i], params));
-      const result = this.ctx.nextTemp();
-      this.ctx.emit(`${result} = call double @llvm.maximum.f64(double ${current}, double ${next})`);
-      current = result;
+      const args = `${this.ctx.emitOperand(current, "double")}, ${this.ctx.emitOperand(next, "double")}`;
+      current = this.ctx.emitCall("double", "@llvm.maximum.f64", args);
     }
     return current;
   }
@@ -212,18 +194,12 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.trunc.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.trunc.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   private generateRandom(expr: MethodCallNode): string {
     this.ctx.setUsesMathRandom(true);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @drand48()`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@drand48", "");
   }
 
   private generateSign(expr: MethodCallNode, params: string[]): string {
@@ -232,18 +208,23 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
+    const dblOp = this.ctx.emitOperand(dblArg, "double");
     const isNaN = this.ctx.nextTemp();
-    this.ctx.emit(`${isNaN} = fcmp uno double ${dblArg}, ${dblArg}`);
+    this.ctx.emit(`${isNaN} = fcmp uno ${dblOp}, ${dblArg}`);
     const isPos = this.ctx.nextTemp();
-    this.ctx.emit(`${isPos} = fcmp ogt double ${dblArg}, 0.0`);
+    this.ctx.emit(`${isPos} = fcmp ogt ${dblOp}, 0.0`);
     const isNeg = this.ctx.nextTemp();
-    this.ctx.emit(`${isNeg} = fcmp olt double ${dblArg}, 0.0`);
+    this.ctx.emit(`${isNeg} = fcmp olt ${dblOp}, 0.0`);
     const posVal = this.ctx.nextTemp();
     this.ctx.emit(`${posVal} = select i1 ${isPos}, double 1.0, double 0.0`);
     const negVal = this.ctx.nextTemp();
-    this.ctx.emit(`${negVal} = select i1 ${isNeg}, double -1.0, double ${posVal}`);
+    this.ctx.emit(
+      `${negVal} = select i1 ${isNeg}, double -1.0, ${this.ctx.emitOperand(posVal, "double")}`,
+    );
     const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = select i1 ${isNaN}, double 0x7FF8000000000000, double ${negVal}`);
+    this.ctx.emit(
+      `${result} = select i1 ${isNaN}, double 0x7FF8000000000000, ${this.ctx.emitOperand(negVal, "double")}`,
+    );
     return result;
   }
 
@@ -253,10 +234,7 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.log.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.log.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   private generateSin(expr: MethodCallNode, params: string[]): string {
@@ -265,10 +243,7 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.sin.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.sin.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   private generateCos(expr: MethodCallNode, params: string[]): string {
@@ -277,10 +252,7 @@ export class MathGenerator {
     }
     const arg = this.ctx.generateExpression(expr.args[0], params);
     const dblArg = this.ctx.ensureDouble(arg);
-    const result = this.ctx.nextTemp();
-    this.ctx.emit(`${result} = call double @llvm.cos.f64(double ${dblArg})`);
-    this.ctx.setVariableType(result, "double");
-    return result;
+    return this.ctx.emitCall("double", "@llvm.cos.f64", this.ctx.emitOperand(dblArg, "double"));
   }
 
   private generateMin(expr: MethodCallNode, params: string[]): string {
@@ -290,9 +262,8 @@ export class MathGenerator {
     let current = this.ctx.ensureDouble(this.ctx.generateExpression(expr.args[0], params));
     for (let i = 1; i < expr.args.length; i++) {
       const next = this.ctx.ensureDouble(this.ctx.generateExpression(expr.args[i], params));
-      const result = this.ctx.nextTemp();
-      this.ctx.emit(`${result} = call double @llvm.minimum.f64(double ${current}, double ${next})`);
-      current = result;
+      const args = `${this.ctx.emitOperand(current, "double")}, ${this.ctx.emitOperand(next, "double")}`;
+      current = this.ctx.emitCall("double", "@llvm.minimum.f64", args);
     }
     return current;
   }

--- a/src/codegen/stdlib/process.ts
+++ b/src/codegen/stdlib/process.ts
@@ -54,17 +54,19 @@ export class ProcessGenerator {
       // Optimization: Use constant 0 directly
       this.ctx.emit(`${exitCode} = add i32 0, 0`);
     } else {
-      this.ctx.emit(`${exitCode} = fptosi double ${dblExit} to i32`);
+      this.ctx.emit(`${exitCode} = fptosi ${this.ctx.emitOperand(dblExit, "double")} to i32`);
     }
 
     // Flush stdout before exiting to ensure all output is printed
-    const stdoutPtr = this.ctx.nextTemp();
-    this.ctx.emit(`${stdoutPtr} = load i8*, i8** @stdout`);
-    const flushResult = this.ctx.nextTemp();
-    this.ctx.emit(`${flushResult} = call i32 @fflush(i8* ${stdoutPtr})`);
+    const stdoutPtr = this.ctx.emitLoad("i8*", this.ctx.emitSymbol("stdout", "@"));
+    this.ctx.emitCall(
+      "i32",
+      this.ctx.emitSymbol("fflush", "@"),
+      this.ctx.emitOperand(stdoutPtr, "i8*"),
+    );
 
     // Call exit syscall (noreturn)
-    this.ctx.emit(`call void @exit(i32 ${exitCode})`);
+    this.ctx.emitCallVoid(this.ctx.emitSymbol("exit", "@"), this.ctx.emitOperand(exitCode, "i32"));
 
     return "0.0";
   }


### PR DESCRIPTION
## Before
Codegen emitted typed LLVM operands via ad-hoc template literals (`` `double ${x}` ``, `` `@${name}` ``) scattered across ~170+ sites. Easy to get the wrong sigil or forget the type prefix, and no single place to hook mangling/validation later.

## After
No user-facing change. Internal refactor only. Two new helpers on `BaseGenerator` + `IGeneratorContext` + `MockGeneratorContext`:

- `emitOperand(value, llvmType)` -> `"<type> <value>"`
- `emitSymbol(name, sigil)` -> `"<sigil><name>"` (idempotent if `name` already starts with `@`/`%`)

Pilot migration of `src/codegen/stdlib/math.ts` and `src/codegen/stdlib/process.ts` proves the pattern. Stage 2 self-hosting stays green.

## Description
Begins Step 2 of #640 (pilot). Scope is intentionally small (~150 LOC) so the helper design can be validated on two self-contained files before the wider ~500-1500 LOC per-file migration begins. Follow-ups will migrate the 22 other codegen files that still concatenate operand strings inline.

Helpers are pure-string utilities — no mangling or validation beyond the `@`/`%` sigil idempotence guard. If future work needs name mangling (e.g. underscore-prefix checks like in symbol-generator), `emitSymbol` is the single choke point to add it. Flagged for later: the sigil/mangle interaction.

Retires no CLAUDE.md rule yet, but sets up the future retirement of "forgot to mangle / wrong sigil" bug class called out in #640.

## Verification
`npm run verify` (full, stage 2 included) green locally.