### PR TITLE
[annotator] admit type_assertion expressions (class-only, #658 step 3)

### DIFF
--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -440,6 +440,31 @@ class TypeAnnotator {
       }
       return;
     }
+    // Type assertions (`x as Foo`). Result type is the literal AST string
+    // `assertedType` — independent of symbol-table state and stable across
+    // codegen phases. Real-world data (#658 comment 2026-04-22): 1611
+    // codegen-time miss events on chad-native.ts; zero hit-diff after
+    // admission would be observable in any cell already in the cache. Gated
+    // through isSafeVariableAnnotationType so only sourceKind=class|interface
+    // with arrayDepth=0 land in the cache — matches the safe subset the
+    // member_access admission uses.
+    if (e.type === "type_assertion") {
+      const ta = expr as TypeAssertionNode;
+      if (!this.isSafelyAnnotatable(ta.assertedType)) return;
+      const resolved = this.sink.resolveExpressionTypeRich(expr);
+      // Class-only — interface assertions destabilized stage 2 self-hosting
+      // (same arch-divergence class as #662; native dispatch through interface
+      // cache mismatched live-resolve). Re-evaluate after Tier 3 #11
+      // (interface concretization pass).
+      if (
+        resolved &&
+        resolved.sourceKind === "class" &&
+        this.isSafeVariableAnnotationType(resolved)
+      ) {
+        this.sink.appendExpressionType(expr, resolved);
+      }
+      return;
+    }
     // let/const decl bindings and interface-typed params are intentionally
     // skipped. Decl bindings can be refined mid-codegen (JSON.parse target
     // type, await result specialization); caching the declared type would


### PR DESCRIPTION
## Before
Type assertions (`x as Foo`) were never admitted to the annotator's typeOf cache. Every `as Foo` expression fired a cache miss at codegen time, forcing `resolveExpressionTypeRich` to recompute a type that's literal in the AST.

## After
Annotator admits `type_assertion` expressions when:
- `assertedType` passes `isSafelyAnnotatable` (no unions, nullable, function types, or inline object shapes)
- Resolved type has `sourceKind === "class"` and passes `isSafeVariableAnnotationType`

Interface-kind assertions intentionally excluded — an earlier attempt to admit them broke stage 2 self-hosting (same arch-divergence class as #662 member_access). Re-evaluate after Tier 3 #11 (interface concretization pass).

## Description
Follows data posted in #658 (comment 2026-04-22): divergence tracer showed 1249 codegen-time miss events for `type_assertion sourceKind=interface` on chad-native compile, zero hit-diff events anywhere. Class-only subset is the narrowest safe admission. ~25 LOC.

Verified with full `npm run verify` (stage 2 self-hosting green).

### Gate-loosen table

| Kind | Class | Interface |
|------|-------|-----------|
| variable | ✅ #660 | ✅ #661 |
| member_access | ✅ #668 | ❌ blocked (Tier 3 #11) |
| type_assertion | ✅ **this PR** | ❌ blocked (Tier 3 #11) |