### PR TITLE
[codegen] generate set/map initializers in class field constructors

### DIFF
--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -636,10 +636,17 @@ export class ClassGenerator {
         initType !== "null" &&
         initType !== "array" &&
         initType !== "new" &&
-        initType !== "unary"
+        initType !== "unary" &&
+        initType !== "set" &&
+        initType !== "map"
       )
         continue;
+      const fieldTsType = classField.tsType as string | undefined;
+      if (fieldTsType && fieldTsType.startsWith("Map<")) {
+        this.ctx.setCurrentDeclaredMapType(fieldTsType);
+      }
       const initResult = this.ctx.generateExpression(classField.initializer, constructor.params);
+      this.ctx.setCurrentDeclaredMapType(undefined);
       if (initResult) {
         const fieldPtr = this.nextTemp();
         const llvmType = this.fieldToLlvmType(classField);
@@ -754,10 +761,17 @@ export class ClassGenerator {
           initType !== "null" &&
           initType !== "array" &&
           initType !== "new" &&
-          initType !== "unary"
+          initType !== "unary" &&
+          initType !== "set" &&
+          initType !== "map"
         )
           continue;
+        const fieldTsType2 = cf.tsType as string | undefined;
+        if (fieldTsType2 && fieldTsType2.startsWith("Map<")) {
+          this.ctx.setCurrentDeclaredMapType(fieldTsType2);
+        }
         const initResult = this.ctx.generateExpression(cf.initializer, []);
+        this.ctx.setCurrentDeclaredMapType(undefined);
         if (initResult) {
           const fieldPtr = this.nextTemp();
           const llvmType = fieldLlvmTypes[fi];

--- a/tests/fixtures/classes/map-field-init.ts
+++ b/tests/fixtures/classes/map-field-init.ts
@@ -1,0 +1,18 @@
+class Registry {
+  entries: Map<string, number> = new Map<string, number>();
+
+  register(name: string, value: number): void {
+    this.entries.set(name, value);
+  }
+
+  lookup(name: string): number {
+    return this.entries.get(name);
+  }
+}
+
+const r = new Registry();
+r.register("x", 42);
+r.register("y", 99);
+if (r.lookup("x") === 42 && r.lookup("y") === 99) {
+  console.log("TEST_PASSED");
+}

--- a/tests/fixtures/classes/set-field-init.ts
+++ b/tests/fixtures/classes/set-field-init.ts
@@ -1,0 +1,14 @@
+class Container {
+  items: Set<string> = new Set<string>();
+
+  hasItem(name: string): boolean {
+    return this.items.has(name);
+  }
+}
+
+const c = new Container();
+c.items.add("hello");
+c.items.add("world");
+if (c.hasItem("hello") && c.hasItem("world") && !c.hasItem("missing")) {
+  console.log("TEST_PASSED");
+}


### PR DESCRIPTION
## Before
Class fields with `Set` or `Map` initializers (`items: Set<string> = new Set<string>()`) were silently skipped during constructor generation. The field was zero-initialized (null pointer), causing segfaults when accessed.

## After
`Set` and `Map` field initializers are properly generated in both explicit and default constructors. `new Set<string>()` and `new Map<string, number>()` on class fields now work correctly.

## Description
The constructor's field init loop had a whitelist of expression types it would generate: `string`, `number`, `boolean`, `null`, `array`, `new`, `unary`. The parser emits Set/Map constructors as `"set"`/`"map"` expression types, which weren't in the whitelist. Added them to both `generateConstructor` and `generateDefaultConstructorFromTypes`.

Also propagates `setCurrentDeclaredMapType` before generating Map initializers per CLAUDE.md rule #8.

Two new test fixtures: `set-field-init.ts` and `map-field-init.ts`.

## Next Steps
- The init type whitelist pattern is fragile — new expression types silently fail. Filed #741 for structured TypeNode migration.
- Other expression types (`call`, `method_call`, `binary`, `object`, etc.) are still excluded — expanding caused a stage 0 regression with lambda names leaking into double positions. These need individual investigation.