### PR TITLE
[codegen] add member_access dispatch to isStringArrayExpression and isArrayExpressionByType

### DIFF
--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -1795,6 +1795,18 @@ export class TypeInference {
           }
         }
       }
+      if (methodObjBase.type === "member_access") {
+        const memberTypeName = this.resolveNestedMemberAccessTsType(
+          methodExpr.object as MemberAccessNode,
+        );
+        if (memberTypeName) {
+          const method = this.getClassMethod(memberTypeName, methodExpr.method);
+          if (method && method.returnType) {
+            const rt = stripNullable(method.returnType);
+            if (rt.endsWith("[]")) return true;
+          }
+        }
+      }
       return false;
     }
     if (e.type === "call") {
@@ -2952,6 +2964,17 @@ export class TypeInference {
         const className = this.st.getClassName((methodExpr.object as VariableNode).name);
         if (className) {
           const method = this.getClassMethod(className, methodExpr.method);
+          if (method && method.returnType === "string[]") {
+            return true;
+          }
+        }
+      }
+      if (objBase.type === "member_access") {
+        const memberTypeName = this.resolveNestedMemberAccessTsType(
+          methodExpr.object as MemberAccessNode,
+        );
+        if (memberTypeName) {
+          const method = this.getClassMethod(memberTypeName, methodExpr.method);
           if (method && method.returnType === "string[]") {
             return true;
           }

--- a/tests/fixtures/classes/class-member-method-number-array.ts
+++ b/tests/fixtures/classes/class-member-method-number-array.ts
@@ -1,0 +1,33 @@
+// @test-description: subscript on this.field.method() returning number[] resolves correctly
+class Scores {
+  data: number[] = [];
+  getAll(): number[] {
+    const r: number[] = [];
+    for (let i = 0; i < this.data.length; i++) {
+      r.push(this.data[i]);
+    }
+    return r;
+  }
+}
+
+class Board {
+  scores: Scores;
+  constructor() {
+    this.scores = new Scores();
+  }
+  check(): void {
+    this.scores.data.push(10);
+    this.scores.data.push(42);
+    const all = this.scores.getAll();
+    const last = all[all.length - 1];
+    if (last === 42) {
+      console.log("TEST_PASSED");
+    }
+  }
+}
+
+function main(): void {
+  const b = new Board();
+  b.check();
+}
+main();

--- a/tests/fixtures/classes/class-member-method-string-array.ts
+++ b/tests/fixtures/classes/class-member-method-string-array.ts
@@ -1,0 +1,33 @@
+// @test-description: subscript on this.field.method() returning string[] resolves correctly
+class TagStore {
+  tags: string[] = [];
+  getAllTags(): string[] {
+    const r: string[] = [];
+    for (let i = 0; i < this.tags.length; i++) {
+      r.push(this.tags[i]);
+    }
+    return r;
+  }
+}
+
+class Registry {
+  store: TagStore;
+  constructor() {
+    this.store = new TagStore();
+  }
+  check(): void {
+    this.store.tags.push("alpha");
+    this.store.tags.push("beta");
+    const all = this.store.getAllTags();
+    const last = all[all.length - 1];
+    if (last === "beta") {
+      console.log("TEST_PASSED");
+    }
+  }
+}
+
+function main(): void {
+  const r = new Registry();
+  r.check();
+}
+main();


### PR DESCRIPTION
## Before
`this.field.method()` returning `string[]` or `number[]` was unhandled in `isStringArrayExpression` and `isArrayExpressionByType`. Same blind spot as #694 — only `this.method()` and `variable.method()` bases were handled, not `member_access.method()`.

## After
Both methods now resolve `member_access` bases via `resolveNestedMemberAccessTsType`, matching the fix in #696 for `isObjectArrayByDispatch`.

## Description
~30 LOC across 2 methods. Adds 2 test fixtures (`class-member-method-string-array.ts`, `class-member-method-number-array.ts`). Part of #697 fail-loud dispatch hardening.