### PR TITLE
[test] retry #682 atop EXP5 fix — empirical root-cause check

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -342,9 +342,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
   public emitError(message: string, loc?: SourceLocation, suggestion?: string): never {
     this.diagnostics.error(message, loc, suggestion);
-    const output = this.diagnostics.formatDiagnostic(
-      this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1],
-    );
+    const errors = this.diagnostics.getErrors();
+    const output = this.diagnostics.formatDiagnostic(errors[errors.length - 1]);
     process.stderr.write(output);
     process.exit(1);
   }

--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -431,12 +431,18 @@ class TypeAnnotator {
     // Issue #658 gate-loosen step 2 (partial).
     if (e.type === "member_access") {
       const resolved = this.sink.resolveExpressionTypeRich(expr);
-      if (
-        resolved &&
-        resolved.sourceKind === "class" &&
-        this.isSafeVariableAnnotationType(resolved)
-      ) {
-        this.sink.appendExpressionType(expr, resolved);
+      if (resolved) {
+        if (resolved.sourceKind === "class" && this.isSafeVariableAnnotationType(resolved)) {
+          this.sink.appendExpressionType(expr, resolved);
+        } else if (this.isSafePrimitiveMemberAccess(resolved)) {
+          // Issue #658 step 4. Narrowest safe primitive cell — `.length` /
+          // `.size` on arrays/strings/maps/sets. Resolved base is "number",
+          // sourceKind=primitive, arrayDepth=0. Stable LLVM type (double),
+          // independent of source-collection layout. Per #658 data: 459
+          // codegen-time miss events on chad-native; zero hit-diff predicted
+          // because resolver is pure (#672) and result kind is closed-form.
+          this.sink.appendExpressionType(expr, resolved);
+        }
       }
       return;
     }
@@ -481,6 +487,19 @@ class TypeAnnotator {
   // layouts that codegen chooses from at symbol-definition time, so the
   // declared answer can disagree with the symbol table's allocated storage
   // and produce wrong IR.
+  // Narrow primitive admission for member_access only. Restricted to
+  // base="number", arrayDepth=0, sourceKind=primitive, no nullable. Covers
+  // `.length` / `.size`. Avoids string/boolean to keep the cell narrow —
+  // boolean has i1↔double crossings in interface structs and string has
+  // null-vs-empty edge cases.
+  private isSafePrimitiveMemberAccess(rt: ResolvedType): boolean {
+    if (rt.sourceKind !== "primitive") return false;
+    if (rt.arrayDepth > 0) return false;
+    if (rt.qualifiers.isNullable) return false;
+    if (rt.base !== "number") return false;
+    return true;
+  }
+
   private isSafeVariableAnnotationType(rt: ResolvedType): boolean {
     if (rt.arrayDepth > 0) return false;
     if (rt.qualifiers.isNullable) return false;


### PR DESCRIPTION
## Purpose
Empirical test: does fixing \`symbol-table.ts:532\` (the \`||\` opacification, shipped in #684) actually unblock PR #682's annotator admission?

## What this PR contains
- All commits from #684 (or-fallback rule + symbol-table fix + walker patch)
- Plus the original PR #682 commit (member_access primitive admission) cherry-picked on top

## Outcome interpretation
- **CI green (Stage 0→1 self-hosting passes)**: confirmed root-cause. symbol-table.ts:532 was the bug all along; #682 just amplified its trigger rate. After this lands, can re-open #682 separately.
- **CI red, same Stage 0→1 segfault**: my hypothesis was wrong. There's another bug. Continue investigation.

## DO NOT MERGE
This is a test branch only. Whichever way CI goes, decide next steps from the result.