### PR TITLE
[ci] pre-push hook: run prettier --check before push

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coverage:report": "c8 report",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "HOOKS=$(git rev-parse --git-common-dir)/hooks && git config core.hooksPath \"$HOOKS\" && cp scripts/pre-commit \"$HOOKS/pre-commit\" && chmod +x \"$HOOKS/pre-commit\""
+    "prepare": "HOOKS=$(git rev-parse --git-common-dir)/hooks && git config core.hooksPath \"$HOOKS\" && cp scripts/pre-commit \"$HOOKS/pre-commit\" && chmod +x \"$HOOKS/pre-commit\" && cp scripts/pre-push \"$HOOKS/pre-push\" && chmod +x \"$HOOKS/pre-push\""
   },
   "keywords": [
     "compiler",

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Block pushes that would fail CI's format-check job.
+# Same command CI runs — if it passes here, it passes there.
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "pre-push: npx not found, skipping format check"
+  exit 0
+fi
+
+echo "pre-push: running prettier --check"
+if ! npx --no-install prettier --check . 2>&1; then
+  echo ""
+  echo "pre-push: format check FAILED — push aborted."
+  echo "  fix:   npm run format"
+  echo "  skip:  git push --no-verify  (do not — CI will fail)"
+  exit 1
+fi


### PR DESCRIPTION
## Before
Format violations only caught by CI (`format-check` job, ~22s after push). Wastes a roundtrip and clutters the PR with a `style: prettier` follow-up commit. Just hit this on PR #682.

## After
`scripts/pre-push` runs `prettier --check .` before every push. Same command as CI — if it passes here, it passes there. Hook is installed alongside the existing pre-commit hook by `npm install` (`prepare` script).

## Description
- New file: `scripts/pre-push`. Aborts push with a clear fix message if prettier finds anything.
- `package.json` `prepare` script extended to install both hooks.
- Users can still bypass with `--no-verify` — but the hook tells them CI will fail anyway, so don't.

After merge, every contributor gets the hook on next `npm install`.