### PR TITLE
[parser] preserve switch statements as AST nodes instead of desugaring to if-else

### DIFF
--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -388,6 +388,7 @@ export type TopLevelItem =
   | WhileStatement
   | DoWhileStatement
   | IfStatement
+  | SwitchStatement
   | TryStatement
   | ThrowStatement
   | CallNode

--- a/src/ast/visitor.ts
+++ b/src/ast/visitor.ts
@@ -44,6 +44,7 @@ import {
   ThrowStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   FunctionNode,
   ClassNode,
   ClassMethod,
@@ -283,7 +284,7 @@ export class RecursiveASTVisitor {
   visitSwitchStatement(node: SwitchStatement): void {
     this.visitExpression(node.discriminant);
     for (let i = 0; i < node.cases.length; i++) {
-      const c = node.cases[i];
+      const c = node.cases[i] as SwitchCase;
       if (c.test) {
         this.visitExpression(c.test);
       }

--- a/src/codegen/infrastructure/function-generator.ts
+++ b/src/codegen/infrastructure/function-generator.ts
@@ -12,6 +12,7 @@ import {
   AssignmentStatement,
   CommonField,
   SwitchStatement,
+  SwitchCase,
   SourceLocation,
   Statement,
   InterfaceDeclaration,
@@ -870,7 +871,7 @@ export class FunctionGenerator {
         const switchStmt = block.statements[i] as SwitchStatement;
         if (!switchStmt.cases) continue;
         for (let j = 0; j < switchStmt.cases.length; j++) {
-          const caseItem = switchStmt.cases[j];
+          const caseItem = switchStmt.cases[j] as SwitchCase;
           if (!caseItem) continue;
           if (!caseItem.consequent) continue;
           for (let k = 0; k < caseItem.consequent.length; k++) {

--- a/src/codegen/infrastructure/int-specialization-detector.ts
+++ b/src/codegen/infrastructure/int-specialization-detector.ts
@@ -54,6 +54,7 @@ import type {
   ThrowStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   BlockStatement,
 } from "../../ast/types.js";
 import { findI64EligibleVariables } from "./integer-analysis.js";
@@ -514,7 +515,7 @@ function collectEscapedVarRefsStmts(stmts: Statement[], out: string[]): void {
       collectEscapedVarRefsExpr(sw.discriminant, out);
       if (sw.cases) {
         for (let j = 0; j < sw.cases.length; j++) {
-          const cs = sw.cases[j];
+          const cs = sw.cases[j] as SwitchCase;
           if (cs.test) collectEscapedVarRefsExpr(cs.test, out);
           if (cs.consequent) collectEscapedVarRefsStmts(cs.consequent, out);
         }

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -54,11 +54,13 @@ export class ControlFlowGenerator {
   private loopContinueLabels: string[];
   private loopBreakLabels: string[];
   private forOfGen: ForOfGenerator;
+  private switchBreakHit: boolean;
 
   constructor(private ctx: IGeneratorContext) {
     this.loopContinueLabels = [];
     this.loopBreakLabels = [];
     this.forOfGen = new ForOfGenerator(ctx, this.loopContinueLabels, this.loopBreakLabels);
+    this.switchBreakHit = false;
   }
 
   // Helper methods delegate to context
@@ -534,6 +536,7 @@ export class ControlFlowGenerator {
     }
     const breakLabel = this.loopBreakLabels[this.loopBreakLabels.length - 1];
     this.ctx.emitBr(breakLabel);
+    this.switchBreakHit = true;
     return "0";
   }
 
@@ -1108,12 +1111,13 @@ export class ControlFlowGenerator {
 
     this.loopContinueLabels.push("");
     this.loopBreakLabels.push(endLabel);
+    this.switchBreakHit = false;
 
     const caseLabels: string[] = [];
     let defaultLabelIndex: number = -1;
 
     for (let i = 0; i < switchStmt.cases.length; i++) {
-      const caseItem = switchStmt.cases[i];
+      const caseItem = switchStmt.cases[i] as SwitchCase;
       if (!caseItem) continue;
       if (caseItem.test === null) {
         defaultLabelIndex = i;
@@ -1128,7 +1132,7 @@ export class ControlFlowGenerator {
     let checkLabels: string[] = [];
     let testCaseCount = 0;
     for (let i = 0; i < switchStmt.cases.length; i++) {
-      const caseItem = switchStmt.cases[i];
+      const caseItem = switchStmt.cases[i] as SwitchCase;
       if (!caseItem) continue;
       if (caseItem.test !== null) {
         testCaseCount++;
@@ -1141,7 +1145,7 @@ export class ControlFlowGenerator {
 
     let checkIndex = 0;
     for (let i = 0; i < switchStmt.cases.length; i++) {
-      const caseItem = switchStmt.cases[i];
+      const caseItem = switchStmt.cases[i] as SwitchCase;
       if (!caseItem) continue;
       if (caseItem.test !== null) {
         if (checkIndex > 0) {
@@ -1170,49 +1174,34 @@ export class ControlFlowGenerator {
       }
     }
 
+    let endReachable = defaultLabelIndex < 0;
+
     for (let i = 0; i < switchStmt.cases.length; i++) {
-      const caseItem = switchStmt.cases[i];
+      const caseItem = switchStmt.cases[i] as SwitchCase;
       if (!caseItem) continue;
       this.ctx.emitLabel(caseLabels[i]);
       this.ctx.setCurrentLabel(caseLabels[i]);
 
-      for (let j = 0; j < caseItem.consequent.length; j++) {
-        const consequentStmt = caseItem.consequent[j];
-        if (!consequentStmt) continue;
-        if (consequentStmt.type === "break") {
-          this.ctx.emitBr(endLabel);
-        } else if (
-          consequentStmt.type === "variable_declaration" ||
-          consequentStmt.type === "return" ||
-          consequentStmt.type === "if" ||
-          consequentStmt.type === "assignment" ||
-          consequentStmt.type === "throw" ||
-          consequentStmt.type === "while" ||
-          consequentStmt.type === "for" ||
-          consequentStmt.type === "for_of" ||
-          consequentStmt.type === "continue" ||
-          consequentStmt.type === "try" ||
-          consequentStmt.type === "switch"
-        ) {
-          this.ctx.generateBlock({ type: "block", statements: [consequentStmt] }, params);
-        } else {
-          this.ctx.generateExpression(consequentStmt as Expression, params);
-        }
+      if (caseItem.consequent.length > 0) {
+        this.ctx.generateBlock({ type: "block", statements: caseItem.consequent }, params);
       }
 
-      const lastStmt = caseItem.consequent[caseItem.consequent.length - 1];
-      if (
-        !lastStmt ||
-        (lastStmt.type !== "break" && lastStmt.type !== "return" && lastStmt.type !== "throw")
-      ) {
+      if (!this.ctx.lastInstructionIsTerminator()) {
         const nextCaseLabel = i < switchStmt.cases.length - 1 ? caseLabels[i + 1] : endLabel;
         this.ctx.emitBr(nextCaseLabel);
+        if (nextCaseLabel === endLabel) endReachable = true;
       }
     }
 
+    if (this.switchBreakHit) endReachable = true;
+
     this.loopContinueLabels.pop();
     this.loopBreakLabels.pop();
+
     this.ctx.emitLabel(endLabel);
+    if (!endReachable) {
+      this.ctx.emitUnreachable();
+    }
 
     return "0";
   }

--- a/src/parser-native/transformer.ts
+++ b/src/parser-native/transformer.ts
@@ -50,6 +50,8 @@ import {
   MapNode,
   SetNode,
   TypeAssertionNode,
+  SwitchStatement,
+  SwitchCase,
 } from "../ast/types.js";
 
 let destructureCounter = 0;
@@ -261,13 +263,10 @@ function transformTopLevelNode(node: TreeSitterNode, ast: AST): void {
       break;
 
     case "switch_statement":
-      const switchBlock = transformSwitchStatement(node);
-      for (let si = 0; si < switchBlock.statements.length; si++) {
-        const s = switchBlock.statements[si];
-        ast.topLevelExpressions.push(s as IfStatement);
-        ast.topLevelItems!.push(s as TopLevelItem);
-        ast.topLevelItemTypes!.push(s.type);
-      }
+      const switchStmt = transformSwitchToAst(node);
+      ast.topLevelExpressions.push(switchStmt as unknown as IfStatement);
+      ast.topLevelItems!.push(switchStmt);
+      ast.topLevelItemTypes!.push("switch");
       break;
 
     case "export_statement":
@@ -1654,7 +1653,7 @@ function transformStatement(node: TreeSitterNode): Statement | null {
       return transformTryStatement(node);
 
     case "switch_statement":
-      return transformSwitchStatement(node);
+      return transformSwitchToAst(node) as unknown as Statement;
 
     case "statement_block":
       return null;
@@ -2266,17 +2265,15 @@ function transformTryStatement(node: TreeSitterNode): TryStatement {
   return { type: "try", tryBlock, catchParam, catchBody, finallyBlock };
 }
 
-function transformSwitchStatement(node: TreeSitterNode): BlockStatement {
+function transformSwitchToAst(node: TreeSitterNode): SwitchStatement {
   const exprNode = getChildByFieldName(node, "value");
   const bodyNode = getChildByFieldName(node, "body");
 
-  const switchExpr = exprNode
+  const discriminant: Expression = exprNode
     ? transformExpression(exprNode)
     : { type: "variable" as const, name: "undefined" };
 
-  let pendingConditions: Expression[] = [];
-  let defaultStatements: Statement[] | null = null;
-  const caseIfNodes: object[] = [];
+  const cases: SwitchCase[] = [];
 
   if (bodyNode) {
     const bn = bodyNode as NodeBase;
@@ -2287,112 +2284,45 @@ function transformSwitchStatement(node: TreeSitterNode): BlockStatement {
 
       if (cl.type === "switch_case") {
         const valueNode = getChildByFieldName(clause, "value");
-        if (valueNode) {
-          const caseExpr = transformExpression(valueNode);
-          const condition: Expression = {
-            type: "binary",
-            op: "===",
-            left: switchExpr,
-            right: caseExpr,
-          };
-
-          const caseStatements: Statement[] = [];
-          for (let j = 0; j < cl.namedChildCount; j++) {
-            const stmtNode = getNamedChild(clause, j);
-            if (!stmtNode) continue;
-            const sn = stmtNode as NodeBase;
-            if (stmtNode !== valueNode && sn.type !== "break_statement") {
-              if (sn.type === "lexical_declaration" || sn.type === "variable_declaration") {
-                const decls = transformLexicalDeclaration(stmtNode);
-                for (let dk = 0; dk < decls.length; dk++) {
-                  caseStatements.push(decls[dk]);
-                }
-              } else {
-                const stmt = transformStatement(stmtNode);
-                if (stmt) caseStatements.push(stmt);
-              }
+        const test: Expression | null = valueNode ? transformExpression(valueNode) : null;
+        const consequent: Statement[] = [];
+        for (let j = valueNode ? 1 : 0; j < cl.namedChildCount; j++) {
+          const stmtNode = getNamedChild(clause, j);
+          if (!stmtNode) continue;
+          const sn = stmtNode as NodeBase;
+          if (sn.type === "lexical_declaration" || sn.type === "variable_declaration") {
+            const decls = transformLexicalDeclaration(stmtNode);
+            for (let dk = 0; dk < decls.length; dk++) {
+              consequent.push(decls[dk]);
             }
-          }
-
-          if (caseStatements.length === 0) {
-            pendingConditions.push(condition);
           } else {
-            let finalCondition: Expression = condition;
-            for (let k = pendingConditions.length - 1; k >= 0; k--) {
-              finalCondition = {
-                type: "binary",
-                op: "||",
-                left: pendingConditions[k],
-                right: finalCondition,
-              };
-            }
-            pendingConditions = [];
-
-            const thenBlock: BlockStatement = { type: "block", statements: caseStatements };
-            const ifStmt: IfStatement = {
-              type: "if",
-              condition: finalCondition,
-              thenBlock: thenBlock,
-              elseBlock: null,
-            };
-            caseIfNodes.push(ifStmt);
+            const stmt = transformStatement(stmtNode);
+            if (stmt) consequent.push(stmt);
           }
         }
+        cases.push({ test, consequent });
       } else if (cl.type === "switch_default") {
-        defaultStatements = [];
+        const consequent: Statement[] = [];
         for (let j = 0; j < cl.namedChildCount; j++) {
           const stmtNode = getNamedChild(clause, j);
           if (!stmtNode) continue;
           const sn = stmtNode as NodeBase;
-          if (sn.type !== "break_statement") {
-            if (sn.type === "lexical_declaration" || sn.type === "variable_declaration") {
-              const decls = transformLexicalDeclaration(stmtNode);
-              for (let dk = 0; dk < decls.length; dk++) {
-                defaultStatements.push(decls[dk]);
-              }
-            } else {
-              const stmt = transformStatement(stmtNode);
-              if (stmt) defaultStatements.push(stmt);
+          if (sn.type === "lexical_declaration" || sn.type === "variable_declaration") {
+            const decls = transformLexicalDeclaration(stmtNode);
+            for (let dk = 0; dk < decls.length; dk++) {
+              consequent.push(decls[dk]);
             }
+          } else {
+            const stmt = transformStatement(stmtNode);
+            if (stmt) consequent.push(stmt);
           }
         }
+        cases.push({ test: null, consequent });
       }
     }
   }
 
-  if (caseIfNodes.length === 0) {
-    const statements: Statement[] = [];
-    if (defaultStatements) {
-      for (let ds = 0; ds < defaultStatements.length; ds++) {
-        statements.push(defaultStatements[ds]);
-      }
-    }
-    return { type: "block", statements: statements };
-  }
-
-  let chainedIf = caseIfNodes[caseIfNodes.length - 1] as IfStatement;
-  if (defaultStatements) {
-    chainedIf = {
-      type: "if",
-      condition: chainedIf.condition,
-      thenBlock: chainedIf.thenBlock,
-      elseBlock: { type: "block", statements: defaultStatements },
-    };
-  }
-  for (let ci = caseIfNodes.length - 2; ci >= 0; ci--) {
-    const prev = caseIfNodes[ci] as IfStatement;
-    const elseWrapper: BlockStatement = { type: "block", statements: [chainedIf] };
-    chainedIf = {
-      type: "if",
-      condition: prev.condition,
-      thenBlock: prev.thenBlock,
-      elseBlock: elseWrapper,
-    };
-  }
-
-  const statements: Statement[] = [];
-  statements.push(chainedIf);
-  return { type: "block", statements: statements };
+  return { type: "switch", discriminant, cases };
 }
 
 function createEmptyBlock(): BlockStatement {

--- a/src/parser-ts/handlers/statements.ts
+++ b/src/parser-ts/handlers/statements.ts
@@ -16,6 +16,8 @@ import {
   IndexAccessNode,
   MemberAccessNode,
   VariableNode,
+  SwitchStatement,
+  SwitchCase,
 } from "../../ast/types.js";
 import { transformExpression } from "./expressions.js";
 import { getLoc } from "../transformer.js";
@@ -84,7 +86,7 @@ export function transformStatement(
       return null;
 
     case ts.SyntaxKind.SwitchStatement:
-      return transformSwitchToIfElse(node as ts.SwitchStatement, checker);
+      return transformSwitchToAst(node as ts.SwitchStatement, checker) as unknown as Statement;
 
     case ts.SyntaxKind.LabeledStatement: {
       const loc = getLoc(node);
@@ -671,83 +673,39 @@ function wrapInBlock(statement: ts.Statement, checker: ts.TypeChecker | undefine
   return { type: "block", statements: transformed ? [transformed] : [] };
 }
 
-function transformSwitchToIfElse(
+function transformSwitchToAst(
   node: ts.SwitchStatement,
   checker: ts.TypeChecker | undefined,
-): IfStatement {
-  const switchExpr = transformExpression(node.expression, checker);
+): SwitchStatement {
+  const discriminant = transformExpression(node.expression, checker);
+  const cases: SwitchCase[] = [];
 
-  const clauses = node.caseBlock.clauses;
-  let result: IfStatement | null = null;
-  let current: IfStatement | null = null;
-  let pendingConditions: Expression[] = [];
-
-  for (const clause of clauses) {
+  for (const clause of node.caseBlock.clauses) {
     if (ts.isCaseClause(clause)) {
-      const caseExpr = transformExpression(clause.expression, checker);
-      const condition: Expression = {
-        type: "binary",
-        op: "===",
-        left: switchExpr,
-        right: caseExpr,
-      };
-
-      const statements: Statement[] = [];
+      const test = transformExpression(clause.expression, checker);
+      const consequent: Statement[] = [];
       for (const stmt of clause.statements) {
-        if (stmt.kind === ts.SyntaxKind.BreakStatement) continue;
-        const transformed = transformStatement(stmt, checker);
-        if (transformed) statements.push(transformed);
-      }
-
-      if (statements.length === 0) {
-        pendingConditions.push(condition);
-      } else {
-        let finalCondition: Expression = condition;
-        for (let k = pendingConditions.length - 1; k >= 0; k--) {
-          finalCondition = {
-            type: "binary",
-            op: "||",
-            left: pendingConditions[k],
-            right: finalCondition,
-          };
-        }
-        pendingConditions = [];
-
-        const ifStmt: IfStatement = {
-          type: "if",
-          condition: finalCondition,
-          thenBlock: { type: "block", statements },
-          elseBlock: null,
-        };
-
-        if (!result) {
-          result = ifStmt;
-          current = ifStmt;
-        } else if (current) {
-          current.elseBlock = { type: "block", statements: [ifStmt] };
-          current = ifStmt;
+        if (stmt.kind === ts.SyntaxKind.BreakStatement) {
+          consequent.push({ type: "break" } as Statement);
+        } else {
+          const transformed = transformStatement(stmt, checker);
+          if (transformed) consequent.push(transformed);
         }
       }
+      cases.push({ test, consequent });
     } else if (ts.isDefaultClause(clause)) {
-      const statements: Statement[] = [];
+      const consequent: Statement[] = [];
       for (const stmt of clause.statements) {
-        if (stmt.kind === ts.SyntaxKind.BreakStatement) continue;
-        const transformed = transformStatement(stmt, checker);
-        if (transformed) statements.push(transformed);
+        if (stmt.kind === ts.SyntaxKind.BreakStatement) {
+          consequent.push({ type: "break" } as Statement);
+        } else {
+          const transformed = transformStatement(stmt, checker);
+          if (transformed) consequent.push(transformed);
+        }
       }
-
-      if (current) {
-        current.elseBlock = { type: "block", statements };
-      }
+      cases.push({ test: null, consequent });
     }
   }
 
-  return (
-    result || {
-      type: "if",
-      condition: { type: "boolean", value: false },
-      thenBlock: { type: "block", statements: [] },
-      elseBlock: null,
-    }
-  );
+  return { type: "switch", discriminant, cases };
 }

--- a/src/parser-ts/transformer.ts
+++ b/src/parser-ts/transformer.ts
@@ -355,10 +355,12 @@ function transformTopLevelStatement(
     }
 
     case ts.SyntaxKind.SwitchStatement: {
-      const switchAsIf = transformStatement(node, checker) as IfStatement;
-      ast.topLevelExpressions.push(switchAsIf);
-      ast.topLevelItems!.push(switchAsIf);
-      ast.topLevelItemTypes!.push(switchAsIf.type);
+      const switchStmt = transformStatement(node, checker);
+      if (switchStmt) {
+        ast.topLevelExpressions.push(switchStmt as unknown as IfStatement);
+        ast.topLevelItems!.push(switchStmt as TopLevelItem);
+        ast.topLevelItemTypes!.push("switch");
+      }
       break;
     }
 

--- a/src/semantic/async-await-checker.ts
+++ b/src/semantic/async-await-checker.ts
@@ -11,6 +11,7 @@ import type {
   ForOfStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   ReturnStatement,
   ThrowStatement,
   CallNode,
@@ -130,7 +131,7 @@ class AsyncAwaitChecker {
       const switchStmt = stmt as SwitchStatement;
       this.checkExpr(switchStmt.discriminant, insideAsync);
       for (let ci = 0; ci < switchStmt.cases.length; ci++) {
-        const c = switchStmt.cases[ci];
+        const c = switchStmt.cases[ci] as SwitchCase;
         if (c.test !== null && c.test !== undefined) {
           this.checkExpr(c.test as Expression, insideAsync);
         }

--- a/src/semantic/binary-type-checker.ts
+++ b/src/semantic/binary-type-checker.ts
@@ -16,6 +16,7 @@ import type {
   ForOfStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   ReturnStatement,
   ThrowStatement,
   BlockStatement,
@@ -178,7 +179,7 @@ function walkStmt(stmt: object, src: string): void {
     checkBinaryInExpr(sw.discriminant, src);
     let ci = 0;
     while (ci < sw.cases.length) {
-      const c = sw.cases[ci];
+      const c = sw.cases[ci] as SwitchCase;
       if (c.test) checkBinaryInExpr(c.test as Expression, src);
       walkStmts(c.consequent, src);
       ci = ci + 1;

--- a/src/semantic/closure-mutation-checker.ts
+++ b/src/semantic/closure-mutation-checker.ts
@@ -18,6 +18,7 @@ import type {
   ForOfStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   ReturnStatement,
   ThrowStatement,
   ArrowFunctionNode,
@@ -172,7 +173,7 @@ class ClosureMutationChecker {
       const switchStmt = stmt as SwitchStatement;
       this.scanExprForCaptures(switchStmt.discriminant, scopeVarNames, capturedNames);
       for (let ci = 0; ci < switchStmt.cases.length; ci++) {
-        const c = switchStmt.cases[ci];
+        const c = switchStmt.cases[ci] as SwitchCase;
         if (c.test !== null && c.test !== undefined) {
           this.scanExprForCaptures(c.test as Expression, scopeVarNames, capturedNames);
         }

--- a/src/semantic/safety-checks.ts
+++ b/src/semantic/safety-checks.ts
@@ -12,6 +12,7 @@ import type {
   ForOfStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   ReturnStatement,
   ThrowStatement,
   BlockStatement,
@@ -157,7 +158,7 @@ function binWalkStmt(stmt: Statement, src: string): void {
     const sw = stmt as SwitchStatement;
     checkBinExpr(sw.discriminant, src);
     for (let ci = 0; ci < sw.cases.length; ci++) {
-      const c = sw.cases[ci];
+      const c = sw.cases[ci] as SwitchCase;
       if (c.test) checkBinExpr(c.test as Expression, src);
       binWalkStmts(c.consequent, src);
     }
@@ -245,8 +246,10 @@ function mrAllReturn(stmts: Statement[], nn: string[]): boolean {
       let hasDef = false;
       let allRet = true;
       for (let ci = 0; ci < sw.cases.length; ci++) {
-        if (sw.cases[ci].test === null) hasDef = true;
-        if (!mrAllReturn(sw.cases[ci].consequent, nn)) allRet = false;
+        const sc = sw.cases[ci] as SwitchCase;
+        if (sc.test === null) hasDef = true;
+        if (sc.consequent.length === 0) continue;
+        if (!mrAllReturn(sc.consequent, nn)) allRet = false;
       }
       if (hasDef && allRet) return true;
       continue;
@@ -435,7 +438,7 @@ class ArgCheckState {
       const sw = stmt as SwitchStatement;
       this.checkExpr(sw.discriminant);
       for (let ci = 0; ci < sw.cases.length; ci++) {
-        const c = sw.cases[ci];
+        const c = sw.cases[ci] as SwitchCase;
         if (c.test) this.checkExpr(c.test as Expression);
         this.walkStmts(c.consequent);
       }

--- a/src/semantic/type-annotator.ts
+++ b/src/semantic/type-annotator.ts
@@ -28,6 +28,7 @@ import type {
   ForOfStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   ReturnStatement,
   ThrowStatement,
   ArrowFunctionNode,
@@ -293,7 +294,7 @@ class TypeAnnotator {
       const sw = stmt as SwitchStatement;
       this.visitExpr(sw.discriminant);
       for (let ci = 0; ci < sw.cases.length; ci++) {
-        const c = sw.cases[ci];
+        const c = sw.cases[ci] as SwitchCase;
         if (c.test) this.visitExpr(c.test as Expression);
         this.walkStmts(c.consequent);
       }

--- a/src/semantic/type-assertion-checker.ts
+++ b/src/semantic/type-assertion-checker.ts
@@ -21,6 +21,7 @@ import type {
   ForOfStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   ReturnStatement,
   ThrowStatement,
   ArrowFunctionNode,
@@ -113,7 +114,7 @@ class TypeAssertionChecker {
       const switchStmt = stmt as SwitchStatement;
       this.checkExpr(switchStmt.discriminant);
       for (let i = 0; i < switchStmt.cases.length; i++) {
-        const c = switchStmt.cases[i];
+        const c = switchStmt.cases[i] as SwitchCase;
         if (c.test) this.checkExpr(c.test as Expression);
         this.walkStatements(c.consequent);
       }

--- a/src/semantic/uninitialized-field-checker.ts
+++ b/src/semantic/uninitialized-field-checker.ts
@@ -12,6 +12,7 @@ import type {
   ForOfStatement,
   TryStatement,
   SwitchStatement,
+  SwitchCase,
   MemberAccessAssignmentNode,
 } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
@@ -151,7 +152,7 @@ class UninitializedFieldChecker {
     } else if (s.type === "switch") {
       const sw = stmt as SwitchStatement;
       for (let i = 0; i < sw.cases.length; i++) {
-        this.walkStatements(sw.cases[i].consequent, assigned);
+        this.walkStatements((sw.cases[i] as SwitchCase).consequent, assigned);
       }
     }
   }

--- a/tests/fixtures/control-flow/switch-string-toplevel.ts
+++ b/tests/fixtures/control-flow/switch-string-toplevel.ts
@@ -1,4 +1,3 @@
-// @test-skip
 const s = "b";
 switch (s) {
   case "a":


### PR DESCRIPTION
## Before
Both parsers (TS API and tree-sitter native) desugared `switch` statements into if-else chains at parse time. The existing `SwitchStatement`/`SwitchCase` AST types and `generateSwitchStatement` codegen existed but were dead code.

## After
Switch statements are preserved as proper `SwitchStatement` AST nodes through to codegen. Break, fallthrough, default, and all-returning switches work correctly in both node and native compilers.

## Description

**Parser changes:**
- Both parsers now produce `SwitchStatement` with `SwitchCase[]` instead of synthesizing `IfStatement` chains
- Native parser: replaced pointer comparison (`stmtNode !== valueNode`) with index-based skip (`j starts at 1`) to avoid tree-sitter node wrapper aliasing bug where `getNamedChild()` returned the same address as `getChildByFieldName()`
- Break statements stay in `consequent` arrays and flow through normal `generateBreakStatement()` dispatch
- `SwitchStatement` added to `TopLevelItem` union for top-level switch support

**Codegen changes:**
- `generateSwitchStatement` now uses `loopBreakLabels` stack for break dispatch — break statements in case consequent arrays are handled by normal statement dispatch
- `endReachable` computed from `switchBreakHit` flag (set by `generateBreakStatement()`) + fallthrough-to-end detection, avoiding AST type scanning on native ObjectArray elements
- Handles string/number discriminants, fallthrough, default cases, all-returning switches

**Semantic pass updates:**
- All semantic passes that walk switch cases updated with `as SwitchCase` casts for native ObjectArray compatibility
- `checkMissingReturns` handles empty fallthrough cases correctly

Closes #730

## Next Steps
- `checkMissingReturns` false positive: all-returning switches with default still warn "may not return on all paths" — harmless but noisy