### PR TITLE
[diagnostics] tighten type-divergence to full tuple + emit cache-side context (#658 tier 1 #4)

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -239,11 +239,30 @@ export class TypeInference {
         liveSourceKind,
         liveArrayDepth,
         liveElementInterface,
+        null,
+        0,
+        null,
       );
       return;
     }
     const cacheBase = cached.base || null;
-    if (cacheBase === liveBase) return;
+    const cacheSourceKind = cached.sourceKind || null;
+    const cacheArrayDepth = cached.arrayDepth || 0;
+    const cacheElementInterface = cached.elementInterface || null;
+    // Agreement requires all four tuple components to match. Base-only
+    // agreement was the original check but missed real divergences — e.g.
+    // cached `{base: "object", sourceKind: "interface"}` vs live
+    // `{base: "object", sourceKind: "class"}` looks equal by base but
+    // resolves to different dispatch strategies. Widening the tuple catches
+    // those before they corrupt codegen. Tier 1 #4 of issue #658.
+    if (
+      cacheBase === liveBase &&
+      cacheSourceKind === liveSourceKind &&
+      cacheArrayDepth === liveArrayDepth &&
+      cacheElementInterface === liveElementInterface
+    ) {
+      return;
+    }
     traceTypeDivergence(
       kind,
       cacheBase,
@@ -252,6 +271,9 @@ export class TypeInference {
       liveSourceKind,
       liveArrayDepth,
       liveElementInterface,
+      cacheSourceKind,
+      cacheArrayDepth,
+      cacheElementInterface,
     );
   }
 

--- a/src/diagnostics/tracers.ts
+++ b/src/diagnostics/tracers.ts
@@ -177,6 +177,9 @@ export function traceTypeDivergence(
   liveSourceKind: string | null,
   liveArrayDepth: number,
   liveElementInterface: string | null,
+  cacheSourceKind: string | null,
+  cacheArrayDepth: number,
+  cacheElementInterface: string | null,
 ): void {
   if (!diagTypeDivergenceEnabled) return;
   const sites = captureSites(2);
@@ -184,9 +187,12 @@ export function traceTypeDivergence(
   diagSeq = diagSeq + 1;
   const cacheJson = cacheType === null ? "null" : jsonEscapeString(cacheType);
   const liveJson = liveType === null ? "null" : jsonEscapeString(liveType);
-  const sourceKindJson = liveSourceKind === null ? "null" : jsonEscapeString(liveSourceKind);
-  const elemIfaceJson =
+  const liveSkJson = liveSourceKind === null ? "null" : jsonEscapeString(liveSourceKind);
+  const liveElemJson =
     liveElementInterface === null ? "null" : jsonEscapeString(liveElementInterface);
+  const cacheSkJson = cacheSourceKind === null ? "null" : jsonEscapeString(cacheSourceKind);
+  const cacheElemJson =
+    cacheElementInterface === null ? "null" : jsonEscapeString(cacheElementInterface);
   const line =
     '{"cat":' +
     jsonEscapeString(CAT_TYPE_DIVERGENCE) +
@@ -200,12 +206,18 @@ export function traceTypeDivergence(
     cacheJson +
     ',"liveType":' +
     liveJson +
+    ',"cacheSourceKind":' +
+    cacheSkJson +
     ',"liveSourceKind":' +
-    sourceKindJson +
+    liveSkJson +
+    ',"cacheArrayDepth":' +
+    cacheArrayDepth.toString() +
     ',"liveArrayDepth":' +
     liveArrayDepth.toString() +
+    ',"cacheElementInterface":' +
+    cacheElemJson +
     ',"liveElementInterface":' +
-    elemIfaceJson +
+    liveElemJson +
     ',"sites":' +
     sitesToJsonArray(sites) +
     "}";


### PR DESCRIPTION
## Before
\`checkDivergence\` agreed whenever \`cacheBase === liveBase\`. Cases where \`base\` matched but \`sourceKind\` / \`arrayDepth\` / \`elementInterface\` differed silently slipped through as \"agreement.\" Events carried only the live side of those fields, so a reader couldn't see what the cache actually held.

## After
Two changes:

1. **Agreement now requires the full 4-tuple to match**: \`base\`, \`sourceKind\`, \`arrayDepth\`, \`elementInterface\`. A mismatch on any one fires a \`hit-diff\` event — e.g. cached \`{base: \"object\", sourceKind: \"interface\"}\` vs live \`{base: \"object\", sourceKind: \"class\"}\` now reports a divergence instead of passing silently.
2. **Event carries both sides** of the tuple: new fields \`cacheSourceKind\`, \`cacheArrayDepth\`, \`cacheElementInterface\` alongside the existing \`liveSourceKind\`, \`liveArrayDepth\`, \`liveElementInterface\`. Readers can see exactly which axis diverged.

Example new event:
\`\`\`json
{\"cat\":\"type-divergence\",\"i\":1,\"kind\":\"new\",\"cacheStatus\":\"miss\",
 \"cacheType\":null,\"liveType\":\"Box\",
 \"cacheSourceKind\":null,\"liveSourceKind\":\"class\",
 \"cacheArrayDepth\":0,\"liveArrayDepth\":0,
 \"cacheElementInterface\":null,\"liveElementInterface\":null,...}
\`\`\`

## Description
Tier 1 #4 of issue #658, previously folded into Tier 1 #1. ~40 LOC.

### Result on chad-native.ts

Still **zero hit-diff events** across 80,701 divergence events (~13.4k codegen-origin). Confirms the current admission set is safe at the full-tuple level, not just base. Strengthens the baseline for future gate-loosen admissions.

Verified with \`npm run verify\` (stage 2 self-hosting green).