### PR TITLE
[codegen] annotate index-access expressions with class/interface element types

### DIFF
--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -434,6 +434,15 @@ class TypeAnnotator {
       }
       return;
     }
+    // Index access element type when it resolves to class/interface
+    // (e.g. Node[] indexed -> Node). Issue #658 gate-loosen step 4.
+    if (e.type === "index_access") {
+      const resolved = this.sink.resolveExpressionTypeRich(expr);
+      if (resolved && this.isSafeVariableAnnotationType(resolved)) {
+        this.sink.appendExpressionType(expr, resolved);
+      }
+      return;
+    }
     // let/const decl bindings and interface-typed params are intentionally
     // skipped. Decl bindings can be refined mid-codegen (JSON.parse target
     // type, await result specialization); caching the declared type would


### PR DESCRIPTION
## Before
\`arr[i]\` expressions weren't cached in typeOf even when the element type was a concrete class/interface.

## After
\`index_access\` expressions whose resolved element type is class/interface are cached.

## Description
Step 4 of #658. Same class/interface filter as steps 1-3. Unblocks cleaner sema on \`Array<Map<...>>\` per the tracker notes.

### Verification
- \`npm run verify\` (Stage 0 + Stage 1 + Stage 2 + full test suite): PASSED

Refs #658.