### PR TITLE
[sema] reject Map<object, V> key type

### DIFF
--- a/src/semantic/map-key-checker.ts
+++ b/src/semantic/map-key-checker.ts
@@ -4,12 +4,14 @@ import type {
   VariableDeclaration,
   ClassNode,
   ClassField,
+  ClassMethod,
+  FunctionNode,
   MapNode,
   NewNode,
 } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
 
-function isMapNumberKey(typeStr: string): string | null {
+function parseMapKeyValue(typeStr: string): { keyType: string; valueType: string } | null {
   if (!typeStr) return null;
   const trimmed = typeStr.trim();
   if (!trimmed.startsWith("Map<")) return null;
@@ -30,32 +32,47 @@ function isMapNumberKey(typeStr: string): string | null {
   }
   if (commaIdx === -1) return null;
   const keyType = inner.substring(0, commaIdx).trim();
-  if (keyType !== "number") return null;
   const valueType = inner.substring(commaIdx + 1).trim();
-  if (valueType === "number" || valueType === "boolean") return null;
-  return valueType;
+  return { keyType, valueType };
+}
+
+function isUnsupportedMapKey(
+  typeStr: string,
+): { keyType: string; valueType: string; reason: string } | null {
+  const parsed = parseMapKeyValue(typeStr);
+  if (!parsed) return null;
+  const { keyType, valueType } = parsed;
+  if (keyType === "object") {
+    return { keyType, valueType, reason: "unsupported_key" };
+  }
+  if (keyType === "number" && valueType !== "number" && valueType !== "boolean") {
+    return { keyType, valueType, reason: "number_key_string_value" };
+  }
+  return null;
 }
 
 function emitMapKeyError(
+  keyType: string,
   valueType: string,
+  reason: string,
   loc: SourceLocation | undefined,
   sourceCode: string,
 ): void {
-  const output = formatCompileError(
-    sourceCode,
-    `Map<number, ${valueType}> is not supported. Use Map<string, ${valueType}> instead`,
-    loc,
-    undefined,
-    [],
-  );
+  let msg: string;
+  if (reason === "unsupported_key") {
+    msg = `Map<${keyType}, ${valueType}> is not supported. Only string and number keys are supported`;
+  } else {
+    msg = `Map<number, ${valueType}> is not supported. Use Map<string, ${valueType}> instead`;
+  }
+  const output = formatCompileError(sourceCode, msg, loc, undefined, []);
   process.stderr.write(output);
   process.exit(1);
 }
 
 function checkTypeStr(typeStr: string, loc: SourceLocation | undefined, sourceCode: string): void {
-  const vt = isMapNumberKey(typeStr);
-  if (vt !== null) {
-    emitMapKeyError(vt, loc, sourceCode);
+  const result = isUnsupportedMapKey(typeStr);
+  if (result !== null) {
+    emitMapKeyError(result.keyType, result.valueType, result.reason, loc, sourceCode);
   }
 }
 
@@ -67,25 +84,48 @@ function checkVarDecl(decl: VariableDeclaration, sourceCode: string): void {
   const exprType = (decl.value as unknown as MapNode).type;
   if (exprType === "map") {
     const m = decl.value as unknown as MapNode;
-    if (
+    if (m.keyType === "object") {
+      emitMapKeyError(m.keyType, m.valueType || "unknown", "unsupported_key", m.loc, sourceCode);
+    } else if (
       m.keyType === "number" &&
       m.valueType &&
       m.valueType !== "number" &&
       m.valueType !== "boolean"
     ) {
-      emitMapKeyError(m.valueType, m.loc, sourceCode);
+      emitMapKeyError("number", m.valueType, "number_key_string_value", m.loc, sourceCode);
     }
   } else if (exprType === "new") {
     const n = decl.value as unknown as NewNode;
     if (n.className === "Map" && n.typeArgs && n.typeArgs.length >= 2) {
-      if (n.typeArgs[0] === "number") {
-        const vt = n.typeArgs[1];
-        if (vt !== "number" && vt !== "boolean") {
-          emitMapKeyError(vt, n.loc, sourceCode);
-        }
+      const kt = n.typeArgs[0];
+      const vt = n.typeArgs[1];
+      if (kt === "object") {
+        emitMapKeyError(kt, vt, "unsupported_key", n.loc, sourceCode);
+      } else if (kt === "number" && vt !== "number" && vt !== "boolean") {
+        emitMapKeyError(kt, vt, "number_key_string_value", n.loc, sourceCode);
       }
     }
   }
+}
+
+function checkParamTypes(
+  paramTypes: string[] | undefined,
+  loc: SourceLocation | undefined,
+  sourceCode: string,
+): void {
+  if (!paramTypes) return;
+  for (let i = 0; i < paramTypes.length; i++) {
+    checkTypeStr(paramTypes[i], loc, sourceCode);
+  }
+}
+
+function checkReturnType(
+  returnType: string | undefined,
+  loc: SourceLocation | undefined,
+  sourceCode: string,
+): void {
+  if (!returnType) return;
+  checkTypeStr(returnType, loc, sourceCode);
 }
 
 export function checkMapKeyTypes(ast: AST, sourceCode: string): void {
@@ -104,5 +144,16 @@ export function checkMapKeyTypes(ast: AST, sourceCode: string): void {
         checkTypeStr(field.tsType, cls.loc, sourceCode);
       }
     }
+    for (let j = 0; j < cls.methods.length; j++) {
+      const method = cls.methods[j] as ClassMethod;
+      checkParamTypes(method.paramTypes, cls.loc, sourceCode);
+      checkReturnType(method.returnType, cls.loc, sourceCode);
+    }
+  }
+
+  for (let i = 0; i < ast.functions.length; i++) {
+    const fn = ast.functions[i] as FunctionNode;
+    checkParamTypes(fn.paramTypes, fn.loc, sourceCode);
+    checkReturnType(fn.returnType, fn.loc, sourceCode);
   }
 }

--- a/tests/fixtures/errors/map-object-key.ts
+++ b/tests/fixtures/errors/map-object-key.ts
@@ -1,0 +1,4 @@
+// @test-compile-error: Map<object, string> is not supported
+// @test-description: Map with generic object key type should give a clear error
+
+const m = new Map<object, string>();


### PR DESCRIPTION
## Before
`Map<object, V>` compiles but segfaults at runtime because the native compiler can't hash/compare generic `object` pointers correctly.

## After
Compile-time error: `Map<object, string> is not supported. Only string and number keys are supported`

Typed pointer maps (`Map<MyInterface, V>`) remain allowed — they work via pointer identity.

## Description
Extends the existing `map-key-checker.ts` sema pass to also reject `object` as a Map key type. Also adds coverage for function params, return types, and class method signatures. Part of #729.

~55 net LOC.