### PR TITLE
[diagnostics] add type-divergence category + shim around resolveExpressionTypeRich

### DIFF
--- a/scripts/analyze-diagnostics.cjs
+++ b/scripts/analyze-diagnostics.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Analyze type-trace JSONL produced by --diag-trace=type-trace.
+// Analyze type-trace / type-divergence JSONL produced by --diag-trace.
 // Usage: node scripts/analyze-diagnostics.cjs [path]
 const fs = require("fs");
 const path = process.argv[2] || "chad-diagnostics.jsonl";
@@ -130,3 +130,29 @@ ${[...richSiteCount.entries()]
   .map(([site, c, n]) => `  ${n}/${c} (${pct(n, c)})  ${site}`)
   .join("\n")}
 `);
+
+const divergence = events.filter((e) => e.cat === "type-divergence");
+if (divergence.length > 0) {
+  const byKind = countBy(divergence, (d) => d.kind || "?");
+  const byPair = countBy(divergence, (d) => `${d.kind}  ${d.cacheType} -> ${d.liveType}`);
+  const bySite = countBy(divergence, (d) => d.site);
+  const cacheNull = divergence.filter((d) => d.cacheType === null).length;
+  const liveNull = divergence.filter((d) => d.liveType === null).length;
+  const bothSet = divergence.filter((d) => d.cacheType !== null && d.liveType !== null).length;
+  console.log(`# Diagnostics type-divergence analysis
+
+Total type-divergence events: ${divergence.length}
+  cache=null, live set:   ${cacheNull}  (annotator missed, live answered)
+  cache set, live=null:   ${liveNull}  (annotator answered, live failed)
+  both set, disagree:     ${bothSet}
+
+## Divergences by expression kind (gate-loosen candidates — low counts = safe)
+${fmt(byKind)}
+
+## Top divergent (kind, cache -> live) pairs
+${fmt(byPair)}
+
+## Top divergence call sites
+${fmt(bySite)}
+`);
+}

--- a/src/chad-node.ts
+++ b/src/chad-node.ts
@@ -33,8 +33,8 @@ import { execSync, spawn as spawnProc, ChildProcess } from "child_process";
 import { installTargetSDK, listInstalledSDKs, getSDKBaseDir } from "./cross-compile.js";
 import { VERSION } from "./version.js";
 import { enableSink, flushDiagnostics } from "./diagnostics/sink.js";
-import { parseCategories, CAT_TYPE_TRACE } from "./diagnostics/categories.js";
-import { enableTypeTrace } from "./diagnostics/tracers.js";
+import { parseCategories, CAT_TYPE_TRACE, CAT_TYPE_DIVERGENCE } from "./diagnostics/categories.js";
+import { enableTypeTrace, enableTypeDivergence } from "./diagnostics/tracers.js";
 
 const parser = new ArgumentParser("chad", "compile TypeScript to native binaries via LLVM");
 parser.setColorEnabled(process.stdout.isTTY === true);
@@ -329,6 +329,7 @@ if (diagTraceCsv) {
   });
   for (const c of cats) {
     if (c === CAT_TYPE_TRACE) enableTypeTrace();
+    if (c === CAT_TYPE_DIVERGENCE) enableTypeDivergence();
   }
 }
 

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -40,7 +40,11 @@ import type {
   ArrayStorageStrategy,
 } from "./type-system.js";
 import type { TypeContext } from "./type-context.js";
-import { traceTypeRich } from "../../diagnostics/tracers.js";
+import {
+  traceTypeRich,
+  traceTypeDivergence,
+  isTypeDivergenceEnabled,
+} from "../../diagnostics/tracers.js";
 
 interface ExprBase {
   type: string;
@@ -76,6 +80,7 @@ export interface TypeInferenceContext {
   typeResolver?: TypeResolver;
   typeResolverGetInterface(name: string): InterfaceDeclaration | null;
   typeResolverGetInterfaceProperty(interfaceName: string, propName: string): InterfaceField | null;
+  getExpressionType?(expr: Expression): ResolvedType | undefined;
 }
 
 export class TypeInference {
@@ -162,11 +167,13 @@ export class TypeInference {
       const cached = this.richCacheLookup(expr);
       if (cached) {
         traceTypeRich(exprTypeTag, cached.base || null);
+        this.checkDivergence(expr, exprTypeTag, cached);
         return cached;
       }
       const baseType = this.resolveExpressionType(expr);
       if (!baseType) {
         traceTypeRich(exprTypeTag, null);
+        this.checkDivergence(expr, exprTypeTag, null);
         return null;
       }
       const enriched = this.enrichResolvedType(baseType);
@@ -175,17 +182,34 @@ export class TypeInference {
         this.richCacheStore(expr, enriched);
       }
       traceTypeRich(exprTypeTag, enriched.base || null);
+      this.checkDivergence(expr, exprTypeTag, enriched);
       return enriched;
     }
     const baseType = this.resolveExpressionType(expr);
     if (!baseType) {
       traceTypeRich(exprTypeTag, null);
+      this.checkDivergence(expr, exprTypeTag, null);
       return null;
     }
     const enriched = this.enrichResolvedType(baseType);
     this.populateArrayStorage(enriched, expr);
     traceTypeRich(exprTypeTag, enriched.base || null);
+    this.checkDivergence(expr, exprTypeTag, enriched);
     return enriched;
+  }
+
+  // Compare the live resolver's answer against the annotator's typeOf cache.
+  // Fires only when --diag-trace=type-divergence is on. Used to pick which
+  // expression kinds are safe to route through the cache (gate loosening).
+  private checkDivergence(expr: Expression, kind: string, live: ResolvedType | null): void {
+    if (!isTypeDivergenceEnabled()) return;
+    if (!expr || typeof expr !== "object") return;
+    if (!this.ctx.getExpressionType) return;
+    const cached = this.ctx.getExpressionType(expr);
+    const cacheBase = cached ? cached.base || null : null;
+    const liveBase = live ? live.base || null : null;
+    if (cacheBase === liveBase) return;
+    traceTypeDivergence(kind, cacheBase, liveBase);
   }
 
   // Expression shapes whose rich resolution is stable across codegen phases.

--- a/src/diagnostics/categories.ts
+++ b/src/diagnostics/categories.ts
@@ -1,6 +1,7 @@
 export const CAT_TYPE_TRACE = "type-trace";
+export const CAT_TYPE_DIVERGENCE = "type-divergence";
 
-export const KNOWN_CATEGORIES: string[] = [CAT_TYPE_TRACE];
+export const KNOWN_CATEGORIES: string[] = [CAT_TYPE_TRACE, CAT_TYPE_DIVERGENCE];
 
 export function parseCategories(csv: string): string[] {
   const result: string[] = [];

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -1,9 +1,17 @@
 export { enableSink, isSinkEnabled, recordEvent, flushDiagnostics } from "./sink.js";
-export { CAT_TYPE_TRACE, KNOWN_CATEGORIES, parseCategories } from "./categories.js";
+export {
+  CAT_TYPE_TRACE,
+  CAT_TYPE_DIVERGENCE,
+  KNOWN_CATEGORIES,
+  parseCategories,
+} from "./categories.js";
 export {
   enableTypeTrace,
   isTypeTraceEnabled,
+  enableTypeDivergence,
+  isTypeDivergenceEnabled,
   traceTypeSet,
   traceTypeGet,
   traceTypeRich,
+  traceTypeDivergence,
 } from "./tracers.js";

--- a/src/diagnostics/tracers.ts
+++ b/src/diagnostics/tracers.ts
@@ -1,7 +1,8 @@
 import { recordEvent } from "./sink.js";
-import { CAT_TYPE_TRACE } from "./categories.js";
+import { CAT_TYPE_TRACE, CAT_TYPE_DIVERGENCE } from "./categories.js";
 
 let diagTypeTraceEnabled = false;
+let diagTypeDivergenceEnabled = false;
 let diagSeq = 0;
 
 export function enableTypeTrace(): void {
@@ -10,6 +11,14 @@ export function enableTypeTrace(): void {
 
 export function isTypeTraceEnabled(): boolean {
   return diagTypeTraceEnabled;
+}
+
+export function enableTypeDivergence(): void {
+  diagTypeDivergenceEnabled = true;
+}
+
+export function isTypeDivergenceEnabled(): boolean {
+  return diagTypeDivergenceEnabled;
 }
 
 // JSON-string-escape a value. Used instead of JSON.stringify on record types
@@ -145,6 +154,34 @@ export function traceTypeRich(exprType: string, result: string | null): void {
     jsonEscapeString(exprType) +
     ',"result":' +
     resultJson +
+    ',"sites":' +
+    sitesToJsonArray(sites) +
+    "}";
+  recordEvent(line);
+}
+
+export function traceTypeDivergence(
+  kind: string,
+  cacheType: string | null,
+  liveType: string | null,
+): void {
+  if (!diagTypeDivergenceEnabled) return;
+  const sites = captureSites(2);
+  const i = diagSeq;
+  diagSeq = diagSeq + 1;
+  const cacheJson = cacheType === null ? "null" : jsonEscapeString(cacheType);
+  const liveJson = liveType === null ? "null" : jsonEscapeString(liveType);
+  const line =
+    '{"cat":' +
+    jsonEscapeString(CAT_TYPE_DIVERGENCE) +
+    ',"i":' +
+    i.toString() +
+    ',"kind":' +
+    jsonEscapeString(kind) +
+    ',"cacheType":' +
+    cacheJson +
+    ',"liveType":' +
+    liveJson +
     ',"sites":' +
     sitesToJsonArray(sites) +
     "}";


### PR DESCRIPTION
## Before
No way to measure where the annotator cache and the live resolver disagree on expression types. Gate-loosening decisions for the typeOf cache rearchitecture (#658) would be blind.

## After
`--diag-trace=type-divergence` emits per-node divergence events; `analyze-diagnostics.cjs` reports per-expression-kind counts plus null/set/disagree splits. Running on `src/chad-native.ts` (Stage 1 compile) yields **44,797 divergence events, 0 both-set disagreements** — all divergences are cache-null/live-set (annotator hasn't populated yet). Per-kind breakdown (top):

```
  33107  string
   4462  template_literal
   4098  number
   1355  boolean
   1335  null
    350  method_call
    135  member_access
     58  array
     55  index_access
     51  type_assertion
     43  variable
     38  regex
     24  conditional
     22  binary
     16  call
```

0 both-set disagreements means: when the annotator DOES answer, it agrees with the live resolver 100%. Safe to admit any of these kinds to the gate once their annotator coverage is backfilled.

## Description
Next step of #658 (typeOf cache gate loosening tracker). ~100 LOC. Off by default, gated identically to type-trace.

- `CAT_TYPE_DIVERGENCE` + `enableTypeDivergence` / `isTypeDivergenceEnabled` / `traceTypeDivergence`
- Shim in `type-inference.ts` wraps `resolveExpressionTypeRich`: on each answer, looks up the typeOf cache (via new optional `ctx.getExpressionType`) and fires a divergence event when `cacheBase !== liveBase`
- Analyzer reports per-kind counts, top (kind, cache→live) pairs, top call sites
- CLI flag wired into `chad-node.ts`

Refs #658.