### PR TITLE
[codegen] migrate endsWith([]) type-mapping to centralized classifyArray

### DIFF
--- a/src/codegen/expressions/access/member.ts
+++ b/src/codegen/expressions/access/member.ts
@@ -34,6 +34,9 @@ import {
   canonicalTypeToLlvm,
   isObjectArrayTsType,
   isAnyArrayTsType,
+  classifyArray,
+  arrayKindToLlvm,
+  ArrayKind_None,
 } from "../../infrastructure/type-system.js";
 import type { ResolvedType } from "../../infrastructure/type-system.js";
 import type {
@@ -1065,17 +1068,12 @@ export class MemberAccessGenerator {
       this.ctx.emit(`${value} = load %StringArray*, %StringArray** ${fieldPtr}`);
       this.ctx.setVariableType(value, "%StringArray*");
       return value;
-    } else if (fieldType.endsWith("[]")) {
+    } else if (isAnyArrayTsType(fieldType)) {
       const resolvedTsType = tsType || fieldType;
-      const isObjectArray = isObjectArrayTsType(resolvedTsType);
+      const llvmT = arrayKindToLlvm(classifyArray(resolvedTsType));
       const value = this.ctx.nextTemp();
-      if (isObjectArray) {
-        this.ctx.emit(`${value} = load %ObjectArray*, %ObjectArray** ${fieldPtr}`);
-        this.ctx.setVariableType(value, "%ObjectArray*");
-      } else {
-        this.ctx.emit(`${value} = load %Array*, %Array** ${fieldPtr}`);
-        this.ctx.setVariableType(value, "%Array*");
-      }
+      this.ctx.emit(`${value} = load ${llvmT}, ${llvmT}* ${fieldPtr}`);
+      this.ctx.setVariableType(value, llvmT);
       return value;
     } else if (fieldType === "boolean") {
       const value = this.ctx.nextTemp();
@@ -1128,16 +1126,11 @@ export class MemberAccessGenerator {
       this.ctx.emit(`${value} = load double, double* ${fieldPtr}`);
       this.ctx.setVariableType(value, "double");
       return value;
-    } else if (tsType && tsType.endsWith("[]")) {
-      const isObjectArray = isObjectArrayTsType(tsType);
+    } else if (tsType && isAnyArrayTsType(tsType)) {
+      const llvmT = arrayKindToLlvm(classifyArray(tsType));
       const value = this.ctx.nextTemp();
-      if (isObjectArray) {
-        this.ctx.emit(`${value} = load %ObjectArray*, %ObjectArray** ${fieldPtr}`);
-        this.ctx.setVariableType(value, "%ObjectArray*");
-      } else {
-        this.ctx.emit(`${value} = load %Array*, %Array** ${fieldPtr}`);
-        this.ctx.setVariableType(value, "%Array*");
-      }
+      this.ctx.emit(`${value} = load ${llvmT}, ${llvmT}* ${fieldPtr}`);
+      this.ctx.setVariableType(value, llvmT);
       return value;
     }
     const value = this.ctx.nextTemp();
@@ -1521,20 +1514,11 @@ export class MemberAccessGenerator {
       this.ctx.emit(`${value} = load double, double* ${fieldPtr}`);
       this.ctx.setVariableType(value, "double");
       return value;
-    } else if (propType === "string[]") {
+    } else if (isAnyArrayTsType(propType)) {
+      const llvmT = arrayKindToLlvm(classifyArray(propType));
       const value = this.ctx.nextTemp();
-      this.ctx.emit(`${value} = load %StringArray*, %StringArray** ${fieldPtr}`);
-      this.ctx.setVariableType(value, "%StringArray*");
-      return value;
-    } else if (propType === "number[]" || propType === "boolean[]") {
-      const value = this.ctx.nextTemp();
-      this.ctx.emit(`${value} = load %Array*, %Array** ${fieldPtr}`);
-      this.ctx.setVariableType(value, "%Array*");
-      return value;
-    } else if (propType.endsWith("[]")) {
-      const value = this.ctx.nextTemp();
-      this.ctx.emit(`${value} = load %ObjectArray*, %ObjectArray** ${fieldPtr}`);
-      this.ctx.setVariableType(value, "%ObjectArray*");
+      this.ctx.emit(`${value} = load ${llvmT}, ${llvmT}* ${fieldPtr}`);
+      this.ctx.setVariableType(value, llvmT);
       return value;
     } else {
       let nestedTypeName = propType;
@@ -1982,7 +1966,8 @@ export class MemberAccessGenerator {
           .replace(/ \| null/g, "")
           .trim();
       }
-      if (ts.endsWith("[]")) return "%ObjectArray*";
+      const akTs = classifyArray(ts);
+      if (akTs !== ArrayKind_None) return arrayKindToLlvm(akTs);
       if (ts.startsWith("Map<")) return ts.startsWith("Map<string,") ? "%StringMap*" : "%Map*";
       if (ts.startsWith("Set<")) return ts === "Set<string>" ? "%StringSet*" : "%Set*";
       const classFields = this.ctx.classGenGetClassFields(ts);
@@ -3244,15 +3229,11 @@ export class MemberAccessGenerator {
                 this.ctx.emit(`${boolVal} = load double, double* ${fieldPtr}`);
                 this.ctx.setVariableType(boolVal, "double");
                 return boolVal;
-              } else if (propType === "string[]") {
+              } else if (isAnyArrayTsType(propType)) {
+                const llvmT = arrayKindToLlvm(classifyArray(propType));
                 const value = this.ctx.nextTemp();
-                this.ctx.emit(`${value} = load %StringArray*, %StringArray** ${fieldPtr}`);
-                this.ctx.setVariableType(value, "%StringArray*");
-                return value;
-              } else if (propType.endsWith("[]")) {
-                const value = this.ctx.nextTemp();
-                this.ctx.emit(`${value} = load %Array*, %Array** ${fieldPtr}`);
-                this.ctx.setVariableType(value, "%Array*");
+                this.ctx.emit(`${value} = load ${llvmT}, ${llvmT}* ${fieldPtr}`);
+                this.ctx.setVariableType(value, llvmT);
                 return value;
               } else {
                 const value = this.ctx.nextTemp();

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -17,6 +17,9 @@ import {
   isNullableType,
   mapParamTypeToLLVM,
   mapReturnTypeToLLVM,
+  classifyArray,
+  arrayKindToLlvm,
+  ArrayKind_None,
 } from "../infrastructure/type-system.js";
 import { createStringConstant } from "../types/collections/string/constants.js";
 import {
@@ -1865,7 +1868,8 @@ export class CallExpressionGenerator {
   private getFieldLlvmType(field: { name: string; fieldType: string; tsType?: string }): string {
     if (field.fieldType === "string") return "i8*";
     if (field.fieldType === "string[]") return "%StringArray*";
-    if (field.fieldType.endsWith("[]")) return "%Array*";
+    const ftAk = classifyArray(field.fieldType);
+    if (ftAk !== ArrayKind_None) return arrayKindToLlvm(ftAk);
     if (field.fieldType === "boolean") return "i1";
     if (field.tsType) {
       const collType = this.getFieldLlvmTypeForTsType(field.tsType);

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -113,6 +113,14 @@ import {
   parseMapTypeString,
   isObjectArrayTsType,
   isAnyArrayTsType,
+  classifyArray,
+  arrayKindToLlvm,
+  arrayElementType,
+  ArrayKind_None,
+  ArrayKind_String,
+  ArrayKind_Number,
+  ArrayKind_Boolean,
+  ArrayKind_Object,
   type ResolvedType,
 } from "./infrastructure/type-system.js";
 import { DiagnosticEngine } from "../diagnostics/engine.js";
@@ -1971,47 +1979,43 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
           );
           return `@${name} = global ${llvmType} null\n`;
         }
-        if (rt.endsWith("[]")) {
-          const elementType = rt.substring(0, rt.length - 2);
-          if (elementType === "string") {
+        const akRt = classifyArray(rt);
+        if (akRt !== ArrayKind_None) {
+          const elementType = arrayElementType(rt);
+          const llvmType = arrayKindToLlvm(akRt);
+          if (akRt === ArrayKind_String) {
             this.globalVariables.set(name, {
-              llvmType: "%StringArray*",
+              llvmType,
               kind: SymbolKind_StringArray,
               initialized: false,
             });
-            this.defineVariable(
-              name,
-              `@${name}`,
-              "%StringArray*",
-              SymbolKind_StringArray,
-              "global",
-            );
-            return `@${name} = global %StringArray* null\n`;
+            this.defineVariable(name, `@${name}`, llvmType, SymbolKind_StringArray, "global");
+            return `@${name} = global ${llvmType} null\n`;
           }
-          if (elementType === "number" || elementType === "boolean") {
+          if (akRt === ArrayKind_Number || akRt === ArrayKind_Boolean) {
             this.globalVariables.set(name, {
-              llvmType: "%Array*",
+              llvmType,
               kind: SymbolKind_Array,
               initialized: false,
             });
-            this.defineVariable(name, `@${name}`, "%Array*", SymbolKind_Array, "global");
-            return `@${name} = global %Array* null\n`;
+            this.defineVariable(name, `@${name}`, llvmType, SymbolKind_Array, "global");
+            return `@${name} = global ${llvmType} null\n`;
           }
           this.globalVariables.set(name, {
-            llvmType: "%ObjectArray*",
+            llvmType,
             kind: SymbolKind_ObjectArray,
             initialized: false,
           });
           this.defineVariableWithMetadata(
             name,
             `@${name}`,
-            "%ObjectArray*",
+            llvmType,
             SymbolKind_ObjectArray,
             "global",
             createInterfaceMetadata(elementType),
           );
           this.symbolTable.setRawInterfaceType(name, elementType);
-          return `@${name} = global %ObjectArray* null\n`;
+          return `@${name} = global ${llvmType} null\n`;
         }
         if (this.isTypeAlias(rt)) {
           const commonProps = this.getTypeAliasCommonProperties(rt);
@@ -2270,7 +2274,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         const parentGlobal = this.globalVariables.get(parentName);
         if (parentGlobal && parentGlobal.llvmType === "%ObjectArray*") {
           const parentRawType = this.symbolTable.getRawInterfaceType(parentName);
-          if (parentRawType && parentRawType.endsWith("[]")) {
+          if (parentRawType && isAnyArrayTsType(parentRawType)) {
             return {
               llvmType: "%ObjectArray*",
               kind: SymbolKind_ObjectArray,
@@ -2944,15 +2948,27 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
               llvmType = "double";
               kind = SymbolKind_Boolean;
               defaultValue = "0.0";
-            } else if (strippedDeclaredType === "string[]") {
-              isStringArray = true;
-            } else if (strippedDeclaredType === "boolean[]") {
-              isUint8Array = true;
-              isArray = false;
-            } else if (strippedDeclaredType === "number[]") {
-              isArray = true;
-            } else if (strippedDeclaredType.endsWith("[]")) {
-              isObjectArray = true;
+            } else {
+              const akDecl = classifyArray(strippedDeclaredType);
+              switch (akDecl) {
+                case ArrayKind_None:
+                  break;
+                case ArrayKind_String:
+                  isStringArray = true;
+                  break;
+                case ArrayKind_Boolean:
+                  isUint8Array = true;
+                  isArray = false;
+                  break;
+                case ArrayKind_Number:
+                  isArray = true;
+                  break;
+                case ArrayKind_Object:
+                  isObjectArray = true;
+                  break;
+                default:
+                  throw new Error(`unknown ArrayKind ${akDecl}`);
+              }
             }
           }
 
@@ -3076,7 +3092,7 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
       this.defineVariable(name, `@${name}`, "%Array*", SymbolKind_Array, "global");
       return `@${name} = global %Array* null\n`;
     }
-    if (baseType.endsWith("[]")) {
+    if (isAnyArrayTsType(baseType)) {
       this.globalVariables.set(name, {
         llvmType: "%ObjectArray*",
         kind: SymbolKind_ObjectArray,

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -113,12 +113,12 @@ export class ClassGenerator {
           return "%StringSet*";
         } else if (ts.startsWith("Set<")) {
           return "%Set*";
-        } else if (ts.endsWith("[]")) {
-          return "%ObjectArray*";
         } else if (ts === "number" || ts === "boolean") {
           return "double";
-        } else if (ts === "number[]" || ts === "boolean[]") {
-          return "%Array*";
+        }
+        const tsAk1 = classifyArray(ts);
+        if (tsAk1 !== ArrayKind_None) {
+          return arrayKindToLlvm(tsAk1);
         }
         const classNode = this.findClassNode(ts);
         if (classNode) {
@@ -138,9 +138,12 @@ export class ClassGenerator {
       return "i8*";
     } else if (ft === "string[]") {
       return "%StringArray*";
-    } else if (ft.endsWith("[]")) {
-      return "%Array*";
-    } else if (ft === "boolean") {
+    }
+    const ftAk = classifyArray(ft);
+    if (ftAk !== ArrayKind_None) {
+      return arrayKindToLlvm(ftAk);
+    }
+    if (ft === "boolean") {
       return "double";
     } else if (ts) {
       if (ts.startsWith("Map<string,")) {
@@ -153,11 +156,12 @@ export class ClassGenerator {
         return "%Set*";
       } else if (ts === "number" || ts === "boolean") {
         return "double";
-      } else if (ts === "number[]" || ts === "boolean[]") {
-        return "%Array*";
-      } else if (ts.endsWith("[]")) {
-        return "%ObjectArray*";
-      } else {
+      }
+      const tsAk2 = classifyArray(ts);
+      if (tsAk2 !== ArrayKind_None) {
+        return arrayKindToLlvm(tsAk2);
+      }
+      {
         const classNode = this.findClassNode(ts);
         if (classNode) {
           return "%" + ts + "_struct*";


### PR DESCRIPTION
## Before
13 scattered `endsWith("[]")` checks across 4 files did ad-hoc array type classification. Some had latent bugs:
- `class.ts fieldToLlvmType`: `ts.endsWith("[]")` checked BEFORE specific `number[]`/`boolean[]` checks, misclassifying them as `%ObjectArray*`
- `calls.ts getFieldLlvmType`: ALL non-string arrays mapped to `%Array*`, wrong for object arrays
- `member.ts` line 3252: `propType.endsWith("[]")` catch-all mapped object arrays to `%Array*`

## After
All 13 sites use `classifyArray()` + `arrayKindToLlvm()` from `type-system.ts`. Type mapping is consistent and centralized. Latent ordering bugs fixed. No user-facing change (bugs were in uncommon code paths), but eliminates a class of silent-wrong errors.

## Description
Batch migration for #710. 4 files, 13 sites:
- `class.ts` (3 sites): replaced manual `endsWith` + `isObjectArrayTsType` dispatch
- `calls.ts` (1 site): fixed bug where object arrays got `%Array*` instead of `%ObjectArray*`
- `member.ts` (5 sites): consolidated 3-branch string/number/object dispatch into single `arrayKindToLlvm(classifyArray(x))` call
- `llvm-generator.ts` (4 sites): used `classifyArray` switch for global variable classification, `isAnyArrayTsType` for gate checks

All tests pass, Stage 0→1 self-hosting clean.

Closes #710