### PR TITLE
[sema] migrate sema passes from topLevelStatements to topLevelItems

### DIFF
--- a/src/semantic/array-of-function-checker.ts
+++ b/src/semantic/array-of-function-checker.ts
@@ -80,9 +80,8 @@ class ArrayOfFunctionChecker {
   }
 
   check(ast: AST): void {
-    if (ast.topLevelStatements) {
-      for (const s of ast.topLevelStatements) this.checkTopLevelStmt(s);
-    }
+    const items = ast.topLevelItems || [];
+    for (const s of items) this.checkTopLevelStmt(s as Statement);
     if (ast.functions) {
       for (const f of ast.functions) this.checkFunction(f);
     }

--- a/src/semantic/duplicate-decl-checker.ts
+++ b/src/semantic/duplicate-decl-checker.ts
@@ -1,4 +1,4 @@
-import type { AST, SourceLocation } from "../ast/types.js";
+import type { AST, SourceLocation, VariableDeclaration } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
 
 export function checkDuplicateDeclarations(ast: AST, sourceCode: string): void {
@@ -32,17 +32,19 @@ export function checkDuplicateDeclarations(ast: AST, sourceCode: string): void {
     seen.set(name, { kind: "function", loc: fn.loc });
   }
 
-  for (let i = 0; i < ast.topLevelStatements.length; i++) {
-    const stmt = ast.topLevelStatements[i];
+  const items = ast.topLevelItems || [];
+  for (let i = 0; i < items.length; i++) {
+    const stmt = items[i] as { type: string };
     if (stmt.type !== "variable_declaration") continue;
-    if (stmt.value === null) continue;
-    const name = stmt.name;
+    const decl = items[i] as VariableDeclaration;
+    if (decl.value === null) continue;
+    const name = decl.name;
     if (importedNames.has(name)) continue;
     const existing = seen.get(name);
     if (existing) {
-      reportDuplicate(sourceCode, name, existing.kind, stmt.kind, stmt.loc);
+      reportDuplicate(sourceCode, name, existing.kind, decl.kind, decl.loc);
     }
-    seen.set(name, { kind: stmt.kind, loc: stmt.loc });
+    seen.set(name, { kind: decl.kind, loc: decl.loc });
   }
 }
 

--- a/src/semantic/interface-layout-normalizer.ts
+++ b/src/semantic/interface-layout-normalizer.ts
@@ -221,20 +221,21 @@ export class InterfaceLayoutNormalizer {
     if (ast.classes) {
       for (let i = 0; i < ast.classes.length; i++) this.visitClass(ast.classes[i]);
     }
-    if (ast.topLevelStatements) {
-      for (let i = 0; i < ast.topLevelStatements.length; i++) {
-        this.visitStatement(ast.topLevelStatements[i]);
-      }
-    }
-    if (ast.topLevelExpressions) {
-      for (let i = 0; i < ast.topLevelExpressions.length; i++) {
-        const e = ast.topLevelExpressions[i];
-        const t = (e as { type: string }).type;
-        if (t === "if" || t === "while" || t === "for" || t === "for_of" || t === "try") {
-          this.visitStatement(e as unknown as Statement);
-        } else {
-          this.visitExpression(e as unknown as Expression);
-        }
+    const items = ast.topLevelItems || [];
+    for (let i = 0; i < items.length; i++) {
+      const t = (items[i] as { type: string }).type;
+      if (
+        t === "variable_declaration" ||
+        t === "assignment" ||
+        t === "if" ||
+        t === "while" ||
+        t === "for" ||
+        t === "for_of" ||
+        t === "try"
+      ) {
+        this.visitStatement(items[i] as unknown as Statement);
+      } else {
+        this.visitExpression(items[i] as unknown as Expression);
       }
     }
   }

--- a/src/semantic/map-key-checker.ts
+++ b/src/semantic/map-key-checker.ts
@@ -129,10 +129,11 @@ function checkReturnType(
 }
 
 export function checkMapKeyTypes(ast: AST, sourceCode: string): void {
-  for (let i = 0; i < ast.topLevelStatements.length; i++) {
-    const stmt = ast.topLevelStatements[i] as VariableDeclaration;
+  const items = ast.topLevelItems || [];
+  for (let i = 0; i < items.length; i++) {
+    const stmt = items[i] as { type: string };
     if (stmt.type === "variable_declaration") {
-      checkVarDecl(stmt, sourceCode);
+      checkVarDecl(items[i] as VariableDeclaration, sourceCode);
     }
   }
 


### PR DESCRIPTION
## Before
Four sema passes (`duplicate-decl-checker`, `map-key-checker`, `array-of-function-checker`, `interface-layout-normalizer`) still read the deprecated `ast.topLevelStatements` and `ast.topLevelExpressions` arrays.

## After
All four passes use the unified `ast.topLevelItems` array, filtering by node `type` field. No user-facing change. Internal refactor only.

## Description
Part of the ongoing `topLevelItems` migration. Each pass now iterates `ast.topLevelItems || []` and dispatches by `type` string to the appropriate handler. `duplicate-decl-checker` filters for `variable_declaration`; `interface-layout-normalizer` dispatches to `visitStatement` or `visitExpression` based on type.