### PR TITLE
[codegen] propagate concreteClass through closure capture for correct field access

### DIFF
--- a/src/codegen/expressions/arrow-functions.ts
+++ b/src/codegen/expressions/arrow-functions.ts
@@ -73,6 +73,7 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
     scopeVarNames?: string[],
     scopeVarTypes?: string[],
     scopeVarInterfaceTypes?: string[],
+    scopeVarConcreteClasses?: string[],
   ): string {
     const funcName = `__lambda_${this.anonFuncCounter++}`;
 
@@ -129,6 +130,7 @@ export class ArrowFunctionExpressionGenerator extends BaseGenerator {
         scopeVarTypes,
         funcName,
         scopeVarInterfaceTypes,
+        scopeVarConcreteClasses,
       );
       closureCaptures = analyzeResult.captures;
       closureEnvStructName = analyzeResult.envStructName;

--- a/src/codegen/expressions/method-calls/promise-handlers.ts
+++ b/src/codegen/expressions/method-calls/promise-handlers.ts
@@ -169,7 +169,12 @@ export function handlePromiseThen(
 
   const promiseCallbackTypes = { paramTypes: ["string", "any"], returnType: "void" };
   const scopeVarsResult = ctx.symbolTable.getScopeVarsArraysForClosure();
-  const scopeVarsTyped = scopeVarsResult as { names: string[]; types: string[] };
+  const scopeVarsTyped = scopeVarsResult as {
+    names: string[];
+    types: string[];
+    interfaceTypes: string[];
+    concreteClasses: string[];
+  };
 
   if (isCatch) {
     if (expr.args.length > 0) {
@@ -182,6 +187,8 @@ export function handlePromiseThen(
           promiseCallbackTypes,
           scopeVarsTyped.names,
           scopeVarsTyped.types,
+          scopeVarsTyped.interfaceTypes,
+          scopeVarsTyped.concreteClasses,
         );
         onRejected = `@${ctx.mangleUserName(callbackName)}`;
       } else if (callbackBase.type === "variable") {
@@ -199,6 +206,8 @@ export function handlePromiseThen(
           promiseCallbackTypes,
           scopeVarsTyped.names,
           scopeVarsTyped.types,
+          scopeVarsTyped.interfaceTypes,
+          scopeVarsTyped.concreteClasses,
         );
         onFulfilled = `@${ctx.mangleUserName(callbackName)}`;
       } else if (callbackBase.type === "variable") {
@@ -215,6 +224,8 @@ export function handlePromiseThen(
           promiseCallbackTypes,
           scopeVarsTyped.names,
           scopeVarsTyped.types,
+          scopeVarsTyped.interfaceTypes,
+          scopeVarsTyped.concreteClasses,
         );
         onRejected = `@${ctx.mangleUserName(callbackName)}`;
       } else if (callbackBase.type === "variable") {
@@ -257,7 +268,12 @@ export function handlePromiseFinally(
   // finally callbacks take no meaningful args but need void(i8*,i8*)* signature
   const finallyCallbackTypes = { paramTypes: ["string", "string"], returnType: "void" };
   const scopeVarsResult = ctx.symbolTable.getScopeVarsArraysForClosure();
-  const scopeVarsTyped = scopeVarsResult as { names: string[]; types: string[] };
+  const scopeVarsTyped = scopeVarsResult as {
+    names: string[];
+    types: string[];
+    interfaceTypes: string[];
+    concreteClasses: string[];
+  };
 
   if (expr.args.length > 0) {
     const callback = expr.args[0] as Expression;

--- a/src/codegen/expressions/orchestrator.ts
+++ b/src/codegen/expressions/orchestrator.ts
@@ -234,6 +234,7 @@ export class ExpressionGenerator {
       names: string[];
       types: string[];
       interfaceTypes: string[];
+      concreteClasses: string[];
     };
     let typeHints: { paramTypes?: string[]; returnType?: string } | undefined = undefined;
     const cbParamTypes = this.ctx.getExpectedCallbackParamTypes();
@@ -257,6 +258,7 @@ export class ExpressionGenerator {
       scopeVarsTyped.names,
       scopeVarsTyped.types,
       scopeVarsTyped.interfaceTypes,
+      scopeVarsTyped.concreteClasses,
     );
 
     const closureInfoResult = this.arrowFunctionGen.getClosureInfoForLambda(lambdaName);

--- a/src/codegen/infrastructure/closure-analyzer.ts
+++ b/src/codegen/infrastructure/closure-analyzer.ts
@@ -31,6 +31,7 @@ export interface CapturedVariable {
   name: string;
   llvmType: string;
   interfaceType?: string;
+  concreteClass?: string;
 }
 
 export interface ClosureInfo {
@@ -44,6 +45,7 @@ export class ClosureAnalyzer {
   private scopeVarNames: string[] = [];
   private scopeVarTypes: string[] = [];
   private scopeVarInterfaceTypes: string[] = [];
+  private scopeVarConcreteClasses: string[] = [];
 
   constructor() {
     this.declaredVars = new Set();
@@ -56,6 +58,7 @@ export class ClosureAnalyzer {
     scopeVarTypesIn: string[],
     lambdaName: string,
     scopeVarInterfaceTypesIn?: string[],
+    scopeVarConcreteClassesIn?: string[],
   ): ClosureInfo {
     this.declaredVars = new Set();
     this.referencedVarsList = [];
@@ -63,11 +66,15 @@ export class ClosureAnalyzer {
     this.scopeVarNames = [];
     this.scopeVarTypes = [];
     this.scopeVarInterfaceTypes = [];
+    this.scopeVarConcreteClasses = [];
     for (let i = 0; i < scopeVarNamesIn.length; i++) {
       this.scopeVarNames.push(scopeVarNamesIn[i]);
       this.scopeVarTypes.push(scopeVarTypesIn[i]);
       this.scopeVarInterfaceTypes.push(
         scopeVarInterfaceTypesIn ? scopeVarInterfaceTypesIn[i] || "" : "",
+      );
+      this.scopeVarConcreteClasses.push(
+        scopeVarConcreteClassesIn ? scopeVarConcreteClassesIn[i] || "" : "",
       );
     }
 
@@ -88,10 +95,12 @@ export class ClosureAnalyzer {
       if (!this.declaredVars.has(varName) && this.hasScopeVar(varName)) {
         const idx = this.scopeVarNames.indexOf(varName);
         const ifaceType = idx >= 0 ? this.scopeVarInterfaceTypes[idx] : "";
+        const cc = idx >= 0 ? this.scopeVarConcreteClasses[idx] : "";
         captures.push({
           name: varName,
           llvmType: this.getScopeVarType(varName),
           interfaceType: ifaceType || undefined,
+          concreteClass: cc || undefined,
         });
       }
     }

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -702,8 +702,24 @@ export class FunctionGenerator {
         this.ctx.emit(`store ${capture.llvmType} ${valueReg}, ${capture.llvmType}* ${allocaReg}`);
 
         const kind = this.llvmTypeToSymbolKind(capture.llvmType);
-        this.ctx.defineVariable(capture.name, allocaReg, capture.llvmType, kind, "local");
-        const captureTyped = capture as { name: string; llvmType: string; interfaceType?: string };
+        const captureTyped = capture as {
+          name: string;
+          llvmType: string;
+          interfaceType?: string;
+          concreteClass?: string;
+        };
+        if (captureTyped.concreteClass) {
+          this.ctx.defineVariableWithMetadata(
+            capture.name,
+            allocaReg,
+            capture.llvmType,
+            kind,
+            "local",
+            createClassMetadata({ className: captureTyped.concreteClass }),
+          );
+        } else {
+          this.ctx.defineVariable(capture.name, allocaReg, capture.llvmType, kind, "local");
+        }
         if (captureTyped.interfaceType && capture.llvmType === "%ObjectArray*") {
           this.ctx.setRawInterfaceType(capture.name, captureTyped.interfaceType);
         }

--- a/src/codegen/infrastructure/generator-context.ts
+++ b/src/codegen/infrastructure/generator-context.ts
@@ -259,6 +259,8 @@ export interface IArrowFunctionGenerator {
     typeHints: { paramTypes?: string[]; returnType?: string } | undefined,
     scopeVarNames: string[] | undefined,
     scopeVarTypes: string[] | undefined,
+    scopeVarInterfaceTypes?: string[],
+    scopeVarConcreteClasses?: string[],
   ): string;
   getClosureInfoForLambda(
     lambdaName: string,
@@ -2155,6 +2157,8 @@ export class MockGeneratorContext implements IGeneratorContext {
       _typeHints: { paramTypes?: string[]; returnType?: string } | undefined,
       _scopeVarNames: string[] | undefined,
       _scopeVarTypes: string[] | undefined,
+      _scopeVarInterfaceTypes?: string[],
+      _scopeVarConcreteClasses?: string[],
     ): string => "__mock_lambda",
     getClosureInfoForLambda: (
       _lambdaName: string,

--- a/src/codegen/infrastructure/symbol-table.ts
+++ b/src/codegen/infrastructure/symbol-table.ts
@@ -1531,10 +1531,16 @@ export class SymbolTable {
     return scopeVars;
   }
 
-  getScopeVarsArraysForClosure(): { names: string[]; types: string[]; interfaceTypes: string[] } {
+  getScopeVarsArraysForClosure(): {
+    names: string[];
+    types: string[];
+    interfaceTypes: string[];
+    concreteClasses: string[];
+  } {
     const names: string[] = [];
     const types: string[] = [];
     const interfaceTypes: string[] = [];
+    const concreteClasses: string[] = [];
     for (let i = 0; i < this.symbolKeys.length; i++) {
       const name = this.symbolKeys[i];
       if (!name) {
@@ -1545,9 +1551,12 @@ export class SymbolTable {
         names.push(name);
         types.push(symbol.llvmType);
         interfaceTypes.push(this.interfaceTypes.get(name) || "");
+        const cc =
+          symbol.concreteClass || (symbol.classMetadata ? symbol.classMetadata.className : "");
+        concreteClasses.push(cc || "");
       }
     }
-    return { names: names, types: types, interfaceTypes: interfaceTypes };
+    return { names, types, interfaceTypes, concreteClasses };
   }
 
   /**

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -112,6 +112,8 @@ interface ArrowFunctionGeneratorLike {
     returnType?: string | { paramTypes?: string[]; returnType?: string },
     scopeVarNames?: string[],
     scopeVarTypes?: string[],
+    scopeVarInterfaceTypes?: string[],
+    scopeVarConcreteClasses?: string[],
   ): string;
   getClosureInfoForLambda(lambdaName: string): ClosureInfoResult | null;
   getLiftedFunctionByName(name: string): { returnType?: string } | undefined;

--- a/tests/fixtures/closures/closure-class-capture.ts
+++ b/tests/fixtures/closures/closure-class-capture.ts
@@ -1,0 +1,22 @@
+class Animal {
+  name: string = "dog";
+  legs: number = 4;
+}
+
+function testClosureClassCapture(): void {
+  const a = new Animal();
+  const items: string[] = ["x"];
+  items.forEach(() => {
+    if (a.name !== "dog") {
+      console.log("FAIL: expected dog, got " + a.name);
+      process.exit(1);
+    }
+    if (a.legs !== 4) {
+      console.log("FAIL: expected 4 legs");
+      process.exit(1);
+    }
+  });
+  console.log("TEST_PASSED");
+}
+
+testClosureClassCapture();


### PR DESCRIPTION
## Before
Accessing a class instance's fields inside a closure produced garbage data. The closure captured the struct pointer correctly, but the codegen lost the `concreteClass` metadata — it didn't know the variable was a class instance, so field access loaded the raw struct pointer as `i8*` instead of GEP-ing into the struct.

```ts
class T { h: string = "hello"; }
const t = new T();
arr.forEach(() => { console.log(t.h); }); // prints garbage
```

## After
Class field access inside closures works correctly. `t.h` resolves to the correct GEP index and prints `"hello"`.

## Description
Plumbs `concreteClass` through the closure capture pipeline:
1. `symbol-table.ts` — `getScopeVarsArraysForClosure()` now returns `concreteClasses` array
2. `closure-analyzer.ts` — `CapturedVariable` gains `concreteClass` field; `analyze()` accepts + propagates it
3. `arrow-functions.ts`, `orchestrator.ts`, `promise-handlers.ts` — pass concreteClasses through
4. `function-generator.ts` — uses `defineVariableWithMetadata` + `createClassMetadata` when capture has concreteClass
5. `variable-allocator.ts`, `generator-context.ts` — interface updates for new optional params

~80 LOC across 9 files + test fixture. Closes #646.