### PR TITLE
[sema] reject f()[expr-with-call] pattern (issue #688 mitigation)

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -167,6 +167,7 @@ import { checkAsyncAwait } from "../semantic/async-await-checker.js";
 import { checkAmbiguousInits } from "../semantic/ambiguous-init-checker.js";
 import { checkUntypedParams } from "../semantic/untyped-param-checker.js";
 import { checkOrFallback } from "../semantic/or-fallback-checker.js";
+import { checkCallResultIndex } from "../semantic/call-result-index-checker.js";
 import { checkMixedOperators } from "../semantic/mixed-operator-checker.js";
 import {
   checkBinaryTypesDeep,
@@ -3064,6 +3065,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     checkAmbiguousInits(this.ast, this.sourceCode);
     checkUntypedParams(this.ast, this.sourceCode);
     checkOrFallback(this.ast, this.sourceCode, this.filename);
+    checkCallResultIndex(this.ast, this.sourceCode, this.filename);
     checkMixedOperators(this.ast, this.sourceCode);
     this.stackEligibleVars = analyzeEscapes(this.ast);
     markIntSpecializedFunctions(this.ast);

--- a/src/semantic/call-result-index-checker.ts
+++ b/src/semantic/call-result-index-checker.ts
@@ -53,7 +53,7 @@ import { formatCompileError } from "../diagnostics/engine.js";
 
 const CALL_RESULT_INDEX_GRANDFATHERED: string[] = [];
 
-function isGrandfathered(filename: string): boolean {
+function isCallResultIndexGrandfathered(filename: string): boolean {
   if (!filename) return false;
   for (let i = 0; i < CALL_RESULT_INDEX_GRANDFATHERED.length; i++) {
     if (filename.endsWith(CALL_RESULT_INDEX_GRANDFATHERED[i])) return true;
@@ -62,7 +62,7 @@ function isGrandfathered(filename: string): boolean {
 }
 
 export function checkCallResultIndex(ast: AST, sourceCode: string, filename?: string): void {
-  if (filename && isGrandfathered(filename)) return;
+  if (filename && isCallResultIndexGrandfathered(filename)) return;
   const checker = new CallResultIndexChecker(sourceCode);
   checker.check(ast);
 }

--- a/src/semantic/call-result-index-checker.ts
+++ b/src/semantic/call-result-index-checker.ts
@@ -1,0 +1,249 @@
+// Call-result index-subscript hazard checker.
+//
+// Rule: `f()[expr]` where `expr` (or any of its subtree) contains a function
+// or method call is banned. Bind the call result to a local first.
+//
+// Reproducible hazard: chad uses Boehm conservative GC. LLVM SSA register
+// promotion can place the result of `f()` in a register only — never spilled
+// to a stack slot. If `expr` triggers another allocation (any call), Boehm
+// can't see the register-only pointer, collects the array, and subsequent
+// indexing reads freed memory. This was the actual cause of the #682 /
+// #689 'Stage 0→1 segfault' class: `getErrors()[getErrors().length - 1]`
+// in emitError.
+//
+// Forcing users to bind to a local (`const arr = f(); arr[expr]`) puts the
+// pointer on the stack where Boehm can scan it. The cost is one extra
+// line; the win is eliminating a whole class of silent miscompiles.
+//
+// Follow-on issue #688 covers the deeper codegen fix (auto-root all pointer
+// SSA values). Until that ships, this sema rule prevents the pattern from
+// appearing in new code.
+
+import type {
+  AST,
+  Statement,
+  Expression,
+  BlockStatement,
+  VariableDeclaration,
+  IfStatement,
+  WhileStatement,
+  DoWhileStatement,
+  ForStatement,
+  ForOfStatement,
+  TryStatement,
+  SwitchStatement,
+  SwitchCase,
+  ReturnStatement,
+  AssignmentStatement,
+  BinaryNode,
+  UnaryNode,
+  ConditionalExpressionNode,
+  CallNode,
+  MethodCallNode,
+  MemberAccessNode,
+  IndexAccessNode,
+  TypeAssertionNode,
+  ObjectNode,
+  ObjectProperty,
+  ArrayNode,
+  TemplateLiteralNode,
+  SourceLocation,
+} from "../ast/types.js";
+import { formatCompileError } from "../diagnostics/engine.js";
+
+const GRANDFATHERED_FILES: string[] = [];
+
+function isGrandfathered(filename: string): boolean {
+  if (!filename) return false;
+  for (let i = 0; i < GRANDFATHERED_FILES.length; i++) {
+    if (filename.endsWith(GRANDFATHERED_FILES[i])) return true;
+  }
+  return false;
+}
+
+export function checkCallResultIndex(ast: AST, sourceCode: string, filename?: string): void {
+  if (filename && isGrandfathered(filename)) return;
+  const checker = new CallResultIndexChecker(sourceCode);
+  checker.check(ast);
+}
+
+class CallResultIndexChecker {
+  constructor(private sourceCode: string) {}
+
+  check(ast: AST): void {
+    const items = ast.topLevelItems;
+    if (items && items.length > 0) this.walkStatements(items as Statement[]);
+    for (let i = 0; i < ast.functions.length; i++) this.walkBlock(ast.functions[i].body);
+    for (let i = 0; i < ast.classes.length; i++) {
+      const cls = ast.classes[i];
+      for (let j = 0; j < cls.methods.length; j++) this.walkBlock(cls.methods[j].body);
+    }
+  }
+
+  private walkBlock(block: BlockStatement): void {
+    if (!block || !block.statements) return;
+    this.walkStatements(block.statements);
+  }
+
+  private walkStatements(stmts: Statement[]): void {
+    for (let i = 0; i < stmts.length; i++) this.walkStatement(stmts[i]);
+  }
+
+  private walkStatement(stmt: Statement): void {
+    if (!stmt) return;
+    const t = (stmt as { type: string }).type;
+    if (!t) return;
+    if (t === "variable_declaration") {
+      const decl = stmt as VariableDeclaration;
+      if (decl.value) this.walkExpr(decl.value);
+    } else if (t === "return") {
+      const ret = stmt as ReturnStatement;
+      if (ret.value) this.walkExpr(ret.value);
+    } else if (t === "assignment") {
+      this.walkExpr((stmt as AssignmentStatement).value);
+    } else if (t === "if") {
+      const ifStmt = stmt as IfStatement;
+      this.walkExpr(ifStmt.condition);
+      this.walkBlock(ifStmt.thenBlock);
+      if (ifStmt.elseBlock) this.walkBlock(ifStmt.elseBlock);
+    } else if (t === "while") {
+      const w = stmt as WhileStatement;
+      this.walkExpr(w.condition);
+      this.walkBlock(w.body);
+    } else if (t === "do_while") {
+      const dw = stmt as DoWhileStatement;
+      this.walkExpr(dw.condition);
+      this.walkBlock(dw.body);
+    } else if (t === "for") {
+      const forStmt = stmt as ForStatement;
+      if (forStmt.init) {
+        const init = forStmt.init as { type: string };
+        if (init.type === "variable_declaration") {
+          const d = forStmt.init as VariableDeclaration;
+          if (d.value) this.walkExpr(d.value);
+        }
+      }
+      if (forStmt.condition) this.walkExpr(forStmt.condition);
+      this.walkBlock(forStmt.body);
+    } else if (t === "for_of") {
+      this.walkBlock((stmt as ForOfStatement).body);
+    } else if (t === "try") {
+      const tryStmt = stmt as TryStatement;
+      this.walkBlock(tryStmt.tryBlock);
+      if (tryStmt.catchBody) this.walkBlock(tryStmt.catchBody);
+      if (tryStmt.finallyBlock) this.walkBlock(tryStmt.finallyBlock);
+    } else if (t === "switch") {
+      const sw = stmt as SwitchStatement;
+      this.walkExpr(sw.discriminant);
+      for (let i = 0; i < sw.cases.length; i++) {
+        this.walkStatements((sw.cases[i] as SwitchCase).consequent);
+      }
+    } else {
+      this.walkExpr(stmt as Expression);
+    }
+  }
+
+  private walkExpr(expr: Expression): void {
+    if (!expr) return;
+    const e = expr as { type: string };
+    if (e.type === "index_access") {
+      const ia = expr as IndexAccessNode;
+      this.checkIndexAccess(ia);
+      this.walkExpr(ia.object);
+      this.walkExpr(ia.index);
+    } else if (e.type === "binary") {
+      const bin = expr as BinaryNode;
+      this.walkExpr(bin.left);
+      this.walkExpr(bin.right);
+    } else if (e.type === "unary") {
+      this.walkExpr((expr as UnaryNode).operand);
+    } else if (e.type === "conditional") {
+      const cond = expr as ConditionalExpressionNode;
+      this.walkExpr(cond.condition);
+      this.walkExpr(cond.consequent);
+      this.walkExpr(cond.alternate);
+    } else if (e.type === "call") {
+      const call = expr as CallNode;
+      for (let i = 0; i < call.args.length; i++) this.walkExpr(call.args[i]);
+    } else if (e.type === "method_call") {
+      const mc = expr as MethodCallNode;
+      this.walkExpr(mc.object);
+      for (let i = 0; i < mc.args.length; i++) this.walkExpr(mc.args[i]);
+    } else if (e.type === "member_access") {
+      this.walkExpr((expr as MemberAccessNode).object);
+    } else if (e.type === "type_assertion") {
+      this.walkExpr((expr as TypeAssertionNode).expression);
+    } else if (e.type === "object") {
+      const obj = expr as ObjectNode;
+      for (let i = 0; i < obj.properties.length; i++) {
+        this.walkExpr((obj.properties[i] as ObjectProperty).value);
+      }
+    } else if (e.type === "array") {
+      const arr = expr as ArrayNode;
+      if (arr.elements) {
+        for (let i = 0; i < arr.elements.length; i++) this.walkExpr(arr.elements[i]);
+      }
+    } else if (e.type === "template_literal") {
+      const tl = expr as TemplateLiteralNode;
+      if (tl.parts) {
+        for (let i = 0; i < tl.parts.length; i++) {
+          const part = tl.parts[i];
+          if (typeof part !== "string") this.walkExpr(part);
+        }
+      }
+    }
+  }
+
+  private checkIndexAccess(ia: IndexAccessNode): void {
+    const objBase = ia.object as { type: string };
+    if (objBase.type !== "call" && objBase.type !== "method_call") return;
+    // Object side is a direct call. Index side must be free of calls.
+    if (this.exprContainsCall(ia.index)) {
+      this.report(ia.loc);
+    }
+  }
+
+  private exprContainsCall(expr: Expression): boolean {
+    if (!expr) return false;
+    const e = expr as { type: string };
+    if (e.type === "call" || e.type === "method_call") return true;
+    if (e.type === "binary") {
+      const bin = expr as BinaryNode;
+      return this.exprContainsCall(bin.left) || this.exprContainsCall(bin.right);
+    }
+    if (e.type === "unary") return this.exprContainsCall((expr as UnaryNode).operand);
+    if (e.type === "conditional") {
+      const c = expr as ConditionalExpressionNode;
+      return (
+        this.exprContainsCall(c.condition) ||
+        this.exprContainsCall(c.consequent) ||
+        this.exprContainsCall(c.alternate)
+      );
+    }
+    if (e.type === "member_access") return this.exprContainsCall((expr as MemberAccessNode).object);
+    if (e.type === "index_access") {
+      const ia = expr as IndexAccessNode;
+      return this.exprContainsCall(ia.object) || this.exprContainsCall(ia.index);
+    }
+    if (e.type === "type_assertion") {
+      return this.exprContainsCall((expr as TypeAssertionNode).expression);
+    }
+    return false;
+  }
+
+  private report(loc: SourceLocation | undefined): void {
+    const output = formatCompileError(
+      this.sourceCode,
+      "indexing a call result with an expression that contains another call is unsafe — bind the call result to a local first",
+      loc,
+      "const tmp = f(); tmp[expr]  // instead of  f()[expr]",
+      [
+        "chad uses Boehm conservative GC. the call result can live in a register only; the second call's allocation may trigger GC and collect it, leaving the index reading freed memory",
+        "root cause: PR #689's emitError segfault was `getErrors()[getErrors().length - 1]` — same pattern",
+        "deeper fix (codegen auto-root): issue #688",
+      ],
+    );
+    process.stderr.write(output);
+    process.exit(1);
+  }
+}

--- a/src/semantic/call-result-index-checker.ts
+++ b/src/semantic/call-result-index-checker.ts
@@ -51,12 +51,12 @@ import type {
 } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
 
-const GRANDFATHERED_FILES: string[] = [];
+const CALL_RESULT_INDEX_GRANDFATHERED: string[] = [];
 
 function isGrandfathered(filename: string): boolean {
   if (!filename) return false;
-  for (let i = 0; i < GRANDFATHERED_FILES.length; i++) {
-    if (filename.endsWith(GRANDFATHERED_FILES[i])) return true;
+  for (let i = 0; i < CALL_RESULT_INDEX_GRANDFATHERED.length; i++) {
+    if (filename.endsWith(CALL_RESULT_INDEX_GRANDFATHERED[i])) return true;
   }
   return false;
 }

--- a/tests/fixtures/errors/call-result-indexed-with-call.ts
+++ b/tests/fixtures/errors/call-result-indexed-with-call.ts
@@ -1,0 +1,12 @@
+// @test-compile-error: indexing a call result
+function getArr(): string[] {
+  return ["a", "b", "c"];
+}
+function getIdx(): number {
+  return 1;
+}
+function main(): void {
+  const x = getArr()[getIdx()];
+  console.log(x);
+}
+main();


### PR DESCRIPTION
## Before
\`f()[expr]\` where \`expr\` contains another call is a latent segfault waiting to happen. Chad's Boehm conservative GC can't see pointers that live only in LLVM registers; if the index-side call triggers allocation, \`f()\`'s returned array may be collected before indexing reads it.

This was the exact root cause of PR #689's emitError segfault (\`getErrors()[getErrors().length - 1]\`). Cost: days of debugging, multiple closed PRs (#662, #681, #682, #690) that all traced back to this class of bug.

## After
New sema pass \`call-result-index-checker.ts\` rejects the pattern at compile time. Users bind the call result to a \`const\` first — the const puts the pointer on the stack where Boehm can scan it.

\`\`\`ts
// Rejected:
const x = getErrors()[getErrors().length - 1];

// Required:
const errors = getErrors();
const x = errors[errors.length - 1];
\`\`\`

## Description
- Scope: just \`f()[expr]\` / \`f.m()[expr]\` where expr subtree contains a call. Doesn't touch \`f().method(g())\`, \`f().field[g()]\`, or other patterns that may also hit issue #688 — those need the deeper codegen fix.
- Severity: ERROR. \`GRANDFATHERED_FILES\` ships EMPTY — probed \`src/chad-native.ts\`, zero existing violations. Rule applies everywhere from day one.
- Positive fixture: \`tests/fixtures/errors/call-result-indexed-with-call.ts\`.

## Why this isn't the full #688 fix
The full fix is a codegen pass that auto-roots every pointer-typed SSA value to a stack slot before any call that could trigger GC. That's ~200-500 LOC of codegen work across expression-dispatch, member.ts, index.ts, and method-calls.ts. Big, risky, and needs its own IR-diff validation.

This PR is a narrow sema rule that eliminates the one specific syntactic pattern that's burned us most. It's complementary to #688 — after #688 lands, this rule becomes redundant but harmless (and can be deleted).

## Lessons from tonight encoded here
See updated commentary in issue #688. Short version: conservative GC + SSA register promotion = any seemingly unrelated codegen change can silently unmask latent pointer-collection bugs elsewhere. Past week's "Stage 0→1 segfaults" were almost entirely this class.