### PR TITLE
[tests] fix self-hosting bootstrap test after .js→.ts fixture rename

### DIFF
--- a/tests/self-hosting.test.ts
+++ b/tests/self-hosting.test.ts
@@ -334,7 +334,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
         assert.ok(fsSync.existsSync(STAGE1), "Stage 1 binary must exist");
         assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
 
-        const testFile = "tests/fixtures/strings/string-length.js";
+        const testFile = "tests/fixtures/strings/string-length.ts";
         const s1Out = "/tmp/bootstrap-s1";
         const s2Out = "/tmp/bootstrap-s2";
         const s1LL = "/tmp/bootstrap-s1.ll";
@@ -371,7 +371,7 @@ describe("Self-Hosting", { timeout: 600000 }, () => {
         assert.ok(fsSync.existsSync(STAGE2), "Stage 2 binary must exist");
         assert.ok(fsSync.existsSync(STAGE3), "Stage 3 binary must exist");
 
-        const testFile = "tests/fixtures/strings/string-length.js";
+        const testFile = "tests/fixtures/strings/string-length.ts";
         const s2Out = "/tmp/bootstrap-s2b";
         const s3Out = "/tmp/bootstrap-s3";
         const s2LL = "/tmp/bootstrap-s2b.ll";


### PR DESCRIPTION
## Before
Self-hosting bootstrap verification (stage 1/2/3 determinism) fails because the test tries to compile \`tests/fixtures/strings/string-length.js\`. That file was renamed to \`string-length.ts\` in #675, and the new compiler now rejects \`.js\` files entirely.

## After
Bootstrap verification uses \`string-length.ts\`. Self-hosting determinism tests pass.

## Description
Two-line fix in \`tests/self-hosting.test.ts\` — update both bootstrap test fixture references.