### PR TITLE
[codegen] fix 2d object-array indexing type propagation

### DIFF
--- a/src/codegen/infrastructure/array-allocator.ts
+++ b/src/codegen/infrastructure/array-allocator.ts
@@ -148,6 +148,21 @@ export class ArrayAllocator {
     if (!elementType && stmt.declaredType && isAnyArrayTsType(stmt.declaredType)) {
       elementType = stmt.declaredType.slice(0, -2);
     }
+    if (!elementType && stmt.value && (stmt.value as { type: string }).type === "index_access") {
+      const idxExpr = stmt.value as IndexAccessNode;
+      if (idxExpr.object && (idxExpr.object as { type: string }).type === "variable") {
+        const parentName = (idxExpr.object as VariableNode).name;
+        const parentResolved = this.ctx.symbolTable.getResolvedType(parentName);
+        if (parentResolved && parentResolved.arrayDepth > 1) {
+          elementType = parentResolved.base;
+        } else {
+          const parentRawType = this.ctx.symbolTable.getRawInterfaceType(parentName);
+          if (parentRawType && this.interfaceAlloc.isKnownClass(parentRawType)) {
+            elementType = parentRawType;
+          }
+        }
+      }
+    }
 
     if (elementType) {
       const typeInfo = this.interfaceAlloc.getTypeInfoForElementType(elementType);

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -2262,6 +2262,41 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         }
       }
     }
+    if (exprNodeType === "index_access" && value) {
+      const idxExpr = value as IndexAccessNode;
+      if (idxExpr.object && (idxExpr.object as { type: string }).type === "variable") {
+        const parentName = (idxExpr.object as VariableNode).name;
+        const parentGlobal = this.globalVariables.get(parentName);
+        if (parentGlobal && parentGlobal.llvmType === "%ObjectArray*") {
+          const parentRawType = this.symbolTable.getRawInterfaceType(parentName);
+          if (parentRawType && parentRawType.endsWith("[]")) {
+            return {
+              llvmType: "%ObjectArray*",
+              kind: SymbolKind_ObjectArray,
+              defaultValue: "null",
+            };
+          }
+          const parentResolved = this.symbolTable.getResolvedType(parentName);
+          if (parentResolved && parentResolved.arrayDepth > 0) {
+            const elemBase = parentResolved.base;
+            const isClass =
+              this.classGen !== null && this.classGen.getClassFields(elemBase).length > 0;
+            if (isClass) {
+              if (name) {
+                this.defineVariable(name, `@${name}`, "i8*", SymbolKind_Object, "global");
+                this.symbolTable.setRawInterfaceType(name, elemBase);
+                this.globalVariables.set(name, {
+                  llvmType: "i8*",
+                  kind: SymbolKind_Object,
+                  initialized: false,
+                });
+              }
+              return { llvmType: "i8*", kind: SymbolKind_Object, defaultValue: "null" };
+            }
+          }
+        }
+      }
+    }
     if (
       exprNodeType === "number" ||
       exprNodeType === "boolean" ||
@@ -2310,6 +2345,34 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               "global",
               createInterfaceMetadata(resolved.base),
             );
+            this.symbolTable.setRawInterfaceType(name, resolved.base);
+            this.globalVariables.set(name, {
+              llvmType: "i8*",
+              kind: SymbolKind_Object,
+              initialized: false,
+            });
+          }
+          return { llvmType: "i8*", kind: SymbolKind_Object, defaultValue: "null" };
+        }
+        if (
+          resolved.arrayDepth === 0 &&
+          resolved.base !== "number" &&
+          resolved.base !== "boolean" &&
+          resolved.base !== "string" &&
+          resolved.base !== "void" &&
+          resolved.base !== "null" &&
+          resolved.base !== "undefined" &&
+          resolved.base !== "any" &&
+          resolved.base !== "unknown" &&
+          resolved.base !== "object" &&
+          !resolved.base.startsWith("Map") &&
+          !resolved.base.startsWith("Set") &&
+          !resolved.base.startsWith("Promise") &&
+          this.classGen &&
+          this.classGen.getClassFields(resolved.base).length > 0
+        ) {
+          if (name) {
+            this.defineVariable(name, `@${name}`, "i8*", SymbolKind_Object, "global");
             this.symbolTable.setRawInterfaceType(name, resolved.base);
             this.globalVariables.set(name, {
               llvmType: "i8*",
@@ -2636,6 +2699,8 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           }
           if (stmt.declaredType) {
             this.symbolTable.setResolvedType(name, parseTypeString(stmt.declaredType));
+          } else if (resolved) {
+            this.symbolTable.setResolvedType(name, resolved);
           }
           continue;
         } else if (isUint8Array) {

--- a/tests/fixtures/classes/class-2d-array-index.ts
+++ b/tests/fixtures/classes/class-2d-array-index.ts
@@ -1,5 +1,3 @@
-// @test-skip
-// passes with node compiler but native compiler fails on 2d object-array indexing
 class Foo {
   value: number;
   constructor(v: number) {


### PR DESCRIPTION
## Before
`const grid: Foo[][] = [[new Foo(1)]]; const row = grid[0]; const item = row[0];` failed with LLVM type error `'%76' defined with type 'ptr' but expected 'double'` — global ObjectArray variables without declared types didn't store their resolved type in the symbol table, so downstream index accesses (row[0]) couldn't resolve the element type.

## After
2D object-array indexing works correctly. `row[0].value` resolves `Foo` and accesses the field via proper GEP.

## Description
Three fixes:
1. **ObjectArray resolved type storage** — the ObjectArray classification branch had an early `continue` that skipped the generic `setResolvedType` at the end of the loop. Added `else if (resolved)` to store resolved type even without a declared type.
2. **Direct index_access check in classifyGlobalCatchAll** — when the RHS is `grid[0]` and grid is an ObjectArray, propagate the element type (class → i8*/SymbolKind_Object, array → ObjectArray).
3. **Class check in classifyGlobalCatchAll** — class instances were falling through to default `double`; added explicit class detection after the existing interface check.
4. **Array-allocator element type propagation** — for local variables initialized from index_access on an ObjectArray parent, derive element type from parent's resolved type.

Closes #719