### PR TITLE
[sema] add duplicate module-level declaration checker

### DIFF
--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -168,6 +168,7 @@ import { checkAmbiguousInits } from "../semantic/ambiguous-init-checker.js";
 import { checkUntypedParams } from "../semantic/untyped-param-checker.js";
 import { checkOrFallback } from "../semantic/or-fallback-checker.js";
 import { checkMixedOperators } from "../semantic/mixed-operator-checker.js";
+import { checkDuplicateDeclarations } from "../semantic/duplicate-decl-checker.js";
 import {
   checkBinaryTypesDeep,
   checkMissingReturns,
@@ -3065,6 +3066,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
     checkUntypedParams(this.ast, this.sourceCode);
     checkOrFallback(this.ast, this.sourceCode, this.filename);
     checkMixedOperators(this.ast, this.sourceCode);
+    checkDuplicateDeclarations(this.ast, this.sourceCode);
     this.stackEligibleVars = analyzeEscapes(this.ast);
     markIntSpecializedFunctions(this.ast);
     // Build pure-AST class + interface catalog so downstream queries

--- a/src/semantic/duplicate-decl-checker.ts
+++ b/src/semantic/duplicate-decl-checker.ts
@@ -1,0 +1,68 @@
+import type { AST, SourceLocation } from "../ast/types.js";
+import { formatCompileError } from "../diagnostics/engine.js";
+
+export function checkDuplicateDeclarations(ast: AST, sourceCode: string): void {
+  const importedNames = new Set<string>();
+  for (let i = 0; i < ast.imports.length; i++) {
+    const imp = ast.imports[i];
+    for (let j = 0; j < imp.specifiers.length; j++) {
+      const spec = imp.specifiers[j];
+      if (spec.startsWith("* as ")) {
+        importedNames.add(spec.substring(5));
+      } else {
+        importedNames.add(spec);
+      }
+    }
+    if (imp.defaultImport) {
+      importedNames.add(imp.defaultImport);
+    }
+  }
+
+  const seen = new Map<string, { kind: string; loc?: SourceLocation }>();
+
+  for (let i = 0; i < ast.functions.length; i++) {
+    const fn = ast.functions[i];
+    if (fn.declare) continue;
+    const name = fn.name;
+    if (importedNames.has(name)) continue;
+    const existing = seen.get(name);
+    if (existing) {
+      reportDuplicate(sourceCode, name, existing.kind, "function", fn.loc);
+    }
+    seen.set(name, { kind: "function", loc: fn.loc });
+  }
+
+  for (let i = 0; i < ast.topLevelStatements.length; i++) {
+    const stmt = ast.topLevelStatements[i];
+    if (stmt.type !== "variable_declaration") continue;
+    if (stmt.value === null) continue;
+    const name = stmt.name;
+    if (importedNames.has(name)) continue;
+    const existing = seen.get(name);
+    if (existing) {
+      reportDuplicate(sourceCode, name, existing.kind, stmt.kind, stmt.loc);
+    }
+    seen.set(name, { kind: stmt.kind, loc: stmt.loc });
+  }
+}
+
+function reportDuplicate(
+  sourceCode: string,
+  name: string,
+  firstKind: string,
+  secondKind: string,
+  loc?: SourceLocation,
+): void {
+  const output = formatCompileError(
+    sourceCode,
+    "duplicate module-level declaration '" + name + "'",
+    loc,
+    "rename one of the declarations to avoid LLVM symbol collision",
+    [
+      "first declared as " + firstKind,
+      "ChadScript merges all files into one flat module — names must be unique across all source files",
+    ],
+  );
+  process.stderr.write(output);
+  process.exit(1);
+}

--- a/tests/fixtures/errors/duplicate-module-decl.ts
+++ b/tests/fixtures/errors/duplicate-module-decl.ts
@@ -1,5 +1,5 @@
 // @test-description: duplicate module-level declarations produce compile error
-// @test-exit-code: 1
+// @test-compile-error: duplicate module-level declaration
 
 const FOO: number = 42;
 const FOO: number = 99;

--- a/tests/fixtures/errors/duplicate-module-decl.ts
+++ b/tests/fixtures/errors/duplicate-module-decl.ts
@@ -1,0 +1,10 @@
+// @test-description: duplicate module-level declarations produce compile error
+// @test-exit-code: 1
+
+const FOO: number = 42;
+const FOO: number = 99;
+
+function main(): void {
+  console.log("should not reach here");
+}
+main();


### PR DESCRIPTION
## Before
Two files defining the same function or const name merged silently — whichever linked last won, producing wrong behavior with no error.

## After
Compile-time error: `duplicate module-level declaration 'FOO'` with help text pointing to the collision.

## Description
New semantic pass `duplicate-decl-checker.ts` scans the merged flat AST for:
- Duplicate function names (skips `declare` functions)
- Duplicate `const`/`let` variable names (skips `declare const` — ambient type decls)
- Properly extracts namespace import names (`* as fs` → `fs`) to avoid false positives
- Excludes imported names from collision checks

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)