### PR TITLE
[semantic] fix binary type and arg count checks inside function bodies

### DIFF
--- a/src/semantic/safety-checks.ts
+++ b/src/semantic/safety-checks.ts
@@ -283,10 +283,16 @@ function mrAllReturn(stmts: Statement[], nn: string[]): boolean {
 export function checkBinaryTypesDeep(ast: AST, sourceCode: string): void {
   const items = ast.topLevelItems;
   if (items) binWalkStmts(items as Statement[], sourceCode);
-  for (let i = 0; i < ast.functions.length; i++) binWalkBlk(ast.functions[i].body, sourceCode);
+  for (let i = 0; i < ast.functions.length; i++) {
+    const fn = ast.functions[i];
+    binWalkBlk(fn.body, sourceCode);
+  }
   for (let i = 0; i < ast.classes.length; i++) {
     const cls = ast.classes[i];
-    for (let j = 0; j < cls.methods.length; j++) binWalkBlk(cls.methods[j].body, sourceCode);
+    for (let j = 0; j < cls.methods.length; j++) {
+      const m = cls.methods[j];
+      binWalkBlk(m.body, sourceCode);
+    }
   }
 }
 
@@ -526,10 +532,16 @@ export function checkArgumentCounts(ast: AST, sourceCode: string): void {
 
   const items = ast.topLevelItems;
   if (items) state.walkStmts(items as Statement[]);
-  for (let i = 0; i < ast.functions.length; i++) state.walkBlk(ast.functions[i].body);
+  for (let i = 0; i < ast.functions.length; i++) {
+    const fn = ast.functions[i];
+    state.walkBlk(fn.body);
+  }
   for (let i = 0; i < ast.classes.length; i++) {
     const cls = ast.classes[i];
-    for (let j = 0; j < cls.methods.length; j++) state.walkBlk(cls.methods[j].body);
+    for (let j = 0; j < cls.methods.length; j++) {
+      const m = cls.methods[j];
+      state.walkBlk(m.body);
+    }
   }
 }
 


### PR DESCRIPTION
## Before
Native-compiled compiler (stage1/stage2) silently accepted `"hello" - 5` inside function bodies — `checkBinaryTypesDeep` and `checkArgumentCounts` used direct property chains (`ast.functions[i].body`) which lose type info when the native compiler accesses ObjectArray elements.

## After
Both sema walkers store ObjectArray elements in local variables before field access, matching the pattern used by every other working sema pass. The `semantic/binary-type-in-function` test passes in stage1/stage2.

## Description
Root cause: `ast.functions[i].body` chains two operations — ObjectArray indexing (returns `i8*`) followed by field access (`.body`). Without an intermediate local variable with a declared type, the native compiler can't generate the correct GEP for the field. Every other sema pass that walks function bodies already stores in a local (`const fn = ast.functions[i]`) — these two were the outliers.

Fixed both `checkBinaryTypesDeep` and `checkArgumentCounts` in `safety-checks.ts`. ~12 LOC change.