### PR TITLE
[codegen] fix emitError swallowing diagnostics (root cause of mystery segfaults)

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -342,9 +342,9 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
 
   public emitError(message: string, loc?: SourceLocation, suggestion?: string): never {
     this.diagnostics.error(message, loc, suggestion);
-    const output = this.diagnostics.formatDiagnostic(
-      this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1],
-    );
+    // Cache result. Two getErrors() calls in one expression hit issue #688.
+    const errors = this.diagnostics.getErrors();
+    const output = this.diagnostics.formatDiagnostic(errors[errors.length - 1]);
     process.stderr.write(output);
     process.exit(1);
   }


### PR DESCRIPTION
## Before
\`emitError\` evaluated \`this.diagnostics.getErrors()[this.diagnostics.getErrors().length - 1]\` — two separate \`getErrors()\` calls in one expression. \`getErrors()\` allocates a fresh filtered array on each call. In native chad, the temporary from the first call had no live ref while the index expression evaluated the second call, so the GC could collect it. Then the bounds check fired on the freed-and-reused buffer with length 0, printing \`Error: array index 0 out of bounds (length 0)\` and exiting 1 — **masking whatever diagnostic emitError was actually trying to print**.

This is the actual root cause of PR #682's 'Stage 0→1 segfault'. After this fix, the real underlying error surfaces: \`slice() was dispatched to string handler but received an array type '%StringArray*'\` — a clean diagnostic that was being eaten by emitError's own bug for days.

## After
Cache \`getErrors()\` to a local variable. Single allocation, GC can't collect it mid-expression, bounds check sees the right length, real diagnostic gets through.

## Description
- 4-line fix (3 changed lines).
- This is a band-aid for a class of bug that exists everywhere in the codebase: any \`f()[expr]\` where \`expr\` contains another call may hit the same race. Issue #688 tracks the proper fix in codegen (auto-root call results across nested-call subscripts).
- Once #688 lands, this fix becomes redundant and the inline form is safe to write.
- Follow-up implication: previously closed PRs (#682) may now be unblocked because the surfaced error is actually a smaller, fixable type-tracking issue, not a codegen segfault.