### PR TITLE
[codegen] add missing map/set/enum handlers to type dispatch functions

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1867,6 +1867,7 @@ export class CallExpressionGenerator {
 
   private getFieldLlvmType(field: { name: string; fieldType: string; tsType?: string }): string {
     if (field.fieldType === "string") return "i8*";
+    if (field.fieldType === "number") return "double";
     if (field.fieldType === "string[]") return "%StringArray*";
     const ftAk = classifyArray(field.fieldType);
     if (ftAk !== ArrayKind_None) return arrayKindToLlvm(ftAk);

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -38,7 +38,12 @@ import {
 } from "../infrastructure/ir-builders.js";
 import { SymbolKind_Number, SymbolKind_String } from "../infrastructure/symbol-table.js";
 import type { FieldInfo } from "../infrastructure/type-resolver/types.js";
-import { stripOptional } from "../infrastructure/type-system.js";
+import {
+  stripOptional,
+  classifyArray,
+  ArrayKind_None,
+  arrayKindToLlvm,
+} from "../infrastructure/type-system.js";
 import { setWantsI1 } from "../expressions/condition-generator.js";
 import { tryOptimizeWhileLoopMap } from "./loop-idiom.js";
 
@@ -869,7 +874,21 @@ export class ControlFlowGenerator {
   private fieldTypeToLlvm(fieldType: string): string {
     const prim = this.fieldTypeToLlvmPrimitive(fieldType);
     if (prim) return prim;
+    const ak = classifyArray(fieldType);
+    if (ak !== ArrayKind_None) return arrayKindToLlvm(ak);
+    if (fieldType.startsWith("Map<"))
+      return fieldType.startsWith("Map<string,") ? "%StringMap*" : "%Map*";
+    if (fieldType === "Set<string>") return "%StringSet*";
+    if (fieldType.startsWith("Set<")) return "%Set*";
     if (this.isEnumType(fieldType)) return "double";
+    if (fieldType.indexOf(" | ") !== -1) {
+      const parts = fieldType.split(" | ");
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i].trim();
+        if (part === "null" || part === "undefined") continue;
+        return this.fieldTypeToLlvm(part);
+      }
+    }
     return "i8*";
   }
 

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -1466,6 +1466,10 @@ export class ClassGenerator {
     if (retAk !== ArrayKind_None) return arrayKindToLlvm(retAk);
     if (returnType === "void") return "void";
     if (returnType === "number" || returnType === "boolean") return "double";
+    if (returnType.startsWith("Map<"))
+      return returnType.startsWith("Map<string,") ? "%StringMap*" : "%Map*";
+    if (returnType === "Set<string>") return "%StringSet*";
+    if (returnType.startsWith("Set<")) return "%Set*";
     if (this.isEnumType(returnType)) return "double";
     if (returnType.indexOf(" | ") !== -1) {
       const parts = returnType.split(" | ");
@@ -1733,6 +1737,11 @@ export class ClassGenerator {
     if (prim) return prim;
     const ak = classifyArray(fieldType);
     if (ak !== ArrayKind_None) return arrayKindToLlvm(ak);
+    if (fieldType.startsWith("Map<"))
+      return fieldType.startsWith("Map<string,") ? "%StringMap*" : "%Map*";
+    if (fieldType === "Set<string>") return "%StringSet*";
+    if (fieldType.startsWith("Set<")) return "%Set*";
+    if (this.isEnumType(fieldType)) return "double";
     if (fieldType.indexOf(" | ") !== -1) {
       const parts = fieldType.split(" | ");
       for (let i = 0; i < parts.length; i++) {


### PR DESCRIPTION
## Before
Type dispatch functions in `calls.ts`, `control-flow.ts`, and `class.ts` were missing handlers for Map, Set, enum, union, and number types. These fell through to the `return "i8*"` silent default, producing wrong LLVM types for class fields of those types.

## After
All three dispatch functions now cover Map/Set/enum/union types consistently with `canonicalTypeToLlvm` and each other. Reduces the blast radius of the remaining `i8*` default to only class/interface/function pointer types (which are legitimately `i8*`).

## Description
Part of #710 (silent-default dispatch). Adds:
- `calls.ts getFieldLlvmType`: missing `number → double` handler
- `control-flow.ts fieldTypeToLlvm`: missing array/Map/Set/union handlers
- `class.ts methodReturnTypeToLlvm`: missing Map/Set handlers
- `class.ts fieldTypeToLlvm`: missing Map/Set/enum handlers

~30 LOC across 3 files. All 886 tests pass.