### PR TITLE
[sema] admit member_access primitive .length/.size in annotator

### DIFF
--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -431,12 +431,21 @@ class TypeAnnotator {
     // Issue #658 gate-loosen step 2 (partial).
     if (e.type === "member_access") {
       const resolved = this.sink.resolveExpressionTypeRich(expr);
-      if (
-        resolved &&
-        resolved.sourceKind === "class" &&
-        this.isSafeVariableAnnotationType(resolved)
-      ) {
-        this.sink.appendExpressionType(expr, resolved);
+      if (resolved) {
+        if (
+          resolved.sourceKind === "class" &&
+          this.isSafeVariableAnnotationType(resolved)
+        ) {
+          this.sink.appendExpressionType(expr, resolved);
+        } else if (this.isSafePrimitiveMemberAccess(resolved)) {
+          // Issue #658 step 4. Narrowest safe primitive cell — `.length` /
+          // `.size` on arrays/strings/maps/sets. Resolved base is "number",
+          // sourceKind=primitive, arrayDepth=0. Stable LLVM type (double),
+          // independent of source-collection layout. Per #658 data: 459
+          // codegen-time miss events on chad-native; zero hit-diff predicted
+          // because resolver is pure (#672) and result kind is closed-form.
+          this.sink.appendExpressionType(expr, resolved);
+        }
       }
       return;
     }
@@ -481,6 +490,19 @@ class TypeAnnotator {
   // layouts that codegen chooses from at symbol-definition time, so the
   // declared answer can disagree with the symbol table's allocated storage
   // and produce wrong IR.
+  // Narrow primitive admission for member_access only. Restricted to
+  // base="number", arrayDepth=0, sourceKind=primitive, no nullable. Covers
+  // `.length` / `.size`. Avoids string/boolean to keep the cell narrow —
+  // boolean has i1↔double crossings in interface structs and string has
+  // null-vs-empty edge cases.
+  private isSafePrimitiveMemberAccess(rt: ResolvedType): boolean {
+    if (rt.sourceKind !== "primitive") return false;
+    if (rt.arrayDepth > 0) return false;
+    if (rt.qualifiers.isNullable) return false;
+    if (rt.base !== "number") return false;
+    return true;
+  }
+
   private isSafeVariableAnnotationType(rt: ResolvedType): boolean {
     if (rt.arrayDepth > 0) return false;
     if (rt.qualifiers.isNullable) return false;

--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -432,10 +432,7 @@ class TypeAnnotator {
     if (e.type === "member_access") {
       const resolved = this.sink.resolveExpressionTypeRich(expr);
       if (resolved) {
-        if (
-          resolved.sourceKind === "class" &&
-          this.isSafeVariableAnnotationType(resolved)
-        ) {
+        if (resolved.sourceKind === "class" && this.isSafeVariableAnnotationType(resolved)) {
           this.sink.appendExpressionType(expr, resolved);
         } else if (this.isSafePrimitiveMemberAccess(resolved)) {
           // Issue #658 step 4. Narrowest safe primitive cell — `.length` /


### PR DESCRIPTION
## Before
Annotator admitted only `member_access` where `sourceKind=class`. `.length` / `.size` (resolved as `sourceKind=primitive, base=number`) fell through to live codegen-time resolution — 459 miss events per compile of chad-native.ts.

## After
Annotator caches `member_access` results when resolved to `sourceKind=primitive, base=number, arrayDepth=0`. New `isSafePrimitiveMemberAccess` predicate keeps the cell narrow: number only, no string/boolean.

## Description
Issue #658 tier 2 step 4 — narrowest safe primitive cell. ~30 LOC.

Safety basis:
- Resolver purity proven (#672) — cached values cannot be corrupted mid-codegen.
- Closed-form result kind: `.length` / `.size` always returns a number with stable LLVM type (double).
- String/boolean deliberately excluded — i1↔double crossings in interface structs and null-vs-empty edge cases would widen the risk surface.

Predicted: zero hit-diff against the divergence harness (#673).