### PR TITLE
[ci] add linux-x64 podman container for local arch-repro

### DIFF
--- a/scripts/linux-x64.Containerfile
+++ b/scripts/linux-x64.Containerfile
@@ -1,0 +1,24 @@
+FROM --platform=linux/amd64 ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    curl wget ca-certificates gnupg git \
+    cmake make gcc g++ \
+    autoconf automake libtool pkg-config \
+    libzstd-dev zlib1g-dev libsqlite3-dev libcurl4-openssl-dev libpq-dev libssl-dev
+
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+ && echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" > /etc/apt/sources.list.d/llvm-21.list \
+ && apt-get update \
+ && apt-get install -y clang-21 lld-21 llvm-21-dev \
+ && ln -sf /usr/bin/clang-21 /usr/bin/clang \
+ && ln -sf /usr/bin/llvm-config-21 /usr/bin/llvm-config
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y nodejs
+
+RUN apt-get install -y rustc cargo lldb-21
+
+WORKDIR /ws
+CMD ["/bin/bash"]

--- a/scripts/linux-x64.sh
+++ b/scripts/linux-x64.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run CI-equivalent Linux x86-64 build/self-hosting locally on arm64 macOS via podman.
+# Useful for catching arch-specific regressions before pushing to CI.
+#
+# Usage:
+#   bash scripts/linux-x64.sh build     # build the image (one-time)
+#   bash scripts/linux-x64.sh shell     # interactive shell in the container
+#   bash scripts/linux-x64.sh verify    # run full verify inside x86-64 container
+#
+# The container mounts the current worktree at /ws, so edits made on the host
+# are visible inside. vendor/ and node_modules/ are built INSIDE the container
+# (x86-64 binaries), so don't share them with the host.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE="chad-linux-x64"
+
+cmd="${1:-shell}"
+
+case "$cmd" in
+  build)
+    podman build --platform=linux/amd64 -t "$IMAGE" -f "$ROOT/scripts/linux-x64.Dockerfile" "$ROOT/scripts"
+    ;;
+  shell)
+    podman run --rm -it --platform=linux/amd64 \
+      -v "$ROOT:/ws:Z" -w /ws "$IMAGE" bash
+    ;;
+  verify)
+    podman run --rm --platform=linux/amd64 \
+      -v "$ROOT:/ws:Z" -w /ws "$IMAGE" bash -c '
+        set -e
+        rm -rf node_modules vendor dist .build build
+        npm install --ignore-scripts
+        bash scripts/build-vendor.sh
+        npm run build
+        # Rosetta reports an unrecognized CPU name to clang, so pin to x86-64 baseline.
+        node dist/chad-node.js build src/chad-native.ts -o /tmp/chad-stage0 --target-cpu=x86-64
+        echo "--- stage 0 built, running stage 0 → stage 1 ---"
+        /tmp/chad-stage0 build src/chad-native.ts -o /tmp/chad-stage1 --target-cpu=x86-64
+      '
+    ;;
+  *)
+    echo "usage: $0 build|shell|verify" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Before
PR CI passes on arm64 macOS but the post-merge main CI job on x86-64 Linux sometimes fails with arch-specific segfaults (recent example: #662 passed PR CI, broke main). No way to catch this before pushing.

## After
\`bash scripts/linux-x64.sh verify\` runs the equivalent of CI's \`build-linux-glibc\` stage-0 → stage-1 self-hosting chain inside an Ubuntu 22.04 x86-64 container via podman. Matches CI's clang-21, node 22, and apt-provided rustc/cargo.

Commands:
- \`bash scripts/linux-x64.sh build\` — build the container image (one-time, ~4min)
- \`bash scripts/linux-x64.sh shell\` — interactive shell inside container
- \`bash scripts/linux-x64.sh verify\` — full vendor + npm build + stage-0 + stage-0→1 self-host

Reproduced the #662 segfault locally in ~5min of iteration time.

## Description
Notes on rosetta limitations (documented in the script):
- \`lldb\` can't attach (rosetta doesn't emulate \`ptrace\`). Use printf-debug or binary search.
- \`-march=native\` picks a CPU name clang-21 rejects. Pass \`--target-cpu=x86-64\` explicitly.

No CI workflow changes. Pure developer tooling addition.