### PR TITLE
[type-system] migrate 4 remaining guard-check sites to isAnyArrayTsType

### DIFF
--- a/src/codegen/infrastructure/type-resolver/type-resolver.ts
+++ b/src/codegen/infrastructure/type-resolver/type-resolver.ts
@@ -42,6 +42,7 @@ import {
   parseSetTypeString,
   parseArrayTypeString,
   canonicalTypeToLlvm,
+  isAnyArrayTsType,
 } from "../type-system.js";
 
 interface ExprBase {
@@ -736,7 +737,7 @@ export class TypeResolver {
     if (!valueType) return null;
     if (valueType === "string" || valueType === "number" || valueType === "boolean") return null;
 
-    if (valueType.endsWith("[]")) {
+    if (isAnyArrayTsType(valueType)) {
       return valueType;
     }
 

--- a/src/codegen/infrastructure/variable-allocator.ts
+++ b/src/codegen/infrastructure/variable-allocator.ts
@@ -609,7 +609,7 @@ export class VariableAllocator {
         );
         this.ctx.emit(`${allocaReg} = alloca %Array*`);
         this.ctx.emit(`store %Array* null, %Array** ${allocaReg}`);
-      } else if (baseType.endsWith("[]")) {
+      } else if (isAnyArrayTsType(baseType)) {
         this.ctx.defineVariableWithMetadata(
           stmt.name,
           allocaReg,
@@ -747,7 +747,7 @@ export class VariableAllocator {
         this.ctx.setExpectedArrayElementType("boolean");
       } else if (strippedType === "number[]") {
         this.ctx.setExpectedArrayElementType("number");
-      } else if (strippedType.endsWith("[]")) {
+      } else if (isAnyArrayTsType(strippedType)) {
         this.ctx.setExpectedArrayElementType("pointer");
       }
     }
@@ -880,7 +880,7 @@ export class VariableAllocator {
       const genericReturn = this.resolveGenericCallReturnType(stmtValue);
       if (genericReturn === "string") isString = true;
       else if (genericReturn === "string[]") isStringArray = true;
-      else if (genericReturn && genericReturn.endsWith("[]")) isObjectArray = true;
+      else if (genericReturn && isAnyArrayTsType(genericReturn)) isObjectArray = true;
     }
 
     if (


### PR DESCRIPTION
## Before
4 sites in variable-allocator.ts and type-resolver.ts used raw `endsWith("[]")` for array type guard checks.

## After
All 4 sites use `isAnyArrayTsType()` from type-system.ts. No behavioral change — both functions return the same boolean result for array types.

No user-facing change. Internal refactor only.

## Description
Part of #710 (eliminate raw string array checks). Fifth PR in series. Migrates:
- `variable-allocator.ts:612` — baseType catch-all after specific array checks
- `variable-allocator.ts:750` — strippedType element type dispatch
- `variable-allocator.ts:883` — genericReturn ObjectArray classification
- `type-resolver.ts:739` — valueType array guard

Total guard-check sites migrated: 57 (53 from PRs #711-#712 + 4 from this PR).