### PR TITLE
[sema] reject ambiguous let x = [] / null / undefined without type annotation

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -164,6 +164,7 @@ import { analyzeEscapes } from "../semantic/escape-analysis.js";
 import { checkEnumDeclarations } from "../semantic/enum-checker.js";
 import { normalizeInterfaceLayouts } from "../semantic/interface-layout-normalizer.js";
 import { checkAsyncAwait } from "../semantic/async-await-checker.js";
+import { checkAmbiguousInits } from "../semantic/ambiguous-init-checker.js";
 import {
   checkBinaryTypesDeep,
   checkMissingReturns,
@@ -3057,6 +3058,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     checkMissingReturns(this.ast, this.sourceCode);
     checkArgumentCounts(this.ast, this.sourceCode);
     checkAsyncAwait(this.ast, this.sourceCode);
+    checkAmbiguousInits(this.ast, this.sourceCode);
     this.stackEligibleVars = analyzeEscapes(this.ast);
     markIntSpecializedFunctions(this.ast);
     // Build pure-AST class + interface catalog so downstream queries

--- a/src/semantic/ambiguous-init-checker.ts
+++ b/src/semantic/ambiguous-init-checker.ts
@@ -1,0 +1,173 @@
+import type {
+  AST,
+  Statement,
+  BlockStatement,
+  VariableDeclaration,
+  IfStatement,
+  WhileStatement,
+  DoWhileStatement,
+  ForStatement,
+  ForOfStatement,
+  TryStatement,
+  SwitchStatement,
+  SwitchCase,
+  ArrayNode,
+  VariableNode,
+  SourceLocation,
+} from "../ast/types.js";
+import { formatCompileError } from "../diagnostics/engine.js";
+
+export function checkAmbiguousInits(ast: AST, sourceCode: string): void {
+  const checker = new AmbiguousInitChecker(sourceCode);
+  checker.check(ast);
+}
+
+class AmbiguousInitChecker {
+  private sourceCode: string;
+
+  constructor(sourceCode: string) {
+    this.sourceCode = sourceCode;
+  }
+
+  check(ast: AST): void {
+    const items = ast.topLevelItems;
+    if (items && items.length > 0) {
+      this.walkStatements(items as Statement[]);
+    }
+
+    for (let i = 0; i < ast.functions.length; i++) {
+      this.walkBlock(ast.functions[i].body);
+    }
+
+    for (let i = 0; i < ast.classes.length; i++) {
+      const cls = ast.classes[i];
+      for (let j = 0; j < cls.methods.length; j++) {
+        this.walkBlock(cls.methods[j].body);
+      }
+    }
+  }
+
+  private walkBlock(block: BlockStatement): void {
+    this.walkStatements(block.statements);
+  }
+
+  private walkStatements(stmts: Statement[]): void {
+    for (let i = 0; i < stmts.length; i++) {
+      this.walkStatement(stmts[i]);
+    }
+  }
+
+  private walkStatement(stmt: Statement): void {
+    const s = stmt as { type: string };
+    const t = s.type;
+
+    if (t === "variable_declaration") {
+      const decl = stmt as VariableDeclaration;
+      this.checkDecl(decl);
+    } else if (t === "if") {
+      const ifStmt = stmt as IfStatement;
+      this.walkBlock(ifStmt.thenBlock);
+      if (ifStmt.elseBlock !== null && ifStmt.elseBlock !== undefined) {
+        this.walkBlock(ifStmt.elseBlock);
+      }
+    } else if (t === "while") {
+      this.walkBlock((stmt as WhileStatement).body);
+    } else if (t === "do_while") {
+      this.walkBlock((stmt as DoWhileStatement).body);
+    } else if (t === "for") {
+      const forStmt = stmt as ForStatement;
+      if (forStmt.init !== null && forStmt.init !== undefined) {
+        const init = forStmt.init as { type: string };
+        if (init.type === "variable_declaration") {
+          this.checkDecl(forStmt.init as VariableDeclaration);
+        }
+      }
+      this.walkBlock(forStmt.body);
+    } else if (t === "for_of") {
+      this.walkBlock((stmt as ForOfStatement).body);
+    } else if (t === "try") {
+      const tryStmt = stmt as TryStatement;
+      this.walkBlock(tryStmt.tryBlock);
+      if (tryStmt.catchBody !== null && tryStmt.catchBody !== undefined) {
+        this.walkBlock(tryStmt.catchBody);
+      }
+      if (tryStmt.finallyBlock !== null && tryStmt.finallyBlock !== undefined) {
+        this.walkBlock(tryStmt.finallyBlock);
+      }
+    } else if (t === "switch") {
+      const sw = stmt as SwitchStatement;
+      for (let i = 0; i < sw.cases.length; i++) {
+        const c = sw.cases[i] as SwitchCase;
+        this.walkStatements(c.consequent);
+      }
+    }
+  }
+
+  private checkDecl(decl: VariableDeclaration): void {
+    if (decl.declaredType !== null && decl.declaredType !== undefined) return;
+    if (decl.value === null || decl.value === undefined) return;
+
+    const vtype = (decl.value as { type: string }).type;
+
+    if (vtype === "array") {
+      const arr = decl.value as ArrayNode;
+      if (arr.elements.length === 0) {
+        this.report(
+          "let " + decl.name + " = []",
+          "empty array literal has unknown element type",
+          "let " + decl.name + ": T[] = []",
+          decl.loc,
+        );
+      }
+    } else if (vtype === "null") {
+      this.report(
+        "let " + decl.name + " = null",
+        "'null' has no type to infer from",
+        "let " + decl.name + ": T | null = null",
+        decl.loc,
+      );
+    } else if (vtype === "undefined") {
+      this.report(
+        "let " + decl.name + " = undefined",
+        "'undefined' has no type to infer from",
+        "let " + decl.name + ": T | undefined = undefined",
+        decl.loc,
+      );
+    } else if (vtype === "variable") {
+      // native parser represents null/undefined literals as variable nodes
+      const varName = (decl.value as VariableNode).name;
+      if (varName === "null") {
+        this.report(
+          "let " + decl.name + " = null",
+          "'null' has no type to infer from",
+          "let " + decl.name + ": T | null = null",
+          decl.loc,
+        );
+      } else if (varName === "undefined") {
+        this.report(
+          "let " + decl.name + " = undefined",
+          "'undefined' has no type to infer from",
+          "let " + decl.name + ": T | undefined = undefined",
+          decl.loc,
+        );
+      }
+    }
+  }
+
+  private report(
+    pattern: string,
+    reason: string,
+    fix: string,
+    loc: SourceLocation | undefined,
+  ): void {
+    const output = formatCompileError(
+      this.sourceCode,
+      "ambiguous initializer: '" + pattern + "' — " + reason,
+      loc,
+      "add a type annotation",
+      ["'" + fix + "'"],
+    );
+    process.stderr.write(output);
+    process.exit(1);
+  }
+}

--- a/tests/fixtures/errors/ambiguous-init-empty-array.ts
+++ b/tests/fixtures/errors/ambiguous-init-empty-array.ts
@@ -1,0 +1,4 @@
+// @test-compile-error: ambiguous initializer
+let items = [];
+items.push(1);
+console.log(items.length);

--- a/tests/fixtures/errors/ambiguous-init-null.ts
+++ b/tests/fixtures/errors/ambiguous-init-null.ts
@@ -1,0 +1,3 @@
+// @test-compile-error: ambiguous initializer
+let x = null;
+console.log(x);


### PR DESCRIPTION
## Before
`let x = []`, `let x = null`, and `let x = undefined` without a declared type compiled silently. The empty array had an unknown element type (produced wrong LLVM IR); null/undefined had no type to infer from (codegen guessed i8* and was often wrong).

## After
A new semantic pass (`ambiguous-init-checker.ts`) rejects all three patterns with a clear error pointing to the fix:

```
error: ambiguous initializer: 'let items = []' — empty array literal has unknown element type
  = help: add a type annotation
  = note: 'let items: T[] = []'
```

## Description
Tier 2 item #5 from issue #658 gate-loosen plan. Catches one of the main sources of type ambiguity that prevents the type annotator from resolving expressions. ~120 LOC new semantic pass. Handles both the Node.js TS parser (NullNode/UndefinedNode with `type: "null"/"undefined"`) and the native tree-sitter parser (which emits `{ type: "variable", name: "null" }` for null literals).

Two test fixtures added under `tests/fixtures/errors/` for the empty-array and null cases.