### PR TITLE
[codegen] annotate member-access expressions with class/interface types

### DIFF
--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -423,6 +423,17 @@ class TypeAnnotator {
       }
       return;
     }
+    // Member access on a class/interface-typed object. Only cache when the
+    // resolved type is itself class/interface (avoids disagreeing with
+    // symbol-table-allocated storage for primitives/arrays/Map/Set).
+    // Issue #658 gate-loosen step 2.
+    if (e.type === "member_access") {
+      const resolved = this.sink.resolveExpressionTypeRich(expr);
+      if (resolved && this.isSafeVariableAnnotationType(resolved)) {
+        this.sink.appendExpressionType(expr, resolved);
+      }
+      return;
+    }
     // let/const decl bindings and interface-typed params are intentionally
     // skipped. Decl bindings can be refined mid-codegen (JSON.parse target
     // type, await result specialization); caching the declared type would


### PR DESCRIPTION
## Before
The typeOf cache held only primitive literals and variable-read results (from #660/#661). Member-access expressions like \`obj.field\` fell through to live-resolution at every codegen site.

## After
\`member_access\` expressions whose resolved type is a concrete class or interface are now annotated. Codegen sites reading \`typeOf(obj.field)\` get the cached answer.

## Description
Step 2 of #658 gate-loosening plan.

Same source-kind filter as step 1 (\`class\` | \`interface\`). Unfiltered annotation (including primitives/arrays/Map/Set) segfaulted Stage 1 self-hosting; filtering to the shapes whose LLVM representation is fully determined by the base name sidesteps the symbol-table disagreement.

### Verification
- \`npm run verify\` (Stage 0 + Stage 1 + Stage 2 self-hosting + full test suite): PASSED

Refs #658.