### PR TITLE
[codegen] fix promise<number> boxing/unboxing in async functions

### DIFF
--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -1379,6 +1379,12 @@ export class VariableAllocator {
       if (inner === "Response") {
         return { llvmType: "%__FetchResponse*", symbolKind: SymbolKind_Object };
       }
+      if (inner === "number" || inner === "boolean") {
+        return { llvmType: "double", symbolKind: SymbolKind_Number };
+      }
+      if (inner === "string") {
+        return { llvmType: "i8*", symbolKind: SymbolKind_String };
+      }
       return null;
     }
     return null;
@@ -1494,10 +1500,17 @@ export class VariableAllocator {
         this.ctx.defineVariable(stmt.name, allocaReg, llvmType, symbolKind, "local");
         this.ctx.emit(`${allocaReg} = alloca ${llvmType}`);
         const value = this.ctx.generateExpression(stmt.value!, params);
-        // value from @__Promise_await is i8*; bitcast to the struct pointer.
-        const cast = this.ctx.nextTemp();
-        this.ctx.emit(`${cast} = bitcast i8* ${value} to ${llvmType}`);
-        this.ctx.emit(`store ${llvmType} ${cast}, ${llvmType}* ${allocaReg}`);
+        if (llvmType === "double") {
+          const dblPtr = this.ctx.nextTemp();
+          this.ctx.emit(`${dblPtr} = bitcast i8* ${value} to double*`);
+          const dblVal = this.ctx.nextTemp();
+          this.ctx.emit(`${dblVal} = load double, double* ${dblPtr}`);
+          this.ctx.emit(`store double ${dblVal}, double* ${allocaReg}`);
+        } else {
+          const cast = this.ctx.nextTemp();
+          this.ctx.emit(`${cast} = bitcast i8* ${value} to ${llvmType}`);
+          this.ctx.emit(`store ${llvmType} ${cast}, ${llvmType}* ${allocaReg}`);
+        }
         return;
       }
     }

--- a/src/codegen/llvm-generator.ts
+++ b/src/codegen/llvm-generator.ts
@@ -4193,10 +4193,36 @@ export class LLVMGenerator extends BaseGenerator implements IGeneratorContext {
         }
 
         if (this.isAsyncFunction) {
-          const valueAsPtr = this.nextTemp();
-          this.emit(`${valueAsPtr} = bitcast i8* ${lastValue} to i8*`);
+          let resolveValue = lastValue;
+          const valueType = this.getVariableType(lastValue);
+          if (
+            valueType === "double" ||
+            valueType === "i64" ||
+            valueType === "i32" ||
+            valueType === "i1"
+          ) {
+            let asDouble = lastValue;
+            if (valueType === "i64") {
+              asDouble = this.nextTemp();
+              this.emit(`${asDouble} = sitofp i64 ${lastValue} to double`);
+            } else if (valueType === "i32") {
+              asDouble = this.nextTemp();
+              this.emit(`${asDouble} = sitofp i32 ${lastValue} to double`);
+            } else if (valueType === "i1") {
+              const ext = this.nextTemp();
+              this.emit(`${ext} = zext i1 ${lastValue} to i64`);
+              asDouble = this.nextTemp();
+              this.emit(`${asDouble} = sitofp i64 ${ext} to double`);
+            }
+            const boxMem = this.nextTemp();
+            this.emit(`${boxMem} = call i8* @GC_malloc_atomic(i64 8)`);
+            const boxPtr = this.nextTemp();
+            this.emit(`${boxPtr} = bitcast i8* ${boxMem} to double*`);
+            this.emit(`store double ${asDouble}, double* ${boxPtr}`);
+            resolveValue = boxMem;
+          }
           this.emit(
-            `call void @__Promise_resolve(%Promise* ${this.asyncResultPromise}, i8* ${lastValue})`,
+            `call void @__Promise_resolve(%Promise* ${this.asyncResultPromise}, i8* ${resolveValue})`,
           );
           this.emit(`ret %Promise* ${this.asyncResultPromise}`);
         } else {

--- a/tests/fixtures/async/promise-number-return.ts
+++ b/tests/fixtures/async/promise-number-return.ts
@@ -1,0 +1,22 @@
+async function getNum(): Promise<number> {
+  return 42;
+}
+
+async function getBool(): Promise<boolean> {
+  return true;
+}
+
+async function getStr(): Promise<string> {
+  return "hello";
+}
+
+async function main(): Promise<void> {
+  const n = await getNum();
+  const b = await getBool();
+  const s = await getStr();
+  if (n === 42 && b === true && s === "hello") {
+    console.log("TEST_PASSED");
+  }
+}
+
+main();


### PR DESCRIPTION
## Before
`async function getNum(): Promise<number>` would pass the raw `double` value to `__Promise_resolve(i8*)`, causing type confusion. On the await side, the `i8*` result was bitcast directly to `double*` without loading — reading garbage memory.

## After
- Return side: numeric values (double, i64, i32, i1) are boxed into heap-allocated `double*` before passing to `__Promise_resolve`
- Await side: `Promise<number>` results are unboxed by bitcasting `i8*` → `double*` then loading the double
- `Promise<boolean>` and `Promise<string>` also handled correctly

## Description
Two changes:
1. `llvm-generator.ts`: async function return path now boxes numeric types (allocates 8 bytes via `GC_malloc_atomic`, stores the double, passes the `i8*`)
2. `variable-allocator.ts`: `tryUnwrapAsyncCallReturnType` now recognizes `Promise<number>`, `Promise<boolean>`, `Promise<string>`. Await allocation unboxes doubles by loading through `double*`.

New test fixture: `tests/fixtures/async/promise-number-return.ts`