### PR TITLE
[type-system] explicit dispatch in fieldToLlvmType, fail-loud on empty interface types

### DIFF
--- a/src/codegen/types/interface-struct-generator.ts
+++ b/src/codegen/types/interface-struct-generator.ts
@@ -159,7 +159,7 @@ export class InterfaceStructGenerator {
 
   private tsTypeToLlvmForField(fieldName: string, tsType: string): string {
     if (tsType === null || tsType === undefined || tsType === "") {
-      return "i8*";
+      throw new Error(`tsTypeToLlvmForField: empty type for field '${fieldName}'`);
     }
     if (this.interfaceStructs.has(tsType)) {
       return "i8*";
@@ -171,7 +171,7 @@ export class InterfaceStructGenerator {
 
   private tsTypeToLlvm(tsType: string): string {
     if (tsType === null || tsType === undefined || tsType === "") {
-      return "i8*";
+      throw new Error("tsTypeToLlvm: empty type");
     }
     if (this.interfaceStructs.has(tsType)) {
       return "i8*";

--- a/src/codegen/types/objects/class.ts
+++ b/src/codegen/types/objects/class.ts
@@ -128,6 +128,15 @@ export class ClassGenerator {
         if (this.isEnumType(ts)) {
           return "double";
         }
+        if (ts === "string" || ts === "void" || ts === "any" || ts === "unknown" || ts === "object")
+          return "i8*";
+        if (ts === "null" || ts === "undefined" || ts === "never") return "i8*";
+        if (ts.indexOf(" | ") !== -1) return "i8*";
+        if (ts.startsWith("{")) return "i8*";
+        if (ts.startsWith('"')) return "i8*";
+        if (ts.indexOf("=>") !== -1 || ts.startsWith("(")) return "i8*";
+        if (ts === "i8*" || ts === "i1") return ts;
+        if (ts.startsWith("%")) return ts;
         return "i8*";
       }
       if (ft === "double") return "double";
@@ -170,6 +179,15 @@ export class ClassGenerator {
         if (this.isEnumType(ts)) {
           return "double";
         }
+        if (ts === "string" || ts === "void" || ts === "any" || ts === "unknown" || ts === "object")
+          return "i8*";
+        if (ts === "null" || ts === "undefined" || ts === "never") return "i8*";
+        if (ts.indexOf(" | ") !== -1) return "i8*";
+        if (ts.startsWith("{")) return "i8*";
+        if (ts.startsWith('"')) return "i8*";
+        if (ts.indexOf("=>") !== -1 || ts.startsWith("(")) return "i8*";
+        if (ts === "i8*" || ts === "i1") return ts;
+        if (ts.startsWith("%")) return ts;
         return "i8*";
       }
     }


### PR DESCRIPTION
## Before
`fieldToLlvmType` in class.ts had two `return "i8*"` catch-alls that silently handled any unrecognized tsType. `tsTypeToLlvm`/`tsTypeToLlvmForField` in interface-struct-generator.ts silently returned `i8*` for null/empty types.

## After
Both `fieldToLlvmType` sites now explicitly dispatch on known type categories (string, void, any/unknown/object, null/undefined/never, unions, inline objects, string literals, function types, LLVM types) before the remaining catch-all. Interface-struct-generator throws on null/empty types instead of silently returning `i8*`.

No user-facing change. Internal refactor only.

## Description
Part of #710 (eliminate silent-default dispatch). Fourth PR in series after #749, #750, #751. The `fieldToLlvmType` catch-all `return "i8*"` is retained because the function can't distinguish interface names from truly unknown types without access to the interface struct generator — but the explicit dispatch narrows it to only interface/class name resolution.