### PR TITLE
[sema] reject inline as { ... } on opaque source types

### DIFF
--- a/src/semantic/type-assertion-checker.ts
+++ b/src/semantic/type-assertion-checker.ts
@@ -254,12 +254,45 @@ class TypeAssertionChecker {
     }
   }
 
+  private checkOpaqueSource(ta: TypeAssertionNode, fields: InterfaceField[]): void {
+    const inner = ta.expression as { type: string };
+    if (inner.type !== "type_assertion") return;
+    const innerTa = ta.expression as TypeAssertionNode;
+    const src = innerTa.assertedType;
+    if (src !== "unknown" && src !== "any" && src !== "object") return;
+
+    const fieldNames: string[] = [];
+    for (let i = 0; i < fields.length; i++) {
+      fieldNames.push(this.stripOpt((fields[i] as InterfaceField).name));
+    }
+
+    const output = formatCompileError(
+      this.sourceCode,
+      "inline type assertion 'as { " +
+        fieldNames.join("; ") +
+        " }' on opaque source (via 'as " +
+        src +
+        "') produces wrong GEP indices at runtime",
+      ta.loc,
+      "use 'as NamedInterface' instead of inline '{ ... }' when casting from '" + src + "'",
+      [
+        "inline assertion field positions become GEP indices in native code",
+        "opaque sources have no source interface for the prefix checker to verify against",
+        "declare a named interface with the correct field layout and cast to that",
+      ],
+    );
+    process.stderr.write(output);
+    process.exit(1);
+  }
+
   private validateInlineAssertion(ta: TypeAssertionNode): void {
     const assertedType = ta.assertedType;
     if (!assertedType.startsWith("{")) return;
 
     const parsedFields = this.parseInlineFields(assertedType);
     if (parsedFields.length < 2) return;
+
+    this.checkOpaqueSource(ta, parsedFields);
 
     const assertedNames: string[] = [];
     for (let i = 0; i < parsedFields.length; i++) {

--- a/tests/fixtures/errors/opaque-inline-cast.ts
+++ b/tests/fixtures/errors/opaque-inline-cast.ts
@@ -1,0 +1,11 @@
+// @test-compile-error: inline type assertion
+interface Node {
+  type: string;
+  value: number;
+  name: string;
+}
+function process(x: Node): number {
+  const y = x as unknown as { type: string; value: number };
+  return y.value;
+}
+console.log(process({ type: "a", value: 42, name: "test" }));


### PR DESCRIPTION
## Before
`(x as unknown as { type: string; value: number })` silently passed the type-assertion prefix checker because there's no source interface to compare against. In native code, the inline fields become GEP indices — if they don't match the actual struct layout, it reads wrong memory.

## After
Compile error when an inline `as { ... }` assertion (2+ fields) follows an `as unknown`, `as any`, or `as object` intermediate cast. Suggests using `as NamedInterface` instead.

## Description
Extends `type-assertion-checker.ts` with a new `checkOpaqueSource` method. This was the last unaccounted-for hazard in the "Patterns That Crash" list — inline `as { ... }` on opaque-typed sources where the prefix checker has nothing to verify against. ~30 LOC.

Closes item #3 from #729.

## Next Steps
- Item #1 from #729 (alloca for collection structs in class fields) is the remaining un-enforced crash pattern