### PR TITLE
[codegen] migrate inline object-array checks to isObjectArrayTsType()

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -32,6 +32,7 @@ import {
   tsTypeToLlvm,
   parseMapTypeString,
   canonicalTypeToLlvm,
+  isObjectArrayTsType,
 } from "../../infrastructure/type-system.js";
 import type { ResolvedType } from "../../infrastructure/type-system.js";
 import type {
@@ -1064,11 +1065,7 @@ export class MemberAccessGenerator {
       return value;
     } else if (fieldType.endsWith("[]")) {
       const resolvedTsType = tsType || fieldType;
-      const isObjectArray =
-        resolvedTsType.endsWith("[]") &&
-        resolvedTsType !== "number[]" &&
-        resolvedTsType !== "string[]" &&
-        resolvedTsType !== "boolean[]";
+      const isObjectArray = isObjectArrayTsType(resolvedTsType);
       const value = this.ctx.nextTemp();
       if (isObjectArray) {
         this.ctx.emit(`${value} = load %ObjectArray*, %ObjectArray** ${fieldPtr}`);
@@ -1130,8 +1127,7 @@ export class MemberAccessGenerator {
       this.ctx.setVariableType(value, "double");
       return value;
     } else if (tsType && tsType.endsWith("[]")) {
-      const isObjectArray =
-        tsType !== "number[]" && tsType !== "string[]" && tsType !== "boolean[]";
+      const isObjectArray = isObjectArrayTsType(tsType);
       const value = this.ctx.nextTemp();
       if (isObjectArray) {
         this.ctx.emit(`${value} = load %ObjectArray*, %ObjectArray** ${fieldPtr}`);

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -2011,23 +2011,11 @@ export class TypeInference {
         const className = this.st.getClassName((memberExpr.object as VariableNode).name);
         if (className) {
           const fieldType = this.ctx.classGenGetFieldType(className, memberExpr.property);
-          if (
-            fieldType &&
-            fieldType.endsWith("[]") &&
-            fieldType !== "string[]" &&
-            fieldType !== "number[]" &&
-            fieldType !== "boolean[]"
-          ) {
+          if (fieldType && isObjectArrayTsType(fieldType)) {
             return true;
           }
           const tsType = this.ctx.classGenGetFieldTsType(className, memberExpr.property);
-          if (
-            tsType &&
-            tsType.endsWith("[]") &&
-            tsType !== "string[]" &&
-            tsType !== "number[]" &&
-            tsType !== "boolean[]"
-          ) {
+          if (tsType && isObjectArrayTsType(tsType)) {
             return true;
           }
         }
@@ -2036,23 +2024,11 @@ export class TypeInference {
         const className = this.ctx.getCurrentClassName();
         if (className) {
           const fieldType = this.ctx.classGenGetFieldType(className, memberExpr.property);
-          if (
-            fieldType &&
-            fieldType.endsWith("[]") &&
-            fieldType !== "string[]" &&
-            fieldType !== "number[]" &&
-            fieldType !== "boolean[]"
-          ) {
+          if (fieldType && isObjectArrayTsType(fieldType)) {
             return true;
           }
           const tsType = this.ctx.classGenGetFieldTsType(className, memberExpr.property);
-          if (
-            tsType &&
-            tsType.endsWith("[]") &&
-            tsType !== "string[]" &&
-            tsType !== "number[]" &&
-            tsType !== "boolean[]"
-          ) {
+          if (tsType && isObjectArrayTsType(tsType)) {
             return true;
           }
         }
@@ -2062,26 +2038,14 @@ export class TypeInference {
         const paramType = this.getParameterType(varName);
         if (paramType) {
           const fieldType = this.getFieldTypeFromType(paramType, memberExpr.property);
-          if (
-            fieldType &&
-            fieldType.endsWith("[]") &&
-            fieldType !== "string[]" &&
-            fieldType !== "number[]" &&
-            fieldType !== "boolean[]"
-          ) {
+          if (fieldType && isObjectArrayTsType(fieldType)) {
             return true;
           }
         }
         const ifaceType2 = this.st.getInterfaceType(varName);
         if (ifaceType2 && ifaceType2.length > 0) {
           const fieldType = this.getFieldTypeFromType(ifaceType2, memberExpr.property);
-          if (
-            fieldType &&
-            fieldType.endsWith("[]") &&
-            fieldType !== "string[]" &&
-            fieldType !== "number[]" &&
-            fieldType !== "boolean[]"
-          ) {
+          if (fieldType && isObjectArrayTsType(fieldType)) {
             return true;
           }
         }
@@ -2090,12 +2054,7 @@ export class TypeInference {
           for (let ki = 0; ki < objMeta.keys.length; ki++) {
             if (objMeta.keys[ki] === memberExpr.property && objMeta.types[ki]) {
               const ft = objMeta.types[ki];
-              if (
-                ft.endsWith("[]") &&
-                ft !== "string[]" &&
-                ft !== "number[]" &&
-                ft !== "boolean[]"
-              ) {
+              if (isObjectArrayTsType(ft)) {
                 return true;
               }
             }
@@ -2111,13 +2070,7 @@ export class TypeInference {
             const fieldTsType = this.ctx.classGenGetFieldTsType(className, nestedMember.property);
             if (fieldTsType) {
               const fieldType = this.getFieldTypeFromType(fieldTsType, memberExpr.property);
-              if (
-                fieldType &&
-                fieldType.endsWith("[]") &&
-                fieldType !== "string[]" &&
-                fieldType !== "number[]" &&
-                fieldType !== "boolean[]"
-              ) {
+              if (fieldType && isObjectArrayTsType(fieldType)) {
                 return true;
               }
             }
@@ -2126,13 +2079,7 @@ export class TypeInference {
         const nestedType = this.resolveNestedMemberAccessTsType(nestedMember);
         if (nestedType) {
           const fieldType = this.getFieldTypeFromType(nestedType, memberExpr.property);
-          if (
-            fieldType &&
-            fieldType.endsWith("[]") &&
-            fieldType !== "string[]" &&
-            fieldType !== "number[]" &&
-            fieldType !== "boolean[]"
-          ) {
+          if (fieldType && isObjectArrayTsType(fieldType)) {
             return true;
           }
         }
@@ -2141,13 +2088,7 @@ export class TypeInference {
         const assertion = memberExpr.object as TypeAssertionNode;
         if (assertion.assertedType) {
           const fieldType = this.getFieldTypeFromType(assertion.assertedType, memberExpr.property);
-          if (
-            fieldType &&
-            fieldType.endsWith("[]") &&
-            fieldType !== "string[]" &&
-            fieldType !== "number[]" &&
-            fieldType !== "boolean[]"
-          ) {
+          if (fieldType && isObjectArrayTsType(fieldType)) {
             return true;
           }
         }
@@ -2258,26 +2199,14 @@ export class TypeInference {
         const paramType = this.getParameterType(varName);
         if (paramType) {
           const fieldType = this.getFieldTypeFromType(paramType, memberExpr.property);
-          if (
-            fieldType &&
-            fieldType.endsWith("[]") &&
-            fieldType !== "string[]" &&
-            fieldType !== "number[]" &&
-            fieldType !== "boolean[]"
-          ) {
+          if (fieldType && isObjectArrayTsType(fieldType)) {
             return fieldType.slice(0, -2);
           }
         }
         const ifaceType3 = this.st.getInterfaceType(varName);
         if (ifaceType3 && ifaceType3.length > 0) {
           const fieldType = this.getFieldTypeFromType(ifaceType3, memberExpr.property);
-          if (
-            fieldType &&
-            fieldType.endsWith("[]") &&
-            fieldType !== "string[]" &&
-            fieldType !== "number[]" &&
-            fieldType !== "boolean[]"
-          ) {
+          if (fieldType && isObjectArrayTsType(fieldType)) {
             return fieldType.slice(0, -2);
           }
         }
@@ -2287,12 +2216,7 @@ export class TypeInference {
         const fieldType = this.getFieldTypeFromType(objectType, memberExpr.property);
         if (fieldType) {
           const baseFieldType = stripNullable(fieldType);
-          if (
-            baseFieldType.endsWith("[]") &&
-            baseFieldType !== "string[]" &&
-            baseFieldType !== "number[]" &&
-            baseFieldType !== "boolean[]"
-          ) {
+          if (isObjectArrayTsType(baseFieldType)) {
             return baseFieldType.slice(0, -2);
           }
         }

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -49,7 +49,7 @@ import {
 import { TypeResolver, UnionCommonFields } from "./type-resolver/index.js";
 import type { FieldInfo } from "./type-resolver/types.js";
 import { stripOptional, stripNullable, tsTypeToLlvmJson } from "./type-system.js";
-import { parseTypeString, type ResolvedType } from "./type-system.js";
+import { parseTypeString, isObjectArrayTsType, type ResolvedType } from "./type-system.js";
 import { InterfaceAllocator } from "./interface-allocator.js";
 import { MapAllocator } from "./map-allocator.js";
 import { ClassAllocator } from "./class-allocator.js";
@@ -812,14 +812,7 @@ export class VariableAllocator {
     if (!isStringArray && strippedDeclType === "string[]") {
       isStringArray = true;
     }
-    if (
-      !isObjectArray &&
-      strippedDeclType &&
-      strippedDeclType.endsWith("[]") &&
-      strippedDeclType !== "string[]" &&
-      strippedDeclType !== "number[]" &&
-      strippedDeclType !== "boolean[]"
-    ) {
+    if (!isObjectArray && strippedDeclType && isObjectArrayTsType(strippedDeclType)) {
       isObjectArray = true;
     }
     if (!isMap && stmtDeclaredType.startsWith("Map<")) {

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -111,6 +111,7 @@ import {
 import {
   parseTypeString,
   parseMapTypeString,
+  isObjectArrayTsType,
   type ResolvedType,
 } from "./infrastructure/type-system.js";
 import { DiagnosticEngine } from "../diagnostics/engine.js";
@@ -2458,14 +2459,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         if (!isStringArray && stmt.declaredType === "string[]") {
           isStringArray = true;
         }
-        if (
-          !isObjectArray &&
-          stmt.declaredType &&
-          stmt.declaredType.endsWith("[]") &&
-          stmt.declaredType !== "string[]" &&
-          stmt.declaredType !== "number[]" &&
-          stmt.declaredType !== "boolean[]"
-        ) {
+        if (!isObjectArray && stmt.declaredType && isObjectArrayTsType(stmt.declaredType)) {
           isObjectArray = true;
         }
         if (

--- a/src/codegen/types/collections/array/iteration.ts
+++ b/src/codegen/types/collections/array/iteration.ts
@@ -13,6 +13,7 @@ import {
   isStringArrayType,
   isObjectArrayType,
 } from "./context.js";
+import { isObjectArrayTsType } from "../../../infrastructure/type-system.js";
 
 interface ExprBase {
   type: string;
@@ -36,13 +37,7 @@ function resolveObjectArrayElementType(gen: IGeneratorContext, objectExpr: ExprB
     }
     if (className) {
       const tsType = gen.classGenGetFieldTsType(className, memberExpr.property);
-      if (
-        tsType &&
-        tsType.endsWith("[]") &&
-        tsType !== "string[]" &&
-        tsType !== "number[]" &&
-        tsType !== "boolean[]"
-      ) {
+      if (tsType && isObjectArrayTsType(tsType)) {
         return tsType.slice(0, -2);
       }
     }

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -25,7 +25,11 @@ import {
   createObjectMetadataWithInterfaceAndPointerAlloca,
   createClassMetadata,
 } from "../../infrastructure/symbol-table.js";
-import { stripOptional, canonicalTypeToLlvm } from "../../infrastructure/type-system.js";
+import {
+  stripOptional,
+  canonicalTypeToLlvm,
+  isObjectArrayTsType,
+} from "../../infrastructure/type-system.js";
 import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
 
 // ============================================
@@ -1517,12 +1521,7 @@ export class ClassGenerator {
     if (returnType === "string") return "i8*";
     if (returnType === "string[]") return "%StringArray*";
     if (returnType === "number[]" || returnType === "boolean[]") return "%Array*";
-    if (
-      returnType.endsWith("[]") &&
-      returnType !== "string[]" &&
-      returnType !== "number[]" &&
-      returnType !== "boolean[]"
-    ) {
+    if (isObjectArrayTsType(returnType)) {
       return "%ObjectArray*";
     }
     if (returnType === "void") return "void";
@@ -1535,12 +1534,7 @@ export class ClassGenerator {
         if (part === "string") return "i8*";
         if (part === "string[]") return "%StringArray*";
         if (part === "number[]" || part === "boolean[]") return "%Array*";
-        if (
-          part.endsWith("[]") &&
-          part !== "string[]" &&
-          part !== "number[]" &&
-          part !== "boolean[]"
-        ) {
+        if (isObjectArrayTsType(part)) {
           return "%ObjectArray*";
         }
       }

--- a/src/codegen/types/objects/object.ts
+++ b/src/codegen/types/objects/object.ts
@@ -1,7 +1,7 @@
 import { Expression, ObjectNode, ObjectProperty } from "../../../ast/types.js";
 import { IGeneratorContext } from "../../infrastructure/generator-context.js";
 import type { InterfaceStructGenerator } from "../interface-struct-generator.js";
-import { tsTypeToLlvm } from "../../infrastructure/type-system.js";
+import { tsTypeToLlvm, isObjectArrayTsType } from "../../infrastructure/type-system.js";
 
 interface ObjectGeneratorContext extends IGeneratorContext {}
 
@@ -123,13 +123,7 @@ export class ObjectGenerator {
       } else {
         const savedExpectedType = this.ctx.getExpectedArrayElementType();
         const tsType = field.type;
-        if (
-          tsType &&
-          tsType.endsWith("[]") &&
-          tsType !== "string[]" &&
-          tsType !== "number[]" &&
-          tsType !== "boolean[]"
-        ) {
+        if (tsType && isObjectArrayTsType(tsType)) {
           this.ctx.setExpectedArrayElementType("pointer");
         } else if (tsType === "string[]") {
           this.ctx.setExpectedArrayElementType("string");
@@ -243,13 +237,7 @@ export class ObjectGenerator {
         const savedExpectedType = this.ctx.getExpectedArrayElementType();
         const savedDeclaredInterface = this.ctx.getCurrentDeclaredInterfaceType();
         const tsType = fieldTsType;
-        if (
-          tsType &&
-          tsType.endsWith("[]") &&
-          tsType !== "string[]" &&
-          tsType !== "number[]" &&
-          tsType !== "boolean[]"
-        ) {
+        if (tsType && isObjectArrayTsType(tsType)) {
           this.ctx.setExpectedArrayElementType("pointer");
         } else if (tsType === "string[]") {
           this.ctx.setExpectedArrayElementType("string");


### PR DESCRIPTION
## Before
~20 sites across 7 files independently check for object array types using:
```typescript
fieldType.endsWith("[]") &&
fieldType !== "string[]" &&
fieldType !== "number[]" &&
fieldType !== "boolean[]"
```

## After
All sites use the centralized `isObjectArrayTsType()` from `type-system.ts`. No user-facing change. Internal refactor only.

## Description
Consolidates scattered inline object-array type discrimination into a single canonical predicate. -148 lines, +32 lines.

Files changed:
- `type-inference.ts` — 13 sites migrated
- `object.ts` — 2 sites
- `class.ts` — 2 sites
- `member.ts` — 2 sites
- `llvm-generator.ts` — 1 site
- `variable-allocator.ts` — 1 site
- `iteration.ts` — 1 site

## Next Steps
- Introduce `ArrayKind` discriminated enum for exhaustive type dispatch (#695)
- Visitor pattern for expression type classification

Closes #695