### PR TITLE
[codegen] deduplicate fieldTypeToLlvmPrimitive into type-system.ts

### DIFF
--- a/src/codegen/infrastructure/type-system.ts
+++ b/src/codegen/infrastructure/type-system.ts
@@ -221,6 +221,14 @@ export function createFloatType(): ResolvedType {
   return createResolvedType("number", { numericKind: "float" });
 }
 
+export function fieldTypeToLlvmPrimitive(fieldType: string): string | null {
+  if (fieldType === "string") return "i8*";
+  if (fieldType === "number") return "double";
+  if (fieldType === "boolean") return "double";
+  if (fieldType.startsWith("'") || fieldType.startsWith('"')) return "i8*";
+  return null;
+}
+
 export function tsTypeToLlvm(tsType: string): string {
   return canonicalTypeToLlvm(tsType, "default", false, false, "");
 }

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -43,6 +43,7 @@ import {
   classifyArray,
   ArrayKind_None,
   arrayKindToLlvm,
+  fieldTypeToLlvmPrimitive,
 } from "../infrastructure/type-system.js";
 import { setWantsI1 } from "../expressions/condition-generator.js";
 import { tryOptimizeWhileLoopMap } from "./loop-idiom.js";
@@ -863,16 +864,8 @@ export class ControlFlowGenerator {
     return type;
   }
 
-  private fieldTypeToLlvmPrimitive(fieldType: string): string | null {
-    if (fieldType === "string") return "i8*";
-    if (fieldType === "number") return "double";
-    if (fieldType === "boolean") return "double";
-    if (fieldType.startsWith("'") || fieldType.startsWith('"')) return "i8*";
-    return null;
-  }
-
   private fieldTypeToLlvm(fieldType: string): string {
-    const prim = this.fieldTypeToLlvmPrimitive(fieldType);
+    const prim = fieldTypeToLlvmPrimitive(fieldType);
     if (prim) return prim;
     const ak = classifyArray(fieldType);
     if (ak !== ArrayKind_None) return arrayKindToLlvm(ak);

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -29,6 +29,7 @@ import {
   classifyArray,
   arrayKindToLlvm,
   ArrayKind_None,
+  fieldTypeToLlvmPrimitive,
 } from "../../infrastructure/type-system.js";
 import type { FieldInfo } from "../../infrastructure/type-resolver/types.js";
 import { emitZext, emitSitofp, emitPtrtoint } from "../../infrastructure/ir-builders.js";
@@ -1724,16 +1725,8 @@ export class ClassGenerator {
     this.ctx.defineVariable(paramName, allocaReg, llvmType, SymbolKind_Object, "local");
   }
 
-  private fieldTypeToLlvmPrimitive(fieldType: string): string | null {
-    if (fieldType === "string") return "i8*";
-    if (fieldType === "number") return "double";
-    if (fieldType === "boolean") return "double";
-    if (fieldType.startsWith("'") || fieldType.startsWith('"')) return "i8*";
-    return null;
-  }
-
   private fieldTypeToLlvm(fieldType: string): string {
-    const prim = this.fieldTypeToLlvmPrimitive(fieldType);
+    const prim = fieldTypeToLlvmPrimitive(fieldType);
     if (prim) return prim;
     const ak = classifyArray(fieldType);
     if (ak !== ArrayKind_None) return arrayKindToLlvm(ak);


### PR DESCRIPTION
## Before
`fieldTypeToLlvmPrimitive()` was duplicated identically in `control-flow.ts` and `class.ts` — same 5-line function mapping string/number/boolean/string-literal to their LLVM types.

## After
No user-facing change. Internal refactor only. Single shared `fieldTypeToLlvmPrimitive()` exported from `type-system.ts`, imported by both callers.

## Description
Part of #710 (eliminate silent-default dispatch). This extracts the primitive type mapping as a shared utility, reducing duplication and making it easier to add new primitive types in one place. Net -6 lines.