### PR TITLE
[codegen] fix static field initializers in native compiler

### DIFF
--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -17,6 +17,7 @@ import {
   InterfaceDeclaration,
   InterfaceField,
   ClassNode,
+  ClassField,
 } from "../../ast/types.js";
 import {
   SymbolKind,
@@ -1105,6 +1106,35 @@ export class FunctionGenerator {
     return "null";
   }
 
+  private staticFieldLlvmType(ft: string): string {
+    if (ft === "string") return "i8*";
+    if (ft === "boolean") return "double";
+    if (ft === "string[]") return "%StringArray*";
+    if (ft === "number[]" || ft === "boolean[]") return "%Array*";
+    return "double";
+  }
+
+  private emitStaticFieldInits(): void {
+    const ast = this.ctx.getAst();
+    if (!ast || !ast.classes) return;
+    for (let ci = 0; ci < ast.classes.length; ci++) {
+      const cls = ast.classes[ci] as ClassNode;
+      if (!cls || !cls.fields) continue;
+      const className = cls.name;
+      for (let fi = 0; fi < cls.fields.length; fi++) {
+        const field = cls.fields[fi] as ClassField;
+        if (!field || !field.isStatic || !field.initializer) continue;
+        const globalName = `@${this.ctx.mangleUserName(className)}_${field.name}`;
+        const llvmType = this.staticFieldLlvmType(field.fieldType);
+        let initVal = this.ctx.generateExpression(field.initializer as Expression, []);
+        if (llvmType === "double") {
+          initVal = this.ctx.ensureDouble(initVal);
+        }
+        this.ctx.emit(`store ${llvmType} ${initVal}, ${llvmType}* ${globalName}`);
+      }
+    }
+  }
+
   generateMain(
     topLevelObjectVariables: Map<string, { ptr: string; keys: string[]; types: string[] }>,
     hasTry?: boolean,
@@ -1129,6 +1159,8 @@ export class FunctionGenerator {
     }
     const mainEligible: string[] = [];
     this.ctx.setI64EligibleVars(mainEligible);
+
+    this.emitStaticFieldInits();
 
     if (topLevelItemsCount > 0) {
       for (let itemIdx = 0; itemIdx < topLevelItemsCount; itemIdx++) {

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -8,8 +8,6 @@ import {
   InterfaceDeclaration,
   CommonField,
   TypeAliasDeclaration,
-  UnaryNode,
-  NumberNode,
 } from "../../../ast/types.js";
 import { IGeneratorContext } from "../../infrastructure/generator-context.js";
 import {
@@ -90,66 +88,6 @@ export class ClassGenerator {
       allFields.push(classNode.fields[i]);
     }
     return allFields;
-  }
-
-  private formatLlvmDouble(v: number): string {
-    const s = v.toString();
-    if (s.indexOf(".") === -1 && s.indexOf("e") === -1) return s + ".0";
-    return s;
-  }
-
-  private resolveStaticInitializer(
-    field: ClassField,
-    llvmType: string,
-    parts: string[],
-  ): string | null {
-    const init = field.initializer;
-    if (!init) return null;
-
-    if (init.type === "number" && llvmType === "double") {
-      const numNode = init as NumberNode;
-      return this.formatLlvmDouble(numNode.value);
-    }
-
-    if (init.type === "boolean" && llvmType === "double") {
-      const boolNode = init as { type: "boolean"; value: boolean; loc?: object };
-      return boolNode.value ? "1.000000e+00" : "0.000000e+00";
-    }
-
-    if (init.type === "unary") {
-      const unary = init as UnaryNode;
-      if (unary.op === "-" && unary.operand.type === "number") {
-        const innerNum = unary.operand as NumberNode;
-        return this.formatLlvmDouble(-innerNum.value);
-      }
-    }
-
-    if (init.type === "string" && llvmType === "i8*") {
-      const strNode = init as { type: "string"; value: string; loc?: object };
-      const strVal = strNode.value;
-      const strId = this.ctx.nextString();
-      let escaped = "";
-      let byteCount = 0;
-      for (let i = 0; i < strVal.length; i++) {
-        const ch = strVal[i];
-        const code = strVal.charCodeAt(i);
-        if (code < 32 || code > 126 || ch === '"' || ch === "\\") {
-          const hex = code.toString(16).padStart(2, "0").toUpperCase();
-          escaped += "\\" + hex;
-          byteCount += 1;
-        } else {
-          escaped += ch;
-          byteCount += 1;
-        }
-      }
-      const len = byteCount + 1;
-      parts.push(
-        `${strId} = private unnamed_addr constant [${len} x i8] c"${escaped}\\00", align 1\n`,
-      );
-      return `getelementptr inbounds ([${len} x i8], [${len} x i8]* ${strId}, i32 0, i32 0)`;
-    }
-
-    return null;
   }
 
   private fieldToLlvmType(f: ClassField): string {

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -534,8 +534,6 @@ export class ClassGenerator {
       if (llvmType === "i8*") defaultVal = "null";
       else if (llvmType === "i1") defaultVal = "0";
       else if (llvmType.endsWith("*")) defaultVal = "null";
-      const initVal = this.resolveStaticInitializer(field, llvmType, parts);
-      if (initVal !== null) defaultVal = initVal;
       parts.push(`${globalName} = global ${llvmType} ${defaultVal}\n`);
     }
 

--- a/tests/fixtures/classes/class-static-init.ts
+++ b/tests/fixtures/classes/class-static-init.ts
@@ -1,5 +1,3 @@
-// @test-skip
-// passes with node compiler but native compiler fails on static field initializers
 class Config {
   static version: string = "1.0.0";
   static maxRetries: number = 5;

--- a/tests/fixtures/control-flow/switch-string-toplevel.ts
+++ b/tests/fixtures/control-flow/switch-string-toplevel.ts
@@ -1,5 +1,3 @@
-// @test-skip
-// passes with node compiler but native compiler fails on toplevel switch-string in self-hosted stages
 const s = "b";
 switch (s) {
   case "a":

--- a/tests/fixtures/control-flow/switch-string-toplevel.ts
+++ b/tests/fixtures/control-flow/switch-string-toplevel.ts
@@ -1,3 +1,4 @@
+// @test-skip
 const s = "b";
 switch (s) {
   case "a":


### PR DESCRIPTION
## Before
`static version: string = "1.0.0"` on a class read as null/zero at runtime in native compiler. `resolveStaticInitializer()` did compile-time constant folding that worked in node compiler but failed silently in the self-hosted native compiler.

## After
Static field initializers work correctly in both node and native compilers.

## Description
Emits runtime `store` instructions at the start of `main()` via `emitStaticFieldInits()` in function-generator.ts. Uses `generateExpression` + `ensureDouble` for the initializer (works reliably in both compilers). Removes dead `resolveStaticInitializer` and `formatLlvmDouble` methods. ~30 LOC net.

Note: switch-string-toplevel remains skipped — passes stage 0 but still fails in self-hosting stages 1/2.

Closes #718.