### PR TITLE
[codegen] fix subscript on this.field.method() result + fail-loud fallthrough

### DIFF
--- a/src/codegen/expressions/access/index.ts
+++ b/src/codegen/expressions/access/index.ts
@@ -126,8 +126,15 @@ export class IndexAccessGenerator {
       }
     }
 
-    // Handle string[index] - returns character code as i32, then convert to double
-    return this.generateStringCharIndex(expr, params);
+    if (this.ctx.isStringExpression(expr.object)) {
+      return this.generateStringCharIndex(expr, params);
+    }
+
+    this.ctx.emitError(
+      "cannot determine element type of subscripted expression",
+      (expr as { loc?: SourceLocation }).loc,
+      "bind the expression to a typed variable first, e.g. `const arr: T[] = expr; arr[i]`",
+    );
   }
 
   private generateProcessArgvIndex(expr: IndexAccessNode, params: string[]): string {

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -32,6 +32,7 @@ import {
   parseMapTypeString,
   createResolvedType,
   tsTypeToLlvm,
+  isObjectArrayTsType,
 } from "./type-system.js";
 import type {
   ResolvedType,
@@ -1882,7 +1883,7 @@ export class TypeInference {
     }
     if (e.type === "call") {
       const rt = this.getCallReturnType(expr);
-      if (rt && rt.endsWith("[]") && rt !== "string[]" && rt !== "number[]" && rt !== "boolean[]") {
+      if (rt && isObjectArrayTsType(rt)) {
         return true;
       }
       return false;
@@ -1931,11 +1932,8 @@ export class TypeInference {
         const className = this.ctx.getCurrentClassName();
         if (className) {
           const method = this.getClassMethod(className, methodExpr.method);
-          if (method && method.returnType) {
-            const rt = stripNullable(method.returnType);
-            if (rt.endsWith("[]") && rt !== "string[]" && rt !== "number[]" && rt !== "boolean[]") {
-              return true;
-            }
+          if (method && method.returnType && isObjectArrayTsType(method.returnType)) {
+            return true;
           }
         }
       }
@@ -1952,11 +1950,19 @@ export class TypeInference {
         }
         if (className) {
           const method = this.getClassMethod(className, methodExpr.method);
-          if (method && method.returnType) {
-            const rt = stripNullable(method.returnType);
-            if (rt.endsWith("[]") && rt !== "string[]" && rt !== "number[]" && rt !== "boolean[]") {
-              return true;
-            }
+          if (method && method.returnType && isObjectArrayTsType(method.returnType)) {
+            return true;
+          }
+        }
+      }
+      if (methodObjBase.type === "member_access") {
+        const memberTypeName = this.resolveNestedMemberAccessTsType(
+          methodExpr.object as MemberAccessNode,
+        );
+        if (memberTypeName) {
+          const method = this.getClassMethod(memberTypeName, methodExpr.method);
+          if (method && method.returnType && isObjectArrayTsType(method.returnType)) {
+            return true;
           }
         }
       }
@@ -2185,11 +2191,8 @@ export class TypeInference {
         const className = this.ctx.getCurrentClassName();
         if (className) {
           const method = this.getClassMethod(className, methodExpr.method);
-          if (method && method.returnType) {
-            const rt = stripNullable(method.returnType);
-            if (rt.endsWith("[]") && rt !== "string[]" && rt !== "number[]" && rt !== "boolean[]") {
-              return rt.slice(0, -2);
-            }
+          if (method && method.returnType && isObjectArrayTsType(method.returnType)) {
+            return stripNullable(method.returnType).slice(0, -2);
           }
         }
       }
@@ -2206,11 +2209,8 @@ export class TypeInference {
         }
         if (className) {
           const method = this.getClassMethod(className, methodExpr.method);
-          if (method && method.returnType) {
-            const rt = stripNullable(method.returnType);
-            if (rt.endsWith("[]") && rt !== "string[]" && rt !== "number[]" && rt !== "boolean[]") {
-              return rt.slice(0, -2);
-            }
+          if (method && method.returnType && isObjectArrayTsType(method.returnType)) {
+            return stripNullable(method.returnType).slice(0, -2);
           }
         }
       }

--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -27,6 +27,14 @@ export function isNullableType(t: string): boolean {
   return false;
 }
 
+// TODO: replace string pattern matching with structured ResolvedType check — fragile against Array<T> syntax and novel primitives
+export function isObjectArrayTsType(tsType: string): boolean {
+  const rt = stripNullable(tsType);
+  if (!rt.endsWith("[]")) return false;
+  const elem = rt.slice(0, rt.length - 2);
+  return elem !== "string" && elem !== "number" && elem !== "boolean";
+}
+
 interface TypeQualifiers {
   isNullable: boolean;
   isOptional: boolean;

--- a/tests/fixtures/classes/class-member-method-subscript.ts
+++ b/tests/fixtures/classes/class-member-method-subscript.ts
@@ -1,0 +1,38 @@
+// @test-description: subscript on this.field.method() result resolves to ObjectArray
+interface Box {
+  tag: string;
+  n: number;
+}
+
+class Inner {
+  items: Box[] = [];
+  getAll(): Box[] {
+    const r: Box[] = [];
+    for (let i = 0; i < this.items.length; i++) {
+      r.push(this.items[i]);
+    }
+    return r;
+  }
+}
+
+class Outer {
+  inner: Inner;
+  constructor() {
+    this.inner = new Inner();
+  }
+  emit(): void {
+    this.inner.items.push({ tag: "a", n: 1 });
+    this.inner.items.push({ tag: "b", n: 2 });
+    const all = this.inner.getAll();
+    const last = all[all.length - 1];
+    if (last.tag === "b" && last.n === 2) {
+      console.log("TEST_PASSED");
+    }
+  }
+}
+
+function main(): void {
+  const o = new Outer();
+  o.emit();
+}
+main();


### PR DESCRIPTION
## Before
`this.inner.getAll()[i]` segfaults (exit 139). `isObjectArrayByDispatch` handles `this.method()` and `var.method()` but not `this.field.method()` — the `member_access` base case was missing. Falls through to `generateStringCharIndex` which does `strlen` on an `%ObjectArray*` pointer.

Additionally, ANY unrecognized subscript expression silently falls through to string byte-indexing — every future blind spot in type-inference.ts is a potential segfault.

## After
- `this.field.method()[i]` resolves correctly via `resolveNestedMemberAccessTsType`
- Unrecognized subscript expressions emit a **compile error** instead of silently generating wrong code
- Extracted `isObjectArrayTsType()` helper to consolidate 6 copies of the fragile `endsWith("[]")` guard

## Description
~38 LOC net. Three changes:
1. Add `member_access` handler to `isObjectArrayByDispatch` (~15 LOC)
2. Replace silent fallthrough in `index.ts:generate()` with `emitError` (~5 LOC)
3. Extract `isObjectArrayTsType` into `type-system.ts`, migrate 6 call sites (~18 LOC)

Fixes #694. See #695 for the broader string-based type system cleanup.

## Test plan
- [x] Repro fixture (`/tmp/repro-694.ts`) no longer segfaults
- [x] New test fixture `class-member-method-subscript.ts` passes
- [x] Full verify (tests + stage 0/1/2 self-hosting) green