### PR TITLE
[codegen] fix element type for this.field.method()[i] subscript

### DIFF
--- a/src/codegen/infrastructure/class-allocator.ts
+++ b/src/codegen/infrastructure/class-allocator.ts
@@ -47,6 +47,7 @@ export interface ClassAllocatorContext {
   classGenGetClassFields(className: string): { name: string; fieldType: string }[];
   classGenGetFieldInfo(className: string | null, fieldName: string | null): FieldInfo | null;
   readonly symbolTable: SymbolTable;
+  getObjectArrayElementType(expr: Expression): string | null;
 }
 
 export class ClassAllocator {
@@ -208,6 +209,10 @@ export class ClassAllocator {
       ) {
         return objArrayMeta.elementInterfaceName;
       }
+    } else if (objBase.type === "method_call") {
+      const methodExpr = indexExpr.object as MethodCallNode;
+      const elemType = this.ctx.getObjectArrayElementType(methodExpr);
+      if (elemType && this.interfaceAlloc.isKnownClass(elemType)) return elemType;
     } else if (objBase.type === "member_access") {
       const memberAccess = indexExpr.object as MemberAccessNode;
       const memberObjBase = memberAccess.object as ExprBase;

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -2226,6 +2226,17 @@ export class TypeInference {
           }
         }
       }
+      if (methodObjBase.type === "member_access") {
+        const memberTypeName = this.resolveNestedMemberAccessTsType(
+          methodExpr.object as MemberAccessNode,
+        );
+        if (memberTypeName) {
+          const method = this.getClassMethod(memberTypeName, methodExpr.method);
+          if (method && method.returnType && isObjectArrayTsType(method.returnType)) {
+            return stripNullable(method.returnType).slice(0, -2);
+          }
+        }
+      }
     }
     if (e.type === "index_access") {
       const resolved = this.resolveExpressionType(expr);

--- a/tests/fixtures/classes/class-member-method-element-type.ts
+++ b/tests/fixtures/classes/class-member-method-element-type.ts
@@ -1,0 +1,31 @@
+class Item {
+  label: string;
+  constructor(label: string) {
+    this.label = label;
+  }
+}
+
+class Inner {
+  getItems(): Item[] {
+    const items: Item[] = [];
+    items.push(new Item("hello"));
+    items.push(new Item("world"));
+    return items;
+  }
+}
+
+class Outer {
+  inner: Inner;
+  constructor() {
+    this.inner = new Inner();
+  }
+  run(): void {
+    const first: Item = this.inner.getItems()[0];
+    if (first.label === "hello") {
+      console.log("TEST_PASSED");
+    }
+  }
+}
+
+const o = new Outer();
+o.run();


### PR DESCRIPTION
## Before
`this.inner.getItems()[0].label` read garbage memory — subscript on `member_access.method()` result couldn't determine the element class, defaulting to numeric indexing.

## After
Element type correctly resolved via `getObjectArrayElementType` → field access works.

## Description
Two fixes in the same `member_access.method()` blind spot pattern as #696/#698:

1. **`getObjectArrayElementType`** in `type-inference.ts`: added `member_access` handler for `method_call` objects so the element type (e.g., `"Item"`) is resolved from the method's return type
2. **`getIndexAccessClassName`** in `class-allocator.ts`: added `method_call` handler so variable-allocator recognizes `method()[i]` as returning a class instance (delegates to `getObjectArrayElementType`)

Also adds `getObjectArrayElementType` to `ClassAllocatorContext` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)