### PR TITLE
[diagnostics] enrich type-divergence event + distinguish cache miss from hit-diff

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -201,15 +201,48 @@ export class TypeInference {
   // Compare the live resolver's answer against the annotator's typeOf cache.
   // Fires only when --diag-trace=type-divergence is on. Used to pick which
   // expression kinds are safe to route through the cache (gate loosening).
+  //
+  // Three distinct cacheStatus outcomes are reported so downstream tooling
+  // can slice by kind:
+  //   - "hit"       : cache has an entry whose base matches live.base.
+  //                   NO event fired.
+  //   - "hit-diff"  : cache has an entry but base disagrees with live.
+  //                   Gate-loosening this (kind,sourceKind) would be unsafe.
+  //   - "miss"      : cache has no entry. Event fires with cacheBase=null
+  //                   so aggregators can count per-kind coverage gaps (i.e.
+  //                   candidates for annotator expansion).
   private checkDivergence(expr: Expression, kind: string, live: ResolvedType | null): void {
     if (!isTypeDivergenceEnabled()) return;
     if (!expr || typeof expr !== "object") return;
     if (!this.ctx.getExpressionType) return;
     const cached = this.ctx.getExpressionType(expr);
-    const cacheBase = cached ? cached.base || null : null;
     const liveBase = live ? live.base || null : null;
+    const liveSourceKind = live ? live.sourceKind || null : null;
+    const liveArrayDepth = live ? live.arrayDepth || 0 : 0;
+    const liveElementInterface = live ? live.elementInterface || null : null;
+    if (cached === undefined) {
+      traceTypeDivergence(
+        kind,
+        null,
+        liveBase,
+        "miss",
+        liveSourceKind,
+        liveArrayDepth,
+        liveElementInterface,
+      );
+      return;
+    }
+    const cacheBase = cached.base || null;
     if (cacheBase === liveBase) return;
-    traceTypeDivergence(kind, cacheBase, liveBase);
+    traceTypeDivergence(
+      kind,
+      cacheBase,
+      liveBase,
+      "hit-diff",
+      liveSourceKind,
+      liveArrayDepth,
+      liveElementInterface,
+    );
   }
 
   // Expression shapes whose rich resolution is stable across codegen phases.

--- a/src/diagnostics/tracers.ts
+++ b/src/diagnostics/tracers.ts
@@ -164,6 +164,10 @@ export function traceTypeDivergence(
   kind: string,
   cacheType: string | null,
   liveType: string | null,
+  cacheStatus: string,
+  liveSourceKind: string | null,
+  liveArrayDepth: number,
+  liveElementInterface: string | null,
 ): void {
   if (!diagTypeDivergenceEnabled) return;
   const sites = captureSites(2);
@@ -171,6 +175,9 @@ export function traceTypeDivergence(
   diagSeq = diagSeq + 1;
   const cacheJson = cacheType === null ? "null" : jsonEscapeString(cacheType);
   const liveJson = liveType === null ? "null" : jsonEscapeString(liveType);
+  const sourceKindJson = liveSourceKind === null ? "null" : jsonEscapeString(liveSourceKind);
+  const elemIfaceJson =
+    liveElementInterface === null ? "null" : jsonEscapeString(liveElementInterface);
   const line =
     '{"cat":' +
     jsonEscapeString(CAT_TYPE_DIVERGENCE) +
@@ -178,10 +185,18 @@ export function traceTypeDivergence(
     i.toString() +
     ',"kind":' +
     jsonEscapeString(kind) +
+    ',"cacheStatus":' +
+    jsonEscapeString(cacheStatus) +
     ',"cacheType":' +
     cacheJson +
     ',"liveType":' +
     liveJson +
+    ',"liveSourceKind":' +
+    sourceKindJson +
+    ',"liveArrayDepth":' +
+    liveArrayDepth.toString() +
+    ',"liveElementInterface":' +
+    elemIfaceJson +
     ',"sites":' +
     sitesToJsonArray(sites) +
     "}";


### PR DESCRIPTION
## Before
`traceTypeDivergence` events were coarse: they carried only `kind` (expression tag) + `cacheType` + `liveType` bases. Worse, `checkDivergence` treated a cache **miss** (no entry for the expression) as identical to a cache **hit with null base**, so every uncached expression with a non-null live answer fired a bogus "divergence." Aggregate counts were unusable for driving per-kind gate-loosening decisions (issue #658).

## After
Two things:

1. `checkDivergence` now distinguishes three outcomes:
   - `hit` — cache entry agrees with live; no event fired.
   - `hit-diff` — cache entry disagrees with live; gate-loosening this `(kind, sourceKind)` is unsafe.
   - `miss` — no cache entry; emitted so tooling can count per-kind coverage gaps (candidates for annotator expansion).

2. Each event now carries `cacheStatus`, `liveSourceKind`, `liveArrayDepth`, and `liveElementInterface` in addition to the existing `kind`/`cacheType`/`liveType`. Lets downstream aggregation slice by expression kind × sourceKind × array depth — the exact axes the Tier 1 #1 plan needs to pick safe gate-loosen cells.

Example event:
```json
{"cat":"type-divergence","i":1,"kind":"new","cacheStatus":"miss","cacheType":null,"liveType":"Box","liveSourceKind":"class","liveArrayDepth":0,"liveElementInterface":null,"sites":[...]}
```

## Description
Tier 1 #1 of issue #658 — visibility tool for gate-loosen decisions. ~50 LOC.

Pivoted from the original "shadow cache" design after a second-opinion review: the annotator-time symbol table is empty, so a shadow cache populated via annotator-time `resolveExpressionTypeRich` would mostly hold null entries (noise, not signal). The real gap was the cache-miss-vs-null collapse + the lack of source-kind context in events. Fixing those directly gives the same per-kind evidence with zero new fields on `IGeneratorContext`, zero GEP-layout risk, and no resolver side-effect exposure.

Zero behavior change when `--diag-trace=type-divergence` is off. Verified with `npm run verify` (stage 2 self-hosting).