### PR TITLE
[type-system] migrate 35 endsWith([]) guard checks to isAnyArrayTsType

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -33,6 +33,7 @@ import {
   parseMapTypeString,
   canonicalTypeToLlvm,
   isObjectArrayTsType,
+  isAnyArrayTsType,
 } from "../../infrastructure/type-system.js";
 import type { ResolvedType } from "../../infrastructure/type-system.js";
 import type {
@@ -1875,7 +1876,7 @@ export class MemberAccessGenerator {
         return elementType;
       }
       const paramType = this.getParameterTypeFromAST(varName);
-      if (paramType && paramType.endsWith("[]")) {
+      if (paramType && isAnyArrayTsType(paramType)) {
         const elemType = paramType.slice(0, -2);
         if (this.ctx.classGenGetClassFields(elemType).length > 0) {
           return elemType;
@@ -1909,7 +1910,7 @@ export class MemberAccessGenerator {
                 .replace(/ \| null/g, "")
                 .trim();
             }
-            if (tsType.endsWith("[]")) {
+            if (isAnyArrayTsType(tsType)) {
               const elemType = tsType.substring(0, tsType.length - 2);
               if (this.ctx.classGenGetClassFields(elemType).length > 0) {
                 return elemType;
@@ -2238,7 +2239,7 @@ export class MemberAccessGenerator {
       const memberAccess = arrayExpr as MemberAccessNode;
       const memberAccessObjBase = memberAccess.object as ExprBase;
       const arrayType = this.resolveMemberAccessType(memberAccess);
-      if (arrayType && arrayType.endsWith("[]")) {
+      if (arrayType && isAnyArrayTsType(arrayType)) {
         const elementType = arrayType.slice(0, -2);
         const interfaceInfoRaw = this.getInterfaceInfo(elementType);
         if (interfaceInfoRaw) {
@@ -2256,7 +2257,7 @@ export class MemberAccessGenerator {
         const paramType = this.getParameterTypeFromAST(varName);
         if (paramType) {
           const fieldType = this.getInterfaceFieldType(paramType, propName);
-          if (fieldType && fieldType.endsWith("[]")) {
+          if (fieldType && isAnyArrayTsType(fieldType)) {
             const fields = this.parseInlineObjectType(fieldType);
             if (fields) {
               const keys: string[] = [];
@@ -2287,7 +2288,7 @@ export class MemberAccessGenerator {
           const idx = objKeys.indexOf(propName);
           if (idx !== -1) {
             const fieldType = objTsTypes[idx];
-            if (fieldType && fieldType.endsWith("[]")) {
+            if (fieldType && isAnyArrayTsType(fieldType)) {
               const fields = this.parseInlineObjectType(fieldType);
               if (fields) {
                 const keys: string[] = [];
@@ -2317,7 +2318,7 @@ export class MemberAccessGenerator {
         const className = this.ctx.getCurrentClassName();
         if (className) {
           const fieldInfo = this.ctx.classGenGetFieldInfo(className, memberAccess.property);
-          if (fieldInfo && fieldInfo.tsType && fieldInfo.tsType.endsWith("[]")) {
+          if (fieldInfo && fieldInfo.tsType && isAnyArrayTsType(fieldInfo.tsType)) {
             const elementType = fieldInfo.tsType.slice(0, -2);
             const interfaceInfo = this.getInterfaceInfo(elementType);
             if (interfaceInfo) return interfaceInfo;
@@ -2328,7 +2329,7 @@ export class MemberAccessGenerator {
         const nestedType = this.resolveExpressionType(memberAccess.object);
         if (nestedType) {
           const fieldInfo = this.ctx.classGenGetFieldInfo(nestedType, memberAccess.property);
-          if (fieldInfo && fieldInfo.tsType && fieldInfo.tsType.endsWith("[]")) {
+          if (fieldInfo && fieldInfo.tsType && isAnyArrayTsType(fieldInfo.tsType)) {
             const elementType = fieldInfo.tsType.slice(0, -2);
             const interfaceInfo = this.getInterfaceInfo(elementType);
             if (interfaceInfo) return interfaceInfo;
@@ -2354,7 +2355,7 @@ export class MemberAccessGenerator {
         }
       }
       const paramType = this.getParameterTypeFromAST(varName);
-      if (paramType && paramType.endsWith("[]")) {
+      if (paramType && isAnyArrayTsType(paramType)) {
         const elemType = paramType.slice(0, -2);
         const interfaceInfo = this.getInterfaceInfo(elemType);
         if (interfaceInfo) {
@@ -2383,7 +2384,7 @@ export class MemberAccessGenerator {
       }
       if (className) {
         const retType = this.ctx.getMethodReturnType(className, mc.method);
-        if (retType && retType.endsWith("[]")) {
+        if (retType && isAnyArrayTsType(retType)) {
           const elemType = retType.slice(0, -2);
           const interfaceInfo = this.getInterfaceInfo(elemType);
           if (interfaceInfo) return interfaceInfo;
@@ -2399,7 +2400,7 @@ export class MemberAccessGenerator {
           const fn = ast.functions[fi] as FunctionNode;
           if (fn && fn.name === fnName && fn.returnType) {
             const rt = fn.returnType;
-            if (rt.endsWith("[]")) {
+            if (isAnyArrayTsType(rt)) {
               const elemType = rt.slice(0, -2);
               const interfaceInfo = this.getInterfaceInfo(elemType);
               if (interfaceInfo) return interfaceInfo;
@@ -3416,7 +3417,7 @@ export class MemberAccessGenerator {
     if (
       field.type &&
       ["string", "number", "boolean"].indexOf(field.type) === -1 &&
-      !field.type.endsWith("[]")
+      !isAnyArrayTsType(field.type)
     ) {
       this.storeInterfaceMetadata(value, field.type);
     }
@@ -3505,7 +3506,7 @@ export class MemberAccessGenerator {
     if (
       propTsType &&
       ["string", "number", "boolean"].indexOf(propTsType) === -1 &&
-      !propTsType.endsWith("[]")
+      !isAnyArrayTsType(propTsType)
     ) {
       this.storeInterfaceMetadata(value, propTsType);
     }
@@ -3591,7 +3592,7 @@ export class MemberAccessGenerator {
     if (
       propTsType &&
       ["string", "number", "boolean"].indexOf(propTsType) === -1 &&
-      !propTsType.endsWith("[]")
+      !isAnyArrayTsType(propTsType)
     ) {
       this.storeInterfaceMetadata(value, propTsType);
     }

--- a/src/codegen/expressions/method-calls/class-dispatch.ts
+++ b/src/codegen/expressions/method-calls/class-dispatch.ts
@@ -15,7 +15,11 @@ import {
 } from "../../../ast/types.js";
 import type { MethodCallGeneratorContext } from "../method-calls.js";
 import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
-import { mapParamTypeToLLVM, mapReturnTypeToLLVM } from "../../infrastructure/type-system.js";
+import {
+  mapParamTypeToLLVM,
+  mapReturnTypeToLLVM,
+  isAnyArrayTsType,
+} from "../../infrastructure/type-system.js";
 
 export interface InterfaceDefInfo {
   properties: { name: string; type: string }[];
@@ -754,7 +758,7 @@ export function handleClassMethods(
                 .replace(/ \| null/g, "")
                 .trim();
             }
-            if (tsType.endsWith("[]")) {
+            if (isAnyArrayTsType(tsType)) {
               tsType = tsType.substring(0, tsType.length - 2);
             }
             const classesLenIA = ctx.getAstClassesLength();

--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -26,7 +26,7 @@ import {
   createObjectMetadata,
   createObjectMetadataWithInterface,
 } from "./symbol-table.js";
-import { stripOptional, parseArrayTypeString } from "./type-system.js";
+import { stripOptional, parseArrayTypeString, isAnyArrayTsType } from "./type-system.js";
 import type { ResolvedType } from "./type-system.js";
 import type { FieldInfo } from "./type-resolver/types.js";
 import type { UnionCommonFields } from "./type-resolver/index.js";
@@ -145,7 +145,7 @@ export class ArrayAllocator {
     const allocaReg = this.ctx.nextAllocaReg(stmt.name);
 
     let elementType = this.ctx.getObjectArrayElementType(stmt.value!);
-    if (!elementType && stmt.declaredType && stmt.declaredType.endsWith("[]")) {
+    if (!elementType && stmt.declaredType && isAnyArrayTsType(stmt.declaredType)) {
       elementType = stmt.declaredType.slice(0, -2);
     }
 
@@ -426,7 +426,7 @@ export class ArrayAllocator {
         const tsTypes = objMeta.tsTypes as string[];
         if (tsTypes.length > 0) {
           const firstType = tsTypes[0];
-          if (firstType && firstType.endsWith("[]")) {
+          if (firstType && isAnyArrayTsType(firstType)) {
             const elementType = firstType.slice(0, -2);
             return this.interfaceAlloc.getTypeInfoForElementType(elementType);
           }
@@ -451,7 +451,7 @@ export class ArrayAllocator {
     if (idxObjBase.type === "method_call") {
       const methodCall = indexExpr.object as MethodCallNode;
       const returnType = this.getMethodCallReturnType(methodCall);
-      if (returnType && returnType.endsWith("[]")) {
+      if (returnType && isAnyArrayTsType(returnType)) {
         const elementType = returnType.slice(0, -2).trim();
         return this.interfaceAlloc.getTypeInfoForElementType(elementType);
       }
@@ -467,7 +467,7 @@ export class ArrayAllocator {
           const fn = funcs[i];
           if (fn.name === callExpr.name && fn.returnType) {
             const rt = fn.returnType;
-            if (rt.endsWith("[]")) {
+            if (isAnyArrayTsType(rt)) {
               const elementType = rt.slice(0, -2).trim();
               return this.interfaceAlloc.getTypeInfoForElementType(elementType);
             }

--- a/src/codegen/infrastructure/class-allocator.ts
+++ b/src/codegen/infrastructure/class-allocator.ts
@@ -17,7 +17,7 @@ import {
   SymbolMetadata,
   createClassMetadata,
 } from "./symbol-table.js";
-import { stripNullable } from "./type-system.js";
+import { stripNullable, isAnyArrayTsType } from "./type-system.js";
 import type { FieldInfo } from "./type-resolver/types.js";
 import type { ResolvedType } from "./type-system.js";
 
@@ -218,7 +218,7 @@ export class ClassAllocator {
               .replace(/ \| null/g, "")
               .trim();
           }
-          if (tsType.endsWith("[]")) {
+          if (isAnyArrayTsType(tsType)) {
             const elemType = tsType.substring(0, tsType.length - 2);
             if (this.interfaceAlloc.isKnownClass(elemType)) return elemType;
           }

--- a/src/codegen/infrastructure/map-allocator.ts
+++ b/src/codegen/infrastructure/map-allocator.ts
@@ -26,7 +26,12 @@ import {
   createObjectMetadataWithInterface,
   createInterfacePointerAllocaMetadata,
 } from "./symbol-table.js";
-import { stripOptional, parseMapTypeString, parseSetTypeString } from "./type-system.js";
+import {
+  stripOptional,
+  parseMapTypeString,
+  parseSetTypeString,
+  isAnyArrayTsType,
+} from "./type-system.js";
 import type { FieldInfo } from "./type-resolver/types.js";
 import type { ResolvedType } from "./type-system.js";
 
@@ -382,7 +387,7 @@ export class MapAllocator {
     if (!valueType) return null;
     if (valueType === "string" || valueType === "number" || valueType === "boolean") return null;
 
-    if (valueType.endsWith("[]")) {
+    if (isAnyArrayTsType(valueType)) {
       return valueType;
     }
 
@@ -397,7 +402,7 @@ export class MapAllocator {
     params: string[],
     interfaceName: string,
   ): void {
-    if (interfaceName.endsWith("[]")) {
+    if (isAnyArrayTsType(interfaceName)) {
       this.allocateMapGetArray(stmt, params, interfaceName);
       return;
     }

--- a/src/codegen/infrastructure/owner-resolver.ts
+++ b/src/codegen/infrastructure/owner-resolver.ts
@@ -1,5 +1,5 @@
 import type { Expression, VariableNode, MemberAccessNode } from "../../ast/types.js";
-import { stripNullable } from "./type-system.js";
+import { stripNullable, isAnyArrayTsType } from "./type-system.js";
 
 interface ExprBase {
   type: string;
@@ -35,7 +35,7 @@ export function resolveOwnerClass(
     const tsType = getFieldTsType(ownerClass, ma.property);
     if (!tsType) return null;
     const stripped = stripNullable(tsType);
-    if (stripped.endsWith("[]") || stripped.startsWith("Map<") || stripped.startsWith("Set<")) {
+    if (isAnyArrayTsType(stripped) || stripped.startsWith("Map<") || stripped.startsWith("Set<")) {
       return null;
     }
     if (isClassType(stripped)) return stripped;

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -33,6 +33,7 @@ import {
   createResolvedType,
   tsTypeToLlvm,
   isObjectArrayTsType,
+  isAnyArrayTsType,
 } from "./type-system.js";
 import type {
   ResolvedType,
@@ -1778,7 +1779,7 @@ export class TypeInference {
           const method = this.getClassMethod(className, methodExpr.method);
           if (method && method.returnType) {
             const rt = stripNullable(method.returnType);
-            if (rt.endsWith("[]")) return true;
+            if (isAnyArrayTsType(rt)) return true;
           }
         }
       }
@@ -1791,7 +1792,7 @@ export class TypeInference {
           const method = this.getClassMethod(className, methodExpr.method);
           if (method && method.returnType) {
             const rt = stripNullable(method.returnType);
-            if (rt.endsWith("[]")) return true;
+            if (isAnyArrayTsType(rt)) return true;
           }
         }
       }
@@ -1803,7 +1804,7 @@ export class TypeInference {
           const method = this.getClassMethod(memberTypeName, methodExpr.method);
           if (method && method.returnType) {
             const rt = stripNullable(method.returnType);
-            if (rt.endsWith("[]")) return true;
+            if (isAnyArrayTsType(rt)) return true;
           }
         }
       }
@@ -1849,14 +1850,14 @@ export class TypeInference {
         const paramType = this.getParameterType(varName);
         if (paramType) {
           const fieldType = this.getFieldTypeFromType(paramType, memberExpr.property);
-          if (fieldType && fieldType.endsWith("[]")) {
+          if (fieldType && isAnyArrayTsType(fieldType)) {
             return true;
           }
         }
         const ifaceType = this.st.getInterfaceType(varName);
         if (ifaceType && ifaceType.length > 0) {
           const fieldType = this.getFieldTypeFromType(ifaceType, memberExpr.property);
-          if (fieldType && fieldType.endsWith("[]")) {
+          if (fieldType && isAnyArrayTsType(fieldType)) {
             return true;
           }
         }
@@ -2636,7 +2637,7 @@ export class TypeInference {
       const method = this.getClassMethod(className, methodExpr.method);
       if (method && method.returnType) {
         const rt = stripNullable(method.returnType);
-        if (rt.endsWith("[]")) {
+        if (isAnyArrayTsType(rt)) {
           const elementTypeName = rt.slice(0, -2).trim();
           if (
             elementTypeName === "string" ||

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -49,7 +49,12 @@ import {
 import { TypeResolver, UnionCommonFields } from "./type-resolver/index.js";
 import type { FieldInfo } from "./type-resolver/types.js";
 import { stripOptional, stripNullable, tsTypeToLlvmJson } from "./type-system.js";
-import { parseTypeString, isObjectArrayTsType, type ResolvedType } from "./type-system.js";
+import {
+  parseTypeString,
+  isObjectArrayTsType,
+  isAnyArrayTsType,
+  type ResolvedType,
+} from "./type-system.js";
 import { InterfaceAllocator } from "./interface-allocator.js";
 import { MapAllocator } from "./map-allocator.js";
 import { ClassAllocator } from "./class-allocator.js";
@@ -1249,7 +1254,7 @@ export class VariableAllocator {
       }
       if (mcClassName) {
         const rt = this.ctx.getMethodReturnType(mcClassName, mc.method);
-        if (rt && !rt.endsWith("[]")) {
+        if (rt && !isAnyArrayTsType(rt)) {
           objectInterfaceType = stripNullable(rt);
         }
       }
@@ -1260,7 +1265,7 @@ export class VariableAllocator {
         const funcs = ast.functions || [];
         for (let i = 0; i < funcs.length; i++) {
           const fn = funcs[i];
-          if (fn.name === ce.name && fn.returnType && !fn.returnType.endsWith("[]")) {
+          if (fn.name === ce.name && fn.returnType && !isAnyArrayTsType(fn.returnType)) {
             objectInterfaceType = stripNullable(fn.returnType);
             break;
           }
@@ -1281,7 +1286,7 @@ export class VariableAllocator {
             const propType = objMeta.tsTypes[keyIdx];
             if (
               propType &&
-              !propType.endsWith("[]") &&
+              !isAnyArrayTsType(propType) &&
               propType !== "string" &&
               propType !== "number" &&
               propType !== "boolean"
@@ -1310,7 +1315,7 @@ export class VariableAllocator {
         const fieldType = field.type;
         if (
           fieldType &&
-          !fieldType.endsWith("[]") &&
+          !isAnyArrayTsType(fieldType) &&
           fieldType !== "string" &&
           fieldType !== "number" &&
           fieldType !== "boolean"

--- a/src/codegen/statements/for-of.ts
+++ b/src/codegen/statements/for-of.ts
@@ -612,7 +612,7 @@ export class ForOfGenerator {
 
   private parseInlineObjectType(typeStr: string): { name: string; type: string }[] | null {
     let str = typeStr.trim();
-    if (str.endsWith("[]")) {
+    if (isAnyArrayTsType(str)) {
       str = str.slice(0, -2).trim();
     }
     if (!str.startsWith("{") || !str.endsWith("}")) {

--- a/src/codegen/stdlib/json.ts
+++ b/src/codegen/stdlib/json.ts
@@ -17,6 +17,7 @@ interface ExprBase {
 }
 
 import { IGeneratorContext } from "../infrastructure/generator-context.js";
+import { isAnyArrayTsType } from "../infrastructure/type-system.js";
 
 export class JsonGenerator {
   private generatedKeys: string[];
@@ -643,7 +644,7 @@ export class JsonGenerator {
           lines.push("  store " + arrT + "* %value_" + fi + ", " + arrT + "** %field_ptr_" + fi);
           lines.push("  br label %" + nextLabel);
           lines.push("");
-        } else if (fieldType.endsWith("[]")) {
+        } else if (isAnyArrayTsType(fieldType)) {
           // Arrays of user-defined types not yet supported in nested parse.
           // Fail loud instead of emitting @parse_json_StackFrame[] broken IR.
           return this.ctx.emitError(


### PR DESCRIPTION
## Before
35 sites across 10 files use raw `endsWith("[]")` string checks to test whether a type is an array. These are fragile — if the internal representation ever changes, every site breaks independently.

## After
All 35 guard-check sites use `isAnyArrayTsType()` from the centralized `type-system.ts`. No user-facing change. Internal refactor only.

## Description
Continuation of #710. Only migrates **guard checks** (boolean is-it-an-array conditions) — NOT type-mapping sites (which determine LLVM struct types). This distinction was learned the hard way: PR #711's initial push included behavioral changes in type-mapping sites that broke Stage 1→2 self-hosting.

**Files changed (10):**
- `member.ts` — 14 sites (11 guards + 3 negated guards)
- `variable-allocator.ts` — 4 negated guards
- `type-inference.ts` — 6 guards
- `array-allocator.ts` — 4 guards
- `map-allocator.ts` — 2 guards
- `owner-resolver.ts` — 1 guard
- `class-allocator.ts` — 1 guard
- `class-dispatch.ts` — 1 guard
- `for-of.ts` — 1 guard
- `json.ts` — 1 guard

**Remaining from #710:** ~15 type-mapping sites + ~5 compound pattern sites still use raw `endsWith("[]")`. These need all-at-once migration to avoid the type inconsistency that broke #711.