### PR TITLE
[codegen] migrate stdlib/fs,child-process,crypto to emitsymbol/emitoperand helpers

### DIFF
--- a/src/codegen/stdlib/child-process.ts
+++ b/src/codegen/stdlib/child-process.ts
@@ -223,7 +223,9 @@ export class ChildProcessGenerator {
     if (argBase.type === "variable") {
       const fnName = this.ctx.mangleUserName((arg as VariableNode).name);
       const bc = this.ctx.nextTemp();
-      this.ctx.emit(`${bc} = bitcast ${bareFnLlvm} @${fnName} to i8*`);
+      this.ctx.emit(
+        `${bc} = bitcast ${this.ctx.emitOperand(this.ctx.emitSymbol(fnName, "@"), bareFnLlvm)} to i8*`,
+      );
       return { fnPtrI8: bc, handle: "-1" };
     }
 
@@ -264,7 +266,9 @@ export class ChildProcessGenerator {
     // `void(payload)` signature and the bridge invokes it directly.
     if (!envPtrRaw) {
       const bc = this.ctx.nextTemp();
-      this.ctx.emit(`${bc} = bitcast ${bareFnLlvm} @${this.ctx.mangleUserName(lambdaName)} to i8*`);
+      this.ctx.emit(
+        `${bc} = bitcast ${this.ctx.emitOperand(this.ctx.emitSymbol(this.ctx.mangleUserName(lambdaName), "@"), bareFnLlvm)} to i8*`,
+      );
       return { fnPtrI8: bc, handle: "-1" };
     }
 
@@ -294,7 +298,7 @@ export class ChildProcessGenerator {
     // Bitcast the lifted lambda's fn ptr to i8* before storing.
     const fnI8 = this.ctx.nextTemp();
     this.ctx.emit(
-      `${fnI8} = bitcast ${liftedFnLlvm} @${this.ctx.mangleUserName(lambdaName)} to i8*`,
+      `${fnI8} = bitcast ${this.ctx.emitOperand(this.ctx.emitSymbol(this.ctx.mangleUserName(lambdaName), "@"), liftedFnLlvm)} to i8*`,
     );
     this.ctx.emit(`store i8* ${fnI8}, i8** ${fpTyped}`);
 

--- a/src/codegen/stdlib/crypto.ts
+++ b/src/codegen/stdlib/crypto.ts
@@ -71,7 +71,7 @@ export class CryptoGenerator {
     this.ctx.emit(`${mdCtx} = call i8* @EVP_MD_CTX_new()`);
 
     const evpMd = this.ctx.nextTemp();
-    this.ctx.emit(`${evpMd} = call i8* @${evpFunc}()`);
+    this.ctx.emit(`${evpMd} = call i8* ${this.ctx.emitSymbol(evpFunc, "@")}()`);
 
     const initResult = this.ctx.nextTemp();
     this.ctx.emit(

--- a/src/codegen/stdlib/fs.ts
+++ b/src/codegen/stdlib/fs.ts
@@ -593,7 +593,11 @@ export class FilesystemGenerator {
     const pathPtr = this.ctx.generateExpression(expr.args[0], params);
     this.ctx.setUsesPromises(true);
     this.ctx.setUsesAsyncFs(true);
-    const temp = this.ctx.emitCall("%Promise*", `@${asyncFnName}`, `i8* ${pathPtr}`);
+    const temp = this.ctx.emitCall(
+      "%Promise*",
+      this.ctx.emitSymbol(asyncFnName, "@"),
+      this.ctx.emitOperand(pathPtr, "i8*"),
+    );
     return temp;
   }
 
@@ -610,7 +614,11 @@ export class FilesystemGenerator {
     const arg2 = this.ctx.generateExpression(expr.args[1], params);
     this.ctx.setUsesPromises(true);
     this.ctx.setUsesAsyncFs(true);
-    const temp = this.ctx.emitCall("%Promise*", `@${asyncFnName}`, `i8* ${arg1}, i8* ${arg2}`);
+    const temp = this.ctx.emitCall(
+      "%Promise*",
+      this.ctx.emitSymbol(asyncFnName, "@"),
+      `${this.ctx.emitOperand(arg1, "i8*")}, ${this.ctx.emitOperand(arg2, "i8*")}`,
+    );
     return temp;
   }
 


### PR DESCRIPTION
## Before
Three stdlib generators emitted LLVM IR with raw sigil-prefixed template interpolations (`@${name}`) and inline operand strings (`${type} ${value}`).

## After
No user-facing change. Internal refactor only — same LLVM IR output, now routed through `ctx.emitSymbol` / `ctx.emitOperand` helpers.

## Description
Continues Step 2 of #640. Scope: symbol/operand helpers only, no structured-builder migration.

- `src/codegen/stdlib/fs.ts` — 2 `emitCall` sites: `@${asyncFnName}` → `emitSymbol`; inline `i8* ${x}` args → `emitOperand`.
- `src/codegen/stdlib/child-process.ts` — 3 bitcast `emit` sites: `${fnType} @${name}` → `emitOperand(emitSymbol(name, "@"), fnType)`.
- `src/codegen/stdlib/crypto.ts` — 1 site: `@${evpFunc}` → `emitSymbol(evpFunc, "@")`.

Verified with `npm run verify:quick` + full `bash scripts/self-hosting.sh` (stage 2 passes).