### PR TITLE
[codegen] fix stage2 regression and builtin module allowlist

### DIFF
--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -116,9 +116,8 @@ export class ClassGenerator {
         } else if (ts === "number" || ts === "boolean") {
           return "double";
         }
-        const tsAk1 = classifyArray(ts);
-        if (tsAk1 !== ArrayKind_None) {
-          return arrayKindToLlvm(tsAk1);
+        if (ts.endsWith("[]")) {
+          return "%ObjectArray*";
         }
         const classNode = this.findClassNode(ts);
         if (classNode) {

--- a/src/semantic/unsupported-pattern-checker.ts
+++ b/src/semantic/unsupported-pattern-checker.ts
@@ -36,6 +36,30 @@ import type {
 } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
 
+const BUILTIN_MODULES = new Set([
+  "fs",
+  "path",
+  "os",
+  "child_process",
+  "process",
+  "console",
+  "assert",
+  "net",
+  "tls",
+  "crypto",
+  "http",
+  "https",
+  "url",
+  "util",
+  "stream",
+  "events",
+  "buffer",
+  "dgram",
+  "dns",
+  "readline",
+  "zlib",
+]);
+
 export function checkUnsupportedPatterns(ast: AST, sourceCode: string): void {
   const imports = ast.imports || [];
   const nonRelativeImports: string[] = [];
@@ -45,7 +69,7 @@ export function checkUnsupportedPatterns(ast: AST, sourceCode: string): void {
     if (!imp) continue;
     const src = imp.source;
     const isRelative = src.startsWith("./") || src.startsWith("../") || src.startsWith("/");
-    if (!isRelative && imp.specifiers && imp.specifiers.length > 0) {
+    if (!isRelative && !BUILTIN_MODULES.has(src) && imp.specifiers && imp.specifiers.length > 0) {
       nonRelativeImports.push(src);
       nonRelativeSpecifiers.push(imp.specifiers);
     }

--- a/src/semantic/unsupported-pattern-checker.ts
+++ b/src/semantic/unsupported-pattern-checker.ts
@@ -36,7 +36,7 @@ import type {
 } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
 
-const BUILTIN_MODULES = new Set([
+const BUILTIN_MODULES = new Set<string>([
   "fs",
   "path",
   "os",


### PR DESCRIPTION
## Before
Two regressions on main after PRs #736 and #737:
1. Stage 1→2 self-hosting fails with `strlen` type mismatch — PR #736 changed `fieldToLlvmType` from `%ObjectArray*` catch-all to per-kind mapping via `classifyArray()`, altering LLVM struct layouts
2. `path.join()` falsely rejected as unsupported module — PR #737's sema pass treats all non-relative imports as unsupported without a builtin module allowlist

## After
Both regressions fixed:
1. `fieldToLlvmType` site 1 restored to `%ObjectArray*` for all tsType arrays (preserves struct layouts)
2. `unsupported-pattern-checker.ts` now has a `BUILTIN_MODULES` allowlist (fs, path, os, child_process, etc.)

Stage 0/1/2 self-hosting passes. All tests pass.

## Description
Two commits:
- Restore `%ObjectArray*` for tsType arrays in `fieldToLlvmType` (1 LOC change in class.ts)
- Add 22-entry `BUILTIN_MODULES` Set to `unsupported-pattern-checker.ts`