### PR TITLE
[llvm-builder] add switch, memcpy, fneg/frem, attrs, constants to builder bridge

### DIFF
--- a/c_bridges/llvm-builder-bridge.c
+++ b/c_bridges/llvm-builder-bridge.c
@@ -870,6 +870,122 @@ char* cs_llvm_build_select(const char* cond_name, const char* then_name, const c
     return strdup(name);
 }
 
+// ============ Switch ============
+
+char* cs_llvm_build_switch(const char* val_name, const char* default_label, double num_cases_d) {
+    int num_cases = (int)num_cases_d;
+    LLVMValueRef val = lookup_value(val_name);
+    LLVMBasicBlockRef def_bb = lookup_block(default_label);
+    if (!val || !def_bb) return strdup("");
+    LLVMValueRef sw = LLVMBuildSwitch(b_builder, val, def_bb, num_cases);
+    char* name = next_temp();
+    register_value(name, sw);
+    return strdup(name);
+}
+
+void cs_llvm_switch_add_case(const char* switch_name, const char* type_str,
+                              double case_val_d, const char* dest_label) {
+    LLVMValueRef sw = lookup_value(switch_name);
+    LLVMBasicBlockRef dest = lookup_block(dest_label);
+    if (!sw || !dest) return;
+    LLVMTypeRef ty = parse_type(type_str);
+    LLVMValueRef on_val = LLVMConstInt(ty, (unsigned long long)(long long)case_val_d, 1);
+    LLVMAddCase(sw, on_val, dest);
+}
+
+// ============ Memcpy / Memset ============
+
+void cs_llvm_build_memcpy(const char* dst_name, const char* src_name,
+                           const char* len_name, double align_d) {
+    LLVMValueRef dst = lookup_value(dst_name);
+    LLVMValueRef src = lookup_value(src_name);
+    LLVMValueRef len = lookup_value(len_name);
+    if (!dst || !src || !len) return;
+    int align = (int)align_d;
+    if (align < 1) align = 1;
+    LLVMBuildMemCpy(b_builder, dst, align, src, align, len);
+}
+
+void cs_llvm_build_memset(const char* dst_name, const char* val_name,
+                           const char* len_name, double align_d) {
+    LLVMValueRef dst = lookup_value(dst_name);
+    LLVMValueRef val = lookup_value(val_name);
+    LLVMValueRef len = lookup_value(len_name);
+    if (!dst || !val || !len) return;
+    int align = (int)align_d;
+    if (align < 1) align = 1;
+    LLVMBuildMemSet(b_builder, dst, val, len, align);
+}
+
+// ============ FRem / FNeg ============
+
+char* cs_llvm_build_frem(const char* lhs_name, const char* rhs_name) {
+    LLVMValueRef lhs = lookup_value(lhs_name);
+    LLVMValueRef rhs = lookup_value(rhs_name);
+    if (!lhs || !rhs) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildFRem(b_builder, lhs, rhs, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+char* cs_llvm_build_fneg(const char* val_name) {
+    LLVMValueRef val = lookup_value(val_name);
+    if (!val) return strdup("");
+    char* name = next_temp();
+    LLVMValueRef result = LLVMBuildFNeg(b_builder, val, name + 1);
+    register_value(name, result);
+    return strdup(name);
+}
+
+// ============ Function attributes ============
+
+void cs_llvm_fn_add_attr(const char* fn_name, const char* attr_name) {
+    LLVMValueRef fn = lookup_function(fn_name);
+    if (!fn) return;
+    unsigned kind = LLVMGetEnumAttributeKindForName(attr_name, strlen(attr_name));
+    if (kind == 0) return;
+    LLVMAttributeRef attr = LLVMCreateEnumAttribute(b_context, kind, 0);
+    LLVMAddAttributeAtIndex(fn, LLVMAttributeFunctionIndex, attr);
+}
+
+// ============ Constants ============
+
+char* cs_llvm_const_int(const char* type_str, double val_d) {
+    LLVMTypeRef ty = parse_type(type_str);
+    long long val = (long long)val_d;
+    LLVMValueRef c = LLVMConstInt(ty, (unsigned long long)val, 1);
+    char* name = next_temp();
+    register_value(name, c);
+    return strdup(name);
+}
+
+char* cs_llvm_const_real(double val) {
+    LLVMValueRef c = LLVMConstReal(LLVMDoubleTypeInContext(b_context), val);
+    char* name = next_temp();
+    register_value(name, c);
+    return strdup(name);
+}
+
+char* cs_llvm_const_null(const char* type_str) {
+    LLVMTypeRef ty = parse_type(type_str);
+    LLVMValueRef c = LLVMConstNull(ty);
+    char* name = next_temp();
+    register_value(name, c);
+    return strdup(name);
+}
+
+// ============ Global variables ============
+
+void cs_llvm_add_global_var(const char* name, const char* type_str, double is_const_d) {
+    LLVMTypeRef ty = parse_type(type_str);
+    LLVMValueRef gv = LLVMAddGlobal(b_module, ty, name);
+    LLVMSetLinkage(gv, LLVMPrivateLinkage);
+    if ((int)is_const_d) LLVMSetGlobalConstant(gv, 1);
+    LLVMSetInitializer(gv, LLVMConstNull(ty));
+    register_value(name, gv);
+}
+
 // ============ Output ============
 
 char* cs_llvm_builder_optimize(double level_d) {

--- a/src/native-compiler-lib.ts
+++ b/src/native-compiler-lib.ts
@@ -140,6 +140,26 @@ declare function cs_llvm_build_phi(
   count: number,
 ): string;
 declare function cs_llvm_build_select(cond: string, then_val: string, else_val: string): string;
+declare function cs_llvm_build_switch(
+  val: string,
+  default_label: string,
+  num_cases: number,
+): string;
+declare function cs_llvm_switch_add_case(
+  sw: string,
+  type_str: string,
+  case_val: number,
+  dest: string,
+): void;
+declare function cs_llvm_build_memcpy(dst: string, src: string, len: string, align: number): void;
+declare function cs_llvm_build_memset(dst: string, val: string, len: string, align: number): void;
+declare function cs_llvm_build_frem(lhs: string, rhs: string): string;
+declare function cs_llvm_build_fneg(val: string): string;
+declare function cs_llvm_fn_add_attr(fn_name: string, attr: string): void;
+declare function cs_llvm_const_int(type_str: string, val: number): string;
+declare function cs_llvm_const_real(val: number): string;
+declare function cs_llvm_const_null(type_str: string): string;
+declare function cs_llvm_add_global_var(name: string, type_str: string, is_const: number): void;
 declare function cs_llvm_builder_optimize(level: number): string;
 declare function cs_llvm_builder_emit_object(path: string): string;
 declare function cs_llvm_builder_print(path: string): string;

--- a/vendor
+++ b/vendor
@@ -1,1 +1,0 @@
-/Users/csmith/git/ChadScript/vendor


### PR DESCRIPTION
## Before
The LLVM builder bridge (`c_bridges/llvm-builder-bridge.c`) was missing several instruction types needed for full codegen coverage: switch, memcpy/memset, frem/fneg, function attributes, and constant creation.

## After
No user-facing change. Internal refactor only.

Bridge now covers all instruction types needed for the LLVM C API integration:
- `LLVMBuildSwitch` + `LLVMAddCase` for switch dispatch
- `LLVMBuildMemCpy` / `LLVMBuildMemSet` for bulk memory ops
- `LLVMBuildFRem` / `LLVMBuildFNeg` (were missing from arithmetic set)
- `LLVMAddAttributeAtIndex` for function attrs (nounwind, noreturn, etc.)
- `LLVMConstInt` / `LLVMConstReal` / `LLVMConstNull` for constant creation
- `LLVMAddGlobal` for global variable definitions

All TS declarations added to `native-compiler-lib.ts`.

## Description
Part of the LLVM C API migration (#721). The bridge C code is now feature-complete for Phase 2 integration — next step is wiring `ir-builders.ts` to call these functions when `useBuilderAPI` is true.