### PR TITLE
[codegen] fix slice() mis-dispatching StringArray variables to string handler

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -2817,6 +2817,17 @@ export class TypeInference {
       if (resolved && resolved.arrayDepth === 1 && resolved.base === "string") {
         return true;
       }
+      // Authoritative fallback: the LLVM type the symbol was bound with.
+      // resolveExpressionType + symbol.kind can disagree with the actual
+      // emitted LLVM type when codegen bound the variable as %StringArray*
+      // but the kind was inferred as ObjectArray. The symbol's llvmType is
+      // what handleSlice etc. will see, so dispatch must agree with it.
+      // Fixes a slice-mis-dispatch on `funcParams` in arrow-functions.ts
+      // surfaced after PR #689 made emitError actually print diagnostics.
+      if (e.type === "variable") {
+        const varName = (expr as VariableNode).name;
+        if (this.st.getType(varName) === "%StringArray*") return true;
+      }
       return false;
     }
     if (e.type === "array") {


### PR DESCRIPTION
## Before
\`isStringArrayExpression\` for variables relied on \`resolveExpressionType\` + \`symbol.kind\`. When codegen bound a variable as \`%StringArray*\` but the symbol-table kind was inferred as \`ObjectArray\` (kind=6), the function returned false. The slice dispatcher then routed the call to \`handleSlice\` (string handler), which immediately errored on the actual \`%StringArray*\` it received.

Example site: \`src/codegen/expressions/arrow-functions.ts:89\` — \`funcParams = funcParams.slice(0)\` where \`funcParams\` came from \`let funcParams = expr.params\` (\`expr.params\` is \`string[]\`). Codegen emitted \`%StringArray*\` correctly; the symbol-table kind was wrong; the dispatcher trusted the wrong source.

## After
\`isStringArrayExpression\` now also checks \`symbol.getType(varName) === \"%StringArray*\"\` as an authoritative fallback. The symbol's llvmType is what handleSlice/handleArraySlice/etc. will actually see, so dispatch must agree with it.

## Description
- Self-hosting: PR #687 retried PR #682's annotator change atop #689 (the emitError fix) and surfaced this exact diagnostic on both Linux and macOS — \`slice() was dispatched to string handler but received an array type '%StringArray*'\`. Confirmed locally as a node-vs-native divergence: \`isStringArrayExpression\` returns true under node, false under native.
- 11-line fix.
- Stage 0→1 self-hosting now passes locally with this + #689 + the previously-blocked PR #682 admission applied.
- **Stage 1→2 still segfaults in a different latent bug** (\`InterfaceStructGenerator_getInheritedFields\` strlen on null at construction time, address 0xc0). That's a separate issue, tracked separately. This PR fixes only the slice dispatch.
- No new fixture: the bug only surfaces under PR #682's annotator admission + the specific funcParams shape; isolated synthetic repro requires too much setup. The chain of evidence is: dispatcher debug print → DBG funcParams kind=6 llvmType=%StringArray* (mismatch confirmed locally).