### PR TITLE
[test] remove Array.isArray from STAGE1_TODO — already passing

### DIFF
--- a/tests/self-hosting.test.ts
+++ b/tests/self-hosting.test.ts
@@ -35,7 +35,7 @@ const NATIVE_ENV: NodeJS.ProcessEnv = {
 
 const STAGE0_TODO = new Set<string>([]);
 
-const STAGE1_TODO = new Set<string>(["arrays/array-isarray"]);
+const STAGE1_TODO = new Set<string>([]);
 
 function isCrashSignal(signal: string | null): boolean {
   return signal === "SIGSEGV" || signal === "SIGABRT" || signal === "SIGBUS";


### PR DESCRIPTION
## Before
`arrays/array-isarray` fixture was in `STAGE1_TODO`, skipped during Stage 1 self-hosting tests.

## After
Fixture runs and passes in Stage 1. Verified locally: `.build/chad build tests/fixtures/arrays/array-isarray.ts -o /tmp/out && /tmp/out` prints `TEST_PASSED`.

## Description
The underlying dispatch bug was fixed by earlier PRs. This just removes the skip marker so CI validates it going forward. Closes #707.