### PR TITLE
[sema] reject || / ?? with mismatched LLVM types

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -166,6 +166,7 @@ import { normalizeInterfaceLayouts } from "../semantic/interface-layout-normaliz
 import { checkAsyncAwait } from "../semantic/async-await-checker.js";
 import { checkAmbiguousInits } from "../semantic/ambiguous-init-checker.js";
 import { checkUntypedParams } from "../semantic/untyped-param-checker.js";
+import { checkMixedOperators } from "../semantic/mixed-operator-checker.js";
 import {
   checkBinaryTypesDeep,
   checkMissingReturns,
@@ -3061,6 +3062,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     checkAsyncAwait(this.ast, this.sourceCode);
     checkAmbiguousInits(this.ast, this.sourceCode);
     checkUntypedParams(this.ast, this.sourceCode);
+    checkMixedOperators(this.ast, this.sourceCode);
     this.stackEligibleVars = analyzeEscapes(this.ast);
     markIntSpecializedFunctions(this.ast);
     // Build pure-AST class + interface catalog so downstream queries

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -73,21 +73,25 @@ class MixedOperatorChecker {
         if (pt) this.scope.set(fn.params[i], declaredTypeToKind(pt));
       }
     }
-    this.walkBlock(fn.body);
+    if (fn.body) this.walkBlock(fn.body);
   }
 
   private walkBlock(block: BlockStatement): void {
+    if (!block || !block.statements) return;
     this.walkStatements(block.statements);
   }
 
   private walkStatements(stmts: Statement[]): void {
+    if (!stmts) return;
     for (let i = 0; i < stmts.length; i++) {
       this.walkStatement(stmts[i]);
     }
   }
 
   private walkStatement(stmt: Statement): void {
+    if (!stmt) return;
     const t = (stmt as { type: string }).type;
+    if (!t) return;
 
     if (t === "variable_declaration") {
       const decl = stmt as VariableDeclaration;

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -41,9 +41,11 @@ export function checkMixedOperators(ast: AST, sourceCode: string): void {
 }
 
 class MixedOperatorChecker {
-  private scope: Map<string, string> = new Map();
+  private scope: Map<string, string>;
 
-  constructor(private sourceCode: string) {}
+  constructor(private sourceCode: string) {
+    this.scope = new Map();
+  }
 
   check(ast: AST): void {
     const items = ast.topLevelItems;

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -1,0 +1,219 @@
+import type {
+  AST,
+  Statement,
+  Expression,
+  BlockStatement,
+  VariableDeclaration,
+  IfStatement,
+  WhileStatement,
+  DoWhileStatement,
+  ForStatement,
+  ForOfStatement,
+  TryStatement,
+  SwitchStatement,
+  SwitchCase,
+  BinaryNode,
+  VariableNode,
+  FunctionNode,
+  SourceLocation,
+  ReturnStatement,
+  AssignmentStatement,
+  ConditionalExpressionNode,
+  CallNode,
+  MethodCallNode,
+} from "../ast/types.js";
+import { formatCompileError } from "../diagnostics/engine.js";
+
+type LlvmKind = "ptr" | "double" | "i1" | "unknown";
+
+function declaredTypeToKind(t: string): LlvmKind {
+  if (t === "number") return "double";
+  if (t === "boolean") return "i1";
+  return "ptr"; // string, class, interface, array, Map, Set, etc.
+}
+
+export function checkMixedOperators(ast: AST, sourceCode: string): void {
+  const checker = new MixedOperatorChecker(sourceCode);
+  checker.check(ast);
+}
+
+class MixedOperatorChecker {
+  private scope: Map<string, LlvmKind> = new Map();
+
+  constructor(private sourceCode: string) {}
+
+  check(ast: AST): void {
+    const items = ast.topLevelItems;
+    if (items && items.length > 0) {
+      this.walkStatements(items as Statement[]);
+    }
+
+    for (let i = 0; i < ast.functions.length; i++) {
+      this.checkFunction(ast.functions[i]);
+    }
+
+    for (let i = 0; i < ast.classes.length; i++) {
+      const cls = ast.classes[i];
+      for (let j = 0; j < cls.methods.length; j++) {
+        this.checkFunction(cls.methods[j] as unknown as FunctionNode);
+      }
+    }
+  }
+
+  private checkFunction(fn: FunctionNode): void {
+    if (fn.params && fn.paramTypes) {
+      for (let i = 0; i < fn.params.length; i++) {
+        const pt = fn.paramTypes[i];
+        if (pt) this.scope.set(fn.params[i], declaredTypeToKind(pt));
+      }
+    }
+    this.walkBlock(fn.body);
+  }
+
+  private walkBlock(block: BlockStatement): void {
+    this.walkStatements(block.statements);
+  }
+
+  private walkStatements(stmts: Statement[]): void {
+    for (let i = 0; i < stmts.length; i++) {
+      this.walkStatement(stmts[i]);
+    }
+  }
+
+  private walkStatement(stmt: Statement): void {
+    const t = (stmt as { type: string }).type;
+
+    if (t === "variable_declaration") {
+      const decl = stmt as VariableDeclaration;
+      if (decl.declaredType) {
+        this.scope.set(decl.name, declaredTypeToKind(decl.declaredType));
+      }
+      if (decl.value) this.walkExpr(decl.value);
+    } else if (t === "return") {
+      const ret = stmt as ReturnStatement;
+      if (ret.value) this.walkExpr(ret.value);
+    } else if (t === "assignment") {
+      this.walkExpr((stmt as AssignmentStatement).value);
+    } else if (t === "if") {
+      const ifStmt = stmt as IfStatement;
+      this.walkExpr(ifStmt.condition);
+      this.walkBlock(ifStmt.thenBlock);
+      if (ifStmt.elseBlock) this.walkBlock(ifStmt.elseBlock);
+    } else if (t === "while") {
+      const w = stmt as WhileStatement;
+      this.walkExpr(w.condition);
+      this.walkBlock(w.body);
+    } else if (t === "do_while") {
+      const dw = stmt as DoWhileStatement;
+      this.walkExpr(dw.condition);
+      this.walkBlock(dw.body);
+    } else if (t === "for") {
+      const forStmt = stmt as ForStatement;
+      if (forStmt.init) {
+        const init = forStmt.init as { type: string };
+        if (init.type === "variable_declaration") {
+          const decl = forStmt.init as VariableDeclaration;
+          if (decl.declaredType) this.scope.set(decl.name, declaredTypeToKind(decl.declaredType));
+          if (decl.value) this.walkExpr(decl.value);
+        }
+      }
+      if (forStmt.condition) this.walkExpr(forStmt.condition);
+      if (forStmt.update) this.walkExpr(forStmt.update as Expression);
+      this.walkBlock(forStmt.body);
+    } else if (t === "for_of") {
+      this.walkBlock((stmt as ForOfStatement).body);
+    } else if (t === "try") {
+      const tryStmt = stmt as TryStatement;
+      this.walkBlock(tryStmt.tryBlock);
+      if (tryStmt.catchBody) this.walkBlock(tryStmt.catchBody);
+      if (tryStmt.finallyBlock) this.walkBlock(tryStmt.finallyBlock);
+    } else if (t === "switch") {
+      const sw = stmt as SwitchStatement;
+      this.walkExpr(sw.discriminant);
+      for (let i = 0; i < sw.cases.length; i++) {
+        this.walkStatements((sw.cases[i] as SwitchCase).consequent);
+      }
+    } else {
+      // standalone expression statement (call, method_call, etc.)
+      this.walkExpr(stmt as Expression);
+    }
+  }
+
+  private walkExpr(expr: Expression): void {
+    if (!expr) return;
+    const e = expr as { type: string };
+
+    if (e.type === "binary") {
+      const bin = expr as BinaryNode;
+      if (bin.op === "||" || bin.op === "??") {
+        const leftKind = this.exprKind(bin.left);
+        const rightKind = this.exprKind(bin.right);
+        if (leftKind !== "unknown" && rightKind !== "unknown" && leftKind !== rightKind) {
+          this.report(bin.op, leftKind, rightKind, bin.loc);
+        }
+      }
+      this.walkExpr(bin.left);
+      this.walkExpr(bin.right);
+    } else if (e.type === "conditional") {
+      const cond = expr as ConditionalExpressionNode;
+      this.walkExpr(cond.condition);
+      this.walkExpr(cond.consequent);
+      this.walkExpr(cond.alternate);
+    } else if (e.type === "call") {
+      const call = expr as CallNode;
+      for (let i = 0; i < call.args.length; i++) {
+        this.walkExpr(call.args[i]);
+      }
+    } else if (e.type === "method_call") {
+      const mc = expr as MethodCallNode;
+      for (let i = 0; i < mc.args.length; i++) {
+        this.walkExpr(mc.args[i]);
+      }
+    }
+  }
+
+  private exprKind(expr: Expression): LlvmKind {
+    if (!expr) return "unknown";
+    const e = expr as { type: string };
+    if (e.type === "number") return "double";
+    if (e.type === "string") return "ptr";
+    if (e.type === "boolean") return "i1";
+    if (e.type === "variable") {
+      const v = expr as VariableNode;
+      if (v.name === "null" || v.name === "undefined") return "unknown";
+      const known = this.scope.get(v.name);
+      return known !== undefined ? known : "unknown";
+    }
+    // null/undefined literals from TS parser — skip, they're pointer-compatible
+    if (e.type === "null" || e.type === "undefined") return "unknown";
+    return "unknown";
+  }
+
+  private report(
+    op: string,
+    leftKind: LlvmKind,
+    rightKind: LlvmKind,
+    loc: SourceLocation | undefined,
+  ): void {
+    const kindLabel = (k: LlvmKind): string => {
+      if (k === "ptr") return "string/object (i8*)";
+      if (k === "double") return "number (double)";
+      if (k === "i1") return "boolean (i1)";
+      return "unknown";
+    };
+    const output = formatCompileError(
+      this.sourceCode,
+      "type mismatch in '" +
+        op +
+        "': left operand is " +
+        kindLabel(leftKind) +
+        ", right operand is " +
+        kindLabel(rightKind),
+      loc,
+      "both sides of '" + op + "' must have the same LLVM representation",
+      ["use a ternary with explicit types: 'left !== null ? left : right'"],
+    );
+    process.stderr.write(output);
+    process.exit(1);
+  }
+}

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -191,26 +191,27 @@ class MixedOperatorChecker {
     return KIND_UNKNOWN;
   }
 
+  private kindLabel(k: string): string {
+    if (k === KIND_PTR) return "string/object (i8*)";
+    if (k === KIND_DOUBLE) return "number (double)";
+    if (k === KIND_I1) return "boolean (i1)";
+    return "unknown";
+  }
+
   private report(
     op: string,
     leftKind: string,
     rightKind: string,
     loc: SourceLocation | undefined,
   ): void {
-    const kindLabel = (k: string): string => {
-      if (k === "ptr") return "string/object (i8*)";
-      if (k === "double") return "number (double)";
-      if (k === "i1") return "boolean (i1)";
-      return "unknown";
-    };
     const output = formatCompileError(
       this.sourceCode,
       "type mismatch in '" +
         op +
         "': left operand is " +
-        kindLabel(leftKind) +
+        this.kindLabel(leftKind) +
         ", right operand is " +
-        kindLabel(rightKind),
+        this.kindLabel(rightKind),
       loc,
       "both sides of '" + op + "' must have the same LLVM representation",
       ["use a ternary with explicit types: 'left !== null ? left : right'"],

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -235,9 +235,7 @@ class MixedOperatorChecker {
         this.kindLabel(rightKind),
       loc,
       "both sides of '" + op + "' must have the same LLVM representation",
-      [
-        "ensure both sides have the same type, e.g. convert to string: 'String(left) || String(right)'",
-      ],
+      ["ensure both sides produce the same LLVM type (both string, both number, or both boolean)"],
     );
     process.stderr.write(output);
     process.exit(1);

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -15,6 +15,7 @@ import type {
   BinaryNode,
   VariableNode,
   FunctionNode,
+  ClassMethod,
   SourceLocation,
   ReturnStatement,
   AssignmentStatement,
@@ -60,7 +61,7 @@ class MixedOperatorChecker {
     for (let i = 0; i < ast.classes.length; i++) {
       const cls = ast.classes[i];
       for (let j = 0; j < cls.methods.length; j++) {
-        this.checkFunction(cls.methods[j] as unknown as FunctionNode);
+        this.checkClassMethod(cls.methods[j]);
       }
     }
   }
@@ -75,6 +76,18 @@ class MixedOperatorChecker {
       }
     }
     if (fn.body) this.walkBlock(fn.body);
+  }
+
+  private checkClassMethod(method: ClassMethod): void {
+    this.scope.clear();
+    if (method.params && method.paramTypes) {
+      for (let i = 0; i < method.params.length; i++) {
+        if (i >= method.paramTypes.length) break;
+        const pt = method.paramTypes[i];
+        if (pt) this.scope.set(method.params[i], declaredTypeToKind(pt));
+      }
+    }
+    if (method.body) this.walkBlock(method.body);
   }
 
   private walkBlock(block: BlockStatement): void {

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -24,12 +24,15 @@ import type {
 } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
 
-type LlvmKind = "ptr" | "double" | "i1" | "unknown";
+const KIND_PTR = "ptr";
+const KIND_DOUBLE = "double";
+const KIND_I1 = "i1";
+const KIND_UNKNOWN = "unknown";
 
-function declaredTypeToKind(t: string): LlvmKind {
-  if (t === "number") return "double";
-  if (t === "boolean") return "i1";
-  return "ptr"; // string, class, interface, array, Map, Set, etc.
+function declaredTypeToKind(t: string): string {
+  if (t === "number") return KIND_DOUBLE;
+  if (t === "boolean") return KIND_I1;
+  return KIND_PTR; // string, class, interface, array, Map, Set, etc.
 }
 
 export function checkMixedOperators(ast: AST, sourceCode: string): void {
@@ -38,7 +41,7 @@ export function checkMixedOperators(ast: AST, sourceCode: string): void {
 }
 
 class MixedOperatorChecker {
-  private scope: Map<string, LlvmKind> = new Map();
+  private scope: Map<string, string> = new Map();
 
   constructor(private sourceCode: string) {}
 
@@ -148,7 +151,7 @@ class MixedOperatorChecker {
       if (bin.op === "||" || bin.op === "??") {
         const leftKind = this.exprKind(bin.left);
         const rightKind = this.exprKind(bin.right);
-        if (leftKind !== "unknown" && rightKind !== "unknown" && leftKind !== rightKind) {
+        if (leftKind !== KIND_UNKNOWN && rightKind !== KIND_UNKNOWN && leftKind !== rightKind) {
           this.report(bin.op, leftKind, rightKind, bin.loc);
         }
       }
@@ -172,30 +175,29 @@ class MixedOperatorChecker {
     }
   }
 
-  private exprKind(expr: Expression): LlvmKind {
-    if (!expr) return "unknown";
+  private exprKind(expr: Expression): string {
+    if (!expr) return KIND_UNKNOWN;
     const e = expr as { type: string };
-    if (e.type === "number") return "double";
-    if (e.type === "string") return "ptr";
-    if (e.type === "boolean") return "i1";
+    if (e.type === "number") return KIND_DOUBLE;
+    if (e.type === "string") return KIND_PTR;
+    if (e.type === "boolean") return KIND_I1;
     if (e.type === "variable") {
       const v = expr as VariableNode;
-      if (v.name === "null" || v.name === "undefined") return "unknown";
+      if (v.name === "null" || v.name === "undefined") return KIND_UNKNOWN;
       const known = this.scope.get(v.name);
-      return known !== undefined ? known : "unknown";
+      return known !== undefined ? known : KIND_UNKNOWN;
     }
-    // null/undefined literals from TS parser — skip, they're pointer-compatible
-    if (e.type === "null" || e.type === "undefined") return "unknown";
-    return "unknown";
+    if (e.type === "null" || e.type === "undefined") return KIND_UNKNOWN;
+    return KIND_UNKNOWN;
   }
 
   private report(
     op: string,
-    leftKind: LlvmKind,
-    rightKind: LlvmKind,
+    leftKind: string,
+    rightKind: string,
     loc: SourceLocation | undefined,
   ): void {
-    const kindLabel = (k: LlvmKind): string => {
+    const kindLabel = (k: string): string => {
       if (k === "ptr") return "string/object (i8*)";
       if (k === "double") return "number (double)";
       if (k === "i1") return "boolean (i1)";

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -235,7 +235,9 @@ class MixedOperatorChecker {
         this.kindLabel(rightKind),
       loc,
       "both sides of '" + op + "' must have the same LLVM representation",
-      ["use a ternary with explicit types: 'left !== null ? left : right'"],
+      [
+        "ensure both sides have the same type, e.g. convert to string: 'String(left) || String(right)'",
+      ],
     );
     process.stderr.write(output);
     process.exit(1);

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -66,6 +66,8 @@ class MixedOperatorChecker {
   }
 
   private checkFunction(fn: FunctionNode): void {
+    const savedScope = new Map(this.scope);
+    this.scope.clear();
     if (fn.params && fn.paramTypes) {
       for (let i = 0; i < fn.params.length; i++) {
         if (i >= fn.paramTypes.length) break;
@@ -74,6 +76,7 @@ class MixedOperatorChecker {
       }
     }
     if (fn.body) this.walkBlock(fn.body);
+    this.scope = savedScope;
   }
 
   private walkBlock(block: BlockStatement): void {

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -66,6 +66,7 @@ class MixedOperatorChecker {
   private checkFunction(fn: FunctionNode): void {
     if (fn.params && fn.paramTypes) {
       for (let i = 0; i < fn.params.length; i++) {
+        if (i >= fn.paramTypes.length) break;
         const pt = fn.paramTypes[i];
         if (pt) this.scope.set(fn.params[i], declaredTypeToKind(pt));
       }

--- a/src/semantic/mixed-operator-checker.ts
+++ b/src/semantic/mixed-operator-checker.ts
@@ -66,7 +66,6 @@ class MixedOperatorChecker {
   }
 
   private checkFunction(fn: FunctionNode): void {
-    const savedScope = new Map(this.scope);
     this.scope.clear();
     if (fn.params && fn.paramTypes) {
       for (let i = 0; i < fn.params.length; i++) {
@@ -76,7 +75,6 @@ class MixedOperatorChecker {
       }
     }
     if (fn.body) this.walkBlock(fn.body);
-    this.scope = savedScope;
   }
 
   private walkBlock(block: BlockStatement): void {

--- a/tests/fixtures/errors/mixed-operator-or.ts
+++ b/tests/fixtures/errors/mixed-operator-or.ts
@@ -1,0 +1,5 @@
+// @test-compile-error: type mismatch in '||'
+let x: string = "hello";
+let y: number = 42;
+const z = x || y;
+console.log(z);


### PR DESCRIPTION
## Before
\`const z = strVar || numVar\` compiled silently, codegen merged the two different LLVM types (i8\* and double) into an opaque i8\* pointer. Subsequent member access on the result produced wrong values, with divergent behavior between arm64 and x86-64.

## After
Compiler rejects \`||\` / \`??\` where the two sides map to different LLVM representations (i8\* vs double, i8\* vs i1, double vs i1). Error message points to the specific operands and suggests using a ternary with explicit types.

## Description
New semantic pass \`src/semantic/mixed-operator-checker.ts\` (~200 LOC). Walks the AST, builds a type-kind scope from declared variable types and function param types, and checks every \`||\` / \`??\` BinaryNode. Only flags when both sides have determinable LLVM kinds (literal or declared-type variable). Unknown-typed expressions (class instances, results of calls, etc.) are not flagged — conservative to avoid false positives.

Part of #658 Tier 2 — item #6.

## Next Steps
- Tier 2 #7: Reject partial \`as { field1, field2 }\` inline type assertions — force named AST types