### PR TITLE
[codegen] annotate call/method-call/ternary with class/interface result types

### DIFF
--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -423,11 +423,17 @@ class TypeAnnotator {
       }
       return;
     }
-    // Member access on a class/interface-typed object. Only cache when the
-    // resolved type is itself class/interface (avoids disagreeing with
-    // symbol-table-allocated storage for primitives/arrays/Map/Set).
-    // Issue #658 gate-loosen step 2.
+    // Member access on a class/interface-typed object. Issue #658 step 2.
     if (e.type === "member_access") {
+      const resolved = this.sink.resolveExpressionTypeRich(expr);
+      if (resolved && this.isSafeVariableAnnotationType(resolved)) {
+        this.sink.appendExpressionType(expr, resolved);
+      }
+      return;
+    }
+    // call / method_call / conditional (ternary) when result is class/interface.
+    // Issue #658 gate-loosen steps 5-7.
+    if (e.type === "call" || e.type === "method_call" || e.type === "conditional") {
       const resolved = this.sink.resolveExpressionTypeRich(expr);
       if (resolved && this.isSafeVariableAnnotationType(resolved)) {
         this.sink.appendExpressionType(expr, resolved);


### PR DESCRIPTION
## Before
\`foo()\`, \`obj.m()\`, and \`a ? b : c\` expressions weren't cached in typeOf even when their result type was a concrete class/interface.

## After
All three kinds are cached when the resolved result type is class/interface.

## Description
Bundled steps 5-7 of #658 into one PR since they share the mechanical pattern (delegate to \`resolveExpressionTypeRich\`, filter by same class/interface source-kind as steps 1-4). With this, all seven candidate kinds from the audit are wired:

1. variable (#660 merged, #661 merged)
2. member_access (#662)
3. binary/unary (#663)
4. index_access (#664)
5. call
6. method_call
7. conditional (ternary)

### Verification
- \`npm run verify\` (Stage 0 + Stage 1 + Stage 2 self-hosting + full test suite): PASSED

Refs #658.