### PR TITLE
[codegen] annotate member-access expressions with concrete class types

### DIFF
--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -423,6 +423,23 @@ class TypeAnnotator {
       }
       return;
     }
+    // Member access whose resolved type is a concrete class. Interfaces
+    // excluded — the previous attempt (#662) included them, which passed
+    // arm64 CI + macOS but segfaulted on x86-64 Stage 0→1 self-hosting
+    // (reverted in #666). Root cause TBD; class-only is the safe subset
+    // reproduced stable across both arches via scripts/linux-x64.sh.
+    // Issue #658 gate-loosen step 2 (partial).
+    if (e.type === "member_access") {
+      const resolved = this.sink.resolveExpressionTypeRich(expr);
+      if (
+        resolved &&
+        resolved.sourceKind === "class" &&
+        this.isSafeVariableAnnotationType(resolved)
+      ) {
+        this.sink.appendExpressionType(expr, resolved);
+      }
+      return;
+    }
     // let/const decl bindings and interface-typed params are intentionally
     // skipped. Decl bindings can be refined mid-codegen (JSON.parse target
     // type, await result specialization); caching the declared type would


### PR DESCRIPTION
## Before
\`obj.field\` expressions where the object is a concrete class weren't cached in the typeOf map. Codegen live-resolved them every time.

## After
Member-access expressions whose resolved type has \`sourceKind === "class"\` are annotated in the typeOf cache.

## Description
Narrower relanding of the reverted #662. That PR also included \`sourceKind === "interface"\`, which caused x86-64-only Stage 0→Stage 1 self-hosting segfaults (passed on arm64, failed on x86-64 Linux CI and macOS CI). Root cause TBD — the class-dispatch path produces arch-divergent IR under \`-O2\` when an interface answer comes from the annotator cache instead of live-resolution.

Reproduced locally via \`scripts/linux-x64.sh verify\` (added in #667). Class-only filter passes full 3-stage bootstrap on both arm64 macOS and x86-64 Linux (via podman).

### Verification
- arm64 macOS: \`npm run verify\` PASSED
- x86-64 Linux (podman): \`bash scripts/linux-x64.sh verify\` PASSED (all 3 bootstrap stages)

Refs #658. Interface-kind member_access annotation remains deferred pending x86-64 UB root-cause.