### PR TITLE
[type-system] migrate remaining 8 guard-check endsWith([]) to isAnyArrayTsType

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -3084,7 +3084,7 @@ export class MemberAccessGenerator {
               );
               const llvmFieldType = this.interfaceTsTypeToLlvm(propType);
               const value = this.ctx.nextTemp();
-              if (propType === "string" || propType.endsWith("[]") || propType.startsWith("%")) {
+              if (propType === "string" || isAnyArrayTsType(propType) || propType.startsWith("%")) {
                 this.ctx.emit(`${value} = load i8*, i8** ${fieldPtr}`);
                 this.ctx.setVariableType(value, "i8*");
               } else if (propType === "number" || propType === "boolean") {

--- a/src/codegen/infrastructure/assignment-generator.ts
+++ b/src/codegen/infrastructure/assignment-generator.ts
@@ -15,7 +15,7 @@ import type { SymbolTable, ClassInfo, ObjectArrayMetadata } from "./symbol-table
 import type { InterfaceStructGenerator } from "../types/interface-struct-generator.js";
 
 import type { FieldInfo } from "./type-resolver/types.js";
-import { stripNullable } from "./type-system.js";
+import { stripNullable, isAnyArrayTsType } from "./type-system.js";
 
 interface ObjectInfo {
   ptr: string;
@@ -650,7 +650,7 @@ export class AssignmentGenerator {
       const ownerClassName = this.ctx.resolveOwnerClass(memberAccess.object);
       if (ownerClassName) {
         const fieldInfo = this.ctx.classGenGetFieldInfo(ownerClassName, memberAccess.property);
-        if (fieldInfo && fieldInfo.tsType && fieldInfo.tsType.endsWith("[]")) {
+        if (fieldInfo && fieldInfo.tsType && isAnyArrayTsType(fieldInfo.tsType)) {
           const elementType = fieldInfo.tsType.slice(0, -2);
           const ifaceProps = this.ctx.getInterfaceProperties(elementType);
           if (ifaceProps) {

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -49,6 +49,7 @@ import {
   tsTypeToLlvm,
   mapParamTypeToLLVM,
   canonicalTypeToLlvm,
+  isAnyArrayTsType,
 } from "./type-system.js";
 import { findI64EligibleVariables } from "./integer-analysis.js";
 import type { LiftedFunction } from "../expressions/arrow-functions.js";
@@ -526,7 +527,7 @@ export class FunctionGenerator {
       } else if (llvmType === "%ObjectArray*") {
         let elementType = "";
         const pt = paramTypes[i] || "";
-        if (pt.endsWith("[]") && pt.length > 2) {
+        if (isAnyArrayTsType(pt)) {
           elementType = pt.substring(0, pt.length - 2);
         }
         if (elementType) {

--- a/src/codegen/infrastructure/type-context.ts
+++ b/src/codegen/infrastructure/type-context.ts
@@ -3,6 +3,7 @@ import {
   createResolvedType,
   createIntegerType,
   parseTypeString,
+  isAnyArrayTsType,
 } from "./type-system.js";
 
 export class TypeContext {
@@ -136,7 +137,7 @@ export class TypeContext {
     const special = this.resolveSpecial(typeStr);
     if (special) return special;
     if (typeStr === "boolean[]") return this.getArrayType("boolean");
-    if (typeStr.endsWith("[]")) {
+    if (isAnyArrayTsType(typeStr)) {
       const parsed = parseTypeString(typeStr);
       if (parsed.arrayDepth > 1) return parsed;
       const elem = typeStr.substring(0, typeStr.length - 2);

--- a/src/codegen/infrastructure/type-inference.ts
+++ b/src/codegen/infrastructure/type-inference.ts
@@ -2569,7 +2569,7 @@ export class TypeInference {
           for (let i = 0; i < parts.length; i++) {
             const part = parts[i].trim();
             if (part !== "null" && part !== "undefined") {
-              if (part.startsWith("{") && !part.endsWith("[]")) {
+              if (part.startsWith("{") && !isAnyArrayTsType(part)) {
                 return part;
               }
               const iface = this.getInterface(part);
@@ -2578,7 +2578,7 @@ export class TypeInference {
           }
         }
 
-        if (returnType.startsWith("{") && !stripNullable(returnType).endsWith("[]")) {
+        if (returnType.startsWith("{") && !isAnyArrayTsType(returnType)) {
           return returnType;
         }
 
@@ -2605,7 +2605,7 @@ export class TypeInference {
           for (let i = 0; i < parts.length; i++) {
             const part = parts[i].trim();
             if (part !== "null" && part !== "undefined") {
-              if (part.startsWith("{") && !part.endsWith("[]")) {
+              if (part.startsWith("{") && !isAnyArrayTsType(part)) {
                 return part;
               }
               const iface = this.getInterface(part);
@@ -2614,7 +2614,7 @@ export class TypeInference {
           }
         }
 
-        if (returnType.startsWith("{") && !stripNullable(returnType).endsWith("[]")) {
+        if (returnType.startsWith("{") && !isAnyArrayTsType(returnType)) {
           return returnType;
         }
 


### PR DESCRIPTION
## Before
8 `endsWith("[]")` guard-check sites in 5 files still used raw string checks instead of the centralized `isAnyArrayTsType()` helper.

## After
All guard-check sites use `isAnyArrayTsType()`. No behavioral change — these are exact equivalents (boolean conditions only, no type-mapping).

## Description
Third batch of guard-check migrations for #710. Sites migrated:
- `function-generator.ts:529` — object array element type extraction guard
- `type-context.ts:139` — array type resolution guard
- `assignment-generator.ts:653` — class field array check
- `type-inference.ts:2572,2581,2608,2617` — negated guards filtering arrays from interface resolution
- `member.ts:3087` — pointer-type field load guard

~19 type-mapping sites remain (tracked in #710) — those need all-at-once migration to avoid LLVM type inconsistencies.