### PR TITLE
[codegen] annotate binary/unary expressions with class/interface result types

### DIFF
--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -423,11 +423,20 @@ class TypeAnnotator {
       }
       return;
     }
-    // Member access on a class/interface-typed object. Only cache when the
-    // resolved type is itself class/interface (avoids disagreeing with
-    // symbol-table-allocated storage for primitives/arrays/Map/Set).
-    // Issue #658 gate-loosen step 2.
+    // Member access on a class/interface-typed object. Issue #658 step 2.
     if (e.type === "member_access") {
+      const resolved = this.sink.resolveExpressionTypeRich(expr);
+      if (resolved && this.isSafeVariableAnnotationType(resolved)) {
+        this.sink.appendExpressionType(expr, resolved);
+      }
+      return;
+    }
+    // Binary/unary operator results whose resolved type is class/interface.
+    // Primitives excluded because LLVM layout is chosen at emit time
+    // (narrow-integer specialization, boolean i1 vs double, etc.) and the
+    // declared answer can disagree with the emitted temp's type. Issue #658
+    // gate-loosen step 3.
+    if (e.type === "binary" || e.type === "unary") {
       const resolved = this.sink.resolveExpressionTypeRich(expr);
       if (resolved && this.isSafeVariableAnnotationType(resolved)) {
         this.sink.appendExpressionType(expr, resolved);


### PR DESCRIPTION
## Before
Binary operators like \`a || b\`, \`a ?? b\`, and unary \`!x\` weren't annotated. Codegen live-resolved their types at each use site.

## After
Binary/unary expressions whose resolved type is a class or interface are cached in the typeOf map.

## Description
Step 3 of #658 gate-loosening plan.

Unfiltered binary/unary annotation broke Stage 0 (\`store i8* defined with type double but expected ptr\`) — binary primitive results pick their LLVM layout at emit time (boolean i1 vs double, narrow-integer specialization) and the declared answer disagreed. Same class/interface filter as steps 1+2 admits the useful cases (null-coalescing into object types) without touching primitives.

### Verification
- \`npm run verify\` (Stage 0 + Stage 1 + Stage 2 self-hosting + full test suite): PASSED

Refs #658.