### PR TITLE
[codegen] fix toplevel switch crash in self-hosted stages

### DIFF
--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -266,7 +266,7 @@ function transformTopLevelNode(node: TreeSitterNode, ast: AST): void {
         const s = switchBlock.statements[si];
         ast.topLevelExpressions.push(s as IfStatement);
         ast.topLevelItems!.push(s as TopLevelItem);
-        ast.topLevelItemTypes!.push(s.type);
+        ast.topLevelItemTypes!.push("if");
       }
       break;
 

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -358,7 +358,7 @@ function transformTopLevelStatement(
       const switchAsIf = transformStatement(node, checker) as IfStatement;
       ast.topLevelExpressions.push(switchAsIf);
       ast.topLevelItems!.push(switchAsIf);
-      ast.topLevelItemTypes!.push(switchAsIf.type);
+      ast.topLevelItemTypes!.push("if");
       break;
     }
 

--- a/tests/fixtures/control-flow/switch-string-toplevel.ts
+++ b/tests/fixtures/control-flow/switch-string-toplevel.ts
@@ -1,4 +1,3 @@
-// @test-skip
 const s = "b";
 switch (s) {
   case "a":


### PR DESCRIPTION
## Before
Top-level `switch` statements segfaulted in stage 1/2 self-hosting. The stage 1 compiler (native-compiled by stage 0) crashed in `strlen` with a corrupted string pointer when processing any top-level switch statement. Tests inside functions worked fine.

## After
Top-level switch statements pass all three stages (0, 1, 2). Test `switch-string-toplevel.ts` un-skipped.

## Description
**Root cause**: Both parsers desugar top-level `switch` into if-else chains and push `s.type` (reading `.type` from an ObjectArray element) into `topLevelItemTypes`. In the stage 1 native compiler, this ObjectArray element field read produced a corrupted string pointer (`0x656c696857006660` — ASCII for "While"), causing a segfault when the type string was later compared.

**Fix**: Push the literal string `"if"` instead of reading `s.type` from the desugared object. The switch-to-if desugaring always produces IfStatement nodes, so `"if"` is always correct.

**Proper fix**: #730 — preserve SwitchStatement through to codegen instead of desugaring in the parser.

**Debugging approach**: Built stage 1 compiler, added trace instrumentation, compared ASTs (identical between stages — parser is correct), isolated the crash to `topLevelItemTypes[1]` being a corrupted pointer despite correct array length.

Closes #720

## Next Steps
- #728 — eliminate parallel type arrays in AST (this bug's root pattern)
- #730 — preserve SwitchStatement node through to codegen