### PR TITLE
[sema] add builtin module allowlist to unsupported pattern checker

### DIFF
--- a/src/semantic/unsupported-pattern-checker.ts
+++ b/src/semantic/unsupported-pattern-checker.ts
@@ -36,6 +36,30 @@ import type {
 } from "../ast/types.js";
 import { formatCompileError } from "../diagnostics/engine.js";
 
+const BUILTIN_MODULES = new Set([
+  "fs",
+  "path",
+  "os",
+  "child_process",
+  "process",
+  "console",
+  "assert",
+  "net",
+  "tls",
+  "crypto",
+  "http",
+  "https",
+  "url",
+  "util",
+  "stream",
+  "events",
+  "buffer",
+  "dgram",
+  "dns",
+  "readline",
+  "zlib",
+]);
+
 export function checkUnsupportedPatterns(ast: AST, sourceCode: string): void {
   const imports = ast.imports || [];
   const nonRelativeImports: string[] = [];
@@ -45,7 +69,7 @@ export function checkUnsupportedPatterns(ast: AST, sourceCode: string): void {
     if (!imp) continue;
     const src = imp.source;
     const isRelative = src.startsWith("./") || src.startsWith("../") || src.startsWith("/");
-    if (!isRelative && imp.specifiers && imp.specifiers.length > 0) {
+    if (!isRelative && !BUILTIN_MODULES.has(src) && imp.specifiers && imp.specifiers.length > 0) {
       nonRelativeImports.push(src);
       nonRelativeSpecifiers.push(imp.specifiers);
     }


### PR DESCRIPTION
## Before
PR #737 extracted the unsupported module check to a sema pass, but the check treats ALL non-relative import sources as unsupported. This falsely rejects built-in modules like `path`, `fs`, `os`, `child_process` — causing `path.join()` to fail with "module 'path' is not supported by ChadScript". This is a regression on main.

## After
Built-in modules (fs, path, os, child_process, net, tls, etc.) are excluded from the unsupported module check via an allowlist. `import path from "path"` followed by `path.join(...)` compiles correctly again.

## Description
Adds a `BUILTIN_MODULES` Set with 22 known Node.js built-in module names. The `checkUnsupportedPatterns` function skips non-relative imports whose source is in this set. The old codegen check avoided this problem because it only triggered after all known method handlers were exhausted — the sema pass runs before codegen, so it needs explicit knowledge of which modules are handled.