### PR TITLE
Revert "[codegen] annotate member-access expressions with class/interface types"

### DIFF
--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -423,17 +423,6 @@ class TypeAnnotator {
       }
       return;
     }
-    // Member access on a class/interface-typed object. Only cache when the
-    // resolved type is itself class/interface (avoids disagreeing with
-    // symbol-table-allocated storage for primitives/arrays/Map/Set).
-    // Issue #658 gate-loosen step 2.
-    if (e.type === "member_access") {
-      const resolved = this.sink.resolveExpressionTypeRich(expr);
-      if (resolved && this.isSafeVariableAnnotationType(resolved)) {
-        this.sink.appendExpressionType(expr, resolved);
-      }
-      return;
-    }
     // let/const decl bindings and interface-typed params are intentionally
     // skipped. Decl bindings can be refined mid-codegen (JSON.parse target
     // type, await result specialization); caching the declared type would


### PR DESCRIPTION
## Before
#662 merged with all PR checks green on arm64 (local + macOS CI). After merge to main, CI on x86-64 Linux + macOS segfaults at Stage 0 → Stage 1 self-hosting:

\`\`\`
Command failed: /tmp/chad-stage0 build -v src/chad-native.ts -o /tmp/chad-stage1 --target-cpu=x86-64
Segmentation fault (core dumped)
\`\`\`

The member_access annotation generates IR that works on arm64 but segfaults the stage-0 compiler on x86-64. Likely an undefined-behavior case that \`-O2\` + x86-64 target exploits differently than arm64.

## After
Main passes CI again. Gate-loosening step 2 (\`member_access\`) reverted; will reland after x86-64 repro.

## Description
PR #662 slipped past its own CI because the PR-level matrix runs macOS+arm64 only (per my observation — \`build-macos pass\`, \`build-linux-glibc pass\` on the PR, but then \`build-linux-glibc fail\` after merge on main CI). Need to either add x86-64 Linux to PR CI or test locally with \`--target-cpu=x86-64\` before merge.

Refs #658.