### PR TITLE
[ci] isolate test build dirs to eliminate .ll file race condition

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -88,7 +88,12 @@ const testFiles = [
 ];
 
 const compilerPath = flag === "--node" ? "node dist/chad-node.js" : ".build/chad";
-const env = { ...process.env, CHADC_COMPILER: compilerPath };
+const compilerLabel = flag === "--node" ? "node" : "native";
+const env = {
+  ...process.env,
+  CHADC_COMPILER: compilerPath,
+  CHADC_BUILD_DIR: `.build/${compilerLabel}`,
+};
 
 console.log(`\nRunning tests with: ${compilerPath}`);
 

--- a/tests/compiler.test.ts
+++ b/tests/compiler.test.ts
@@ -23,6 +23,7 @@ if (!process.env.CHADC_COMPILER) {
 const compilerBase = process.env.CHADC_COMPILER;
 const compiler = `${compilerBase} build`;
 const compilerLabel = compilerBase.includes("chad-node") ? "node" : "native";
+const buildDir = process.env.CHADC_BUILD_DIR || ".build";
 
 describe(`ChadScript Compiler (${compilerLabel})`, () => {
   describe("Compilation and Execution", { concurrency: 32 }, () => {
@@ -32,7 +33,7 @@ describe(`ChadScript Compiler (${compilerLabel})`, () => {
         const fixturePath = testCase.fixture; // Use relative path, not resolved
         // Binaries now go in .build/ directory
         const fixtureDir = path.dirname(testCase.fixture);
-        const outputDir = path.join(".build", fixtureDir);
+        const outputDir = path.join(buildDir, fixtureDir);
         const extension = path.extname(fixturePath);
         const baseName = path.basename(fixturePath, extension);
         const llFile = path.join(outputDir, `${baseName}.ll`);
@@ -51,7 +52,7 @@ describe(`ChadScript Compiler (${compilerLabel})`, () => {
           if (testCase.compileError) {
             await assert.rejects(
               async () => {
-                await execAsync(`${compiler} ${fixturePath}`);
+                await execAsync(`${compiler} ${fixturePath} -o ${exeFile}`);
               },
               (err: any) => {
                 const output = (err.stderr || "") + (err.stdout || "") + (err.message || "");
@@ -69,8 +70,7 @@ describe(`ChadScript Compiler (${compilerLabel})`, () => {
             return;
           }
 
-          // Compile the fixture (no console.log to avoid parallel output issues)
-          await execAsync(`${compiler} ${fixturePath}`);
+          await execAsync(`${compiler} ${fixturePath} -o ${exeFile}`);
 
           // Verify executable was generated (intermediate files are cleaned up by default)
           assert.ok(fsSync.existsSync(exeFile), `Executable should exist at ${exeFile}`);
@@ -131,7 +131,7 @@ describe(`ChadScript Compiler (${compilerLabel})`, () => {
   describe("LLVM IR Generation", () => {
     it("should generate valid LLVM IR structure", async () => {
       const fixturePath = "tests/fixtures/arithmetic/simple-add.ts"; // Use relative path
-      const outputDir = path.join(".build", path.dirname(fixturePath));
+      const outputDir = path.join(buildDir, path.dirname(fixturePath));
       const baseName = path.basename(fixturePath, ".ts");
       const llFile = path.join(outputDir, `${baseName}.ll`);
 
@@ -143,7 +143,7 @@ describe(`ChadScript Compiler (${compilerLabel})`, () => {
       }
 
       try {
-        await execAsync(`${compilerBase} ir ${fixturePath}`);
+        await execAsync(`${compilerBase} ir ${fixturePath} -o ${path.join(outputDir, baseName)}`);
 
         // Read and verify LLVM IR
         const llContent = await fs.readFile(llFile, "utf-8");

--- a/tests/http-headers.test.ts
+++ b/tests/http-headers.test.ts
@@ -14,9 +14,10 @@ if (!process.env.CHADC_COMPILER) {
   );
 }
 const compiler = `${process.env.CHADC_COMPILER} build`;
+const buildDir = process.env.CHADC_BUILD_DIR || ".build";
 
 const SERVER_SOURCE = "tests/fixtures/network/http-headers-test.ts";
-const SERVER_BINARY = ".build/tests/fixtures/network/http-headers-test";
+const SERVER_BINARY = `${buildDir}/tests/fixtures/network/http-headers-test`;
 let PORT = 0;
 
 function sleep(ms: number): Promise<void> {
@@ -44,7 +45,7 @@ describe("HTTP Headers Tests", { concurrency: 1 }, () => {
       });
       srv.on("error", reject);
     });
-    await execAsync(`${compiler} ${SERVER_SOURCE}`, { timeout: 60000 });
+    await execAsync(`${compiler} ${SERVER_SOURCE} -o ${SERVER_BINARY}`, { timeout: 60000 });
     assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");
   });
 

--- a/tests/http-query-string.test.ts
+++ b/tests/http-query-string.test.ts
@@ -13,9 +13,10 @@ if (!process.env.CHADC_COMPILER) {
   );
 }
 const compiler = `${process.env.CHADC_COMPILER} build`;
+const buildDir = process.env.CHADC_BUILD_DIR || ".build";
 
 const SERVER_SOURCE = "tests/fixtures/network/http-query-string-test.ts";
-const SERVER_BINARY = ".build/tests/fixtures/network/http-query-string-test";
+const SERVER_BINARY = `${buildDir}/tests/fixtures/network/http-query-string-test`;
 let PORT = 0;
 
 function sleep(ms: number): Promise<void> {
@@ -43,7 +44,7 @@ describe("HTTP Query String Tests", { concurrency: 1 }, () => {
       });
       srv.on("error", reject);
     });
-    await execAsync(`${compiler} ${SERVER_SOURCE}`, { timeout: 60000 });
+    await execAsync(`${compiler} ${SERVER_SOURCE} -o ${SERVER_BINARY}`, { timeout: 60000 });
     assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");
   });
 

--- a/tests/http-routes.test.ts
+++ b/tests/http-routes.test.ts
@@ -15,9 +15,10 @@ if (!process.env.CHADC_COMPILER) {
   );
 }
 const compiler = `${process.env.CHADC_COMPILER} build`;
+const buildDir = process.env.CHADC_BUILD_DIR || ".build";
 
 const SERVER_SOURCE = "tests/fixtures/network/http-route-isolation-test.ts";
-const SERVER_BINARY = ".build/tests/fixtures/network/http-route-isolation-test";
+const SERVER_BINARY = `${buildDir}/tests/fixtures/network/http-route-isolation-test`;
 let PORT = 0;
 
 function sleep(ms: number): Promise<void> {
@@ -45,7 +46,7 @@ describe("HTTP Route Isolation Tests", { concurrency: 1 }, () => {
       });
       srv.on("error", reject);
     });
-    await execAsync(`${compiler} ${SERVER_SOURCE}`, { timeout: 60000 });
+    await execAsync(`${compiler} ${SERVER_SOURCE} -o ${SERVER_BINARY}`, { timeout: 60000 });
     assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");
   });
 

--- a/tests/multipart.test.ts
+++ b/tests/multipart.test.ts
@@ -14,9 +14,10 @@ if (!process.env.CHADC_COMPILER) {
   );
 }
 const compiler = `${process.env.CHADC_COMPILER} build`;
+const buildDir = process.env.CHADC_BUILD_DIR || ".build";
 
 const SERVER_SOURCE = "tests/fixtures/network/multipart-test.ts";
-const SERVER_BINARY = ".build/tests/fixtures/network/multipart-test";
+const SERVER_BINARY = `${buildDir}/tests/fixtures/network/multipart-test`;
 let PORT = 0;
 
 function sleep(ms: number): Promise<void> {
@@ -44,7 +45,7 @@ describe("Multipart Parser Tests", { concurrency: 1 }, () => {
       });
       srv.on("error", reject);
     });
-    await execAsync(`${compiler} ${SERVER_SOURCE}`, {
+    await execAsync(`${compiler} ${SERVER_SOURCE} -o ${SERVER_BINARY}`, {
       timeout: 60000,
     });
     assert.ok(fsSync.existsSync(SERVER_BINARY), "Server binary should exist");

--- a/tests/network.test.ts
+++ b/tests/network.test.ts
@@ -14,6 +14,7 @@ if (!process.env.CHADC_COMPILER) {
 }
 const compiler = `${process.env.CHADC_COMPILER} build`;
 const isNodeCompiler = process.env.CHADC_COMPILER.includes("chad-node");
+const buildDir = process.env.CHADC_BUILD_DIR || ".build";
 
 function getRandomPort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -52,10 +53,12 @@ describe("Network Tests", () => {
 
     try {
       const testFile = "tests/fixtures/network/fetch-integration-test.ts";
-      await execAsync(`${compiler} ${testFile}`);
+      await execAsync(
+        `${compiler} ${testFile} -o ${buildDir}/tests/fixtures/network/fetch-integration-test`,
+      );
 
       const { stdout } = await execAsync(
-        `.build/tests/fixtures/network/fetch-integration-test -p ${port}`,
+        `${buildDir}/tests/fixtures/network/fetch-integration-test -p ${port}`,
       );
 
       assert.ok(stdout.includes("TEST_PASSED"), "fetch() integration test should pass");
@@ -90,9 +93,11 @@ describe("Network Tests", () => {
 
     try {
       const testFile = "tests/fixtures/network/promise-all-fetch-test.ts";
-      await execAsync(`${compiler} ${testFile}`);
+      await execAsync(
+        `${compiler} ${testFile} -o ${buildDir}/tests/fixtures/network/promise-all-fetch-test`,
+      );
       const { stdout } = await execAsync(
-        `.build/tests/fixtures/network/promise-all-fetch-test -p ${port}`,
+        `${buildDir}/tests/fixtures/network/promise-all-fetch-test -p ${port}`,
       );
       assert.ok(stdout.includes("TEST_PASSED"), "Promise.all + fetch test should pass");
     } finally {
@@ -114,9 +119,11 @@ describe("Network Tests", () => {
 
     try {
       const testFile = "tests/fixtures/network/async-fetch-test.ts";
-      await execAsync(`${compiler} ${testFile}`);
+      await execAsync(
+        `${compiler} ${testFile} -o ${buildDir}/tests/fixtures/network/async-fetch-test`,
+      );
       const { stdout } = await execAsync(
-        `.build/tests/fixtures/network/async-fetch-test -p ${port}`,
+        `${buildDir}/tests/fixtures/network/async-fetch-test -p ${port}`,
       );
       assert.ok(stdout.includes("TEST_PASSED"), "async fetch test should pass");
     } finally {
@@ -141,9 +148,11 @@ describe("Network Tests", () => {
 
     try {
       const testFile = "tests/fixtures/network/promise-all-concurrent.ts";
-      await execAsync(`${compiler} ${testFile}`);
+      await execAsync(
+        `${compiler} ${testFile} -o ${buildDir}/tests/fixtures/network/promise-all-concurrent`,
+      );
       const { stdout } = await execAsync(
-        `.build/tests/fixtures/network/promise-all-concurrent -p ${port}`,
+        `${buildDir}/tests/fixtures/network/promise-all-concurrent -p ${port}`,
       );
       assert.ok(stdout.includes("TEST_PASSED"), "Promise.all concurrent test should pass");
     } finally {
@@ -170,9 +179,11 @@ describe("Network Tests", () => {
 
     try {
       const testFile = "tests/fixtures/network/json-parse-and-response-json-test.ts";
-      await execAsync(`${compiler} ${testFile}`);
+      await execAsync(
+        `${compiler} ${testFile} -o ${buildDir}/tests/fixtures/network/json-parse-and-response-json-test`,
+      );
       const { stdout } = await execAsync(
-        `.build/tests/fixtures/network/json-parse-and-response-json-test -p ${port}`,
+        `${buildDir}/tests/fixtures/network/json-parse-and-response-json-test -p ${port}`,
       );
       assert.ok(
         stdout.includes("TEST_PASSED"),
@@ -185,21 +196,22 @@ describe("Network Tests", () => {
 
   it("should run Promise.race with resolved promises", { skip: isNodeCompiler }, async () => {
     const testFile = "tests/fixtures/network/promise-race-test.ts";
-    await execAsync(`${compiler} ${testFile}`);
-    const { stdout } = await execAsync(".build/tests/fixtures/network/promise-race-test");
+    const exeFile = `${buildDir}/tests/fixtures/network/promise-race-test`;
+    await execAsync(`${compiler} ${testFile} -o ${exeFile}`);
+    const { stdout } = await execAsync(exeFile);
     assert.ok(stdout.includes("TEST_PASSED"), "Promise.race test should pass");
   });
 
   it("should run HTTP server using httpServe()", async () => {
     const port = await getRandomPort();
     const testFile = "tests/fixtures/network/http-server-test.ts";
-    await execAsync(`${compiler} ${testFile}`);
+    const serverExe = `${buildDir}/tests/fixtures/network/http-server-test`;
+    await execAsync(`${compiler} ${testFile} -o ${serverExe}`);
 
-    const serverProcess = spawn(
-      ".build/tests/fixtures/network/http-server-test",
-      ["-p", String(port)],
-      { detached: true, stdio: "ignore" },
-    );
+    const serverProcess = spawn(serverExe, ["-p", String(port)], {
+      detached: true,
+      stdio: "ignore",
+    });
 
     async function waitForServer(maxMs = 10000): Promise<void> {
       const start = Date.now();

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -13,7 +13,9 @@ if (!process.env.CHADC_COMPILER) {
     "CHADC_COMPILER env var is required. Run via: npm test, npm run test:node, or npm run test:native",
   );
 }
-const compiler = `${process.env.CHADC_COMPILER} build`;
+const compilerBase = process.env.CHADC_COMPILER;
+const compiler = `${compilerBase} build`;
+const buildDir = process.env.CHADC_BUILD_DIR || ".build";
 
 interface TestCase {
   name: string;
@@ -134,7 +136,7 @@ describe("Smoke Tests", { concurrency: 8 }, () => {
     it(testCase.description, async () => {
       const fixturePath = testCase.fixture;
       const fixtureDir = path.dirname(testCase.fixture);
-      const outputDir = path.join(".build", fixtureDir);
+      const outputDir = path.join(buildDir, fixtureDir);
       const extension = path.extname(fixturePath);
       const baseName = path.basename(fixturePath, extension);
       const llFile = path.join(outputDir, `${baseName}.ll`);
@@ -146,7 +148,7 @@ describe("Smoke Tests", { concurrency: 8 }, () => {
       } catch (err) {}
 
       try {
-        await execAsync(`${compiler} ${fixturePath}`);
+        await execAsync(`${compiler} ${fixturePath} -o ${exeFile}`);
 
         // Verify executable was generated (intermediate files are cleaned up by default)
         assert.ok(fsSync.existsSync(exeFile), `Executable should exist at ${exeFile}`);


### PR DESCRIPTION
## Before
`test:native` and `test:node` run in parallel in CI, both writing intermediate `.ll` files and compiled binaries to the same `.build/tests/fixtures/...` directory. When both compile the same fixture simultaneously, one process's cleanup deletes the other's `.ll` file mid-compilation, causing flaky `clang: error: no such file or directory` failures — almost exclusively on macOS CI.

## After
Each compiler label gets its own build directory: `.build/node/...` for test:node, `.build/native/...` for test:native. Tests pass `-o` explicitly to the compiler so outputs never collide. Zero `.ll` race conditions possible.

## Description
- `scripts/test.js` sets `CHADC_BUILD_DIR` env var based on `--node` / `--native` flag
- All test files (`compiler.test.ts`, `smoke.test.ts`, `network.test.ts`, `http-headers.test.ts`, `http-query-string.test.ts`, `http-routes.test.ts`, `multipart.test.ts`) read `CHADC_BUILD_DIR` and use it for output paths
- All compiler invocations now pass `-o` explicitly, ensuring the output goes to the label-specific directory
- Fallback to `.build` when `CHADC_BUILD_DIR` is unset (backward compat for manual runs)

Root cause: CI runs `npm run test:native &` and `npm run test:node &` simultaneously (ci.yml lines 317/496). Both invoke compiler.test.ts with concurrency 32. For a given fixture like `subcommand-basic.ts`, both processes write to `.build/tests/fixtures/argparse/subcommand-basic.ll`. Process A's pre-test cleanup can delete Process B's `.ll` file between its `writeFileSync` and `execSync(clang)` calls.